### PR TITLE
Invalidate path_found before dictionary opening.

### DIFF
--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -367,6 +367,7 @@ void dictionary_delete(Dictionary dict)
 #endif
 	free_dictionary(dict);
 	xfree(dict, sizeof(struct Dictionary_s));
+	cache_data_path(NULL, /*set*/true);
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -613,6 +613,7 @@ Dictionary dictionary_create_from_file(const char * lang)
 		affix_name = join_path(lang, "4.0.affix");
 		regex_name = join_path(lang, "4.0.regex");
 
+		cache_data_path(NULL, /*set*/true);
 		dictionary = dictionary_six(lang, dict_name, pp_name, cons_name,
 		                            affix_name, regex_name);
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -389,6 +389,7 @@ void * object_open(const char *filename,
 
 bool file_exists(const char * dict_name);
 char * get_file_contents(const char *filename);
+const char *cache_data_path(const char *, bool);
 
 /**
  * Returns the smallest power of two that is at least i and at least 1


### PR DESCRIPTION
This allows adaption of the path_found cache to
dictionary_set_data_dir(newdir) or program chdir() (followed by a
dictionary opening), and different languages in different data
directories. It also causes a printout of
"Info: Dictionary found at ..." for any dictionary open, not only the
first one.

The memory for path_found is now freed on dictionary_delete (just for
less noise on unfreed memory).

The path_found cache still doesn't work as intended - a dictpath search
is still done (an old problem). This needs another fix.