### PR TITLE
Add a new COi link type for openers that lead into imperative sentences.

### DIFF
--- a/data/en/4.0.constituent-knowledge
+++ b/data/en/4.0.constituent-knowledge
@@ -4,7 +4,7 @@ TI BIt MVs TO Mv Mg* MVa OF ON IN QI Ma CP* CPi CPx MVt S##w MX#r Pp MVi MVg Mgp
 S##t S##h S##b S##q L MX#a MG JG MX#x U S##d JT MVh Mr B#w B#d MVb COq Mj OD CX S##g PF Zc MX#d Bc
 K NIax 
 
-DOMAIN_CONTAINS_LINKS: 
+DOMAIN_CONTAINS_LINKS:
 
 URFL_ONLY_DOMAIN_STARTER_LINKS: 
 
@@ -115,7 +115,7 @@ NIax h
 ; These links are not put in the word/link graph. They also cannot be the 
 ; starter links for a domain. 
 
-IGNORE_THESE_LINKS: Xca  HA
+IGNORE_THESE_LINKS: Xca  HA COi
 
 
 
@@ -127,5 +127,5 @@ IGNORE_THESE_LINKS: Xca  HA
 
 RESTRICTED_LINKS: 
    B#*  D##w   B#w   B#d   AFh  MVt   Xx   HL   SFsic  AFd   Bc   CX  EAh  
-   H   HA   PFc   B#j   Wd   PF   Z   BW   CV   IV   WV
+   H   HA   PFc   B#j   Wd   PF   Z   BW   CV   IV   WV   Wi
 

--- a/data/en/4.0.constituent-knowledge
+++ b/data/en/4.0.constituent-knowledge
@@ -4,7 +4,7 @@ TI BIt MVs TO Mv Mg* MVa OF ON IN QI Ma CP* CPi CPx MVt S##w MX#r Pp MVi MVg Mgp
 S##t S##h S##b S##q L MX#a MG JG MX#x U S##d JT MVh Mr B#w B#d MVb COq Mj OD CX S##g PF Zc MX#d Bc
 K NIax 
 
-DOMAIN_CONTAINS_LINKS:
+DOMAIN_CONTAINS_LINKS: 
 
 URFL_ONLY_DOMAIN_STARTER_LINKS: 
 
@@ -127,5 +127,5 @@ IGNORE_THESE_LINKS: Xca  HA COi
 
 RESTRICTED_LINKS: 
    B#*  D##w   B#w   B#d   AFh  MVt   Xx   HL   SFsic  AFd   Bc   CX  EAh  
-   H   HA   PFc   B#j   Wd   PF   Z   BW   CV   IV   WV   Wi
+   H   HA   PFc   B#j   Wd   PF   Z   BW   CV   IV   WV
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2285,7 +2285,7 @@ per "/.per": Us+ & Mp-;
 
 % Wi- & {NM+}: imperative numbered lists: "Step 5. Do this."
 <verb-i>:    {@E-} & I- & <verb-wall>;
-<verb-ico>:  {@E-} & ((I- & {<verb-wall>} & {@E-}) or ({CO-} & Wi- & {NM+}));
+<verb-ico>:  {@E-} & ((I- & {<verb-wall>} & {@E-}) or ({COi-} & Wi- & {NM+}));
 <verb-pl,i>:  <verb-pl> or <verb-ico>;
 
 % <b-minus> is meant to be a generic replacement in the naked B- in
@@ -8242,7 +8242,8 @@ across along: <prep-across>;
 
 off:
   <prep-across>
-  or (MVp+ & {Xc+ & {Xd-}} & COp+);
+  or (MVp+ & {Xc+ & {Xd-}} & COp+)
+  or K-;
 
 past.p:
   ({Yd-} & {JQ+} & J+ & (<prep-main-a> or FM-))

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -8242,8 +8242,7 @@ across along: <prep-across>;
 
 off:
   <prep-across>
-  or (MVp+ & {Xc+ & {Xd-}} & COp+)
-  or K-;
+  or (MVp+ & {Xc+ & {Xd-}} & COp+);
 
 past.p:
   ({Yd-} & {JQ+} & J+ & (<prep-main-a> or FM-))


### PR DESCRIPTION
This is my first attempt at addressing the issue I brought up here: https://groups.google.com/forum/?hl=en#!topic/link-grammar/liEFQWU7eBQ

It seems to work in all my test sentences (including non-imperative sentences with openers). Basically, I found only one place where an imperative verb accepted a CO- link, so I changed that to COi-. I'm a little less certain of the constituent changes. It does make things work a lot better, but it misses the phrase type for the opener. I tried several ways to fix that, but was unsuccessful. Any input there would be helpful.

Thanks,

Mike
