### PR TITLE
Fix memory leak in freeing linkages->pp_info.

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -369,6 +369,7 @@ struct Linkage_s
 
 	Linkage_info    lifo;         /* Parse_set index and cost information */
 	PP_info *       pp_info;      /* PP domain info, one for each link */
+	size_t          ppisz;        /* Alloc'ed length of pp_info */
 	PP_data         hpsg_pp_data; /* Used in constituent code */
 
 	Sentence        sent;         /* Used for common linkage data */

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -349,9 +349,9 @@ void linkage_free_pp_info(Linkage lkg)
 	size_t j;
 	if (!lkg || !lkg->pp_info) return;
 
-	for (j = 0; j < lkg->num_links; ++j)
+	for (j = 0; j < lkg->ppisz; ++j)
 		exfree_domain_names(&lkg->pp_info[j]);
-	exfree(lkg->pp_info, sizeof(PP_info) * lkg->num_links);
+	exfree(lkg->pp_info, sizeof(PP_info) * lkg->ppisz);
 	lkg->pp_info = NULL;
 }
 
@@ -374,6 +374,10 @@ void linkage_set_domain_names(Postprocessor * postprocessor, Linkage linkage)
 
 	/* The only reason to build the type array is for this function. */
 	build_type_array(postprocessor);
+
+	/* Keep track of pp_info's alloc'ed length, in case linkage->num_links
+	 * shrinks due to discarded ZZZ links (and maybe others). */
+	linkage->ppisz = linkage->num_links;
 
 	linkage->pp_info = (PP_info *) exalloc(sizeof(PP_info) * linkage->num_links);
 


### PR DESCRIPTION
It happens when num_links shrinks due to discarded stem links,
because the pp_info array is allocated before this potential shrinkage.

The shrinking of num_links due to discarded ZZZ links in remove_empty_words() is not
problematic because it happens before the pp_info array is allocated. (The shrinking of  num_words there is not problematic for the size of chosen_disjuncts because it is tracked by cdsz.)

Here is how this memory leak is observed:
```
$ link-parser ru
link-grammar: Info: Dictionary found at ../ru/4.0.dict
link-grammar: Info: Using locale en_US.utf8.
link-grammar: Info: Dictionary version 5.1.0.
link-grammar: Info: Library version link-grammar-5.3.0. Enter "!help" for help.
linkparser> вверху плыли редкие облачка.
Found 2 linkages (2 had no P.P. violations)
	Linkage 1, cost vector = (UNUSED=0 DIS= 3.00 LEN=14)

    +-------------------------Xp-------------------------+
    +---------Wd---------+----------SIp----------+       |
    |         +----EI----+           +----Api----+       |
    |         |          |           |           |       |
LEFT-WALL вверху.e плыли.vnndpp редкие.api облачка.ndnpi . 

Press RETURN for the next linkage.
linkparser> ^Dlink-grammar: Info: Freeing dictionary ru/4.0.dict
link-grammar: Info: Freeing dictionary ru/4.0.affix
Bye.

=================================================================
==28181==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f4e0e0e9a0a in malloc (/lib64/libasan.so.2+0x98a0a)
    #1 0x7f4e0dcc8292 in exalloc /usr/local/src/link-grammar-devel/master/link-grammar/utilities.c:504
    #2 0x7f4e0dc7a58a in linkage_set_domain_names /usr/local/src/link-grammar-devel/master/link-grammar/post-process.c:398
    #3 0x7f4e0dc2b676 in post_process_linkages /usr/local/src/link-grammar-devel/master/link-grammar/api.c:724
    #4 0x7f4e0dc310fc in chart_parse /usr/local/src/link-grammar-devel/master/link-grammar/api.c:1431
    #5 0x7f4e0dc3193c in sentence_parse /usr/local/src/link-grammar-devel/master/link-grammar/api.c:1506
    #6 0x406cda in main /usr/local/src/link-grammar-devel/master/link-parser/link-parser.c:835
    #7 0x3649c206ff in __libc_start_main (/lib64/libc.so.6+0x3649c206ff)

SUMMARY: AddressSanitizer: 16 byte(s) leaked in 2 allocation(s)
```

BTW, I cannot understand why it says
`Direct leak of 16 byte(s) in 2 object(s)`
since 3 links are discarded in this sentence, + a shorter pp_info array gets freed, so this is apparently a leak in 4 objects. Valgrind also reports on 2 blocks:
`16 bytes in 2 blocks are definitely lost`

I'm also not sure why we have not observed this leak earlier.
(Maybe it started due to the recent post processing rearrangements?)