### PR TITLE
Restore lost "Found x linkages"

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -509,8 +509,10 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 
 	/* Now actually malloc the array in which we will process linkages. */
 	/* We may have been called before, e.g this might be a panic parse,
-	 * and the linkages array may still be there from last time. */
+	 * and the linkages array may still be there from last time.
+	 * XXX free_linkages() zeros sent->num_linkages_found. */
 	if (sent->lnkages) free_linkages(sent);
+	sent->num_linkages_found = N_linkages_found;
 	sent->lnkages = linkage_array_new(N_linkages_alloced);
 
 	/* Generate an array of linkage indices to examine */


### PR DESCRIPTION
In "Fix another mem leak", free_linkages() got added in select_linkages().
It sometime causes the "Found x linkages" to get lost due to zeroing `sent->num_linkages_found`.

For example, it happens with this sentence
	`they report less robust earnings than they did previously`
which parses as:
`LEFT-WALL they report.v less robust.a earnings.n than they [did] previously`

Fixed by restoring `sent->num_linkages_found`. 