### PR TITLE
Fix a bug created due to the recent addition of negative regex'es.

### DIFF
--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -313,6 +313,7 @@ static Regex_node * regbuild(const char **regstring, int n, int classnum)
 		new_re->pattern = s;
 		new_re->re      = NULL;
 		new_re->next    = NULL;
+		new_re->neg = false; /* TODO (if needed): Negative regex'es. */
 		*tail = new_re;
 		tail	= &new_re->next;
 	}

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -370,6 +370,7 @@ static bool afdict_init(Dictionary dict)
 		sm_re->name = strdup(afdict_classname[AFDICT_SANEMORPHISM]);
 		sm_re->re = NULL;
 		sm_re->next = NULL;
+		sm_re->neg = false;
 		rc = compile_regexs(afdict->regex_root, afdict);
 		if (rc) {
 			prt_error("Error: afdict_init: Failed to compile "


### PR DESCRIPTION
There is a need to initialize the Regex_node neg field to false when creating the SANEMORPHISM regex and the anysplit regex'es (all defined in 4.0.affix).