### PR TITLE
Spell-checker related fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -340,25 +340,8 @@ AC_ARG_WITH([hunspell-dictdir], [AS_HELP_STRING([--with-hunspell-dictdir=DIR],
 
 # ====================================================================
 
-ASpellFound=no
-if test "$do_aspell" = yes ; then
-	PKG_CHECK_MODULES([ASPELL], [aspell], [ASpellFound=yes], [ASpellFound=no])
-	save_cpp_flags=${CPPFLAGS}
-	CPPFLAGS="${CPPFLAGS} ${ASPELL_CFLAGS}"
-	AC_CHECK_HEADER([aspell.h], [ASpellFound=yes], ASpellFound=no)
-	AC_CHECK_LIB(aspell, new_aspell_config, [], [ASpellFound=no])
-	CPPFLAGS=$save_cpp_flags
-	if test  "x${ASpellFound}" = "xyes"; then
-		AC_DEFINE(HAVE_ASPELL, 1, [Define for compilation])
-		AC_SUBST(ASPELL_LIBS)
-		AC_SUBST(ASPELL_CFLAGS)
-
-		# If aspell enabled and found, then do NOT do hunspell
-		do_hunspell=no
-	fi
-fi
-
-AM_CONDITIONAL(HAVE_ASPELL, test x${ASpellFound} = xyes)
+# 2015-08: The current default for speller is hunspell, since aspell is not
+# yet thread safe.
 
 HunSpellDictDir=
 HunSpellFound=no
@@ -386,11 +369,31 @@ if test x"$do_hunspell" = xyes; then
 			echo "WARN HunSpell Dictionaries do not exist at \"$HunSpellDictDir\""
 		fi
 		AC_DEFINE_UNQUOTED(HUNSPELL_DICT_DIR, "$HunSpellDictDir", [Defining the  dictionary path])
+
+		# If hunspell enabled and found, then do NOT do aspell
+		do_aspell=no
 	fi
 
 fi
 
 AM_CONDITIONAL(HAVE_HUNSPELL, test x${HunSpellFound} = xyes)
+
+ASpellFound=no
+if test "$do_aspell" = yes ; then
+	PKG_CHECK_MODULES([ASPELL], [aspell], [ASpellFound=yes], [ASpellFound=no])
+	save_cpp_flags=${CPPFLAGS}
+	CPPFLAGS="${CPPFLAGS} ${ASPELL_CFLAGS}"
+	AC_CHECK_HEADER([aspell.h], [ASpellFound=yes], ASpellFound=no)
+	AC_CHECK_LIB(aspell, new_aspell_config, [], [ASpellFound=no])
+	CPPFLAGS=$save_cpp_flags
+	if test  "x${ASpellFound}" = "xyes"; then
+		AC_DEFINE(HAVE_ASPELL, 1, [Define for compilation])
+		AC_SUBST(ASPELL_LIBS)
+		AC_SUBST(ASPELL_CFLAGS)
+	fi
+fi
+
+AM_CONDITIONAL(HAVE_ASPELL, test x${ASpellFound} = xyes)
 
 # ====================================================================
 

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -467,6 +467,13 @@ dictionary_six_str(const char * lang,
 	{
 		/* To disable spell-checking, just set the checker to NULL */
 		dict->spell_checker = spellcheck_create(dict->lang);
+#if defined HAVE_HUNSPELL || defined HAVE_ASPELL
+		/* TODO:
+		 * 1. Set the spell option to 0, to signify no spell checking is done.
+		 * 2. On verbosity >= 1, add a detailed message on the reason. */
+		if (NULL == dict->spell_checker)
+			prt_error("Info: Spell checker disabled.");
+#endif
 		dict->insert_entry = insert_list;
 
 		dict->lookup_list = lookup_list;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -327,6 +327,10 @@ Dictionary dictionary_create_from_db(const char *lang)
 
 	/* To disable spell-checking, just set the checker to NULL */
 	dict->spell_checker = spellcheck_create(dict->lang);
+#if defined HAVE_HUNSPELL || defined HAVE_ASPELL
+	if (NULL == dict->spell_checker)
+		prt_error("Info: Spell checker disabled.");
+#endif
 	dict->base_knowledge = NULL;
 	dict->hpsg_knowledge = NULL;
 

--- a/link-grammar/spellcheck-aspell.c
+++ b/link-grammar/spellcheck-aspell.c
@@ -28,7 +28,8 @@ static const char *spellcheck_lang_mapping[] = {
 	"en", "en_US",
 	"ru", "ru_RU",
 	"he", "he_IL",
-	"de", "de_DE"
+	"de", "de_DE",
+	"lt", "lt_LT",
 };
 
 struct linkgrammar_aspell {

--- a/link-grammar/spellcheck-aspell.c
+++ b/link-grammar/spellcheck-aspell.c
@@ -145,7 +145,7 @@ int spellcheck_suggest(void * chk, char ***sug, const char * word)
 	return 0;
 }
 
-void spellcheck_free_suggest(char **sug, int size)
+void spellcheck_free_suggest(void *chk, char **sug, int size)
 {
 	int i = 0;
 	for (i = 0; i < size; ++i) {

--- a/link-grammar/spellcheck-hun.c
+++ b/link-grammar/spellcheck-hun.c
@@ -122,9 +122,9 @@ int spellcheck_suggest(void * chk, char ***sug, const char * word)
 	return Hunspell_suggest((Hunhandle *)chk, sug, word);
 }
 
-void spellcheck_free_suggest(char **sug, int size)
+void spellcheck_free_suggest(void *chk, char **sug, int size)
 {
-	free(sug);
+	Hunspell_free_list((Hunhandle *)chk, &sug, size);
 }
 
 #endif /* #ifdef HAVE_HUNSPELL */

--- a/link-grammar/spellcheck-hun.c
+++ b/link-grammar/spellcheck-hun.c
@@ -31,7 +31,7 @@ static const char *hunspell_dict_dirs[] = {
 	"/usr/share/hunspell",
 	"/usr/local/share/myspell",
 	"/usr/local/share/hunspell",
-	HUNSPELL_DICT_DIR	
+	HUNSPELL_DICT_DIR
 };
 
 static const char *spellcheck_lang_mapping[] = {

--- a/link-grammar/spellcheck-hun.c
+++ b/link-grammar/spellcheck-hun.c
@@ -35,8 +35,17 @@ static const char *hunspell_dict_dirs[] = {
 };
 
 static const char *spellcheck_lang_mapping[] = {
-	"en" /* link-grammar language */, "en-US" /* hunspell filename */,
-	"en" /* link-grammar language */, "en_US" /* hunspell filename */
+/* link-grammar language, Hunspell filename */
+	"en", "en-US",
+	"en", "en_US",
+	"ru", "ru-RU",
+	"ru", "ru_RU",
+	"he", "he-IL",
+	"he", "he_IL",
+	"de", "de-DE",
+	"de", "de_DE",
+	"lt", "lt-LT",
+	"lt", "lt_LT",
 };
 
 #define FPATHLEN 256

--- a/link-grammar/spellcheck.h
+++ b/link-grammar/spellcheck.h
@@ -16,7 +16,7 @@ void * spellcheck_create(const char * lang);
 void spellcheck_destroy(void *);
 bool spellcheck_test(void *, const char * word);
 int spellcheck_suggest(void * chk, char ***sug, const char * word);
-void spellcheck_free_suggest(char **sug, int size);
+void spellcheck_free_suggest(void * chk, char **sug, int size);
 
 #else
 
@@ -26,6 +26,6 @@ static inline void * spellcheck_create(const char * lang) { return NULL; }
 static inline void spellcheck_destroy(void * chk) {}
 static inline bool spellcheck_test(void * chk, const char * word) { return false; }
 static inline int spellcheck_suggest(void * chk, char ***sug, const char * word) { return 0; }
-static inline void spellcheck_free_suggest(char **sug, int size) {}
+static inline void spellcheck_free_suggest(void * chk, char **sug, int size) {}
 
 #endif 

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1441,8 +1441,6 @@ static bool morpheme_split(Sentence sent, Gword *unsplit_word, const char *word)
 }
 
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
-/* TODO Change !spell to be an integer which will be this limit. */
-
 static bool is_known_word(Sentence sent, const char *word)
 {
 	return (boolean_dictionary_lookup(sent->dict, word) ||

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1527,7 +1527,7 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 
 		if (num_guesses >= opts->use_spell_guess) break;
 	}
-	if (alternates) spellcheck_free_suggest(alternates, n);
+	if (alternates) spellcheck_free_suggest(dict->spell_checker, alternates, n);
 
 	return ((num_guesses > 0) || (runon_word_corrections > 0));
 }

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1155,8 +1155,10 @@ static void tokenization_done(Dictionary dict, Gword *altp)
 	}
 }
 
+#if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 /**
  * Set the status of all the words in a given alternative.
+ * Currently used to mark words that are a result of a spelling.
  */
 static void set_alt_word_status(Dictionary dict, Gword *altp,
                                 unsigned int status)
@@ -1181,6 +1183,7 @@ static void set_alt_word_status(Dictionary dict, Gword *altp,
 		if (MT_INFRASTRUCTURE == altp->unsplit_word->morpheme_type) break;
 	}
 }
+#endif /* HAVE_HUNSPELL */
 
 
 #define HEB_PRENUM_MAX 5   /* no more than 5 prefix "subwords" */


### PR DESCRIPTION
Changes:
1. Change the default configured speller to hunspell, because aspell is currently not thread safe.
(I actually observed failures due to that several times.)
2. Fix accumulated **memory leak** in spellcheck-hun.c.
3. Fix a compilation warning when no spell checker is configured.
4. Fix a **bug** in spell results which can stem-suffix split.
5. Add more languages to the aspell/hunspell hard coded configuration.
6. If the spell checker feature is configured in, but the spell checker
initialization fails from some reason (e.g. system misconfiguration or
missing spelling support for the language), currently no warning
is printed. Add: `Info: Spell checker disabled.`
Add TODOs regarding the above:
  - Set the spell option to 0, to signify no spell checking is done.
  - On verbosity >= 1, add a detailed message on the reason.

-7. Remove a TODO comment that has already implemented:
`/* TODO Change !spell to be an integer which will be this limit. */`

---
Should it be done (it's easy to implement):
Instead of hard coding  the list of languages and their suffix file names, add a definition in the **affix** file, e.g:
`en_US:  SPELLCHECK+;`

This has the following benefits:
- Easy to add/remove the spelling feature for existing/new languages.
- The user can select the variant of the spelling, e.g. en_GB instead of en_US.

Actually, I would implement a list, when the first one that is found is used (7 here is the number of guesses used, so even this would not be hard coded):
`en_US en-US 7: SPELLCHECK+;`