### PR TITLE
python binding module access improvement

### DIFF
--- a/bindings/python/__init__.py.in
+++ b/bindings/python/__init__.py.in
@@ -2,3 +2,5 @@
 # __init__.py  file for Link Grammar Python bindings
 #
 __version__ = "@VERSION@"
+
+from .linkgrammar import *

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -6,6 +6,10 @@ import locale
 
 import _clinkgrammar as clg
 
+
+__all__ = ['Parser', 'ParseOptions', 'Dictionary', 'Link', 'Linkage']
+
+
 class Parser(object):
     # A cost of 2.7 allows the usual cost-2 connectors, plus the
     # assorted fractional costs, without going to cost 3.0, which


### PR DESCRIPTION
Small improvement for better usage.

I saw next message into python binding:
> May need to set the PYTHONPATH to get this to work:
> PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/dist-packages/link-grammar
> or something similar ...

Problem is in the package name: It shouldn't be "link-grammar", but "linkgrammar" or "link_grammar".
Can you help me to fix it? - I found, that this name had been taken from PACKAGE (file "configure.ac") and uses globally. So, I can offer to convert a minus-char into underscore or drop it especially for python package name (See http://stackoverflow.com/a/1706459/2261861).
