### PR TITLE
Fix rare crash on long sentences

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Version 5.3.0: (XXX 2015)
  * Improve support for splitting sentences.
  * Change default setting of 'islands_ok' to true.
  * Improve performance on long sentences.
+ * Fix rare crash due to memory corruption on long sentences.
 
 Version 5.2.5: (1 February 2015)
  * Fix contracted "is" verb.

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -285,7 +285,7 @@ struct PP_data_s
 	size_t N_domains;
 	Domain * domain_array;          /* The domains, sorted by size */
 	size_t domlen;                  /* Allocated size of domain_array */
-	size_t length;                  /* Length of current linkage */
+	size_t num_words;               /* Number of words in linkage */
 	List_o_links * links_to_ignore;
 };
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1407,7 +1407,12 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 	mchxt = alloc_fast_matcher(sent);
 	ctxt = alloc_count_context(sent->length);
 	print_time(opts, "Initialized fast matcher");
-	if (resources_exhausted(opts->resources)) return;
+	if (resources_exhausted(opts->resources))
+	{
+		free_count_context(ctxt);
+		free_fast_matcher(mchxt);
+		return;
+	}
 
 	/* A parse set may have been already been built for this sentence,
 	 * if it was previously parsed.  If so we free it up before

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -503,6 +503,9 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 	}
 
 	/* Now actually malloc the array in which we will process linkages. */
+	/* We may have been called before, e.g this might be a panic parse,
+	 * and the linkages array may stiil be there from last time. */
+	if (sent->lnkages) free_linkages(sent);
 	sent->lnkages = linkage_array_new(N_linkages_alloced);
 
 	/* Generate an array of linkage indices to examine */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -392,7 +392,7 @@ bool parse_options_memory_exhausted(Parse_Options opts) {
 }
 
 bool parse_options_resources_exhausted(Parse_Options opts) {
-	return (resources_timer_expired(opts->resources) || resources_memory_exhausted(opts->resources));
+	return (resources_exhausted(opts->resources));
 }
 
 void parse_options_reset_resources(Parse_Options opts) {

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -1248,8 +1248,10 @@ static CNode * linkage_constituent_tree(Linkage linkage)
 }
 
 /* Make the compiler shut up about the deprecated functions */
+/*
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+*/
 
 static void linkage_free_constituent_tree(CNode * n)
 {
@@ -1302,4 +1304,3 @@ void linkage_free_constituent_tree_str(char * s)
 {
 	exfree(s, strlen(s)+1);
 }
-

--- a/link-grammar/malloc-dbg.c
+++ b/link-grammar/malloc-dbg.c
@@ -9,11 +9,14 @@
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
 #include <execinfo.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <malloc.h>
 
 /* ======================================================== */
+void report_mem_dbg(void);
+
 static void *(*old_malloc_hook)(size_t, const void *);
 static void (*old_free_hook)(void *, const void *);
 static void *(*old_realloc_hook)(void *, size_t, const void *);
@@ -21,15 +24,18 @@ static void *(*old_realloc_hook)(void *, size_t, const void *);
 static void my_free_hook(void * mem, const void * caller);
 static void * my_malloc_hook(size_t n_bytes, const void * caller);
 
-#define TBLSZ 366000
+#define TBLSZ 511366000
+// #define TBLSZ 41366000
 typedef struct {
 	void * mem;
 	const void * caller;
-	int cnt;
 	size_t sz;
+	int cnt;
+	bool free;
 } loc_t;
 
-static loc_t loc[TBLSZ];
+// static loc_t loc[TBLSZ];
+static loc_t *loc;
 static int mcnt = 0;
 
 static FILE *fh = NULL;
@@ -41,37 +47,66 @@ static void init_io(void)
 	fh = stdout;
 }
 
+// #define allprt(f, varargs...) fprintf(f, ##varargs)
+#define allprt(f, varargs...) 
 
 static void * my_realloc_hook(void * mem, size_t n_bytes, const void *caller)
 {
+	int i;
+	for (i=0; i<TBLSZ; i++)
+	{
+		if (mem == loc[i].mem)
+		{
+#if TRACK_LEAK
+			loc[i].mem = nm;
+			loc[i].caller = (void *) -1;
+			loc[i].sz = n_bytes;
+#endif
+			allprt(fh, "realloc free %d %p\n", i, mem);
+			if (loc[i].free)
+			{
+				fprintf(fh, "Error realloc of prev free %d %p\n", i, mem);
+			}
+			loc[i].free = true;
+			break;
+		}
+	}
+	if (TBLSZ == i)
+	{
+		fprintf(fh, "Error: realloc address not previously alloed!\n");
+	}
+
 	__realloc_hook = old_realloc_hook;
 	void * nm = realloc(mem, n_bytes);
 	old_realloc_hook = __realloc_hook;
 	__realloc_hook = my_realloc_hook;
 
-	int i;
+#if TRACK_LEAK
+	if (i < TBLSZ) return nm;
+#endif
+	if (i < TBLSZ)
+	{
+		loc[i].mem = nm;
+		loc[i].caller = caller;
+		loc[i].sz = n_bytes;
+		mcnt++;
+		loc[i].cnt = mcnt;
+		loc[i].free = false;
+		allprt(fh, "realloc reuse alloc %d %p\n", i, nm);
+		return nm;
+	}
+
 	for (i=0; i<TBLSZ; i++)
 	{
-		if(mem == loc[i].mem)
+		if ((void *) -1 == loc[i].mem)
 		{
 			loc[i].mem = nm;
-			loc[i].caller = (void *) -1;
-			loc[i].sz = n_bytes;
-			/* loc[i].cnt = -1;
-			   fprintf(fh, "realloc %d %p\n", i, mem); */
-			break;
-		}
-	}
-	if (i <= TBLSZ) return nm;
-	for (i=0; i<TBLSZ; i++)
-	{
-		if((void *) -1 == loc[i].mem)
-		{
-			loc[i].mem = mem;
 			loc[i].sz = n_bytes;
 			loc[i].caller = caller;
-			loc[i].cnt = -2;
-			/* fprintf(fh, "realloc %d %p\n", i, mem); */
+			mcnt ++;
+			loc[i].cnt = mcnt;
+			loc[i].free = false;
+			allprt(fh, "realloc new alloc %d %p\n", i, nm);
 			break;
 		}
 	}
@@ -91,15 +126,33 @@ static void * my_malloc_hook(size_t n_bytes, const void * caller)
 	int i;
 	for (i=0; i<TBLSZ; i++)
 	{
-		if((void *) -1 == loc[i].mem)
+		if (mem == loc[i].mem)
 		{
 			loc[i].mem = mem;
 			loc[i].caller = caller;
-			/* fprintf(fh,"malloc %d %p\n", i, mem); */
+			allprt(fh,"malloc reuse %d %p\n", i, mem);
+			loc[i].sz = n_bytes;
 			mcnt ++;
 			loc[i].cnt = mcnt;
-			loc[i].sz = n_bytes;
+			loc[i].free = false;
 			break;
+		}
+	}
+	if (i == TBLSZ)
+	{
+		for (i=0; i<TBLSZ; i++)
+		{
+			if ((void *) -1 == loc[i].mem)
+			{
+				loc[i].mem = mem;
+				loc[i].caller = caller;
+				allprt(fh,"malloc fresh %d %p\n", i, mem);
+				loc[i].sz = n_bytes;
+				mcnt ++;
+				loc[i].cnt = mcnt;
+				loc[i].free = false;
+				break;
+			}
 		}
 	}
 
@@ -107,6 +160,7 @@ static void * my_malloc_hook(size_t n_bytes, const void * caller)
 	if (i == TBLSZ)
 	{
 		size_t totsz=0;
+#if REPORT
 		for (i=0; i<TBLSZ; i++)
 		{
 		  /* size_t off = loc[i].caller - (void *) my_malloc_hook; */
@@ -114,7 +168,8 @@ static void * my_malloc_hook(size_t n_bytes, const void * caller)
 			       i, loc[i].caller, loc[i].sz, loc[i].cnt);
 			totsz += loc[i].sz;
 		}
-		fprintf (fh, "Total Size=%x\n", totsz);
+#endif
+		fprintf (fh, "Total Size=%zu\n", totsz);
 		*((int *)0) = 1; /* Force a crash, pop into debugger. */
 		exit(1);
 	}
@@ -132,24 +187,32 @@ static void my_free_hook(void * mem, const void * caller)
 	int i;
 	for (i=0; i<TBLSZ; i++)
 	{
-		if(mem == loc[i].mem)
+		if (mem == loc[i].mem)
 		{
+#if TRACK_LEAK
 			loc[i].mem = (void *) -1;
 			loc[i].caller = 0;
 			loc[i].sz = 0;
 			loc[i].cnt = -3;
-			/* fprintf(fh, "free %d %p\n", i, mem); */
+#endif
+			allprt(fh, "free %d %p\n", i, mem);
+			if (loc[i].free)
+			{
+				fprintf(fh, "Error double free %d %p\n", i, mem);
+			}
+			loc[i].free = true;
 			break;
 		}
 	}
 
 	/* Its a double-free if the mem address wasn't found! */
+#if TRACK_LEAK
 	if (TBLSZ == i)
 	{
 		int i;
 #define BTSZ 10
 		void * btbuf[BTSZ];
-		fprintf(fh, "Double free of mem location %p\n", mem);
+		fprintf(fh, "Mem location %p is not alloced!\n", mem);
 		int nt = backtrace (btbuf, BTSZ);
 		char ** bt = backtrace_symbols(btbuf, nt);
 		for (i=0; i<nt; i++)
@@ -160,6 +223,7 @@ static void my_free_hook(void * mem, const void * caller)
 		*((int *)0) = 1; /* Force a crash, pop into debugger. */
 		exit(1);
 	}
+#endif
 
 	__malloc_hook = my_malloc_hook;
 
@@ -181,11 +245,21 @@ void report_mem_dbg(void)
 			totsz += loc[i].sz;
 		}
 	}
-	fprintf (fh, "tbl slots used = %d alloc mem=%d\n", cnt, totsz);
+	fprintf (fh, "tbl slots used = %d alloc mem=%zu\n", cnt, totsz);
 }
 
+void my_init_hook(void);
 void my_init_hook(void)
 {
+	static bool is_init = false;
+	if (is_init) return;
+	is_init = true;
+
+	printf("init malloc trace hook loc_t size=%d mbytes=%d\n",
+		sizeof(loc_t), (TBLSZ * sizeof(loc_t))/(1024*1024));
+
+	loc = (loc_t*) malloc (TBLSZ * sizeof(loc_t));
+
 	old_malloc_hook = __malloc_hook;
 	__malloc_hook = my_malloc_hook;
 
@@ -200,10 +274,11 @@ void my_init_hook(void)
 	{
 		loc[i].mem = (void *) -1;
 		loc[i].caller = 0;
-		loc[i].cnt = 0;
 		loc[i].sz = 0;
+		loc[i].cnt = 0;
+		loc[i].free = true;
 	}
 }
 
-void (*__malloc_initialize_hook)(void) = my_init_hook;
+void (*__MALLOC_HOOK_VOLATILE __malloc_initialize_hook)(void) = my_init_hook;
 #endif /*_MSC_VER && __MINGW32__*/

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -617,7 +617,7 @@ static void setup_domain_array(Postprocessor *pp,
 		incsz = DOMINC * sizeof(Domain);
 		pp->pp_data.domain_array = (Domain *) realloc(pp->pp_data.domain_array,
 			newsz);
-		memset(&pp->pp_data.domain_array[pp->pp_data.domlen], 0, incsz);
+		memset(&pp->pp_data.domain_array[n], 0, incsz);
 	}
 
 	pp->pp_data.domain_array[n].string = string;

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -212,7 +212,7 @@ static void connectivity_dfs(Postprocessor *pp, Linkage sublinkage,
                              int w, pp_linkset *ls)
 {
 	List_o_links *lol;
-	assert(w < pp->pp_data.length, "Bad word index");
+	assert(w < pp->pp_data.num_words, "Bad word index");
 	pp->visited[w] = true;
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
@@ -284,7 +284,7 @@ static void alloc_pp_node(Postprocessor *pp)
 	PP_node *ppn = (PP_node *) malloc(sizeof(PP_node));
 
 	/* highly unlikely that the number of links will ever exceed this */
-	ppn->dtsz = 2 * pp->pp_data.length;
+	ppn->dtsz = 2 * pp->pp_data.num_words;
 	dz = ppn->dtsz * sizeof(D_type_list*);
 	ppn->d_type_array = (D_type_list **) malloc (dz);
 	memset(ppn->d_type_array, 0, dz);
@@ -462,11 +462,11 @@ static void reachable_without_dfs(Postprocessor *pp,
 	/* This is a depth first search of words reachable from w, excluding
 	 * any direct edge between word a and word b. */
 	List_o_links *lol;
-	assert(w < pp->pp_data.length, "Bad word index");
+	assert(w < pp->pp_data.num_words, "Bad word index");
 	pp->visited[w] = true;
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
-		assert(lol->word < pp->pp_data.length, "Bad word index");
+		assert(lol->word < pp->pp_data.num_words, "Bad word index");
 		if (!pp->visited[lol->word] &&
 		    !(w == a && lol->word == b) &&
 		    !(w == b && lol->word == a))
@@ -488,14 +488,14 @@ apply_must_form_a_cycle(Postprocessor *pp, Linkage sublinkage, pp_rule *rule)
 {
 	List_o_links *lol;
 	size_t w;
-	for (w = 0; w < pp->pp_data.length; w++)
+	for (w = 0; w < pp->pp_data.num_words; w++)
 	{
 		for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 		{
 			if (w > lol->word) continue;	/* only consider each edge once */
 			if (!pp_linkset_match(rule->link_set, sublinkage->link_array[lol->link].link_name)) continue;
 
-			memset(pp->visited, 0, pp->pp_data.length*(sizeof pp->visited[0]));
+			memset(pp->visited, 0, pp->pp_data.num_words * sizeof(bool));
 			reachable_without_dfs(pp, sublinkage, w, lol->word, w);
 			if (!pp->visited[lol->word]) return false;
 		}
@@ -507,10 +507,10 @@ apply_must_form_a_cycle(Postprocessor *pp, Linkage sublinkage, pp_rule *rule)
 		/* (w, lol->word) are the left and right ends of the edge we're considering */
 		if (!pp_linkset_match(rule->link_set, sublinkage->link_array[lol->link].link_name)) continue;
 
-		memset(pp->visited, 0, pp->pp_data.length*(sizeof pp->visited[0]));
+		memset(pp->visited, 0, pp->pp_data.num_words * sizeof(bool));
 		reachable_without_dfs(pp, sublinkage, w, lol->word, w);
 
-		assert(lol->word < pp->pp_data.length, "Bad word index");
+		assert(lol->word < pp->pp_data.num_words, "Bad word index");
 		if (!pp->visited[lol->word]) return false;
 	}
 
@@ -552,10 +552,10 @@ static void build_graph(Postprocessor *pp, Linkage sublinkage)
 	List_o_links * lol;
 
 	/* Get more size, if needed */
-	if (pp->pp_data.wowlen <= pp->pp_data.length)
+	if (pp->pp_data.wowlen <= pp->pp_data.num_words)
 	{
 		size_t newsz;
-		pp->pp_data.wowlen += pp->pp_data.length;
+		pp->pp_data.wowlen += pp->pp_data.num_words;
 		newsz = pp->pp_data.wowlen * sizeof(List_o_links *);
 		pp->pp_data.word_links = (List_o_links **) realloc(
 			pp->pp_data.word_links, newsz);
@@ -596,16 +596,8 @@ static void setup_domain_array(Postprocessor *pp,
 {
 	size_t n = pp->pp_data.N_domains;
 
-	/* set pp->visited[i] to false */
-	/* Grab more memory if needed */
-	if (pp->vlength <= pp->pp_data.length)
-	{
-		size_t newsz;
-		pp->vlength += pp->pp_data.length;
-		newsz = pp->vlength * sizeof(bool);
-		pp->visited = (bool *) realloc(pp->visited, newsz);
-	}
-	memset(pp->visited, 0, pp->pp_data.length*(sizeof pp->visited[0]));
+	/* set pp->visited to false */
+	memset(pp->visited, 0, pp->pp_data.num_words * sizeof(bool));
 
 	/* Grab more memory if needed */
 	if (pp->pp_data.domlen <= n)
@@ -644,7 +636,7 @@ static void depth_first_search(Postprocessor *pp, Linkage sublinkage,
                                size_t w, size_t root, size_t start_link)
 {
 	List_o_links *lol;
-	assert(w < pp->pp_data.length, "Bad word index");
+	assert(w < pp->pp_data.num_words, "Bad word index");
 	pp->visited[w] = true;
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
@@ -669,7 +661,7 @@ static void bad_depth_first_search(Postprocessor *pp, Linkage sublinkage,
                                    size_t w, size_t root, size_t start_link)
 {
 	List_o_links * lol;
-	assert(w < pp->pp_data.length, "Bad word index");
+	assert(w < pp->pp_data.num_words, "Bad word index");
 	pp->visited[w] = true;
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
@@ -680,7 +672,7 @@ static void bad_depth_first_search(Postprocessor *pp, Linkage sublinkage,
 	}
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
-		assert(lol->word < pp->pp_data.length, "Bad word index");
+		assert(lol->word < pp->pp_data.num_words, "Bad word index");
 		if ((!pp->visited[lol->word]) && !(w == root && lol->word < w) &&
 		     !(lol->word < root && lol->word < w &&
 		          pp_linkset_match(pp->knowledge->restricted_links,
@@ -695,7 +687,7 @@ static void d_depth_first_search(Postprocessor *pp, Linkage sublinkage,
                     size_t w, size_t root, size_t right, size_t start_link)
 {
 	List_o_links * lol;
-	assert(w < pp->pp_data.length, "Bad word index");
+	assert(w < pp->pp_data.num_words, "Bad word index");
 	pp->visited[w] = true;
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
@@ -706,7 +698,7 @@ static void d_depth_first_search(Postprocessor *pp, Linkage sublinkage,
 	}
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
-		assert(lol->word < pp->pp_data.length, "Bad word index");
+		assert(lol->word < pp->pp_data.num_words, "Bad word index");
 		if (!pp->visited[lol->word] && !(w == root && lol->word >= right) &&
 		    !(w == root && lol->word < root) &&
 		       !(lol->word < root && lol->word < w &&
@@ -722,7 +714,7 @@ static void left_depth_first_search(Postprocessor *pp, Linkage sublinkage,
                                     size_t w, size_t right, size_t start_link)
 {
 	List_o_links *lol;
-	assert(w < pp->pp_data.length, "Bad word index");
+	assert(w < pp->pp_data.num_words, "Bad word index");
 	pp->visited[w] = true;
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
@@ -733,7 +725,7 @@ static void left_depth_first_search(Postprocessor *pp, Linkage sublinkage,
 	}
 	for (lol = pp->pp_data.word_links[w]; lol != NULL; lol = lol->next)
 	{
-		assert(lol->word < pp->pp_data.length, "Bad word index");
+		assert(lol->word < pp->pp_data.num_words, "Bad word index");
 		if (!pp->visited[lol->word] && (lol->word != right))
 		{
 			depth_first_search(pp, sublinkage, lol->word, right, start_link);
@@ -997,6 +989,7 @@ Postprocessor * post_process_new(pp_knowledge * kno)
 	/* 60 is just starting size, these are expanded if needed */
 	pp->vlength = 60;
 	pp->visited = (bool*) malloc(pp->vlength * sizeof(bool));
+	memset(pp->visited, 0, pp->vlength * sizeof(bool));
 
 	pp->pp_data.links_to_ignore = NULL;
 	pp->pp_data.domlen = 60;
@@ -1121,7 +1114,17 @@ PP_node *do_post_process(Postprocessor *pp, Linkage sublinkage, bool is_long)
 	// XXX wtf .. why is this not leaking memory ?
 	pp->pp_data.links_to_ignore = NULL;
 
-	pp->pp_data.length = sublinkage->num_words;
+	pp->pp_data.num_words = sublinkage->num_words;
+
+	/* Grab more memory if needed */
+	if (pp->vlength <= pp->pp_data.num_words)
+	{
+		size_t newsz;
+		pp->vlength += pp->pp_data.num_words;
+		newsz = pp->vlength * sizeof(bool);
+		pp->visited = (bool *) realloc(pp->visited, newsz);
+	}
+	memset(pp->visited, 0, pp->pp_data.num_words * sizeof(bool));
 
 	/* In the name of responsible memory management, we retain a copy of the
 	 * returned data structure pp_node as a field in pp, so that we can clear

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -122,25 +122,34 @@ static bool link_in_domain(size_t link, const Domain * d)
 /* Returns true if the domains actually form a properly nested structure */
 static bool check_domain_nesting(Postprocessor *pp, int num_links)
 {
+	size_t id1, id2;
 	Domain * d1, * d2;
 	int counts[4];
 	char mark[MAX_NUM_LINKS];
 	List_o_links * lol;
 	int i;
-	for (d1=pp->pp_data.domain_array; d1 < pp->pp_data.domain_array + pp->pp_data.N_domains; d1++) {
-		for (d2=d1+1; d2 < pp->pp_data.domain_array + pp->pp_data.N_domains; d2++) {
-			memset(mark, 0, num_links*(sizeof mark[0]));
-			for (lol=d2->lol; lol != NULL; lol = lol->next) {
+	for (id1 = 0; id1 < pp->pp_data.N_domains; id1++)
+	{
+		d1 = &pp->pp_data.domain_array[id1];
+		for (id2 = id1+1; id2 < pp->pp_data.N_domains; id2++)
+		{
+			d2 = &pp->pp_data.domain_array[id2];
+
+			memset(mark, 0, num_links);
+			for (lol=d2->lol; lol != NULL; lol = lol->next)
 				mark[lol->link] = 1;
-			}
-			for (lol=d1->lol; lol != NULL; lol = lol->next) {
+
+			for (lol=d1->lol; lol != NULL; lol = lol->next)
 				mark[lol->link] += 2;
-			}
+
 			counts[0] = counts[1] = counts[2] = counts[3] = 0;
 			for (i=0; i<num_links; i++)
-				counts[(int)mark[i]]++;/* (int) cast avoids compiler warning DS 7/97 */
+			{
+				assert(mark[i] < 4, "Miscount of link marks!");
+				counts[(size_t)mark[i]]++; /* cast avoids compiler warning */
+			}
 			if ((counts[1] > 0) && (counts[2] > 0) && (counts[3] > 0))
-		return false;
+				return false;
 		}
 	}
 	return true;


### PR DESCRIPTION
Crash was due to memory corruption; the bug is old, its in all the 5.2.0 series.