### PR TITLE
Add support for alloca() and also functions used by the Wordgraph displa...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,12 @@ AC_C_CONST
 
 AC_CHECK_FUNCS(towupper)
 
+AC_FUNC_ALLOCA
+
+# For the Wordgraph display code
+AC_FUNC_FORK
+AC_CHECK_FUNCS(prctl)
+
 dnl ====================================================================
 
 AC_MSG_CHECKING([for native Win32])


### PR DESCRIPTION
Currently alloca.h is not #included.
GCC needs a definition from it for inlining alloca().
Other compiler/systems may need this file too.

Support is added also for 2 functions used in the Wordgraph display code,
so they will not be used if not available.
