### PR TITLE
More Python bindings fixes

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf8 -*-
 #
-# Link Grammar example usage 
+# Link Grammar example usage
 #
 import locale
 
@@ -13,10 +13,10 @@ locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
 po = ParseOptions()
 
-def desc(linkage):
-    print linkage.diagram()
+def desc(lkg):
+    print lkg.diagram()
     print 'Postscript:'
-    print linkage.postscript()
+    print lkg.postscript()
     print '---'
 
 

--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -8,10 +8,10 @@ import locale
 from linkgrammar import Sentence, ParseOptions, Dictionary
 # from linkgrammar import _clinkgrammar as clg
 
-
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
 po = ParseOptions()
+#po = ParseOptions(linkage_limit=3)
 
 def desc(lkg):
     print lkg.diagram()
@@ -19,24 +19,40 @@ def desc(lkg):
     print lkg.postscript()
     print '---'
 
+def s(q):
+    return '' if q == 1 else 's'
+
+def linkage_stat(psent, lang):
+    """
+    This function mimics the linkage status report style of link-parser
+    """
+    random = ' of {0} random linkages'. \
+             format(psent.num_linkages_post_processed()) \
+             if psent.num_valid_linkages() < psent.num_linkages_found() else ''
+
+    print '{0}: Found {1} linkage{2} ({3}{4} had no P.P. violations)'. \
+          format(lang, psent.num_linkages_found(),
+                 s(psent.num_linkages_found()),
+                 psent.num_valid_linkages(), random)
+
 
 # English is the default language
 sent = Sentence("This is a test.", Dictionary(), po)
 linkages = sent.parse()
-print "English: found ", sent.num_valid_linkages(), "linkages"
+linkage_stat(sent, 'English')
 for linkage in linkages:
     desc(linkage)
 
 # Russian
 sent = Sentence("это большой тест.", Dictionary('ru'), po)
 linkages = sent.parse()
-print "Russian: found ", sent.num_valid_linkages(), "linkages"
+linkage_stat(sent, 'Russian')
 for linkage in linkages:
     desc(linkage)
 
 # Turkish
 sent = Sentence("çok şişman adam geldi", Dictionary('tr'), po)
 linkages = sent.parse()
-print "Turkish: found ", sent.num_valid_linkages(), "linkages"
+linkage_stat(sent, 'Turkish')
 for linkage in linkages:
     desc(linkage)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -344,8 +344,10 @@ class Sentence(object):
             clg.sentence_delete(self._obj)
             del self._obj
 
-    def split(self):
-        return clg.sentence_split(self._obj)
+    def split(self, parse_options=None):
+        if not parse_options:
+            parse_options = self.parse_options
+        return clg.sentence_split(self._obj, parse_options._obj)
 
     def num_valid_linkages(self):
         return clg.sentence_num_valid_linkages(self._obj)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -362,6 +362,12 @@ class Sentence(object):
     def num_valid_linkages(self):
         return clg.sentence_num_valid_linkages(self._obj)
 
+    def num_linkages_found(self):
+        return clg.sentence_num_linkages_found(self._obj)
+
+    def num_linkages_post_processed(self):
+        return clg.sentence_num_linkages_post_processed(self._obj)
+
     class sentence_parse(object):
         def __init__(self, sent):
             self.sent = sent

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -330,7 +330,10 @@ class Linkage(object):
 class Sentence(object):
     """
     sent = Sentence("This is a test.", Dictionary(), ParseOptions())
-    if sent.split(ParseOptions(verbosity=2)) < 0: # split() before parse() is optional
+    # split() before parse() is optional.
+    # split() has ParseOptions as an optional argument
+    # (defaults to that of Sentence)
+    if sent.split(ParseOptions(verbosity=2)) < 0:
         print "Cannot split sentence"
     else
         linkages = sent.parse()

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -328,14 +328,21 @@ class Linkage(object):
         return clg.linkage_print_constituent_tree(self._obj, mode)
 
 class Sentence(object):
+    """
+    sent = Sentence("This is a test.", Dictionary(), ParseOptions())
+    if sent.split(ParseOptions(verbosity=2)) < 0: # split() before parse() is optional
+        print "Cannot split sentence"
+    else
+        linkages = sent.parse()
+        print "English: found ", sent.num_valid_linkages(), "linkages"
+        for linkage in linkages:
+            print linkage.diagram()
+    """
     text = None
     dict = None
     parse_options = None
 
     def __init__(self, text, dict, parse_options):
-        """
-        In python 2.x, txt should be unicode string like u'Bo-bo-bo'
-        """
         self.text, self.dict, self.parse_options = text, dict, parse_options  # keep all args passed into clg.* fn
         self._obj = clg.sentence_create(self.text, self.dict._obj)
 


### PR DESCRIPTION
**1.** Bug fix::
```
  File "/usr/local/src/link-grammar-devel/python/bindings/python/linkgrammar.py", line 353, in split
    return clg.sentence_split(self._obj)
TypeError: sentence_split() takes exactly 2 arguments (1 given)
```
The required ParseOptions argument has been added as an optional one, which defaults to the ParseOptions of Sentence().

Currently Sentence.parse() has no arguments, and it uses the ParseOptions of Sentence().
**Question**: Is it useful to add it an optional ParseOptions argument?

**2.** For Sentence(), add a docstring describing the usage.

**3.** Add ￼	bindings for sentence_num_valid_linkages() and sentence_num_linkages_post_processed(). Also extend example.py to use them, mimicking the linkage status message of link-parser.