### PR TITLE
Fix "Error: Illegal domain" (issue #183)

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -444,7 +444,6 @@ static void free_linkages(Sentence sent)
 		/* Note: linkage->hpsg_pp_data.domain_array originally got
 		 * allocated in sent->constituent_pp->pp_data. */
 		pp_free_domain_array(&linkage->hpsg_pp_data);
-		free(linkage->hpsg_pp_data.domain_array);
 
 		linkage_free_pp_info(linkage);
 

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -1046,6 +1046,8 @@ exprint_constituent_structure(con_context_t *ctxt,
 	return p;
 }
 
+void free_List_o_links(List_o_links *lol);
+
 static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 {
 	int numcon_total= 0, numcon_subl;
@@ -1058,6 +1060,7 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 
 	if (NULL ==  sent->constituent_pp)         /* First time for this sentence */
 		sent->constituent_pp = post_process_new(sent->dict->hpsg_knowledge);
+
 	do_post_process(sent->constituent_pp, linkage, linkage->is_sent_long);
 
 	/** No-op. If we wanted to debug domain names, we could do this...
@@ -1066,7 +1069,6 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	 */
 
 	linkage->hpsg_pp_data = sent->constituent_pp->pp_data;
-	pp_new_domain_array(&linkage->hpsg_pp_data);
 
 	numcon_subl = read_constituents_from_domains(ctxt, linkage, numcon_total);
 	numcon_total += numcon_subl;
@@ -1080,6 +1082,9 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	q = exprint_constituent_structure(ctxt, linkage, numcon_total);
 	string_set_delete(ctxt->phrase_ss);
 	ctxt->phrase_ss = NULL;
+
+	post_process_free_data(&sent->constituent_pp->pp_data);
+
 	return q;
 }
 


### PR DESCRIPTION
Fix allocation/free of constituent's pp_data,  to prevent double allocation and double free.

I must admit I don't completely understand some fine details in the allocation/free of these data structures.
However:
1. This fixes the problem without adding any  more overhead.
2. I checked it by a detailed run of all the linkages, with `!constituents=1`, of `en/4.0.batch`,
comparing it to a and older version of version just before we started to do the `pp_data` rearrangements (de7458b3b6fee2947f914573c95d9273af37a725). Both runs were done using the dict directory of the older version. There were absolutely no changes.
3. I made the said batch run with memory checks, to validate no use-after-free and that everything gets freed.