### PR TITLE
Defer computing link domain names.

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -283,6 +283,9 @@ struct PP_data_s
 	List_o_links * links_to_ignore;
 };
 
+/* A new Postprocessor stuct is alloe for each sentence. It contains
+ * sentence-specific post-processing nformation.
+ */
 struct Postprocessor_s
 {
 	pp_knowledge  * knowledge;           /* Internal rep'n of the actual rules */
@@ -293,9 +296,10 @@ struct Postprocessor_s
 	int *relevant_contains_one_rules;        /* -1-terminated list of indices  */
 	int *relevant_contains_none_rules;
 	bool q_pruned_rules;       /* don't prune rules more than once in p.p. */
-
-	/* The following maintain state during a call to post_process() */
 	String_set *string_set;      /* Link names seen for sentence */
+
+	/* Per-linkage state; this data must be reset prior to processing
+	 * each new linkage. */
 	bool *visited;               /* For the depth-first search */
 	size_t vlength;              /* Length of visited array */
 	PP_node *pp_node;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -695,9 +695,12 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 
 		/* XXX There is no need to set the domain names if we are not
 		 * printing them. However, deferring this until later requires
-		 * a huge code re-org, because the needed info is discarded
-		 * much too soon. This costs about 1% performance penalty. */
-		linkage_set_domain_names(sent->postprocessor, lkg);
+		 * a huge code re-org, because pp_data is needed to get the
+		 * domain type array, and pp_data is deleted immedately below.
+		 * Basically, pp_data should be a part of the linkage, and not
+		 * part of the Postprocessor struct.
+		 * This costs about 1% performance penalty. */
+		build_type_array(sent->postprocessor);
 
 	   post_process_free_data(&sent->postprocessor->pp_data);
 

--- a/link-grammar/post-process.h
+++ b/link-grammar/post-process.h
@@ -41,6 +41,7 @@ bool     post_process_match(const char *, const char *);  /* utility function */
 bool sane_linkage_morphism(Sentence, Linkage, Parse_Options);
 
 void linkage_free_pp_info(Linkage);
-void linkage_set_domain_names(Postprocessor *, Linkage);
+
+void build_type_array(Postprocessor*);
 
 #endif


### PR DESCRIPTION
If these are never printed, then the names do not need to be computed.

Pursuant to discussion in bug #160 