### PR TITLE
Avoid sorting the linkages if no linkages found

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -766,6 +766,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 
 static void sort_linkages(Sentence sent, Parse_Options opts)
 {
+	if (0 == sent->num_linkages_found) return;
 	qsort((void *)sent->lnkages, sent->num_linkages_alloced,
 	      sizeof(struct Linkage_s),
 	      (int (*)(const void *, const void *))opts->cost_model.compare_fn);

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -1056,8 +1056,6 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	ctxt->phrase_ss = string_set_create();
 	generate_misc_word_info(ctxt, linkage);
 
-	if (NULL ==  sent->constituent_pp)         /* First time for this sentence */
-		sent->constituent_pp = post_process_new(sent->dict->hpsg_knowledge);
 	linkage_post_process(linkage, sent->constituent_pp);
 	linkage->hpsg_pp_data = sent->constituent_pp->pp_data;
 	post_process_new_domain_array(sent->constituent_pp);

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -857,6 +857,9 @@ void linkage_free_pp_info(Linkage lkg)
 
 /**
  * Part of the API. Although maybe it shouldn't be.
+ * It has been updated to initialize sent->constituent_pp, instead of
+ * doing it in linkage_create(), so it will be done only on demand.
+ *
  * This is just a wrapper around do_post_process, and all that it does
  * is to set up some domain data in the linkage->pp_info pointer.
  * There do not seem to be any users for this data !?  Should this
@@ -876,7 +879,14 @@ void linkage_post_process(Linkage linkage, Postprocessor * postprocessor)
 	D_type_list * d;
 
 	if (NULL == linkage) return;
-	if (NULL == postprocessor) return;
+
+	if (NULL == postprocessor)
+	{
+		Sentence sent = linkage->sent;
+
+		sent->constituent_pp = post_process_new(sent->dict->hpsg_knowledge);
+		postprocessor = sent->constituent_pp;
+	}
 
 	/* Step one: because we might be called multiple times, first we clean
 	 * up and free the domain name data left over from a previous call. */

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -185,6 +185,8 @@ char * linkage_print_links_and_domains(const Linkage linkage)
 	char * links_string;
 	const char ** dname;
 
+	linkage_post_process(linkage, linkage->sent->constituent_pp);
+
 	longest = 0;
 	for (link=0; link<N_links; link++)
 	{


### PR DESCRIPTION
1. Avoid sorting the linkages if no linkages found.
Else, qsort() is invoked with NULL as its first argument,
but the function template states the first argument should not be null.
2. Fix possible missing linkage->pp_info.