### PR TITLE
Fix crash in flattening the wordgraph (issue #146)

### DIFF
--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -81,9 +81,11 @@ set_centers(const Linkage linkage, int center[], int word_offset[],
 		 */
 		len = utf8_strlen(linkage->word[i]);
 		center_t = tot + (len/2);
+#if 0
 		if (i > start_word)
 			center[i] = MAX(center_t, center[i-1] + link_len[i] + 1);
 		else
+#endif
 			center[i] = center_t;
 		word_offset[i] = center[i] - center_t;
 		tot += len+1 + word_offset[i];
@@ -1429,9 +1431,9 @@ void print_wordgraph_pathpos(const Wordgraph_pathpos *wp)
 	lgdebug(+D_WPP, "\n");
 	for (; NULL != wp->word; wp++)
 	{
-		lgdebug(D_WPP, "%zu: word '%s', same=%d used=%d level=%zu\n",
-		        i++, wp->word->subword, wp->same_word, wp->used,
-		        wp->word->hier_depth);
+		lgdebug(D_WPP, "%zu: %zu:word '%s', same=%d used=%d level=%zu\n",
+		        i++, wp->word->node_num, wp->word->subword, wp->same_word,
+		        wp->used, wp->word->hier_depth);
 	}
 }
 #undef D_WPP

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2697,10 +2697,9 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 	/* Populate the pathpos word queue */
 	for (next = sent->wordgraph->next; *next; next++)
 	{
-		wordgraph_pathpos_append(&wp_new, *next,
-		                         false/* used */,
-		                         false/* same_word */,
-		                         true/* diff_alternative */);
+		wordgraph_pathpos_add(&wp_new, *next,
+		                      false/* used */, false/* same_word */,
+		                      true/* diff_alternative */);
 	}
 
 	/* Scan the wordgraph and flatten it. */
@@ -2824,10 +2823,9 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 				        wg_word->subword);
 				for (next = wg_word->next; NULL != *next; next++)
 				{
-					wordgraph_pathpos_append(&wp_new, *next,
-					                         false/* used */,
-					                         false/* same_word */,
-					                         true/* diff_alternative */);
+					wordgraph_pathpos_add(&wp_new, *next,
+					                      false/* used */, false/* same_word */,
+					                      true/* diff_alternative */);
 				}
 			}
 		}
@@ -2876,20 +2874,19 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 				if (same_alternative)
 				{
 					lgdebug(D_FW, "No (same alt) used=%d\n", wpp_old->used);
-					wordgraph_pathpos_append(&wp_new, wg_word,
-					                         wpp_old->used,
-					                         true/* same_word */,
-					                         true/* diff_alternative */);
+					wordgraph_pathpos_add(&wp_new, wg_word,
+					                      wpp_old->used, true/* same_word */,
+					                      true/* diff_alternative */);
 				}
 				else
 				{
 					bool added = false;
 
 					for (next = wg_word->next; NULL != *next; next++)
-						added |= wordgraph_pathpos_append(&wp_new, *next,
-						                                  false/* used */,
-						                                  false/* same_word */,
-						                                  true/* diff_alternative */);
+						added |= wordgraph_pathpos_add(&wp_new, *next,
+						                               false/* used */,
+						                               false/* same_word */,
+						                               true/* diff_alternative */);
 					if (added)
 					{
 						lgdebug(D_FW, "Yes\n");

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2573,7 +2573,8 @@ static Word *word_new(Sentence sent)
  * program will work fine (print_sentence_word_alternatives(),
  * sentence_in_dictionary(), verr_msg()).
  */
-#define D_AXN 5
+#define D_X_NODE 8
+#define D_DWE 5
 static bool determine_word_expressions(Sentence sent, Gword *w,
                                        Parse_Options opts)
 {
@@ -2583,27 +2584,27 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	const char *s = w->subword;
 	X_node * we = NULL;
 
-	lgdebug(+D_AXN, "Word %zu subword '%s'", wordpos, s);
+	lgdebug(+D_DWE, "Word %zu subword %zu:'%s'", wordpos, w->node_num, s);
 	if (NULL != sent->word[wordpos].unsplit_word)
-		lgdebug(D_AXN, " (unsplit '%s')", sent->word[wordpos].unsplit_word);
-	lgdebug(D_AXN, "\n");
+		lgdebug(D_DWE, " (unsplit '%s')", sent->word[wordpos].unsplit_word);
+	lgdebug(D_DWE, "\n");
 
 	/* Generate an "alternatives" component. */
 	altappend(sent, &sent->word[wordpos].alternatives, s);
 
 	if (w->status & WS_INDICT)
 	{
-		lgdebug(D_AXN, "WS_INDICT %s\n", w->subword);
+		lgdebug(D_DWE, "WS_INDICT %s\n", w->subword);
 		we = build_word_expressions(sent, w, NULL);
 	}
 	else if (w->status & WS_REGEX)
 	{
-		lgdebug(D_AXN, "WS_REGEX %s\n", w->subword);
+		lgdebug(D_DWE, "WS_REGEX %s\n", w->subword);
 		we = build_word_expressions(sent, w, w->regex_name);
 	}
 	else if (dict->unknown_word_defined && dict->use_unknown_word)
 	{
-		lgdebug(+D_AXN, "UNKNOWN_WORD %s\n", s);
+		lgdebug(+D_DWE, "UNKNOWN_WORD %s\n", s);
 		we = build_word_expressions(sent, w, UNKNOWN_WORD);
 		assert(we, UNKNOWN_WORD "must be defined in the dictionary!");
 		w->morpheme_type = MT_UNKNOWN;
@@ -2629,7 +2630,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	/* At last .. concatenate the word expressions we build for
 	 * this alternative. */
 	sent->word[wordpos].x = catenate_X_nodes(sent->word[wordpos].x, we);
-	if (3 < opts->verbosity)
+	if (D_X_NODE <= opts->verbosity)
 	{
 		/* Print the X_node details for the word. */
 		printf("Tokenize word/alt=%zu/%zu '%s' re=%s\n",
@@ -2645,6 +2646,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 
 	return true;
 }
+#undef D_DWE
 
 /**
  * Find whether w1 and w2 have been generated together in the same alternative.

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -137,10 +137,8 @@ Wordgraph_pathpos *wordgraph_pathpos_resize(Wordgraph_pathpos *wp,
  * For validation code only (until the wordgraph version is mature):
  *   used: mark that the word has already been issued into the 2D-array.
  *   diff_alternative: validate we don't queue words from the same alternative.
- *
- * FIXME: Change the function name to wordgraph_pathpos_add().
  */
-bool wordgraph_pathpos_append(Wordgraph_pathpos **wp, Gword *p, bool used,
+bool wordgraph_pathpos_add(Wordgraph_pathpos **wp, Gword *p, bool used,
                               bool same_word, bool diff_alternative)
 {
 	size_t n = wordgraph_pathpos_len(*wp);
@@ -169,7 +167,7 @@ bool wordgraph_pathpos_append(Wordgraph_pathpos **wp, Gword *p, bool used,
 			if (diff_alternative)
 			{
 				assert(same_word||wpt->same_word||!in_same_alternative(p,wpt->word),
-				       "wordgraph_pathpos_append(): "
+				       "wordgraph_pathpos_add(): "
 				       "Word%zu '%s' is from same alternative of word%zu '%s'",
 				       p->node_num, p->subword,
 				       wpt->word->node_num, wpt->word->subword);

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -125,13 +125,32 @@ Wordgraph_pathpos *wordgraph_pathpos_resize(Wordgraph_pathpos *wp,
 	return wp;
 }
 
-bool wordgraph_pathpos_append(Wordgraph_pathpos **wp, Gword *p, bool same_word,
-                           bool diff_alternative)
+/**
+ * Insert the gword into the path queue in reverse order of its hier_depth.
+ *
+ * The deepest wordgraph alternatives must be scanned first.
+ * Otherwise, this sentence fails: "T" to let there a notice
+ * (It depends on "T" matching EMOTICON.)
+ *
+ * Parameters:
+ *   same_word: mark that the same word is queued again.
+ * For validation code only (until the wordgraph version is mature):
+ *   used: mark that the word has already been issued into the 2D-array.
+ *   diff_alternative: validate we don't queue words from the same alternative.
+ *
+ * FIXME: Change the function name to wordgraph_pathpos_add().
+ */
+bool wordgraph_pathpos_append(Wordgraph_pathpos **wp, Gword *p, bool used,
+                              bool same_word, bool diff_alternative)
 {
 	size_t n = wordgraph_pathpos_len(*wp);
 	Wordgraph_pathpos *wpt;
+	size_t insert_here = n;
 
 	assert(NULL != p);
+	wordgraph_hier_position(p); /* in case it is not set yet */
+
+	if (7 <= verbosity) { printf("\n"); print_hier_position(p); }
 
 	if (NULL != *wp)
 	{
@@ -140,8 +159,13 @@ bool wordgraph_pathpos_append(Wordgraph_pathpos **wp, Gword *p, bool same_word,
 			if (p == wpt->word)
 				return false; /* already in the pathpos queue - nothing to do */
 
+			/* Insert in reverse order of hier_depth. */
+			if ((n == insert_here) && (p->hier_depth >= wpt->word->hier_depth))
+				insert_here = wpt - *wp;
+
 			/* Validate that there are no words in the pathpos queue from the same
-			 * alternative */
+			 * alternative. This can be commented out when the wordgraph code is
+			 * mature. FIXME */
 			if (diff_alternative)
 			{
 				assert(same_word||wpt->same_word||!in_same_alternative(p,wpt->word),
@@ -153,11 +177,18 @@ bool wordgraph_pathpos_append(Wordgraph_pathpos **wp, Gword *p, bool same_word,
 		}
 	}
 
+
 	*wp = wordgraph_pathpos_resize(*wp, n);
-	(*wp)[n].word = p;
-	(*wp)[n].same_word = same_word;
-	(*wp)[n].used = false;
-	(*wp)[n].next_ok = false;
+	if (insert_here < n)
+	{
+		memmove(&(*wp)[insert_here+1], &(*wp)[insert_here],
+		        (n - insert_here) * sizeof (*wpt));
+	}
+
+	(*wp)[insert_here].word = p;
+	(*wp)[insert_here].same_word = same_word;
+	(*wp)[insert_here].used = used;
+	(*wp)[insert_here].next_ok = false;
 
 	return true;
 }
@@ -172,6 +203,7 @@ GNUC_UNUSED void print_hier_position(const Gword *word)
 {
 	const Gword **p;
 
+	fflush(stdout);
 	fprintf(stderr, "[Word %zu:%s hier_position(hier_depth=%zu): ",
 	        word->node_num, word->subword, word->hier_depth);
 	assert(2*word->hier_depth==gwordlist_len(word->hier_position), "word '%s'",

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -25,7 +25,7 @@ Gword *find_real_unsplit_word(Gword *, bool);
 
 size_t wordgraph_pathpos_len(Wordgraph_pathpos *);
 Wordgraph_pathpos *wordgraph_pathpos_resize(Wordgraph_pathpos *, size_t);
-bool wordgraph_pathpos_append(Wordgraph_pathpos **, Gword *, bool, bool, bool);
+bool wordgraph_pathpos_add(Wordgraph_pathpos **, Gword *, bool, bool, bool);
 
 const char *gword_status(Sentence, const Gword *);
 const char *gword_morpheme(Sentence sent, const Gword *w);

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -25,7 +25,7 @@ Gword *find_real_unsplit_word(Gword *, bool);
 
 size_t wordgraph_pathpos_len(Wordgraph_pathpos *);
 Wordgraph_pathpos *wordgraph_pathpos_resize(Wordgraph_pathpos *, size_t);
-bool wordgraph_pathpos_append(Wordgraph_pathpos **, Gword *, bool, bool);
+bool wordgraph_pathpos_append(Wordgraph_pathpos **, Gword *, bool, bool, bool);
 
 const char *gword_status(Sentence, const Gword *);
 const char *gword_morpheme(Sentence sent, const Gword *w);


### PR DESCRIPTION
It was hard to find the reason of the problem, but fortunately the fix was easy enough.
I had to scan a large volume of debug output, and hence this patch contains also debug printout enhancement.

I also added two assert()'s (see the commit message) so if there still exist similar problems in the flattening code,  they will be noticed instead of producing corrupted results.