### PR TITLE
Fixes for Windows

### DIFF
--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -33,6 +33,15 @@ static void verr_msg(err_ctxt *ec, severity sev, const char *fmt, va_list args)
 
 static void verr_msg(err_ctxt *ec, severity sev, const char *fmt, va_list args)
 {
+#ifdef _MSC_VER
+	char * tmp = alloca(strlen(fmt)+1);
+	char * tok = tmp;
+
+	strcpy(tmp, fmt);
+	while ((tok = strstr(tok, "%zu"))) { tok[1] = 'I'; tok++;}
+	fmt = tmp;
+#endif
+
 	/* As we are printing to stderr, make sure that stdout has been
 	 * written out first. */
 	fflush(stdout);
@@ -112,6 +121,14 @@ void prt_error(const char *fmt, ...)
 	severity sev;
 	err_ctxt ec;
 	va_list args;
+#ifdef _MSC_VER
+	char * tmp = alloca(strlen(fmt)+1);
+	char * tok = tmp;
+
+	strcpy(tmp, fmt);
+	while ((tok = strstr(tok, "%zu"))) { tok[1] = 'I'; tok++;}
+	fmt = tmp;
+#endif
 
 	sev = Error;
 	if (0 == strncmp(fmt, "Fatal", 5)) sev = Fatal;

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -137,3 +137,6 @@ compute_chosen_words
 regex_tokenizer_test
 check_link_size
 partial_init_linkage
+printf_compat
+fprintf_compat
+sprintf_compat

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -344,7 +344,10 @@ link_public_api(void)
      left_print_string(FILE* fp, const char *, const char *);
 link_public_api(bool)
      lg_expand_disjunct_list(Sentence sent);
-
+link_public_api(int)
+     printf_compat(const char *, ...);
+link_public_api(int)
+     fprintf_compat(FILE *, const char *, ...);
 
 /**********************************************************************
  *

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -708,7 +708,8 @@ char * dictionary_get_data_dir(void)
 #ifdef ENABLE_BINRELOC
 	data_dir = safe_strdup (BR_DATADIR("/link-grammar"));
 #elif defined(_WIN32)
-	/* Dynamically locate library and return containing directory */
+	/* Dynamically locate library and return containing directory.
+	 * FIXME: A rewrite is needed. */
 	hInstance = GetModuleHandle("link-grammar.dll");
 	if (hInstance != NULL)
 	{
@@ -734,27 +735,33 @@ char * dictionary_get_data_dir(void)
 			if (GetModuleFileName(hInstance, prog_path16, MAX_PATH))
 			{
 				char * data_dir16 = NULL;
-				// convert 2-byte to 1-byte encoding of prog_path
-				char prog_path[MAX_PATH/2];
-				int i, k;
-				for (i = 0; i < MAX_PATH; i++)
-				{
-					k = i + i;
-					if (prog_path16[k] == 0 )
-					{
-						prog_path[i] = 0;
-						break; // found the string ending null char
-					}
-					// XXX this cannot possibly be correct for UTF-16 filepaths!! ?? FIXME
-					prog_path[i] = prog_path16[k];
-				}
-#ifdef _DEBUG
-				prt_error("Info: GetModuleFileName=%s", (prog_path ? prog_path : "NULL"));
-#endif
+
 				if (sizeof(TCHAR) == 1)
+				{
 				    data_dir16 = path_get_dirname(prog_path16);
+				}
 				else
+				{
+					// convert 2-byte to 1-byte encoding of prog_path
+					char prog_path[MAX_PATH/2];
+
+					int i, k;
+					for (i = 0; i < MAX_PATH; i++)
+					{
+						k = i + i;
+						if (prog_path16[k] == 0 )
+						{
+							prog_path[i] = 0;
+							break; // found the string ending null char
+						}
+						// XXX this cannot possibly be correct for UTF-16 filepaths!! ?? FIXME
+						prog_path[i] = prog_path16[k];
+					}
+#ifdef _DEBUG
+					prt_error("Info: GetModuleFileName=%s", (prog_path ? prog_path : "NULL"));
+#endif
 				    data_dir16 = path_get_dirname(prog_path);
+				}
 				if (data_dir16 != NULL)
 				{
 					printf("   found dir for current prog %s\n", data_dir16);

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdarg.h>
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -1128,6 +1129,55 @@ char * get_default_locale(void)
 
 	return locale;
 }
+
+/* ============================================================= */
+/* MSVC: Utilities for converting %zu to %Iu */
+
+#ifdef _MSC_VER
+int printf_compat(const char *format, ...)
+{
+	char * tmp = alloca(strlen(format)+1);
+	char * tok = tmp;
+	va_list args;
+
+	strcpy(tmp, format);
+	while ((tok = strstr(tok, "%zu"))) { tok[1] = 'I'; tok++;}
+	va_start(args, format);
+	return vprintf(tmp, args); /* fine on MSVC to return before va_end() */
+	va_end(args);
+}
+
+int fprintf_compat(FILE *file, const char *format, ...)
+{
+	char * tmp = alloca(strlen(format)+1);
+	char * tok = tmp;
+	va_list args;
+
+	strcpy(tmp, format);
+	while ((tok = strstr(tok, "%zu"))) { tok[1] = 'I'; tok++;}
+	va_start(args, format);
+	return vfprintf(file, tmp, args); /* fine on MSVC to return before va_end() */
+	va_end(args);
+}
+
+int sprintf_compat(char *str, const char *format, ...)
+{
+	char * tmp = alloca(strlen(format)+1);
+	char * tok = tmp;
+	va_list args;
+
+	strcpy(tmp, format);
+	while ((tok = strstr(tok, "%zu"))) { tok[1] = 'I'; tok++;}
+	va_start(args, format);
+	return vsprintf(str, tmp, args); /* fine on MSVC to return before va_end() */
+	va_end(args);
+}
+#else
+/* Defined in linkgrammar.def, so also here */
+int printf_compat(const char *format, ...) {return -1;}
+int fprintf_compat(FILE *file, const char *format, ...) {return -1;}
+int sprintf_compat(char *str, const char *format, ...) {return -1;}
+#endif /* _MSC_VER */
 
 /* ============================================================= */
 /* Alternatives utilities */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -58,6 +58,11 @@ extern "C"
 void *alloca (size_t);
 #endif
 
+/* Utilities for converting %zu to %Iu, defined in utilities.c */
+int printf_compat(const char *, ...);
+int fprintf_compat(FILE *, const char *, ...);
+int sprintf_compat(char *, const char *, ...);
+
 #ifdef _WIN32
 #include <windows.h>
 #include <mbctype.h>
@@ -84,6 +89,10 @@ void *alloca (size_t);
 
 /* MS changed the name of rand_r to rand_s */
 #define rand_r(seedp) rand_s(seedp)
+
+#define fprintf fprintf_compat
+#define printf printf_compat
+#define sprintf sprintf_compat
 
 #endif /* _MSC_VER */
 


### PR DESCRIPTION
Two fixes:
The first one solves a crash when the program path contains an even number of characters.
The second one solves issue #88 by converting the format on the fly as discussed.