### PR TITLE
Windows / Visual Studio support

### DIFF
--- a/link-grammar/corpus/corpus.h
+++ b/link-grammar/corpus/corpus.h
@@ -13,6 +13,7 @@
 
 #include "../api-types.h"
 #include "../link-includes.h"
+#include "../utilities.h"
 
 #ifdef USE_CORPUS
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -77,8 +77,8 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 {
 	size_t i, j, l;
 	char * s, *u;
-	const char * chosen_words[sent->length];
-	size_t remap[sent->length];
+	const char ** chosen_words = alloca(sent->length*sizeof(char*));
+	size_t *remap = alloca(sent->length*sizeof(size_t));
 	bool display_morphology = opts->display_morphology;
 	const char infix_mark = INFIX_MARK(sent->dict->affix_table);
 

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -95,7 +95,7 @@ static size_t find_domain_name(Postprocessor *pp, const char *link)
 static int contained_in(const Domain * d1, const Domain * d2,
                         const Linkage sublinkage)
 {
-	bool mark[sublinkage->num_links];
+	bool *mark = alloca(sublinkage->num_links*sizeof(bool));
 	List_o_links * lol;
 	memset(mark, 0, sublinkage->num_links*(sizeof(bool)));
 	for (lol=d2->lol; lol != NULL; lol = lol->next)

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -376,11 +376,11 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	bool print_word_0 , print_word_N;
 	int N_wall_connectors;
 	bool suppressor_used;
-	int center[linkage->num_words+1];
+	int *center = alloca((linkage->num_words+1)*sizeof(int));
 	unsigned int line_len, link_length;
 	unsigned int N_links = linkage->num_links;
 	Link *ppla = linkage->link_array;
-	String * string;
+	String * string;  
 	char * gr_string;
 	unsigned int N_words_to_print;
 

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1029,7 +1029,7 @@ static bool strip_right(Sentence sent,
 	Dictionary dict = sent->dict;
 	Dictionary afdict = dict->affix_table;
 	const char * temp_wend = *wend;
-	char *word = alloca(temp_wend-w);
+	char *word = alloca(temp_wend-w+1);
 	size_t sz;
 	size_t i;
 	size_t nrs = 0;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -109,7 +109,7 @@ char * strndup (const char *str, size_t size);
  * cygwin just doesn't work very well. So we use our own custom version,
  * instead.
  */
-size_t lg_mbrtowc(wchar_t *, const char *, size_t, mbstate_t *);
+link_public_api(size_t) lg_mbrtowc(wchar_t *, const char *, size_t, mbstate_t *);
 #ifdef mbrtowc
 #undef mbrtowc
 #endif

--- a/msvc12/LinkGrammar.sln
+++ b/msvc12/LinkGrammar.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LinkGrammarJava", "LinkGrammarJava.vcxproj", "{D74DF531-C18E-4988-8A8C-4F23556DEC1B}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -31,8 +31,8 @@ Global
 		{D74DF531-C18E-4988-8A8C-4F23556DEC1B}.Release|Win32.Build.0 = Release|Win32
 		{D74DF531-C18E-4988-8A8C-4F23556DEC1B}.Release|x64.ActiveCfg = Release|x64
 		{D74DF531-C18E-4988-8A8C-4F23556DEC1B}.Release|x64.Build.0 = Release|x64
-		{0A6C539A-3140-48BD-865C-05F45637B93B}.Debug|Win32.ActiveCfg = Debug|x64
-		{0A6C539A-3140-48BD-865C-05F45637B93B}.Debug|Win32.Build.0 = Debug|x64
+		{0A6C539A-3140-48BD-865C-05F45637B93B}.Debug|Win32.ActiveCfg = Debug|Win32
+		{0A6C539A-3140-48BD-865C-05F45637B93B}.Debug|Win32.Build.0 = Debug|Win32
 		{0A6C539A-3140-48BD-865C-05F45637B93B}.Debug|x64.ActiveCfg = Debug|x64
 		{0A6C539A-3140-48BD-865C-05F45637B93B}.Debug|x64.Build.0 = Debug|x64
 		{0A6C539A-3140-48BD-865C-05F45637B93B}.Release|Win32.ActiveCfg = Release|Win32

--- a/msvc12/LinkGrammar.vcxproj
+++ b/msvc12/LinkGrammar.vcxproj
@@ -60,38 +60,36 @@
     <_ProjectFileVersion>12.0.21005.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Debug\</OutDir>
-    <IntDir>Debug\</IntDir>
-    <LinkIncremental>true</LinkIncremental>
+    <TargetName>link-grammar-x86</TargetName>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <TargetName>link-grammar-x64</TargetName>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Release\</OutDir>
-    <IntDir>Release\</IntDir>
-    <LinkIncremental>true</LinkIncremental>
+    <TargetName>link-grammar-x86</TargetName>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <TargetName>link-grammar-x64</TargetName>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..;..\link-grammar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LGSVN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
-      <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)link-grammar.dll</OutputFile>
-      <AdditionalLibraryDirectories>$(GNUREGEX)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -100,39 +98,30 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\link-grammar;G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\;..\.;G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\lib;G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\include\tre;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..;..\link-grammar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LGSVN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <DebugInformationFormat>None</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>tre.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)link-grammar.dll</OutputFile>
-      <AdditionalLibraryDirectories>G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\vcbuild\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..;..\link-grammar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LGSVN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader />
-      <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)link-grammar.dll</OutputFile>
-      <AdditionalLibraryDirectories>$(GNUREGEX)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -142,41 +131,48 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..\.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GNUREGEX)\include;..;..\link-grammar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LGSVN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)link-grammar.dll</OutputFile>
-      <AdditionalLibraryDirectories>$(GNUREGEX)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\link-grammar\analyze-linkage.h" />
     <ClInclude Include="..\link-grammar\and.h" />
+    <ClInclude Include="..\link-grammar\anysplit.h" />
     <ClInclude Include="..\link-grammar\api-structures.h" />
     <ClInclude Include="..\link-grammar\api-types.h" />
     <ClInclude Include="..\link-grammar\api.h" />
     <ClInclude Include="..\link-grammar\build-disjuncts.h" />
     <ClInclude Include="..\link-grammar\constituents.h" />
     <ClInclude Include="..\link-grammar\count.h" />
+    <ClInclude Include="..\link-grammar\dict-api.h" />
+    <ClInclude Include="..\link-grammar\dict-common.h" />
+    <ClInclude Include="..\link-grammar\dict-file\read-dict.h" />
+    <ClInclude Include="..\link-grammar\dict-file\read-regex.h" />
+    <ClInclude Include="..\link-grammar\dict-file\word-file.h" />
+    <ClInclude Include="..\link-grammar\dict-structures.h" />
+    <ClInclude Include="..\link-grammar\disjunct-utils.h" />
+    <ClInclude Include="..\link-grammar\disjuncts.h" />
     <ClInclude Include="..\link-grammar\error.h" />
+    <ClInclude Include="..\link-grammar\expand.h" />
     <ClInclude Include="..\link-grammar\externs.h" />
     <ClInclude Include="..\link-grammar\extract-links.h" />
     <ClInclude Include="..\link-grammar\fast-match.h" />
     <ClInclude Include="..\link-grammar\idiom.h" />
     <ClInclude Include="..\link-grammar\link-features.h" />
     <ClInclude Include="..\link-grammar\link-includes.h" />
+    <ClInclude Include="..\link-grammar\linkage.h" />
     <ClInclude Include="..\link-grammar\massage.h" />
     <ClInclude Include="..\link-grammar\post-process.h" />
     <ClInclude Include="..\link-grammar\pp_knowledge.h" />
@@ -188,7 +184,11 @@
     <ClInclude Include="..\link-grammar\print.h" />
     <ClInclude Include="..\link-grammar\prune.h" />
     <ClInclude Include="..\link-grammar\read-dict.h" />
+    <ClInclude Include="..\link-grammar\regex-morph.h" />
+    <ClInclude Include="..\link-grammar\regex-tokenizer.h" />
     <ClInclude Include="..\link-grammar\resources.h" />
+    <ClInclude Include="..\link-grammar\score.h" />
+    <ClInclude Include="..\link-grammar\spellcheck.h" />
     <ClInclude Include="..\link-grammar\string-set.h" />
     <ClInclude Include="..\link-grammar\structures.h" />
     <ClInclude Include="..\link-grammar\tokenize.h" />
@@ -198,12 +198,16 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\link-grammar\analyze-linkage.c" />
-    <ClCompile Include="..\link-grammar\and.c" />
+    <ClCompile Include="..\link-grammar\anysplit.c" />
     <ClCompile Include="..\link-grammar\api.c" />
     <ClCompile Include="..\link-grammar\build-disjuncts.c" />
     <ClCompile Include="..\link-grammar\constituents.c" />
     <ClCompile Include="..\link-grammar\count.c" />
-    <ClCompile Include="..\link-grammar\dictionary.c" />
+    <ClCompile Include="..\link-grammar\dict-common.c" />
+    <ClCompile Include="..\link-grammar\dict-file\dictionary.c" />
+    <ClCompile Include="..\link-grammar\dict-file\read-dict.c" />
+    <ClCompile Include="..\link-grammar\dict-file\read-regex.c" />
+    <ClCompile Include="..\link-grammar\dict-file\word-file.c" />
     <ClCompile Include="..\link-grammar\disjunct-utils.c" />
     <ClCompile Include="..\link-grammar\disjuncts.c" />
     <ClCompile Include="..\link-grammar\error.c" />
@@ -211,7 +215,8 @@
     <ClCompile Include="..\link-grammar\extract-links.c" />
     <ClCompile Include="..\link-grammar\fast-match.c" />
     <ClCompile Include="..\link-grammar\idiom.c" />
-    <ClCompile Include="..\link-grammar\massage.c" />
+    <ClCompile Include="..\link-grammar\linkage.c" />
+    <ClCompile Include="..\link-grammar\malloc-dbg.c" />
     <ClCompile Include="..\link-grammar\post-process.c" />
     <ClCompile Include="..\link-grammar\pp_knowledge.c" />
     <ClCompile Include="..\link-grammar\pp_lexer.c" />
@@ -221,17 +226,19 @@
     <ClCompile Include="..\link-grammar\print-util.c" />
     <ClCompile Include="..\link-grammar\print.c" />
     <ClCompile Include="..\link-grammar\prune.c" />
-    <ClCompile Include="..\link-grammar\read-dict.c" />
-    <ClCompile Include="..\link-grammar\read-regex.c" />
     <ClCompile Include="..\link-grammar\regex-morph.c" />
+    <ClCompile Include="..\link-grammar\regex-tokenizer.c" />
     <ClCompile Include="..\link-grammar\resources.c" />
+    <ClCompile Include="..\link-grammar\score.c" />
     <ClCompile Include="..\link-grammar\spellcheck-aspell.c" />
     <ClCompile Include="..\link-grammar\spellcheck-hun.c" />
     <ClCompile Include="..\link-grammar\string-set.c" />
     <ClCompile Include="..\link-grammar\tokenize.c" />
     <ClCompile Include="..\link-grammar\utilities.c" />
-    <ClCompile Include="..\link-grammar\word-file.c" />
     <ClCompile Include="..\link-grammar\word-utils.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\link-grammar\link-features.h.in" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc12/LinkGrammar.vcxproj.filters
+++ b/msvc12/LinkGrammar.vcxproj.filters
@@ -114,12 +114,54 @@
     <ClInclude Include="..\link-grammar\word-utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\link-grammar\anysplit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-api.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-structures.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\disjuncts.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\disjunct-utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\expand.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\linkage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\regex-morph.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\regex-tokenizer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\score.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\spellcheck.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-file\read-dict.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-file\read-regex.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-file\word-file.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\link-grammar\analyze-linkage.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\and.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\api.c">
@@ -132,9 +174,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\count.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\dictionary.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\disjunct-utils.c">
@@ -156,9 +195,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\idiom.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\massage.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\post-process.c">
@@ -188,12 +224,6 @@
     <ClCompile Include="..\link-grammar\prune.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\read-dict.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\read-regex.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\link-grammar\regex-morph.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -215,11 +245,41 @@
     <ClCompile Include="..\link-grammar\utilities.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\word-file.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\link-grammar\word-utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\link-grammar\anysplit.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\malloc-dbg.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\regex-tokenizer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\score.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-file\dictionary.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-file\read-dict.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-file\read-regex.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-file\word-file.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\link-grammar\link-features.h.in" />
   </ItemGroup>
 </Project>

--- a/msvc12/LinkGrammarExe.vcxproj
+++ b/msvc12/LinkGrammarExe.vcxproj
@@ -18,6 +18,15 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\link-parser\command-line.c" />
+    <ClCompile Include="..\link-parser\lg_readline.c" />
+    <ClCompile Include="..\link-parser\link-parser.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\link-parser\command-line.h" />
+    <ClInclude Include="..\link-parser\lg_readline.h" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{532EFF4D-758A-4705-91EE-9A4AC72C017B}</ProjectGuid>
     <RootNamespace>LinkGrammarExe</RootNamespace>
@@ -27,24 +36,20 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -66,150 +71,100 @@
     <_ProjectFileVersion>12.0.21005.1</_ProjectFileVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(GNUREGEX)\include;../.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)link-grammar.exe</OutputFile>
-      <AdditionalLibraryDirectories>$(GNUREGEX)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Configuration)\link-grammar-x86.lib;$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\link-grammar;G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\include;../.;G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\lib\;G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\include\tre;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
-      <DebugInformationFormat>None</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
+      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>tre.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)link-grammar.exe</OutputFile>
-      <AdditionalLibraryDirectories>G:\DEV\Java\SourceControlled\RelEx\link-grammar\trunk\tre\vcbuild\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(GNUREGEX)\include;../.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(GNUREGEX)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Configuration)\link-grammar-x86.lib;$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(GNUREGEX)\include;../.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(GNUREGEX)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>$(GNUREGEX)\lib\regex.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <ClCompile Include="..\link-grammar\analyze-linkage.c" />
-    <ClCompile Include="..\link-grammar\and.c" />
-    <ClCompile Include="..\link-grammar\api.c" />
-    <ClCompile Include="..\link-grammar\build-disjuncts.c" />
-    <ClCompile Include="..\link-grammar\constituents.c" />
-    <ClCompile Include="..\link-grammar\count.c" />
-    <ClCompile Include="..\link-grammar\dictionary.c" />
-    <ClCompile Include="..\link-grammar\disjunct-utils.c" />
-    <ClCompile Include="..\link-grammar\disjuncts.c" />
-    <ClCompile Include="..\link-grammar\error.c" />
-    <ClCompile Include="..\link-grammar\expand.c" />
-    <ClCompile Include="..\link-grammar\extract-links.c" />
-    <ClCompile Include="..\link-grammar\fast-match.c" />
-    <ClCompile Include="..\link-grammar\idiom.c" />
-    <ClCompile Include="..\link-grammar\massage.c" />
-    <ClCompile Include="..\link-grammar\post-process.c" />
-    <ClCompile Include="..\link-grammar\pp_knowledge.c" />
-    <ClCompile Include="..\link-grammar\pp_lexer.c" />
-    <ClCompile Include="..\link-grammar\pp_linkset.c" />
-    <ClCompile Include="..\link-grammar\prefix.c" />
-    <ClCompile Include="..\link-grammar\preparation.c" />
-    <ClCompile Include="..\link-grammar\print-util.c" />
-    <ClCompile Include="..\link-grammar\print.c" />
-    <ClCompile Include="..\link-grammar\prune.c" />
-    <ClCompile Include="..\link-grammar\read-dict.c" />
-    <ClCompile Include="..\link-grammar\read-regex.c" />
-    <ClCompile Include="..\link-grammar\regex-morph.c" />
-    <ClCompile Include="..\link-grammar\resources.c" />
-    <ClCompile Include="..\link-grammar\spellcheck-aspell.c" />
-    <ClCompile Include="..\link-grammar\spellcheck-hun.c" />
-    <ClCompile Include="..\link-grammar\string-set.c" />
-    <ClCompile Include="..\link-grammar\tokenize.c" />
-    <ClCompile Include="..\link-grammar\utilities.c" />
-    <ClCompile Include="..\link-grammar\word-file.c" />
-    <ClCompile Include="..\link-grammar\word-utils.c" />
-    <ClCompile Include="..\link-parser\command-line.c" />
-    <ClCompile Include="..\link-parser\lg_readline.c" />
-    <ClCompile Include="..\link-parser\link-parser.c" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/msvc12/LinkGrammarExe.vcxproj.filters
+++ b/msvc12/LinkGrammarExe.vcxproj.filters
@@ -15,111 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\link-grammar\analyze-linkage.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\and.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\api.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\build-disjuncts.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\constituents.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\count.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\dictionary.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\disjunct-utils.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\disjuncts.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\error.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\expand.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\extract-links.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\fast-match.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\idiom.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\massage.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\post-process.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\pp_knowledge.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\pp_lexer.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\pp_linkset.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\prefix.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\preparation.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\print-util.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\print.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\prune.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\read-dict.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\read-regex.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\regex-morph.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\resources.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\spellcheck-aspell.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\spellcheck-hun.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\string-set.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\tokenize.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\utilities.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\word-file.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\word-utils.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\link-parser\command-line.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -129,5 +24,13 @@
     <ClCompile Include="..\link-parser\link-parser.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\link-parser\command-line.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-parser\lg_readline.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/msvc12/LinkGrammarJava.vcxproj
+++ b/msvc12/LinkGrammarJava.vcxproj
@@ -60,19 +60,21 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>Debug\</OutDir>
-    <IntDir>Debug\</IntDir>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>Release\</OutDir>
-    <IntDir>Release\</IntDir>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -159,15 +161,15 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\link-grammar\jni-client.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\link-grammar\jni-client.c" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="LinkGrammar.vcxproj">
       <Project>{0a6c539a-3140-48bd-865c-05f45637b93b}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\bindings\java-jni\jni-client.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\bindings\java-jni\jni-client.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc12/LinkGrammarJava.vcxproj.filters
+++ b/msvc12/LinkGrammarJava.vcxproj.filters
@@ -15,13 +15,13 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\link-grammar\jni-client.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\link-grammar\jni-client.c">
+    <ClCompile Include="..\bindings\java-jni\jni-client.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\bindings\java-jni\jni-client.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi guys,

This is Artem, the memory leak guy :)
These are fixes for Visual Studio 2013, where for the moment it doesn't even compile because of lack of C99 support in VS. Could you please merge these changes into the master branch? It would really make our life easier. 

Thanks in advance,
Artem.
- Updated the Visual Studio 2013 project with a current file list, fixed project dependencies and compile options;
- Made the parser actually compile under MSVC that doesn't have C99 support;
- fixed a crash on Windows / potential memory corruption on other platforms (tokenize.c)
