### PR TITLE
Prevent a crash when creating diagrams of extra-long sentences

### DIFF
--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -435,6 +435,13 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 
 	set_centers(linkage, center, print_word_0, N_words_to_print);
 	line_len = center[N_words_to_print-1]+1;
+	if (line_len + strlen(linkage->word[N_words_to_print-1])/2 + 1 >= MAX_LINE)
+	{
+		append_string(string, "The diagram is too long.\n");
+		gr_string = string_copy(string);
+		string_delete(string);
+		return gr_string;
+	}
 
 	for (k=0; k<MAX_HEIGHT; k++) {
 		for (j=0; j<line_len; j++) picture[k][j] = ' ';


### PR DESCRIPTION
Fix issue #101.

When a line with more than MAX_LINE of characters are needed for the
linkage diagram, a buffer overrun *may* occur. Even when it doesn't
occur in such cases (a much longer sentence is normally needed for
that), this would write into the next diagram row.

A check was added to detect a diagram line overrun, by checking the
length of the printed sentence.  It acts the same as in the case of a
row overrun, which is already checked: putting an error message into
the returned diagram.