### PR TITLE
constituents.c: Initialize err_ctxt before error messages.

### DIFF
--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -651,7 +651,7 @@ static const char * cons_of_domain(const Linkage linkage, char domain_type)
 		return "VP";
 	default:
 		{
-			err_ctxt ec;
+			err_ctxt ec = { linkage->sent };
 			err_msg(&ec, Error, "Error: Illegal domain: %c\n", domain_type);
 			return "";
 		}
@@ -807,12 +807,12 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 
 		if (ctxt->constituent[c].domain_type == '\0')
 		{
-			err_ctxt ec;
+			err_ctxt ec = { linkage->sent };
 			err_msg(&ec, Error, "Error: no domain type assigned to constituent\n");
 		}
 		if (ctxt->constituent[c].start_link == NULL)
 		{
-			err_ctxt ec;
+			err_ctxt ec = { linkage->sent };
 			err_msg(&ec, Error, "Error: no type assigned to constituent\n");
 		}
 	}
@@ -917,7 +917,7 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 					{
 						if (verbosity >= 2)
 						{
-							err_ctxt ec;
+							err_ctxt ec = { linkage->sent };
 							err_msg(&ec, Warn,
 							      "Warning: the constituents aren't nested! "
 							      "Adjusting them. (%d, %d)\n", c, c2);


### PR DESCRIPTION
This fixes the crash when notifying domain errors.
You may want to apply it before starting debugging #183. 