### PR TITLE
Fix memory leak in bindings (linkage_print_constituent_tree)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,8 @@ Version 5.3.0: (XXX 2015)
  * Random morphology generation can be enabled at runtime.
  * Remove obsolete, unmaintained MacOSX build file.
  * Extensive updates to man page.
- * Fix crash on long sentences (issue #137)
+ * Fix crash on long sentences (issue #137).
+ * Fix a memory leak in language bindings (issue #138).
 
 Version 5.2.5: (1 February 2015)
  * Fix contracted "is" verb.

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -122,6 +122,7 @@ int  sentence_link_cost(Sentence sent, int i);
 %newobject linkage_print_links_and_domains;
 %newobject linkage_print_diagram;
 %newobject linkage_print_postscript;
+%newobject linkage_print_constituent_tree;
 
 Linkage linkage_create(int index, Sentence sent, Parse_Options opts);
 void linkage_delete(Linkage linkage);


### PR DESCRIPTION
Mentioned in issue #138.