### PR TITLE
Fix TypeError (#78)

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -6,7 +6,7 @@
 
 # Run tests.py if the user says 'make check'
 TESTS = tests.py
-TESTS_ENVIRONMENT = PYTHONPATH=../python/.libs LINK_GRAMMAR_DATA=../../data
+TESTS_ENVIRONMENT = PYTHONPATH=$(srcdir)/../python:../python/.libs LINK_GRAMMAR_DATA=$(srcdir)/../../data
 
 EXTRA_DIST =         \
    AUTHORS           \

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -413,7 +413,7 @@ class ZENLangTestCase(unittest.TestCase):
 
     # Reads linkages from a test-file.
     def test_getting_links(self):
-        parses = open("parses-en.txt")
+        parses = open(os.getenv("srcdir") + "/" + "parses-en.txt")
         diagram = None
         sent = None
         for line in parses :
@@ -474,7 +474,7 @@ class ZLTLangTestCase(unittest.TestCase):
 
     # Reads linkages from a test-file.
     def test_getting_links(self):
-        parses = open("parses-lt.txt")
+        parses = open(os.getenv("srcdir") + "/" + "parses-lt.txt")
         diagram = None
         sent = None
         for line in parses :

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -309,10 +309,10 @@ class Linkage(object):
     def violation_name(self):
         return clg.linkage_get_violation_name(self._obj)
 
-    def diagram(self, display_walls=0, screen_width=180):
+    def diagram(self, display_walls=False, screen_width=180):
         return clg.linkage_print_diagram(self._obj, display_walls, screen_width)
 
-    def postscript(self, display_walls=1, print_ps_header=0):
+    def postscript(self, display_walls=True, print_ps_header=0):
         return clg.linkage_print_postscript(self._obj, display_walls, print_ps_header)
 
     def senses(self):


### PR DESCRIPTION
    Fix the following error, that causes 3 tests to fail:
      File ".../bindings/python/linkgrammar.py", line 313, in diagram
        return clg.linkage_print_diagram(self._obj, display_walls, screen_width)
    TypeError: in method 'linkage_print_diagram', argument 2 of type 'bool'

Plus two additional commits, see my next comment.