### PR TITLE
Python binding fixes

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -21,20 +21,22 @@ def desc(linkage):
 
 
 # English is the default language
-linkages = Sentence("This is a test.", Dictionary(), po).parse()
-print "English: found ", len(linkages), "linkages"
+sent = Sentence("This is a test.", Dictionary(), po)
+linkages = sent.parse()
+print "English: found ", sent.num_valid_linkages(), "linkages"
 for linkage in linkages:
     desc(linkage)
 
 # Russian
-linkages = Sentence("это большой тест.", Dictionary('ru'), po).parse()
-print "Russian: found ", len(linkages), "linkages"
+sent = Sentence("это большой тест.", Dictionary('ru'), po)
+linkages = sent.parse()
+print "Russian: found ", sent.num_valid_linkages(), "linkages"
 for linkage in linkages:
     desc(linkage)
 
 # Turkish
-linkages = Sentence("çok şişman adam geldi", Dictionary('tr'), po).parse()
-print "Turkish: found ", len(linkages), "linkages"
+sent = Sentence("çok şişman adam geldi", Dictionary('tr'), po)
+linkages = sent.parse()
+print "Turkish: found ", sent.num_valid_linkages(), "linkages"
 for linkage in linkages:
     desc(linkage)
-

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -5,7 +5,6 @@
 #
 import os
 import locale
-from itertools import chain
 import unittest
 
 from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -508,7 +508,6 @@ class ZRULangTestCase(unittest.TestCase):
         self.assertEqual(linkage.link(5),
                          Link(linkage, 5, '.','RW','RW','RIGHT-WALL'))
 
-
     # Expect morphological splitting to apply.
     def test_d_morphology(self):
         self.po.display_morphology = True
@@ -528,9 +527,9 @@ def linkage_testfile(self, dict, popt):
     parses = open(clg.test_data_srcdir + "parses-" + clg.dictionary_get_lang(dict._obj) + ".txt")
     diagram = None
     sent = None
-    for line in parses :
+    for line in parses:
         # Lines starting with I are the input sentences
-        if 'I' == line[0] :
+        if 'I' == line[0]:
             sent = line[1:]
             diagram = ""
             constituents = ""
@@ -538,22 +537,22 @@ def linkage_testfile(self, dict, popt):
             linkage = linkages.next()
 
         # Generate the next linkage of the last input sentence
-        if 'N' == line[0] :
+        if 'N' == line[0]:
             diagram = ""
             constituents = ""
             linkage = linkages.next()
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line
-        if 'O' == line[0] :
+        if 'O' == line[0]:
             diagram += line[1:]
-            if '\n' == line[1] and 1 < len(diagram) :
+            if '\n' == line[1] and 1 < len(diagram):
                 self.assertEqual(linkage.diagram(), diagram)
 
         # Lines starting with C are the constituent output (type 1)
         # It ends with an empty line
-        if 'C' == line[0] :
-            if '\n' == line[1] and 1 < len(constituents) :
+        if 'C' == line[0]:
+            if '\n' == line[1] and 1 < len(constituents):
                 self.assertEqual(linkage.constituent_tree(), constituents)
             constituents += line[1:]
     parses.close()

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -13,16 +13,16 @@ __all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence']
 
 class ParseOptions(object):
     def __init__(self, verbosity=0,
-                       linkage_limit=100,
-                       min_null_count=0,
-                       max_null_count=0,
-                       islands_ok=False,
-                       short_length=6,
-                       all_short_connectors=False,
-                       display_morphology=False,
-                       spell_guess=False,
-                       max_parse_time=-1,
-                       disjunct_cost=2.7):
+                 linkage_limit=100,
+                 min_null_count=0,
+                 max_null_count=0,
+                 islands_ok=False,
+                 short_length=6,
+                 all_short_connectors=False,
+                 display_morphology=False,
+                 spell_guess=False,
+                 max_parse_time=-1,
+                 disjunct_cost=2.7):
 
         self._obj = clg.parse_options_create()
         self.verbosity = verbosity
@@ -326,7 +326,6 @@ class Linkage(object):
 
     def constituent_tree(self, mode=1):
         return clg.linkage_print_constituent_tree(self._obj, mode)
-
 
 class Sentence(object):
     text = None

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -318,7 +318,7 @@ class Linkage(object):
     def diagram(self, display_walls=False, screen_width=180):
         return clg.linkage_print_diagram(self._obj, display_walls, screen_width)
 
-    def postscript(self, display_walls=True, print_ps_header=0):
+    def postscript(self, display_walls=True, print_ps_header=False):
         return clg.linkage_print_postscript(self._obj, display_walls, print_ps_header)
 
     def senses(self):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -347,8 +347,24 @@ class Sentence(object):
     def split(self):
         return clg.sentence_split(self._obj)
 
-    def parse(self):
-        n = clg.sentence_parse(self._obj, self.parse_options._obj)
-        for i in xrange(n):
-            yield Linkage(i, self, self.parse_options._obj)
+    def num_valid_linkages(self):
+        return clg.sentence_num_valid_linkages(self._obj)
 
+    class sentence_parse(object):
+        def __init__(self, sent):
+            self.sent = sent
+            self.num = 0
+            clg.sentence_parse(sent._obj, sent.parse_options._obj)
+
+        def __iter__(self):
+            return self
+
+        def next(self):
+            if self.num == clg.sentence_num_valid_linkages(self.sent._obj):
+                raise StopIteration()
+            linkage = Linkage(self.num, self.sent, self.sent.parse_options._obj)
+            self.num += 1
+            return linkage
+
+    def parse(self):
+        return self.sentence_parse(self)


### PR DESCRIPTION
This patch includes a major implementation change (in a backward compatible way to the current implementation) of the linkage iterator. It enables obtaining the number of linkages without pre-computing all the linkages in advance.

It passes tests.py, and I also tested it with a sentence parse interleaving (using 2 sentences from different dictionaries).

