### PR TITLE
Include @ in disjuct_list_str

### DIFF
--- a/link-grammar/disjuncts.c
+++ b/link-grammar/disjuncts.c
@@ -31,13 +31,17 @@
 static char * reversed_conlist_str(Connector* c, char dir, char* buf, size_t sz)
 {
 	char* p;
-	size_t len;
+	size_t len = 0;
 
 	if (NULL == c) return buf;
 	p = reversed_conlist_str(c->next, dir, buf, sz);
 
 	sz -= (p-buf);
-	len = lg_strlcpy(p, c->string, sz);
+
+	if (c->multi)
+		p[len++] = '@';
+
+	len += lg_strlcpy(p+len, c->string, sz-len);
 	if (3 < sz-len)
 	{
 		p[len++] = dir;


### PR DESCRIPTION
Not sure why the multi-connector property is not included in the string.  This change is not really necessary, but it does make sure the disjunct of a WordInstanceNode outputted by RelEx really is the original disjunct.

Apparently the corpus code uses the disjunct_str also.  I am not sure how to test whether this breaks that or not.  Where is the unit test for LG?