### PR TITLE
Update parses-en.txt - labels between adjacent words are not truncated now

### DIFF
--- a/bindings/python-examples/parses-en.txt
+++ b/bindings/python-examples/parses-en.txt
@@ -4,9 +4,8 @@
 
 Ithis is a test
 O
-O    +----->WV----->+--Osm--+
-O    +---Wd---+-Ss*b+  +Ds**+
-O    |        |     |  |    |
-OLEFT-WALL this.p is.v a test.n 
+O    +----->WV----->+---Osm--+
+O    +---Wd---+-Ss*b+  +Ds**c+
+O    |        |     |  |     |
+OLEFT-WALL this.p is.v a  test.n 
 O
-


### PR DESCRIPTION
Fix a tests.py  failure.