### PR TITLE
Fix setting dict-lang to freed memory.

### DIFF
--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -462,9 +462,12 @@ dictionary_six_str(const char * lang,
 
 	/* Language and file-name stuff */
 	dict->string_set = string_set_create();
-	dict->lang = lang;
 	t = strrchr (lang, '/');
-	if (t) dict->lang = string_set_add(t+1, dict->string_set);
+	t = (NULL == t) ? lang : t+1;
+	dict->lang = string_set_add(t, dict->string_set);
+#ifdef _DEBUG
+	prt_error("Info: Language: %s\n", dict->lang);
+#endif
 	dict->name = string_set_add(dict_name, dict->string_set);
 
 	/*

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -265,7 +265,7 @@ bool check_db(const char *lang)
 	return retval;
 }
 
-static void* db_open(const char * fullname, void * user_data)
+static void* db_open(const char * fullname, const void * user_data)
 {
 	int fd;
 	struct stat buf;
@@ -323,9 +323,12 @@ Dictionary dictionary_create_from_db(const char *lang)
 
 	/* Language and file-name stuff */
 	dict->string_set = string_set_create();
-	dict->lang = lang;
 	t = strrchr (lang, '/');
-	if (t) dict->lang = string_set_add(t+1, dict->string_set);
+	t = (NULL == t) ? lang : t+1;
+	dict->lang = string_set_add(t, dict->string_set);
+#ifdef _DEBUG
+	prt_error("Info: Language: %s\n", dict->lang);
+#endif
 
 	/* To disable spell-checking, just set the checker to NULL */
 	dict->spell_checker = spellcheck_create(dict->lang);


### PR DESCRIPTION
If lang contains no slashes (the normal situation), dict->lang could get set to malloc'ed
memory that is being freed soon (in dictionary_create_from_utf8()
or dictionary_create_default_lang()). Fixed to always use string set.

Also add a debug message for printing the found language, using
_DEBUG (that already enables printing dictionary paths).
It can be included using:
./configure CPPFLAGS=-D_DEBUG=1