### PR TITLE
Fix crash in batch mode: bug #63

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
-Version 5.x.x: (XXX 2015)
+Version 5.2.5: (XXX 2015)
  * Fix contracted "is" verb.
+ * Fix crash in batch mode (issue #63)
 
 Version 5.2.4: (12 January 2015)
  * Fix usage of 'less'.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -426,7 +426,7 @@ static void free_linkages(Sentence sent)
 		free(linkage->link_array);
 
 		/* Q: Why isn't this in a string set ?? A: Because there is no
-		 * string-set handy when we  compute this */
+		 * string-set handy when we compute this. */
 		if (linkage->disjunct_list_str)
 		{
 			for (j=0; j<linkage->num_words; j++)
@@ -445,6 +445,9 @@ static void free_linkages(Sentence sent)
 
 	exfree(lkgs, sent->num_linkages_alloced * sizeof(struct Linkage_s));
 	sent->num_linkages_alloced = 0;
+	sent->num_linkages_found = 0;
+	sent->num_linkages_post_processed = 0;
+	sent->num_valid_linkages = 0;
 	sent->lnkages = NULL;
 }
 
@@ -1222,7 +1225,8 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 	free_parse_info(sent->parse_info);
 	sent->parse_info = parse_info_new(sent->length);
 
-	for (nl = opts->min_null_count; nl <= opts->max_null_count ; ++nl)
+	nl = opts->min_null_count;
+	while (true)
 	{
 		s64 total;
 		if (resources_exhausted(opts->resources)) break;
@@ -1236,8 +1240,8 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 		}
 
 		/* total is 64-bit, num_linkages_found is 32-bit. Clamp */
-		total = (total>INT_MAX) ? INT_MAX : total;
-		total = (total<0) ? INT_MAX : total;
+		total = (total > INT_MAX) ? INT_MAX : total;
+		total = (total < 0) ? INT_MAX : total;
 
 		sent->num_linkages_found = (int) total;
 		print_time(opts, "Counted parses");
@@ -1252,8 +1256,12 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 		 * If there was a parse overflow, give up now. */
 		if (PARSE_NUM_OVERFLOW < total) break;
 
+		/* loop termination */
+		if (nl == opts->max_null_count) break;
+
 		/* If we are here, we are going round again. Free stuff. */
 		free_linkages(sent);
+		nl++;
 	}
 	sort_linkages(sent, opts);
 


### PR DESCRIPTION
Not only was there a crash, but bad linkages could no longer be printed.