### PR TITLE
Rewrite the dictionary file opening stuff (issue #56)

### DIFF
--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -113,6 +113,8 @@ Dictionary dictionary_create_lang(const char * lang)
 {
 	Dictionary dictionary = NULL;
 
+	object_open(NULL, NULL, NULL); /* Invalidate the directory path cache */
+
 	/* If an sql database exists, try to read that. */
 	if (check_db(lang))
 	{
@@ -367,6 +369,7 @@ void dictionary_delete(Dictionary dict)
 #endif
 	free_dictionary(dict);
 	xfree(dict, sizeof(struct Dictionary_s));
+	object_open(NULL, NULL, NULL); /* Free the directory path cache */
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1403,7 +1403,7 @@ static Dict_node * dsw_tree_to_vine (Dict_node *root)
 			vine_tail = rest;
 			rest = rest->right;
 		}
-	 	/* eliminate the left subtree */
+		/* eliminate the left subtree */
 		else
 		{
 			rest = rotate_right(rest);
@@ -1623,9 +1623,11 @@ static bool read_entry(Dictionary dict)
 			const char * save_pin;
 			char save_already_got_it;
 			int save_line_number;
+			size_t skip_slash;
 
 			if (!link_advance(dict)) goto syntax_error;
 
+			skip_slash          = ('/' == dict->token[0]) ? 1 : 0;
 			dict_name           = strdup(dict->token);
 			save_name           = dict->name;
 			save_is_special     = dict->is_special;
@@ -1635,7 +1637,7 @@ static bool read_entry(Dictionary dict)
 			save_line_number    = dict->line_number;
 
 			/* OK, token contains the filename to read ... */
-			instr = get_file_contents(dict_name);
+			instr = get_file_contents(dict_name + skip_slash);
 			if (NULL == instr)
 			{
 				prt_error("Error: Could not open subdictionary %s", dict_name);

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -265,7 +265,7 @@ bool check_db(const char *lang)
 	return retval;
 }
 
-static void* db_open(const char * fullname, void * user_data)
+static void* db_open(const char * fullname, const void * user_data)
 {
 	int fd;
 	struct stat buf;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -384,8 +384,8 @@ char * join_path(const char * prefix, const char * suffix);
 
 FILE * dictopen(const char *filename, const char *how);
 void * object_open(const char *filename,
-                   void * (*opencb)(const char *, void *),
-                   void * user_data);
+                   void * (*opencb)(const char *, const void *),
+                   const void * user_data);
 
 bool file_exists(const char * dict_name);
 char * get_file_contents(const char *filename);


### PR DESCRIPTION
 - Invalidate the dictionary path cache on each dictionary create.
   This has the benefit of notifying the path of each dictionary open,
   not only the first one.
 - The algorithm now really ensures that all the files will be opened
   from within the same dictionary directory.
 - Free the dictionary path cache on dictionary delete.
 - Don't try to append full-path dictionary arguments to the dictpath.
 - Prefer dictionaries at relative paths (usually user or source
   directory dictionaries) over a system-installed dictionary.
 - The path_found dictionary path cache now uses the previous prevpath
   mechanism (that didn't work as intended).
 - Fix opencb() last argument declaration to avoid the need of const
   conversion.
 - Change dictpath from a dynamically generated string path to an array
   of paths.
 - on binreloc, search essentially the same path (with the addition of
   the binreloc path after the relative paths, but before the shared
   system path).
 - dictionary_get_data_dir() is not invoked any more for each file
   open, but only until the dictionary path cache is created.
 - Remove the leading slashes in #include paths, so they are not
   tried any more as absolute paths. This allows not retrying opening
   failed real absolute paths as relative ones (using the dictpath or
   the dictionary path cache).
 - Simplified dict_file_open() and dictopen() to the minimum possible.
 - Minor cleanup: white space.