### PR TITLE
History handling improvments

### DIFF
--- a/data/ar/4.0.batch
+++ b/data/ar/4.0.batch
@@ -1,8 +1,8 @@
 
+!batch
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 !spell=0

--- a/data/en/4.0.batch
+++ b/data/en/4.0.batch
@@ -1,8 +1,8 @@
 
+!batch
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 !spell=0

--- a/data/en/4.0.biolg.batch
+++ b/data/en/4.0.biolg.batch
@@ -1,7 +1,7 @@
+!batch
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 !spell=0

--- a/data/en/4.0.fix-long.batch
+++ b/data/en/4.0.fix-long.batch
@@ -1,8 +1,8 @@
 
+!batch
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 !spell=0

--- a/data/en/4.0.fixes.batch
+++ b/data/en/4.0.fixes.batch
@@ -1,7 +1,7 @@
+!batch
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 !spell=0

--- a/data/en/4.0.voa.batch
+++ b/data/en/4.0.voa.batch
@@ -1,8 +1,8 @@
 
+!batch
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 !spell=0

--- a/data/lt/4.0.batch
+++ b/data/lt/4.0.batch
@@ -1,3 +1,4 @@
+!batch
 %
 % * reiškia kad tai blogas sakinys, ir turetu buti atmestas.
 %
@@ -5,7 +6,6 @@
 !verbosity=1
 !echo
 !limit=1000
-!batch
 !short=20
 !constituents=1
 

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -65,17 +65,17 @@ char *lg_readline(const char *mb_prompt)
 		mbstowcs(wc_prompt, mb_prompt, sz);
 
 		hist = history_winit();    /* Init built-in history */
-		history_w(hist, &ev, H_SETSIZE, 20);  /* Remember 20 events */
-		history_w(hist, &ev, H_LOAD, HFILE);
 		el = el_init("link-parser", stdin, stdout, stderr);
+		history_w(hist, &ev, H_SETSIZE, 20);   /* Remember 20 events */
+		el_wset(el, EL_HIST, history_w, hist);
+		el_source(el, NULL);       /* Source the user's defaults file. */
+		history_w(hist, &ev, H_LOAD, HFILE);
 
 		/* By default, it comes up in vi mode, with the editor not in
 		 * insert mode; and even when in insert mode, it drops back to
 		 * command mode at the drop of a hat. Totally confusing/lame. */
 		el_wset(el, EL_EDITOR, L"emacs");
-		el_wset(el, EL_HIST, history_w, hist);
 		el_wset(el, EL_PROMPT_ESC, prompt, '\1'); /* Set the prompt function */
-		el_source(el, NULL); /* Source the user's defaults file. */
 	}
 
 	wc_line = el_wgets(el, &numc);

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -22,6 +22,9 @@
  * the unicode angle-brackets. 
  */
 
+#include <stdbool.h>
+#include <stdlib.h>
+
 #include "lg_readline.h"
 
 #ifdef HAVE_EDITLINE
@@ -31,17 +34,13 @@
 
 #ifdef HAVE_WIDECHAR_EDITLINE
 
-#include <stdbool.h>
-#include <stdlib.h>
-
 static wchar_t * wc_prompt = NULL;
 static wchar_t * prompt(EditLine *el)
 {
 	return wc_prompt;
 }
 
-
-char *lg_readline(const char *mb_prompt)
+char *lg_readline(const char *mb_prompt, bool nohistory)
 {
 	static bool is_init = false;
 	static HistoryW *hist = NULL;
@@ -93,7 +92,7 @@ char *lg_readline(const char *mb_prompt)
 		return NULL;
 	}
 
-	if (1 < numc)
+	if (1 < numc && !nohistory)
 	{
 		history_w(hist, &ev, H_ENTER, wc_line);
 		history_w(hist, &ev, H_SAVE, HFILE);
@@ -116,12 +115,12 @@ char *lg_readline(const char *mb_prompt)
 
 #include <editline/readline.h>
 
-char *lg_readline(const char *prompt)
+char *lg_readline(const char *prompt, bool nohistory)
 {
 	char * pline = readline(prompt);
 
 	/* Save non-blank lines */
-   if (pline && *pline)
+   if (pline && *pline && !nohistory)
    {
       if (*pline) add_history(pline);
    }

--- a/link-parser/lg_readline.h
+++ b/link-parser/lg_readline.h
@@ -10,5 +10,5 @@
 /***************************************************************************/
 
 #ifdef HAVE_EDITLINE
-char *lg_readline(const char *mb_prompt);
+char *lg_readline(const char *, bool);
 #endif /* HAVE_EDITLINE */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -145,7 +145,7 @@ fget_input_string(FILE *in, FILE *out, Command_Options* copts)
 	}
 	input_pending = false;
 	if (pline) free(pline);
-	pline = lg_readline(prompt);
+	pline = lg_readline(prompt, copts->batch_mode);
 
 	return pline;
 


### PR DESCRIPTION
3 patches, to fix these problems:

- If the user has a .editrc file with an history size of more than 20, e.g:
history size 100
it is not observed on start-up history reading - only the last 20  entries (the hard-coded default history size)  get read.

- Reading batch files overwrites the user input history.  This is a misfeature.

- After this problem was fixed, still several input history lines got overwritten.