### PR TITLE
Change !spell to be the max. number of spell corrections per word.

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -271,7 +271,7 @@ class EEnglishLinkageTestCase(unittest.TestCase):
                          Link(linkage, 6, '.','RW','RW','RIGHT-WALL'))
 
     def test_d_spell_guessing_on(self):
-        self.po.spell_guess = True
+        self.po.spell_guess = 7
         result = self.parse_sent("I love going to shoop.")
         resultx = result[0] if result else []
         for resultx in result:
@@ -281,7 +281,7 @@ class EEnglishLinkageTestCase(unittest.TestCase):
              ['LEFT-WALL', 'I.p', 'love.v', 'going.v', 'to.r', 'shop[~].v', '.', 'RIGHT-WALL'])
 
     def test_e_spell_guessing_off(self):
-        self.po.spell_guess = False
+        self.po.spell_guess = 0
         result = self.parse_sent("I love going to shoop.")
         self.assertEqual(list(result[0].words()),
              ['LEFT-WALL', 'I.p', 'love.v', 'going.v', 'to.r', 'shoop[?].v', '.', 'RIGHT-WALL'])

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -197,15 +197,21 @@ class ParseOptions(object):
     @property
     def spell_guess(self):
         """
-         Whether or not to running the spelling guesser on unknown words.
+         Whether or not to run the spelling guesser on unknown words.
+         The default number of maximum number of spell corrections per word
+         is 7, and can be set when an optional value is supplied.
         """
-        return clg.parse_options_get_spell_guess(self._obj) == 1
+        return clg.parse_options_get_spell_guess(self._obj) == 7
 
     @spell_guess.setter
     def spell_guess(self, value):
-        if not isinstance(value, bool):
-            raise TypeError("spell_guess must be set to a bool")
-        clg.parse_options_set_spell_guess(self._obj, 1 if value else 0)
+        """
+         The value is the maximum number of spell corrections per word.
+         If non-zero, unlimited run-on corrections will be issued too.
+        """
+        if not isinstance(value, int):
+            raise TypeError("spell_guess must be set to an integer")
+        clg.parse_options_set_spell_guess(self._obj, value)
 
     @property
     def all_short_connectors(self):

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -67,7 +67,7 @@ struct Parse_Options_s
 	Resources resources;   /* For deciding when to abort the parsing */
 
 	/* Options governing the tokenizer (sentence-splitter) */
-	bool use_spell_guess;  /* Perform spell-guessing of unknown words. */
+	int use_spell_guess;  /* Perform spell-guessing of unknown words. */
 
 	/* Choice of the parser to use */
 	bool use_sat_solver;   /* Use the Boolean SAT based parser */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -115,7 +115,7 @@ Parse_Options parse_options_create(void)
 	po->min_null_count = 0;
 	po->max_null_count = 0;
 	po->islands_ok = true;
-	po->use_spell_guess = true;
+	po->use_spell_guess = 7;
 	po->use_sat_solver = false;
 	po->use_viterbi = false;
 
@@ -319,11 +319,11 @@ bool parse_options_get_islands_ok(Parse_Options opts) {
 	return opts->islands_ok;
 }
 
-void parse_options_set_spell_guess(Parse_Options opts, bool dummy) {
+void parse_options_set_spell_guess(Parse_Options opts, int dummy) {
 	opts->use_spell_guess = dummy;
 }
 
-bool parse_options_get_spell_guess(Parse_Options opts) {
+int parse_options_get_spell_guess(Parse_Options opts) {
 	return opts->use_spell_guess;
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1814,7 +1814,7 @@ static void display_word_split(Dictionary dict,
 	Sentence sent;
 	struct Parse_Options_s display_word_opts = *opts;
 
-	parse_options_set_spell_guess(&display_word_opts, false);
+	parse_options_set_spell_guess(&display_word_opts, 0);
 	sent = sentence_create(word, dict);
 	if (0 > sentence_split(sent, &display_word_opts)) return;
 

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -116,8 +116,8 @@ link_public_api(void)
 link_public_api(bool)
      parse_options_get_islands_ok(Parse_Options opts);
 link_public_api(void)
-     parse_options_set_spell_guess(Parse_Options opts, bool spell_guess);
-link_public_api(bool)
+     parse_options_set_spell_guess(Parse_Options opts, int spell_guess);
+link_public_api(int)
      parse_options_get_spell_guess(Parse_Options opts);
 link_public_api(void)
      parse_options_set_short_length(Parse_Options opts, int short_length);

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1417,7 +1417,6 @@ static bool morpheme_split(Sentence sent, Gword *unsplit_word, const char *word)
 }
 
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
-#define MAX_NUM_SPELL_GUESSES 3 /* FIXME */
 /* TODO Change !spell to be an integer which will be this limit. */
 
 static bool is_known_word(Sentence sent, const char *word)
@@ -1430,7 +1429,7 @@ static bool is_known_word(Sentence sent, const char *word)
  * Try to spell guess an unknown word, and issue the results as alternatives.
  * There are two kind of guesses:
  * - Separating run-on words into an exact combination of words, usually 2.
- * - Find similar words.
+ * - Find similar words. These are limited to use_spell_guess alternatives.
  *
  * Return true if corrections have been issued, else false.
  *
@@ -1470,7 +1469,10 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 			printf("- %s\n", alternates[j]);
 		}
 	}
-	/* Word split for run-on and guessed words. */
+	/* Word split for run-on and guessed words.
+	 * Note: We suppose here, for the purpose of checking the use_spell_guess
+	 * limit, that spellcheck_suggest() returns the run-on splits before the
+	 * spell corrections. */
 	for (j=0; j<n; j++)
 	{
 		Gword *altp;
@@ -1520,7 +1522,7 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 			//else printf("Spell guess '%s' ignored\n", alternates[j]);
 		}
 
-		if (num_guesses > MAX_NUM_SPELL_GUESSES) break;
+		if (num_guesses >= opts->use_spell_guess) break;
 	}
 	if (alternates) spellcheck_free_suggest(alternates, n);
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -94,7 +94,7 @@ static Switch default_switches[] =
 	{"senses",     Bool, "Display of word senses",          &local.display_senses},
 	{"short",      Int,  "Max length of short links",       &local.short_length},
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
-	{"spell",      Bool, "Use spell-guesser for unknown words",  &local.spell_guess},
+	{"spell",      Int, "Use up to this many spell-guesses per unknown word", &local.spell_guess},
 #endif /* HAVE_HUNSPELL */
 	{"timeout",    Int,  "Abort parsing after this many seconds", &local.timeout},
 #ifdef USE_SAT_SOLVER
@@ -246,14 +246,14 @@ static int x_issue_special_command(const char * line, Command_Options *copts, Di
 
 	if (strcmp(s, "variables") == 0)
 	{
-		printf(" Variable     Controls                                      Value\n");
-		printf(" --------     --------                                      -----\n");
+		printf(" Variable     Controls                                          Value\n");
+		printf(" --------     --------                                          -----\n");
 		for (i = 0; as[i].string != NULL; i++)
 		{
 			printf(" ");
 			left_print_string(stdout, as[i].string, "             ");
 			left_print_string(stdout, as[i].description,
-			            "                                              ");
+			            "                                                  ");
 			if (Float == as[i].param_type)
 			{
 				/* Float point print! */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -540,7 +540,7 @@ static void setup_panic_parse_options(Parse_Options opts)
 	parse_options_set_short_length(opts, 12);
 	parse_options_set_all_short_connectors(opts, 1);
 	parse_options_set_linkage_limit(opts, 100);
-	parse_options_set_spell_guess(opts, false);
+	parse_options_set_spell_guess(opts, 0);
 }
 
 static void print_usage(char *str)

--- a/tests/dict-reopen.cc
+++ b/tests/dict-reopen.cc
@@ -28,7 +28,7 @@ int main()
 	setlocale(LC_ALL, "en_US.UTF-8");
 
 	Parse_Options opts = parse_options_create();
-	parse_options_set_spell_guess(opts, false);
+	parse_options_set_spell_guess(opts, 0);
 
 	for (int i=0; i<20; i++)
 	{
@@ -51,8 +51,8 @@ int main()
 			sentence_split(sent, opts);
 			int num_linkages = sentence_parse(sent, opts);
 			if (num_linkages > 0) {
-		   	Linkage linkage = linkage_create(0, sent, opts);
-		   	linkage_delete(linkage);
+				Linkage linkage = linkage_create(0, sent, opts);
+				linkage_delete(linkage);
 			}
 			sentence_delete(sent);
 		}

--- a/tests/mem-leak.cc
+++ b/tests/mem-leak.cc
@@ -17,7 +17,7 @@ int main()
     opts = parse_options_create();
     parse_options_set_max_null_count(opts, 10);
     parse_options_set_display_morphology(opts, 1);
-    parse_options_set_spell_guess(opts, false);
+    parse_options_set_spell_guess(opts, 0);
 
     dict = dictionary_create_lang("en");
     if (!dict) {


### PR DESCRIPTION
As prior to this change, if the value of !spell is zero, no spell and
run-on corrections of unknown words are performed.

Else, use up to this many spell-guesses per unknown word.  This is an
API change. In that case, still (as before) the number of run-on
corrections (word split) of unknown words is not limited.