### PR TITLE
Manpage

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -2,7 +2,7 @@
 
 dist_man_MANS = link-parser.1
 
+# Change the system dictionary location according the configuration options.
+# This tracks --enable-binreloc, --bindir, and --datadir.
 link-parser.1: link-parser.man1
-	# Change the system dictionary location according the configuration options.
-	# This tracks --enable-binreloc, --bindir, and --datadir.
 	sed 's,%DATA_DIR%,$(datadir),;s,%BIN_DIR%,$(bindir),;s/%BINRELOC%/$(BINRELOC_CFLAGS)/' $< >$@

--- a/man/link-parser.man1
+++ b/man/link-parser.man1
@@ -1,4 +1,13 @@
-.\" Portability macros.
+.\" Portability macros (not validated).
+.\" Check whether we are using grohtml.
+.nr mH 0
+.nr mR 1
+.if \n(.g \
+.  if '\*(.T'html' \{\
+.    nr mH 1
+.    nr mR 0
+\}
+.
 .\" Start URL.
 .de UR
 .  ds m1 \\$1\"
@@ -359,8 +368,8 @@ Post-processing definitions.
 .TP
 .I \fILL\fP/4.0.constituent\-knowledge
 Definitions for producing a constituent tree.
-.TP 0
-.sp
+.sp 2
+.TP
 The directory search order for these files is:
 .I "./"
 .br
@@ -369,7 +378,12 @@ The directory search order for these files is:
 .I "../"
 .br
 .I "../data/"
-.sp -1
+.br
+.\" A tricky adaptation for man2html (1.6.15) and grohtml (1.22.2),
+.\" to prevent an extra blank line.
+.\" XXX May need to change/omit this when their bugs are fixed...
+.ie '\n(mR'\n(mH' .nop
+.el .sp -1
 .ie "\?%BINRELOC%\?"\?-DENABLE_BINRELOC\?" \{
 .I "%BIN_DIR%/link\-grammar/"
 \}

--- a/man/link-parser.man1
+++ b/man/link-parser.man1
@@ -1,12 +1,13 @@
 .\" Portability macros (not validated).
+.\" FIXME: For some reason in man2html the registers are always null-strings.
+.\" Also, in man2html the code doesn't display the <a> HTML code even
+.\" if the conditionals are changed to always be true.
+.
 .\" Check whether we are using grohtml.
 .nr mH 0
-.nr mR 1
 .if \n(.g \
-.  if '\*(.T'html' \{\
+.  if '\*(.T'html' \
 .    nr mH 1
-.    nr mR 0
-\}
 .
 .\" Start URL.
 .de UR
@@ -382,8 +383,9 @@ The directory search order for these files is:
 .\" A tricky adaptation for man2html (1.6.15) and grohtml (1.22.2),
 .\" to prevent an extra blank line.
 .\" XXX May need to change/omit this when their bugs are fixed...
-.ie '\n(mR'\n(mH' .nop
+.ie '\n(mH'' .nop
 .el .sp -1
+.\" End of adaptation
 .ie "\?%BINRELOC%\?"\?-DENABLE_BINRELOC\?" \{
 .I "%BIN_DIR%/link\-grammar/"
 \}


### PR DESCRIPTION
- Fix autogen breakage caused by the previous man page fix.
- Adapt the man page for man2html and grohtml.
