### PR TITLE
Bug fixes in spell handling (++)

### DIFF
--- a/link-grammar/README
+++ b/link-grammar/README
@@ -21,10 +21,10 @@ Instead of tokenizing all the words in one pass directly into the
 word-array of the parser, it now tokenizes them using a graph which its
 nodes are "subwords".  Initially the original sentence words are tokenized
 to subwords only by whitespace. After that step, each subword is handled in
-its turn, and get split to further subwords if needed. A special care is
+its turn, and gets split to further subwords if needed. A special care is
 taken if one of the alternatives of a subword is the subword itself
-(alone, which is usual, or with a dict-cap token - a thing that is not
-explained here).
+(alone, which is usual, or with a dict-cap token - a new experimental
+mechanism which is described below).
 
 The new way of tokenizing is much more flexible that the old one, and it
 serves as an infrastructure on which new tokenizing and display features
@@ -104,7 +104,7 @@ It can display the graph using X11 if available when the x flag is set
 uses the "dot" command of Graphviz. Graphviz can be installed as part of
 Cygwin, or separately (http://www.graphviz.org/Download_windows.php).
 Both PhotoViewer.dll (if used) and "dot" must be in the command path.
-BTW, when running under Cygwin, don't exist LinkGrammarExe by using ^C or
+BTW, when running under Cygwin, don't exit LinkGrammarExe by using ^C or
 ^Z - the shell may get stuck because the program somehow continues to run
 in the background. Instead, exit using !exit .
 
@@ -126,7 +126,7 @@ following can be used: !test=dictcap,removeZZZ .
 
 HOWTO use the new regex tokenizer/splitter
 ------------------------------------------
-Its new, experimental code. 
+It's new, experimental code. 
 
 To compile: ../configure --enable-regex-tokenizer
 

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -365,11 +365,11 @@ struct Linkage_s
 	size_t          cdsz;         /* Alloc'ed length of chosen_disjuncts */
 	char **         disjunct_list_str; /* Stringified version of above */
 #ifdef USE_CORPUS
-	Sense **        sense_list;   /* Word senses, infered from disjuncts */
+	Sense **        sense_list;   /* Word senses, inferred from disjuncts */
 #endif
 
    Gword **wg_path;              /* Linkage Wordgraph path */
-   Gword **wg_path_display;      /* ... for !morfology=0. Exprimental. */
+   Gword **wg_path_display;      /* ... for !morphology=0. Experimental. */
    //size_t *wg_path_index;      /* Displayed-word indices in wg_path (FIXME?)*/
 
 	Linkage_info    lifo;         /* Parse_set index and cost information */

--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -404,7 +404,7 @@ unsigned int count_disjunct_for_dict_node(Dict_node *dn)
  * expressions.  Returns NULL if it's not there.  If there, it builds the list
  * of expressions for the word, and returns a pointer to it.
  * The subword of Gword w is used for this lookup, unless the subword is
- * explicitely given as parameter s. The subword of Gword w is always used as
+ * explicitly given as parameter s. The subword of Gword w is always used as
  * the base word for each expression, and its subscript is the one from the
  * dictionary word of the expression.
  */

--- a/link-grammar/disjuncts.c
+++ b/link-grammar/disjuncts.c
@@ -24,7 +24,7 @@
 
 /**
  * Print connector list to string.
- * This reverses the order of the connecters in the connector list,
+ * This reverses the order of the connectors in the connector list,
  * so that the resulting list is in the same order as it would appear
  * in the dictionary. The character 'dir' is appended to each connector.
  */

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -146,8 +146,8 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
 #define SUFFIX_SUPPRESS_L 2    /* length of above */
 
 #define HIDE_MORPHO   (!display_morphology)
-/* TODO? !display_->regex_name_marks is not implemented. */
-#define DISPLAY_GUESS_MARKS true // (opts->display_->regex_name_marks)
+/* TODO? !display_guess_marks is not implemented. */
+#define DISPLAY_GUESS_MARKS true // (opts->display_guess_marks)
 
 /**
  * This takes the Wordgraph path array and uses it to
@@ -157,16 +157,16 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
  *    A pointer to an array of pointers to strings.  These are the words to be
  *    displayed when printing the solution, the links, etc.  Computed as a
  *    function of chosen_disjuncts[] by compute_chosen_words().  This differs
- *    from sentence[].alternatives because it contains the subscripts.  It
+ *    from sentence.word[].alternatives because it contains the subscripts.  It
  *    differs from chosen_disjunct[].string in that the idiom symbols have been
  *    removed.  Furthermore, several chosen_disjuncts[].string elements may be
  *    combined into one chosen_words[] element if opts->display_morphology==0 or
  *    that they where linkage null-words that are morphemes of the same original
  *    word (i.e. subwords of an unsplit_word which are marked as morphemes).
  *
- * wordgraph_path
+ * wg_path
  *    A pointer to a NULL-terminated array of pointers to Wordgraph words.
- *    It corresponds 1-1 to the chosen_disjuncts array in parse_info.
+ *    It corresponds 1-1 to the chosen_disjuncts array in Linkage structure.
  *    A new one is constructed below to correspond 1-1 to chosen_words.
  *
  *    FIXME Sometimes the word strings are taken from chosen_disjuncts,
@@ -322,7 +322,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 
 			if (0)
 			{
-				/* TOOO */
+				/* TODO */
 			}
 			else
 			{
@@ -339,7 +339,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				{
 					/* Concatenate the word morphemes together into one word.
 					 * Concatenate their subscripts into one subscript.
-					 * Use suffix separator SUBSCRIPT_SEP.
+					 * Use subscript separator SUBSCRIPT_SEP.
 					 * XXX Check whether we can encounter an idiom word here.
 					 * FIXME Combining contracted words is not handled yet, because
 					 * combining morphemes which have non-LL links to other words is
@@ -378,7 +378,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 						 * less clear).
 						 * Put SUBSCRIPT_SEP between the subscripts.
 						 * XXX No 1-1 correspondence between the hidden base words
-						 * and the subscripts after the join, in case there are a base
+						 * and the subscripts after the join, in case there are base
 						 * words with and without subscripts. */
 
 						const char subscript_sep_str[] = { SUBSCRIPT_SEP, '\0'};

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -193,21 +193,21 @@ typedef enum
 
 /* Word status */
 /* - Tokenization */
-#define WS_UNKNOWN   1<<0 /* Unknown word (FIXME? Unused) */
-#define WS_REGEX     1<<1 /* Matches a regex */
-#define WS_SPELL     1<<2 /* Result of a spell guess */
-#define WS_RUNON     1<<3 /* Separated from words run-on */
-#define WS_HASALT    1<<4 /* Has alternatives (one or more)*/
-#define WS_UNSPLIT   1<<5 /* It's an alternative to itself as an unsplit word */
-#define WS_INDICT    1<<6 /* boolean_dictionary_lookup() is true */
-#define WS_FIRSTUPPER 1<<7 /* Subword is the lc version of its unsplit_word.
+#define WS_UNKNOWN (1<<0) /* Unknown word (FIXME? Unused) */
+#define WS_REGEX   (1<<1) /* Matches a regex */
+#define WS_SPELL   (1<<2) /* Result of a spell guess */
+#define WS_RUNON   (1<<3) /* Separated from words run-on */
+#define WS_HASALT  (1<<4) /* Has alternatives (one or more)*/
+#define WS_UNSPLIT (1<<5) /* It's an alternative to itself as an unsplit word */
+#define WS_INDICT  (1<<6) /* boolean_dictionary_lookup() is true */
+#define WS_FIRSTUPPER (1<<7) /* Subword is the lc version of its unsplit_word.
                               The idea of marking subwords this way, in order to
                               enable restoring their original capitalization,
                               may be wrong in general, since in some languages
                               the process is not always reversible. Instead,
                               the original word may be saved. */
 /* - Post linkage stage. XXX Experimental. */
-#define WS_PL        1<<14 /* Post-Linkage, not belonging to tokenization */
+#define WS_PL      (1<<14) /* Post-Linkage, not belonging to tokenization */
 
 #define WS_GUESS (WS_SPELL|WS_RUNON|WS_REGEX)
 

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2131,36 +2131,40 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 * FIXME: Capitalization handling should be done using the dict.
 			 *
 			 * If the word is capitalized and, issue as alternatives:
-			 * - Issue its lowercase version if it is in a capitalizable position
-			 *   and also it is in the dict.
+			 * - Issue its lowercase version if it is in a capitalizable
+			 *   position and also it is in the dict.
 			 * - Issue it (capitalized) too as a word to regex (so the
 			 *   capitalized-words regex disjuncts will be used), in these
-			 *   conditions (cumulative): -- It could not be split (else
-			 *   capitalization has been handled XXX).  -- It is not in the dict
-			 *   (it has already been issued in that case).  -- It is not in a
-			 *   capitalizable position in the sentence.  -- Its lowercase version
-			 *   is in the dict file (not regex) and it is an entity (checked
-			 *   capitalized) or a common entity (checked as lowercase).
+			 *   conditions (cumulative):
+			 *   -- It could not be split (else capitalization has been
+			 *      handled XXX).
+			 *   -- It is not in the dict (it has already been issued in
+			 *      that case).
+			 *   -- It is not in a capitalizable position in the sentence.
+			 *   -- Its lowercase version is in the dict file (not regex) and
+			 *      it is an entity (checked capitalized) or a common entity
+			 *      (checked as lowercase).
 			 *
 			 *   Comments from a previous release:
 			 *
-			 * * Common entity (checked as lowercase): This allows common nouns
-			 *   and adjectives to be used for entity names: e.g. "Great Southern
-			 *   Union declares bankruptcy", allowing Great to be capitalized,
-			 *   while preventing an upper-case "She" being used as a proper name
-			 *   in "She declared bankruptcy".
+			 * * Common entity (checked as lowercase): This allows common
+			 *   nouns and adjectives to be used for entity names: e.g. "Great
+			 *   Southern Union declares bankruptcy", allowing Great to be
+			 *   capitalized, while preventing an upper-case "She" being used
+			 *   as a proper name in "She declared bankruptcy".
 			 *
 			 * * Entity (checked capitalized): We need to *add* Sue.f (female
-			 *   name Sue) even though sue.v (the verb "to sue") is in the dict. So
-			 *   test for capitalized entity names.  FIXME: [ap] Since capitalized
-			 *   words which are in the dict file are now issued anyway as
-			 *   uppercase, and the capitalized-words regexes are not marked in the
-			 *   dict as entities, this may have effect only for capitalized words
-			 *   that match non-capitalized-words regexes that are marked as
-			 *   entities. I don't know about such, and if there are indeed no such
-			 *   regexes, it looks like the is_entity() check is redundant.  A test
-			 *   "is_entity" added below to check if there is any sentence in the
-			 *   batches that contradicts that.
+			 *   name Sue) even though sue.v (the verb "to sue") is in the
+			 *   dict.  So test for capitalized entity names.  FIXME: [ap]
+			 *   Since capitalized words which are in the dict file are now
+			 *   issued anyway as uppercase, and the capitalized-words regexes
+			 *   are not marked in the dict as entities, this may have effect
+			 *   only for capitalized words that match non-capitalized-words
+			 *   regexes that are marked as entities. I don't know about such,
+			 *   and if there are indeed no such regexes, it looks like the
+			 *   is_entity() check is redundant.  A test "is_entity" added
+			 *   below to check if there is any sentence in the batches that
+			 *   contradicts that.
 			 */
 			bool word_is_capitalizable = is_capitalizable(dict, unsplit_word);
 

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -539,7 +539,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				{
 					/* If we are here, there is tokenization logic error in the
 					 * program, as the word has been issued as an alternative of
-					 * itself an additional time. If we proceed would mess the
+					 * itself an additional time. If we proceed it would mess the
 					 * Wordgraph pointers. Just warn (if verbosity>0) and return.
 					 * The return value is not likely to be used in such a case,
 					 * since this is an issuing of a single word.
@@ -1935,7 +1935,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 * http://en.wiktionary.org/wiki/Category:English_double_contractions*/
 			if (!word_is_known)
 			{
-				/* This is not a really a debug message, so it is in verbosity 1.
+				/* This is not really a debug message, so it is in verbosity 1.
 				 * XXX Maybe prt_error()? */
 				lgdebug(+1, "Contracted word part %s is not in the dict\n", word);
 			}
@@ -2060,7 +2060,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 				  print_rev_word_array(sent, r_stripped, n_r_stripped),
 				  word, wend, units_wend, temp_word);
 
-		/* If n_r_stripped exceed max, the "word" is most likely includes a long
+		/* If n_r_stripped exceed max, the "word" most likely includes a long
 		 * sequence of periods.  Just accept it as an unknown "word",
 		 * and move on.
 		 * FIXME: Word separation may still be needed, e.g. for a table of
@@ -2147,7 +2147,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 *
 			 * FIXME: Capitalization handling should be done using the dict.
 			 *
-			 * If the word is capitalized and, issue as alternatives:
+			 * If the word is capitalized, then issue as alternatives:
 			 * - Issue its lowercase version if it is in a capitalizable
 			 *   position and also it is in the dict.
 			 * - Issue it (capitalized) too as a word to regex (so the

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2204,9 +2204,6 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 					(is_entity(dict, word) || is_common_entity(dict, downcase)))))
 			{
 				/* Issue it (capitalized) too */
-
-		/* This is the lc version. The original word can be restored later, if
-		 * needed, through the unsplit word. */
 				if ((NULL != regex_name))
 				{
 					lgdebug(+D_SW, "Adding uc word=%s RE=%s\n", word, regex_name);

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1918,7 +1918,8 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 * contents:
 			 * ............................something
 			 */
-			if (n_r_stripped >= MAX_STRIP-1) {
+			if (n_r_stripped >= MAX_STRIP-1)
+			{
 				lgdebug(+D_SW, "Left-strip of >= %d tokens\n", MAX_STRIP-1);
 				return; /* XXX */
 			}
@@ -2026,7 +2027,8 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 		 * contents:
 		 * 10............................
 		 */
-		if (n_r_stripped >= MAX_STRIP-1) {
+		if (n_r_stripped >= MAX_STRIP-1)
+		{
 			lgdebug(+D_SW, "Right-strip of >= %d tokens\n", MAX_STRIP-1);
 			return; /* XXX */
 		}
@@ -2123,8 +2125,10 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 	        word, word_can_split, word_is_known,
 	        (NULL == unsplit_word->regex_name) ? "" : unsplit_word->regex_name);
 
-	if (is_utf8_upper(word)) {
-		if (!test_enabled("dictcap")) {
+	if (is_utf8_upper(word))
+	{
+		if (!test_enabled("dictcap"))
+		{
 			/** Hard-coded English-centric capitalization handling.
 			 *
 			 * FIXME: Capitalization handling should be done using the dict.
@@ -2609,7 +2613,8 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 		printf("Tokenize word/alt=%zu/%zu '%s' re=%s\n",
 				 wordpos, altlen(sent->word[wordpos].alternatives), s,
 				 w->regex_name ? w->regex_name : "");
-		while (we) {
+		while (we)
+		{
 			printf(" xstring='%s' expr=", we->string);
 			print_expression(we->exp);
 			we = we->next;

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1022,8 +1022,7 @@ static bool add_alternative_with_subscr(Sentence sent,
  *
  * The prefix code is only lightly validated by actual use.
  */
-static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w,
-                         bool issue_alternatives)
+static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 {
 	int i, j;
 	Afdict_class *prefix_list, *suffix_list;
@@ -1034,6 +1033,7 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w,
 	const Dictionary dict = sent->dict;
 	const char *wend = w + strlen(w);
 	char *newword = alloca(wend-w+1);
+	bool issue_alternatives = (NULL != unsplit_word);
 
 	/* Set up affix tables. */
 	if (NULL == dict->affix_table) return false;
@@ -1382,7 +1382,7 @@ static bool is_capitalizable(const Dictionary dict, const Gword *word)
 static bool is_known_word(Sentence sent, const char *word)
 {
 	return (boolean_dictionary_lookup(sent->dict, word) ||
-	        suffix_split(sent, NULL, word, /*issue_alternatives*/false));
+	        suffix_split(sent, NULL, word));
 }
 
 /**
@@ -1792,8 +1792,7 @@ static bool is_re_capitalized(const char *regex_name)
 	return ((NULL != regex_name) && (NULL != strstr(regex_name, "CAPITALIZED")));
 }
 
-static bool morpheme_split(Sentence sent, Gword *unsplit_word,
-                           bool issue_alternatives)
+static bool morpheme_split(Sentence sent, Gword *unsplit_word)
 {
 	bool word_can_split;
 	const char *word =unsplit_word->subword;
@@ -1807,7 +1806,7 @@ static bool morpheme_split(Sentence sent, Gword *unsplit_word,
 	}
 	else
 	{
-		word_can_split = suffix_split(sent, unsplit_word, word, issue_alternatives);
+		word_can_split = suffix_split(sent, unsplit_word, word);
 		lgdebug(+D_SW, "Tried to split word=%s, can_split=%d\n",
 				  word, word_can_split);
 
@@ -1820,7 +1819,7 @@ static bool morpheme_split(Sentence sent, Gword *unsplit_word,
 
 			downcase_utf8_str(downcase, word, downcase_size);
 			word_can_split |=
-				suffix_split(sent, unsplit_word, downcase, issue_alternatives);
+				suffix_split(sent, unsplit_word, downcase);
 			lgdebug(+D_SW, "Tried to split lc=%s, now can_split=%d\n",
 					  downcase, word_can_split);
 		}
@@ -2123,7 +2122,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 		anysplit(sent, unsplit_word);
 
 	/* OK, now try to strip affixes. */
-	word_can_split = morpheme_split(sent, unsplit_word, true);
+	word_can_split = morpheme_split(sent, unsplit_word);
 
 	if (!word_is_known)
 	{

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1787,7 +1787,7 @@ static const char *print_rev_word_array(Sentence sent, const char **w,
  * Check if the word is capitalized according to the regex definitions.
  * XXX Not nice - try to avoid the need of using it.
  */
-static bool is_re_capitalized(const char *word, const char *regex_name)
+static bool is_re_capitalized(const char *regex_name)
 {
 	return ((NULL != regex_name) && (NULL != strstr(regex_name, "CAPITALIZED")));
 }
@@ -2249,7 +2249,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 *   it also should not be issued, even if is_utf8_upper(word),
 			 *   e.g Y'gonna or Let's. */
 			if (!(unsplit_word->status & WS_INDICT) &&
-			    is_re_capitalized(word, unsplit_word->regex_name))
+			    is_re_capitalized(unsplit_word->regex_name))
 			{
 				issue_dictcap(sent, /*is_cap*/true, unsplit_word, word);
 			}

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1396,6 +1396,10 @@ static bool is_known_word(Sentence sent, const char *word)
  * Note: spellcheck_suggest(), which is invoked by this function, returns
  * guesses for words containing numbers (including words consisting of digits
  * only). Hence this function should not be called for such words.
+ * 
+ * Note that a lowercase word can be spell-corrected to an uppercase word.
+ * FIXME? Should we allow that only if the lc version of the corrected word
+ * is the same?
  */
 static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
                                   Parse_Options opts)
@@ -2099,7 +2103,8 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 					  word, word_can_split);
 
 			/* XXX WS_FIRSTUPPER marking is missing here! */
-			if ((is_capitalizable(dict, unsplit_word)) && is_utf8_upper(word))
+			if ((is_capitalizable(dict, unsplit_word)) && is_utf8_upper(word) &&
+			    !(unsplit_word->status & (WS_SPELL|WS_RUNON)))
 			{
 				downcase_utf8_str(downcase, word, downcase_size);
 				word_can_split |=

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -792,7 +792,7 @@ char * dictionary_get_data_dir(void)
  * Otherwise, it looks for the file in a sequence of directories, as
  * specified in the dictpath array, until it finds it.
  *
- * If it s still not found, it may be that the user specified a relative
+ * If it is still not found, it may be that the user specified a relative
  * path, so it tries to open the exact file.
  *
  * Associated data files are looked in the *same* directory in which the

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -297,7 +297,7 @@ bool in_same_alternative(Gword *w1, Gword *w2)
 	/* The following is wrong!  Comparison to the hier_position of the
 	 * termination word is actually needed when there are alternatives of
 	 * different lengthes at the end of a sentence.  This check then prevents
-	 * the generation of null words on the shorter alternative. */
+	 * the generation of empty words on the shorter alternative. */
 	if ((NULL == w1->next) || (NULL == w2->next)) return false;/* termination */
 #endif
 
@@ -837,7 +837,7 @@ static void wordgraph_unlink_xtmpfile(void)
 }
 
 /**
- * Display the word-graph it in the indicated mode.
+ * Display the word-graph in the indicated mode.
  * This is for debug. It is not reentrant due to the static pid and the
  * possibly created fixed filenames.
  * When Using X11, a "dot -Txlib" program is launched on the graph
@@ -915,7 +915,7 @@ void wordgraph_show(Sentence sent, const char *modestr)
 	}
 
 #if !defined HAVE_FORK || defined POPEN_DOT
-	x_popen((mode & WGR_X11)? POPEN_DOT_CMD: POPEN_DOT_CMD_WINDOWS, wgds);
+	x_popen((mode & WGR_X11)? POPEN_DOT_CMD : POPEN_DOT_CMD_WINDOWS, wgds);
 #else
 	{
 		const char *const args[] = { DOT_COMMAND, DOT_DRIVER, gvf_name, NULL };

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -1,13 +1,13 @@
 #ifdef USE_WORDGRAPH_DISPLAY
 /* Wordgraph display representation modes. */
 #define lo(l) (l-'a')
-#define WGR_SUB        1<<lo('s') /* Unsplit words as subgraphs */
-#define WGR_PREV       1<<lo('p') /* Prev links */
-#define WGR_UNSPLIT    1<<lo('u') /* Unsplit_word links */
-#define WGR_DBGLABEL   1<<lo('d') /* Debug label addition */
-#define WGR_DOTDEBUG   1<<lo('h') /* Hex node numbers, for dot commands debug */
-#define WGR_LEGEND     1<<lo('l') /* Add a legend */
-#define WGR_X11        1<<lo('x') /* Display using X11 even on Windows */
+#define WGR_SUB      (1<<lo('s')) /* Unsplit words as subgraphs */
+#define WGR_PREV     (1<<lo('p')) /* Prev links */
+#define WGR_UNSPLIT  (1<<lo('u')) /* Unsplit_word links */
+#define WGR_DBGLABEL (1<<lo('d')) /* Debug label addition */
+#define WGR_DOTDEBUG (1<<lo('h')) /* Hex node numbers, for dot commands debug */
+#define WGR_LEGEND   (1<<lo('l')) /* Add a legend */
+#define WGR_X11      (1<<lo('x')) /* Display using X11 even on Windows */
 #endif /* USE_WORDGRAPH_DISPLAY */
 
 void wordgraph_show(Sentence, const char *);


### PR DESCRIPTION
This pull request mainly fixes two problems that caused an assert() "NULL X-node", due to an acceptance of an unknown word as a spell correction.

In addition, it includes code rearrangement and formatting, and typo fixes.