### PR TITLE
Links

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -657,6 +657,7 @@ static void compute_chosen_disjuncts(Sentence sent)
 	{
 		Linkage lkg = &sent->lnkages[in];
 		Linkage_info *lifo = &lkg->lifo;
+
 		if (lifo->discarded || lifo->N_violations) continue;
 
 		partial_init_linkage(lkg, pi->N_words);
@@ -691,8 +692,8 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 		{
 			Linkage lkg = &sent->lnkages[in];
 			Linkage_info *lifo = &lkg->lifo;
-			if (lifo->discarded) continue;
-			if (lifo->N_violations) continue;
+
+			if (lifo->discarded || lifo->N_violations) continue;
 
 			post_process_scan_linkage(sent->postprocessor, lkg);
 
@@ -707,7 +708,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 		Linkage lkg = &sent->lnkages[in];
 		Linkage_info *lifo = &lkg->lifo;
 
-		if (lifo->discarded) continue; /* Invalid morphism construction */
+		if (lifo->discarded || lifo->N_violations) continue;
 
 		ppn = do_post_process(sent->postprocessor, lkg, twopass);
 
@@ -743,7 +744,9 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 	{
 		Linkage lkg = &sent->lnkages[in];
 		Linkage_info *lifo = &lkg->lifo;
-		if (lifo->discarded) continue;
+
+		if (lifo->discarded || lifo->N_violations) continue;
+
 		N_valid_linkages--;
 		lifo->N_violations++;
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -776,7 +776,7 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
 	      sizeof(struct Linkage_s),
 	      (int (*)(const void *, const void *))opts->cost_model.compare_fn);
 
-#if 0
+#ifdef DEBUG
 	/* num_linkages_post_processed sanity check (ONLY). */
 	{
 		size_t in;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -718,7 +718,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 		ppn = do_post_process(sent->postprocessor, lkg, twopass);
 
 		/* XXX There is no need to set the domain names if we are not
-		 * printing them. However, defering this until later requires
+		 * printing them. However, deferring this until later requires
 		 * a huge code re-org, because the needed info is discarded
 		 * much too soon. This costs about 1% performance penalty. */
 		linkage_set_domain_names(sent->postprocessor, lkg);
@@ -1081,13 +1081,13 @@ static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
  * FIXME? In this version of the function, 'b' is not yet supported,
  * so "w|ts" is converted to "^(w|ts)+$" for now. */
 
-#define AFFIXTYPE_PREFIX	'p'	/* prefix */
-#define AFFIXTYPE_STEM		't'	/* stem */
-#define AFFIXTYPE_SUFFIX	's'	/* suffix */
-#define AFFIXTYPE_MIDDLE	'm'	/* middle morpheme */
-#define AFFIXTYPE_WORD		'w'	/* regular word */
+#define AFFIXTYPE_PREFIX   'p'   /* prefix */
+#define AFFIXTYPE_STEM     't'   /* stem */
+#define AFFIXTYPE_SUFFIX   's'   /* suffix */
+#define AFFIXTYPE_MIDDLE   'm'   /* middle morpheme */
+#define AFFIXTYPE_WORD     'w'   /* regular word */
 #ifdef WORD_BOUNDARIES
-#define AFFIXTYPE_END		'b'	/* end of input word */
+#define AFFIXTYPE_END      'b'   /* end of input word */
 #endif
 
 /**

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -624,26 +624,7 @@ static void remove_empty_words(Linkage lkg)
 		print_chosen_disjuncts_words(lkg);
 	}
 
-	for (i = 0, j = 0; i < lkg->num_links; i++)
-	{
-		const Link *old_lnk = &(lkg->link_array[i]);
-
-		if ((-1 != remap[old_lnk->rw]) && (-1 != remap[old_lnk->lw]))
-		{
-			Link *new_lnk = &(lkg->link_array[j]);
-
-			/* Copy the entire link contents, thunking the word numbers.
-			 * Note that j is always <= i so this is always safe. */
-			new_lnk->lw = remap[old_lnk->lw];
-			new_lnk->rw = remap[old_lnk->rw];
-			new_lnk->lc = old_lnk->lc;
-			new_lnk->rc = old_lnk->rc;
-			new_lnk->link_name = old_lnk->link_name;
-			j++;
-		}
-	}
-	lkg->num_links = j;
-	/* Unused memory not freed - all of it will be freed in free_linkages(). */
+	remap_linkages(lkg, remap); /* Update lkg->link_array and lkg->num_links. */
 }
 
 /** The extract_links() call sets the chosen_disjuncts array */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -661,6 +661,7 @@ static void compute_chosen_disjuncts(Sentence sent)
 
 		partial_init_linkage(lkg, pi->N_words);
 		extract_links(lkg, pi);
+		compute_link_names(lkg, sent->string_set);
 		/* Because the empty words are used only in the parsing stage, they are
 		 * removed here along with their links, so from now on we will not need to
 		 * consider them. */
@@ -691,10 +692,6 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 			Linkage lkg = &sent->lnkages[in];
 			Linkage_info *lifo = &lkg->lifo;
 			if (lifo->discarded) continue;
-
-			/* We still need link names, even if there has been a morfo
-			 * violation. */
-			compute_link_names(lkg, sent->string_set);
 			if (lifo->N_violations) continue;
 
 			post_process_scan_linkage(sent->postprocessor, lkg);
@@ -711,9 +708,6 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 		Linkage_info *lifo = &lkg->lifo;
 
 		if (lifo->discarded) continue; /* Invalid morphism construction */
-
-		/* We need link names, even if morfo check fails */
-		if (!twopass) compute_link_names(lkg, sent->string_set);
 
 		ppn = do_post_process(sent->postprocessor, lkg, twopass);
 
@@ -750,7 +744,6 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 		Linkage lkg = &sent->lnkages[in];
 		Linkage_info *lifo = &lkg->lifo;
 		if (lifo->discarded) continue;
-		if (!twopass) compute_link_names(lkg, sent->string_set);
 		N_valid_linkages--;
 		lifo->N_violations++;
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -153,6 +153,13 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
 /* TODO? !display_guess_marks is not implemented. */
 #define DISPLAY_GUESS_MARKS true // (opts->display_guess_marks)
 
+/* FIXME: Define an affix class MORPHOLOGY_LINKS. */
+static inline bool is_morphology_link(const char *link_name)
+{
+	return (NULL != link_name) &&
+	        (0 == strncmp(link_name, SUFFIX_SUPPRESS, SUFFIX_SUPPRESS_L));
+}
+
 /*
  * Remap the link array according to discarded words.
  * The remap[] elements indicate the new WordIdx of the word.
@@ -216,7 +223,8 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 	WordIdx j;
 	Disjunct **cdjp = linkage->chosen_disjuncts;
 	const char **chosen_words = alloca(linkage->num_words * sizeof(*chosen_words));
-	size_t *remap = alloca(linkage->num_words * sizeof(*remap));
+	int *remap = alloca(linkage->num_words * sizeof(*remap));
+	bool *show_word = alloca(linkage->num_words * sizeof(*show_word));
 	bool display_morphology = opts->display_morphology;
 
 	Gword **lwg_path = linkage->wg_path;
@@ -232,6 +240,8 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 	Gword **nullblock_start = NULL; /* start of a null block, to be put in [] */
 	size_t nbsize = 0;              /* number of word in a null block */
 	Gword *unsplit_word = NULL;
+
+	memset(show_word, 0, linkage->num_words * sizeof(*show_word));
 
 	if (D_CCW <= opts->verbosity)
 		print_lwg_path(lwg_path);
@@ -327,6 +337,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 
 				nullblock_start = NULL;
 				nbsize = 0;
+				show_word[i] = true;
 
 				/* Put brackets around the null word. */
 				l = strlen(t) + 2;
@@ -337,6 +348,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				s[l] = '\0';
 				t = string_set_add(s, sent->string_set);
 				lgdebug(D_CCW, " %s\n", t);
+				/* Null words have no links, so take care not to drop them. */
 			}
 		}
 		else
@@ -450,13 +462,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 								{
 									sm += 1 + STEM_MARK_L; /* sm+strlen(".=") */
 									if ('\0' == *sm) sm = NULL;
-									/* FIXME: By NULLifying the stem subword here, we
-									 * suppose thats a stem has only LL-type link, which
-									 * will get removed here later. In case it has non-LL
-									 * links, then drawing the links diagram would
-									 * segfault. We could use " " but it draws an
-									 * extra blank in the diagram. */
-									chosen_words[i+m] = NULL;
 #if 0
 									if ((cnt-1) == m)
 									{
@@ -595,86 +600,48 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		}
 	}
 
+	if (HIDE_MORPHO)
+	{
+		/* Discard morphology links. */
+		for (i=0; i<linkage->num_links; i++)
+		{
+			Link * lnk = &linkage->link_array[i];
+
+			if (is_morphology_link(lnk->link_name))
+			{
+				/* Mark link for discarding. */
+				lnk->link_name = NULL;
+			}
+			else
+			{
+				/* Mark word for not discarding. */
+				show_word[lnk->rw] = true;
+				show_word[lnk->lw] = true;
+			}
+		}
+	}
+
 	/* We alloc a little more than needed, but so what... */
 	linkage->word = (const char **) exalloc(linkage->num_words*sizeof(char *));
 
 	/* Copy over the chosen words, dropping the discarded words. */
 	for (i=0, j=0; i<linkage->num_words; ++i)
 	{
-		if (chosen_words[i])
+		if (chosen_words[i] && (!HIDE_MORPHO || show_word[i]))
 		{
 			linkage->word[j] = chosen_words[i];
 			remap[i] = j;
 			j++;
 		}
+		else
+		{
+			remap[i] = -1;
+		}
 	}
 	linkage->num_words = j;
 
-#if 0
-	/* Now, discard links to the empty word.  If morphology printing
-	 * is being suppressed, then all links connecting morphemes will
-	 * be discarded as well.
-	 */
-	for (i=0, j=0; i<linkage->num_links; i++)
-	{
-		Link * lnk = &(linkage->link_array[i]);
-		if (NULL == chosen_words[lnk->lw] ||
-		    NULL == chosen_words[lnk->rw])
-		{
-			bool sane = (0 == strcmp(lnk->link_name, EMPTY_WORD_SUPPRESS));
-			sane = sane || (HIDE_MORPHO &&
-			     0 == strncmp(lnk->link_name, SUFFIX_SUPPRESS, SUFFIX_SUPPRESS_L));
-			assert(sane, "Something wrong with linkage processing");
-		}
-		else
-		{
-			/* Copy the entire link contents, thunking the word numbers.
-			 * Note that j is always <= i so this is always safe. */
-			linkage->link_array[j].lw = remap[lnk->lw];
-			linkage->link_array[j].rw = remap[lnk->rw];
-			linkage->link_array[j].lc = linkage->link_array[i].lc;
-			linkage->link_array[j].rc = linkage->link_array[i].rc;
-			linkage->link_array[j].link_name = linkage->link_array[i].link_name;
-			j++;
-		}
-	}
-	linkage->num_links = j;
-#else
-	/* A try to be more general (FIXME: It is not enough).
-	 * Discard the LL links unconditionally.
-	 * The NULL||'\0'||' ' is to allow easy feature experiments.
-	 * FIXME: Define an affix class MORPHOLOGY_LINKS. */
-	for (i=0, j=0; i<linkage->num_links; i++)
-	{
-		Link *old_lnk = &(linkage->link_array[i]);
-		const char *lcw = chosen_words[old_lnk->lw];
-		const char *rcw = chosen_words[old_lnk->rw];
+	remap_linkages(linkage, remap); /* Update linkage->link_array / num_links. */
 
-		if (((NULL == lcw) || ('\0' == *lcw) || (' ' == *lcw) ||
-			 (NULL == rcw) || ('\0' == *rcw) || (' ' == *rcw)) &&
-			 ((0 == strcmp(old_lnk->link_name, EMPTY_WORD_SUPPRESS)) ||
-			  (HIDE_MORPHO &&
-			   (0 == strncmp(old_lnk->link_name, SUFFIX_SUPPRESS, SUFFIX_SUPPRESS_L)))))
-		{
-			;
-		}
-		else
-		{
-			Link * new_lnk = &(linkage->link_array[j]);
-
-			/* Copy the entire link contents, thunking the word numbers.
-			 * Note that j is always <= i so this is always safe. */
-			new_lnk->lw = remap[old_lnk->lw];
-			new_lnk->rw = remap[old_lnk->rw];
-			new_lnk->lc = old_lnk->lc;
-			new_lnk->rc = old_lnk->rc;
-			new_lnk->link_name = old_lnk->link_name;
-			j++;
-		}
-	}
-#endif
-
-	linkage->num_links = j;
 	linkage->wg_path_display = n_lwg_path;
 
 	if (D_CCW <= opts->verbosity)

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -591,6 +591,8 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		}
 	}
 
+	/* If morphology printing is being suppressed, then all links
+	 * connecting morphemes will be discarded. */
 	if (HIDE_MORPHO)
 	{
 		/* Discard morphology links. */

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -339,16 +339,19 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				nbsize = 0;
 				show_word[i] = true;
 
-				/* Put brackets around the null word. */
-				l = strlen(t) + 2;
-				s = (char *) alloca(l+1);
-				s[0] = NULLWORD_START;
-				strcpy(&s[1], t);
-				s[l-1] = NULLWORD_END;
-				s[l] = '\0';
-				t = string_set_add(s, sent->string_set);
-				lgdebug(D_CCW, " %s\n", t);
-				/* Null words have no links, so take care not to drop them. */
+				if (MT_WALL != w->morpheme_type)
+				{
+					/* Put brackets around the null word. */
+					l = strlen(t) + 2;
+					s = (char *) alloca(l+1);
+					s[0] = NULLWORD_START;
+					strcpy(&s[1], t);
+					s[l-1] = NULLWORD_END;
+					s[l] = '\0';
+					t = string_set_add(s, sent->string_set);
+					lgdebug(D_CCW, " %s\n", t);
+					/* Null words have no links, so take care not to drop them. */
+				}
 			}
 		}
 		else
@@ -576,15 +579,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 
 		assert(t != NULL, "Word %zu: NULL", i);
 		chosen_words[i] = t;
-	}
-
-	if (sent->dict->left_wall_defined)
-	{
-		chosen_words[0] = LEFT_WALL_DISPLAY;
-	}
-	if (sent->dict->right_wall_defined)
-	{
-		chosen_words[linkage->num_words-1] = RIGHT_WALL_DISPLAY;
 	}
 
 	/* Conditional test removal of quotation marks and the "capdict" tokens,

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -35,6 +35,10 @@
 #define INFIX_MARK_L 1 /* INFIX_MARK is 1 character */
 #define STEM_MARK_L  1 /* stem mark is 1 character */
 
+/* Marks around a null word. */
+#define NULLWORD_START '['
+#define NULLWORD_END   ']'
+
 /**
  * Append an unmarked (i.e. without INFIXMARK) morpheme to join_buff.
  * join_buff is a zeroed-out buffer which has enough room for morpheme to be
@@ -327,9 +331,9 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				/* Put brackets around the null word. */
 				l = strlen(t) + 2;
 				s = (char *) alloca(l+1);
-				s[0] = '[';
+				s[0] = NULLWORD_START;
 				strcpy(&s[1], t);
-				s[l-1] = ']';
+				s[l-1] = NULLWORD_END;
 				s[l] = '\0';
 				t = string_set_add(s, sent->string_set);
 				lgdebug(D_CCW, " %s\n", t);

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -40,7 +40,7 @@
  * join_buff is a zeroed-out buffer which has enough room for morpheme to be
  * added + terminating NUL.
  * In case INFIXMARK is not defined in the affix file, it is '\0'. However,
- * in that case are no MT_PREFIX, MT_SUFFIX and MT_MIDDLE morpheme types.
+ * in that case there are no MT_PREFIX, MT_SUFFIX and MT_MIDDLE morpheme types.
  *
  * FIXME Combining contracted words is not handled yet, because combining
  * morphemes which have non-LL links to other words is not yet implemented.
@@ -214,8 +214,8 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		size_t m;
 
 		lgdebug(D_CCW, "Loop start, word%zu: cdj %s, path %s\n",
-				  i, cdj ? cdj->string : "NULL",
-				  lwg_path[i] ? lwg_path[i]->subword : "NULL");
+		        i, cdj ? cdj->string : "NULL",
+		        lwg_path[i] ? lwg_path[i]->subword : "NULL");
 
 		w = lwg_path[i];
 		nw = lwg_path[i+1];
@@ -264,7 +264,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 					lgdebug(D_CCW, "Combining null subwords");
 					/* Use alternative_id to check for start of alternative. */
 					if (((*nullblock_start)->alternative_id == *nullblock_start)
-								&& nb_end)
+					    && nb_end)
 					{
 						/* Case 2: A null unsplit_word (all-nulls alternative).*/
 						lgdebug(D_CCW, " (null alternative)\n");
@@ -692,7 +692,7 @@ size_t linkage_get_num_links(const Linkage linkage)
 static inline bool verify_link_index(const Linkage linkage, LinkIdx index)
 {
 	if (!linkage) return false;
-	if	(index >= linkage->num_links) return false;
+	if (index >= linkage->num_links) return false;
 	return true;
 }
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -466,7 +466,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 			if (!join_alt) gwordlist_append(&n_lwg_path, *wgp);
 
 			/*
-			 * Add ->regex_name marks in [] if needed, at the end of the base word.
+			 * Add guess marks in [] if needed, at the end of the base word.
 			 * Convert the badly-printing ^C into a period.
 			 */
 			if (t)

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -358,9 +358,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		{
 			/* This word has a linkage. */
 
-			/* FIXME If the original word was capitalized in a capitalizable
-			 * position, the displayed word may be its downcase version. */
-
 			/* TODO: Suppress "virtual-morphemes", currently the dictcap ones. */
 			char *sm;
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -133,10 +133,10 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
  * below, we remove them from the linkage, as well as the links that
  * connect to them.
  *
- * The empty word device must be defined in the dictionary of every language for
- * which alternatives can be generated. This may happen in case of morpheme and
- * contraction splitting, spell ->regex_names, and unit-strip.
- * For more information, see EMPTY_WORD.zzz in the dict file.
+ * When the word-graph is converted ("flattened") to the 2D array used by
+ * the parser, empty words are issued whenever needed.  This essentially
+ * means that the empty word (EMPTY-WORD.zzz) must be defined in the
+ * dictionary of every language.
  */
 #define EMPTY_WORD_SUPPRESS ("ZZZ") /* link to pure whitespace */
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -149,6 +149,39 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
 /* TODO? !display_guess_marks is not implemented. */
 #define DISPLAY_GUESS_MARKS true // (opts->display_guess_marks)
 
+/*
+ * Remap the link array according to discarded words.
+ * The remap[] elements indicate the new WordIdx of the word.
+ * A value which is -1 indicates a discarded word.
+ * A NULL link_array element indicates a discarded link.
+ */
+void remap_linkages(Linkage lkg, const int *remap)
+{
+	LinkIdx i, j;
+
+	for (i = 0, j = 0; i < lkg->num_links; i++)
+	{
+		const Link *old_lnk = &lkg->link_array[i];
+
+		if (NULL == old_lnk->link_name) continue; /* discarded link */
+		if ((-1 != remap[old_lnk->rw]) && (-1 != remap[old_lnk->lw]))
+		{
+			Link *new_lnk = &lkg->link_array[j];
+
+			/* Copy the entire link contents, thunking the word numbers.
+			 * Note that j is always <= i so this is always safe. */
+			new_lnk->lw = remap[old_lnk->lw];
+			new_lnk->rw = remap[old_lnk->rw];
+			new_lnk->lc = old_lnk->lc;
+			new_lnk->rc = old_lnk->rc;
+			new_lnk->link_name = old_lnk->link_name;
+			j++;
+		}
+	}
+	lkg->num_links = j;
+	/* Unused memory not freed - all of it will be freed in free_linkages(). */
+}
+
 /**
  * This takes the Wordgraph path array and uses it to
  * compute the chosen_words array.  "I.xx" suffixes are eliminated.

--- a/link-grammar/linkage.h
+++ b/link-grammar/linkage.h
@@ -1,4 +1,4 @@
-
+void remap_linkages(Linkage, const int *remap);
 void compute_chosen_words(Sentence, Linkage, Parse_Options);
 
 void partial_init_linkage(Linkage, unsigned int N_words);


### PR DESCRIPTION
- Bug fix - HIDE_MORPHO correct the handling of stems with non-LL links.
- Cosmetic changes (fix whitespace/typos).
- Comment changes (correct/improve/remove).
- Code rearrangement, simplification  and unification.
- Add hooks for extensions (is_morphology_link(), macros).

BTW, I didn't forget the need to move the HIDE_MPRPHO stuff to a separate function (issue #39).