### PR TITLE
Fix the SAT solver

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -894,7 +894,6 @@ int sentence_num_violations(Sentence sent, LinkageIdx i)
 {
 	if (!sent) return 0;
 
-	/* The sat solver (currently) fails to fill in link_info */
 	if (!sent->lnkages) return 0;
 	if (sent->num_linkages_alloced <= i) return 0; /* bounds check */
 	return sent->lnkages[i].lifo.N_violations;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -580,48 +580,6 @@ void check_link_size(Linkage lkg)
 	}
 }
 
-/**
- * Remove the empty words from a linkage.
- * XXX Should we remove here also the dict-cap tokens? In any case, for now they
- * are left for debug.
- */
-static void remove_empty_words(Linkage lkg)
-{
-	size_t i, j;
-	Disjunct **cdj = lkg->chosen_disjuncts;
-	int *remap = alloca(lkg->num_words * sizeof(*remap));
-
-	if (4 <= verbosity)
-	{
-		lgdebug(0, "Info: chosen_disjuncts before removing empty words:\n");
-		print_chosen_disjuncts_words(lkg);
-	}
-
-	for (i = 0, j = 0; i < lkg->num_words; i++)
-	{
-		if ((NULL != cdj[i]) && (MT_EMPTY == cdj[i]->word[0]->morpheme_type))
-		{
-			remap[i] = -1;
-		}
-		else
-		{
-			cdj[j] = cdj[i];
-			remap[i] = j;
-			j++;
-		}
-	}
-	lkg->num_words = j;
-	/* Unused memory not freed - all of it will be freed in free_linkages(). */
-
-	if (4 <= verbosity)
-	{
-		lgdebug(0, "Info: chosen_disjuncts after removing empty words:\n");
-		print_chosen_disjuncts_words(lkg);
-	}
-
-	remap_linkages(lkg, remap); /* Update lkg->link_array and lkg->num_links. */
-}
-
 /** The extract_links() call sets the chosen_disjuncts array */
 static void compute_chosen_disjuncts(Sentence sent)
 {

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -412,16 +412,10 @@ static Linkage linkage_array_new(int num_to_alloc)
 	return lkgs;
 }
 
-static void free_linkages(Sentence sent)
+void free_linkage(Linkage linkage)
 {
-	size_t in;
-	Linkage lkgs = sent->lnkages;
-	if (!lkgs) return;
-
-	for (in=0; in<sent->num_linkages_alloced; in++)
-	{
 		size_t j;
-		Linkage linkage = &lkgs[in];
+
 		exfree((void *) linkage->word, sizeof(const char *) * linkage->num_words);
 		exfree(linkage->chosen_disjuncts, linkage->num_words * sizeof(Disjunct *));
 		free(linkage->link_array);
@@ -446,6 +440,17 @@ static void free_linkages(Sentence sent)
 		/* XXX FIXME */
 		free(linkage->wg_path);
 		free(linkage->wg_path_display);
+}
+
+static void free_linkages(Sentence sent)
+{
+	size_t in;
+	Linkage lkgs = sent->lnkages;
+	if (!lkgs) return;
+
+	for (in=0; in<sent->num_linkages_alloced; in++)
+	{
+		free_linkage(&lkgs[in]);
 	}
 
 	exfree(lkgs, sent->num_linkages_alloced * sizeof(struct Linkage_s));

--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -497,7 +497,7 @@ void build_sentence_disjuncts(Sentence sent, double cost_cutoff)
 		for (x = sent->word[w].x; x != NULL; x = x->next)
 		{
 			Disjunct *dx = build_disjuncts_for_exp(x->exp, x->string, cost_cutoff);
-			word_record_in_disjunct(x, dx);
+			word_record_in_disjunct(x->word, dx);
 			d = catenate_disjuncts(dx, d);
 		}
 		sent->word[w].d = d;

--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -347,6 +347,41 @@ void prt_exp(Exp *e, int i)
 		printf("con=%s\n", e->u.string);
 	}
 }
+
+void prt_exp_mem(Exp *e, int i)
+{
+	const char *type;
+
+	if (e == NULL) return;
+
+	if (e->type > 0 && e->type < 4)
+	{
+		type = ((const char *[]) {"OR_type", "AND_type", "CONNECTOR_type"}) [e->type-1];
+	}
+	else
+	{
+		type = "unknown";
+	}
+
+	for(int j =0; j<i; j++) printf(" ");
+	printf ("e=%p: type=%d (%s) dir=%c multi=%d cost=%f\n", e, e->type, type, e->dir, e->multi, e->cost);
+	if (e->type != CONNECTOR_type)
+	{
+		E_list *l = e->u.l;
+		for(int j =0; j<i+2; j++) printf(" ");
+		printf("E_list=%p\n", l);
+		while(l)
+		{
+			prt_exp_mem(l->e, i+2);
+			l = l->next;
+		}
+	}
+	else
+	{
+		for(int j =0; j<i; j++) printf(" ");
+		printf("con=%s\n", e->u.string);
+	}
+}
 #endif
 
 /**

--- a/link-grammar/build-disjuncts.h
+++ b/link-grammar/build-disjuncts.h
@@ -22,4 +22,5 @@ unsigned int count_disjunct_for_dict_node(Dict_node *dn);
 
 #ifdef DEBUG
 void prt_exp(Exp *, int);
+void prt_exp_mem(Exp *, int);
 #endif

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -977,8 +977,6 @@ static Exp * make_connector(Dictionary dict)
 /* ======================================================================== */
 /* Empty-word handling. */
 
-#define EMPTY_CONNECTOR "ZZZ"
-
 /** Insert empty-word connectors.
  *
  * The "empty word" is a concept used in order to make the current parser able

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -265,11 +265,11 @@ char * print_one_disjunct(Disjunct *dj)
  * Record the wordgraph word to which the X-node belongs, in each of its
  * disjuncts.
  */
-void word_record_in_disjunct(X_node * x, Disjunct * d)
+void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 {
 	for (;d != NULL; d=d->next) {
 		d->word = malloc(sizeof(*d->word)*2);
-		d->word[0] = x->word;
+		d->word[0] = gw;
 		d->word[1] = NULL;
 	}
 }

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -22,7 +22,7 @@ unsigned int count_disjuncts(Disjunct *);
 Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct * );
 char * print_one_disjunct(Disjunct *);
-void word_record_in_disjunct(X_node *, Disjunct *);
+void word_record_in_disjunct(const Gword *, Disjunct *);
 void disjunct_word_print(Disjunct *);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -15,12 +15,12 @@
 
 #include "link-includes.h"
 
-typedef struct 
+typedef struct
 {
 	Sentence sent;
 } err_ctxt;
 
-typedef enum 
+typedef enum
 {
 	Fatal = 1,
 	Error,
@@ -45,9 +45,9 @@ const char *feature_enabled(const char *, const char *);
  */
 #define lgdebug(level, ...) \
 (((verbosity >= (level)) && \
-	 (('\0' == debug[0]) || feature_enabled(debug, __func__))) \
-	 ? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : (void)0), \
-	 printf(__VA_ARGS__)) : (void)0)
+	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
+	? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : (void)0), \
+	printf(__VA_ARGS__)) : (void)0)
 
 /**
  * Return TRUE if the given feature (a string) is set in the !test variable

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -46,8 +46,8 @@ const char *feature_enabled(const char *, const char *);
 #define lgdebug(level, ...) \
 (((verbosity >= (level)) && \
 	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
-	? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : (void)0), \
-	printf(__VA_ARGS__)) : (void)0)
+	? ((STRINGIFY(level)[0] == '+' ? (void)printf("%s: ", __func__) : (void)0), \
+	(void)printf(__VA_ARGS__)) : (void)0)
 
 /**
  * Return TRUE if the given feature (a string) is set in the !test variable

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -143,3 +143,6 @@ feature_enabled
 empty_word
 remove_empty_words
 free_Exp
+linkage_set_domain_names
+post_process_free_data
+build_type_array

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -140,3 +140,4 @@ check_link_size
 partial_init_linkage
 word_record_in_disjunct
 feature_enabled
+remove_empty_words

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -140,4 +140,5 @@ check_link_size
 partial_init_linkage
 word_record_in_disjunct
 feature_enabled
+empty_word
 remove_empty_words

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -139,3 +139,4 @@ regex_tokenizer_test
 check_link_size
 partial_init_linkage
 word_record_in_disjunct
+feature_enabled

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -142,3 +142,4 @@ word_record_in_disjunct
 feature_enabled
 empty_word
 remove_empty_words
+free_Exp

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -146,3 +146,4 @@ free_Exp
 linkage_set_domain_names
 post_process_free_data
 build_type_array
+free_linkage

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -138,3 +138,4 @@ compute_chosen_words
 regex_tokenizer_test
 check_link_size
 partial_init_linkage
+word_record_in_disjunct

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -211,6 +211,48 @@ void remap_linkages(Linkage lkg, const int *remap)
 }
 
 /**
+ * Remove the empty words from a linkage.
+ * XXX Should we remove here also the dict-cap tokens? In any case, for now they
+ * are left for debug.
+ */
+void remove_empty_words(Linkage lkg)
+{
+	size_t i, j;
+	Disjunct **cdj = lkg->chosen_disjuncts;
+	int *remap = alloca(lkg->num_words * sizeof(*remap));
+
+	if (4 <= verbosity)
+	{
+		lgdebug(0, "Info: chosen_disjuncts before removing empty words:\n");
+		print_chosen_disjuncts_words(lkg);
+	}
+
+	for (i = 0, j = 0; i < lkg->num_words; i++)
+	{
+		if ((NULL != cdj[i]) && (MT_EMPTY == cdj[i]->word[0]->morpheme_type))
+		{
+			remap[i] = -1;
+		}
+		else
+		{
+			cdj[j] = cdj[i];
+			remap[i] = j;
+			j++;
+		}
+	}
+	lkg->num_words = j;
+	/* Unused memory not freed - all of it will be freed in free_linkages(). */
+
+	if (4 <= verbosity)
+	{
+		lgdebug(0, "Info: chosen_disjuncts after removing empty words:\n");
+		print_chosen_disjuncts_words(lkg);
+	}
+
+	remap_linkages(lkg, remap); /* Update lkg->link_array and lkg->num_links. */
+}
+
+/**
  * This takes the Wordgraph path array and uses it to
  * compute the chosen_words array.  "I.xx" suffixes are eliminated.
  *

--- a/link-grammar/linkage.h
+++ b/link-grammar/linkage.h
@@ -4,3 +4,4 @@ void compute_chosen_words(Sentence, Linkage, Parse_Options);
 void partial_init_linkage(Linkage, unsigned int N_words);
 void check_link_size(Linkage);
 void remove_empty_words(Linkage);
+void free_linkage(Linkage);

--- a/link-grammar/linkage.h
+++ b/link-grammar/linkage.h
@@ -3,3 +3,4 @@ void compute_chosen_words(Sentence, Linkage, Parse_Options);
 
 void partial_init_linkage(Linkage, unsigned int N_words);
 void check_link_size(Linkage);
+void remove_empty_words(Linkage);

--- a/link-grammar/sat-solver/guiding.hpp
+++ b/link-grammar/sat-solver/guiding.hpp
@@ -11,7 +11,7 @@ extern "C" {
 
 };
 
-// This class represents different guding strategies of LinkParser SAT search
+// This class represents different guiding strategies of LinkParser SAT search
 class Guiding {
 public:
   struct SATParameters {
@@ -21,7 +21,7 @@ public:
     /* What is the decision priority of the variable with the given number
        during the SAT search? */
     double priority;
-    /* What is the preffered polarity of the variable with the given number
+    /* What is the preferred polarity of the variable with the given number
        during the SAT search? */
     double polarity;
   };

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1539,18 +1539,26 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     // set for this word .. don't set it again.  Oh, and it should
     // be consistent, too ...
 
-    if (_sent->word[var->left_word].d == NULL) {
+    if (lkg->chosen_disjuncts[var->left_word] == NULL) {
+      if (var->left_exp == NULL) {
+        lgdebug(+1, "left_exp==NULL for: left_word %d connector %s\n",
+             var->left_word, clink.lc->string);
+      }
       d = build_disjuncts_for_exp(var->left_exp, lpc->gword->subword, UNLIMITED_LEN);
       word_record_in_disjunct(lpc->gword, d);
-      _sent->word[var->left_word].d = d;
-      lkg->chosen_disjuncts[clink.lw] = d;
+      lkg->chosen_disjuncts[var->left_word] = d;
+      _sent->word[var->left_word].d = d; // for free_disjuncts()
     }
 
-    if (_sent->word[var->right_word].d == NULL) {
+    if (lkg->chosen_disjuncts[var->right_word] == NULL) {
+      if (var->right_exp == NULL) {
+        lgdebug(+1, "right_exp==NULL for: right_word %d connector %s\n",
+             var->right_word, clink.lc->string);
+      }
       d = build_disjuncts_for_exp(var->right_exp, rpc->gword->subword, UNLIMITED_LEN);
       word_record_in_disjunct(rpc->gword, d);
-      _sent->word[var->right_word].d = d;
-      lkg->chosen_disjuncts[clink.rw] = d;
+      lkg->chosen_disjuncts[var->right_word] = d;
+      _sent->word[var->right_word].d = d; // for free_disjuncts()
     }
 
     current_link++;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1544,13 +1544,16 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 // all teh exp flow through this code could be removed. Arghhh.
     Disjunct *d;
 
+    const X_node *left_xnode = lpc->w_xnode;
+    const X_node *right_xnode = rpc->w_xnode;
+
     // For empty words, only create a dummy disjunct - for remove_empty_word()
-    if (lpc->gword->morpheme_type == MT_EMPTY ||
-        rpc->gword->morpheme_type == MT_EMPTY) {
+    if (left_xnode->word->morpheme_type == MT_EMPTY ||
+        right_xnode->word->morpheme_type == MT_EMPTY) {
       // XXX Why right_expression is NULL? And why left_expression is only ZZZ+?
       // Hence, to prevent triggering an assert() in build_clause(), the
       // disjunct for the empty word (right_word) is built with left_exp.
-      d = build_disjuncts_for_exp(var->left_exp, rpc->gword->subword, UNLIMITED_LEN);
+      d = build_disjuncts_for_exp(var->left_exp, right_xnode->string, UNLIMITED_LEN);
       word_record_in_disjunct(empty_word(), d);
       lkg->chosen_disjuncts[var->right_word] = d;
       continue;
@@ -1565,8 +1568,8 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
         lgdebug(+1, "left_exp==NULL for: left_word %d connector %s\n",
              var->left_word, clink.lc->string);
       }
-      d = build_disjuncts_for_exp(var->left_exp, lpc->gword->subword, UNLIMITED_LEN);
-      word_record_in_disjunct(lpc->gword, d);
+      d = build_disjuncts_for_exp(var->left_exp, left_xnode->string, UNLIMITED_LEN);
+      word_record_in_disjunct(left_xnode->word, d);
       lkg->chosen_disjuncts[var->left_word] = d;
       _sent->word[var->left_word].d = d; // for free_disjuncts()
     }
@@ -1576,8 +1579,8 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
         lgdebug(+1, "right_exp==NULL for: right_word %d connector %s\n",
              var->right_word, clink.lc->string);
       }
-      d = build_disjuncts_for_exp(var->right_exp, rpc->gword->subword, UNLIMITED_LEN);
-      word_record_in_disjunct(rpc->gword, d);
+      d = build_disjuncts_for_exp(var->right_exp, right_xnode->string, UNLIMITED_LEN);
+      word_record_in_disjunct(right_xnode->word, d);
       lkg->chosen_disjuncts[var->right_word] = d;
       _sent->word[var->right_word].d = d; // for free_disjuncts()
     }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1719,16 +1719,6 @@ extern "C" void sat_sentence_delete(Sentence sent)
   Linkage lkgs = sent->lnkages;
   if (!lkgs) return;
 
-  for (LinkIdx li = 0; li < sent->num_linkages_alloced; li++) {
-    Linkage lkg = &lkgs[li];
-    // Free the connectors
-    for(size_t lai = 0; lai < lkg->num_links; lai++) {
-      free(lkg->link_array[lai].rc);
-      free(lkg->link_array[lai].lc);
-    }
-    // Free the disjuncts
-    for (size_t cdi = 0; cdi < lkg->num_words; cdi++) {
-      free_disjuncts(lkg->chosen_disjuncts[cdi]);
-    }
-  }
+  for (LinkIdx li = 0; li < sent->num_linkages_alloced; li++)
+    free_linkage(&lkgs[li]);
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1245,22 +1245,23 @@ void SATEncoder::pp_prune()
  *                         D E C O D I N G                                  *
  *--------------------------------------------------------------------------*/
 
-/* This is very similar to the api call linkage_create(), except that
- * sat_extract_links is called, instead of normal extract_links().
+/**
+ * Create the next linkage.
+ * This is very similar to compute_chosen_disjuncts(), except that
+ * sat_extract_links() is called, instead of normal extract_links().
  * It would be good to refactor this and the other to make them even
- * more similar, because right now, its confusing ...
- * XXX Now the corresponding function is compute_chosen_disjuncts(),
- * which may be even more confusing.
+ * more similar, because else, its confusing ...
+ * FIXME? Use a shared function for the code here.
  */
 Linkage SATEncoder::create_linkage()
 {
   /* Using exalloc since this is external to the parser itself. */
   Linkage linkage = (Linkage) exalloc(sizeof(struct Linkage_s));
   memset(linkage, 0, sizeof(struct Linkage_s));
+
   partial_init_linkage(linkage, _sent->length);
-
   sat_extract_links(linkage);
-
+  compute_link_names(linkage, _sent->string_set);
   /* Because the empty words are used only in the parsing stage, they are
    * removed here along with their links, so from now on we will not need to
    * consider them. */
@@ -1671,11 +1672,12 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     lkg->chosen_disjuncts[wi] = d;
     free_Exp(de);
   }
+
+  // This is needed so the empty-word disjuncts will get freed
   assert(lkg->chosen_disjuncts[0], "Must have at least one non-empty word");
   catenate_disjuncts(lkg->chosen_disjuncts[0], empty_words_tofree);
 
   lkg->num_links = current_link;
-  compute_link_names(lkg, _sent->string_set);
 
   DEBUG_print("Total: ." <<  lkg->num_links << "." << endl);
   return false;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1516,8 +1516,8 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 
     PositionConnector* lpc = _word_tags[var->left_word].get(var->left_position);
     PositionConnector* rpc = _word_tags[var->right_word].get(var->right_position);
-    lpc->connector->word = var->left_word; // XXX is this needed ?
-    rpc->connector->word = var->right_word; // XXX is this needed ?
+    //lpc->connector->word = var->left_word; // XXX is this needed ?
+    //rpc->connector->word = var->right_word; // XXX is this needed ?
     clink.lc = lpc->connector;
     clink.rc = rpc->connector;
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -383,7 +383,7 @@ void SATEncoder::generate_satisfaction_for_expression(int w, int& dfs_position, 
         Lit lhs = Lit(_variables->string_cost(var, e->cost));
         generate_and_definition(lhs, rhs);
 
-        /* Preceeds */
+        /* Precedes */
         int dfs_position_tmp = dfs_position;
         for (l = e->u.l; l->next != NULL; l = l->next) {
           generate_conjunct_order_constraints(w, l->e, l->next->e, dfs_position_tmp);
@@ -559,7 +559,7 @@ int SATEncoder::empty_connectors(Exp* e, char dir)
     }
     return true;
   } else
-    throw std::string("Unkown connector type");
+    throw std::string("Unknown connector type");
 }
 
 int SATEncoder::non_empty_connectors(Exp* e, char dir)
@@ -579,7 +579,7 @@ int SATEncoder::non_empty_connectors(Exp* e, char dir)
     }
     return false;
   } else
-    throw std::string("Unkown connector type");
+    throw std::string("Unknown connector type");
 }
 
 bool SATEncoder::trailing_connectors_and_aux(int w, E_list* l, char dir, int& dfs_position,

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1538,15 +1538,20 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     // XXX FIXME -- the chosen disjunct has probably already been
     // set for this word .. don't set it again.  Oh, and it should
     // be consistent, too ...
-    d = build_disjuncts_for_exp(var->left_exp, lpc->gword->subword, UNLIMITED_LEN);
-    word_record_in_disjunct(lpc->gword, d);
-    _sent->word[var->left_word].d = d;
-    lkg->chosen_disjuncts[clink.lw] = d;
 
-    d = build_disjuncts_for_exp(var->right_exp, rpc->gword->subword, UNLIMITED_LEN);
-    word_record_in_disjunct(rpc->gword, d);
-    _sent->word[var->right_word].d = d;
-    lkg->chosen_disjuncts[clink.rw] = d;
+    if (_sent->word[var->left_word].d == NULL) {
+      d = build_disjuncts_for_exp(var->left_exp, lpc->gword->subword, UNLIMITED_LEN);
+      word_record_in_disjunct(lpc->gword, d);
+      _sent->word[var->left_word].d = d;
+      lkg->chosen_disjuncts[clink.lw] = d;
+    }
+
+    if (_sent->word[var->right_word].d == NULL) {
+      d = build_disjuncts_for_exp(var->right_exp, rpc->gword->subword, UNLIMITED_LEN);
+      word_record_in_disjunct(rpc->gword, d);
+      _sent->word[var->right_word].d = d;
+      lkg->chosen_disjuncts[clink.rw] = d;
+    }
 
     current_link++;
   }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1700,5 +1700,5 @@ extern "C" void sat_sentence_delete(Sentence sent)
   if (!lkgs) return;
 
   for (LinkIdx li = 0; li < sent->num_linkages_alloced; li++)
-    free_linkage(&lkgs[li]);
+    free_linkage_connectors_and_disjuncts(&lkgs[li]);
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1507,7 +1507,7 @@ void SATEncoder::generate_linked_min_max_planarity()
   }
 }
 
-static Exp *null_exp()
+static Exp* null_exp()
 {
   static Exp e;
 
@@ -1516,6 +1516,24 @@ static Exp *null_exp()
   e.type = AND_type;
   return &e;
 }
+
+static Exp* PositionConnector2exp(const PositionConnector* pc)
+{
+    Exp* e = (Exp*)xalloc(sizeof(Exp));
+    e->type = CONNECTOR_type;
+    e->dir = pc->dir;
+    e->multi = pc->connector->multi;
+    e->u.string = pc->connector->string;
+    e->cost = pc->cost;
+
+    return e;
+}
+
+#if 0
+static bool is_multi(const Connector* c, const Exp *e)
+{
+}
+#endif
 
 static void add_anded_exp(Exp*& orig, Exp* addit)
 {
@@ -1534,7 +1552,7 @@ static void add_anded_exp(Exp*& orig, Exp* addit)
       elist->e = addit;
 
       // The updated orig is addit & orig
-      orig =(Exp*)xalloc(sizeof(Exp));
+      orig = (Exp*)xalloc(sizeof(Exp));
       orig->type = AND_type;
       orig->cost = 0.0;
       orig->u.l = elist;
@@ -1591,12 +1609,16 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
       continue;
     }
 
-    add_anded_exp(exp_word[var->left_word], var->left_exp);
-    add_anded_exp(exp_word[var->right_word], var->right_exp);
+    Exp* lcexp = PositionConnector2exp(lpc);
+    Exp* rcexp = PositionConnector2exp(rpc);
+    add_anded_exp(exp_word[var->left_word], lcexp);
+    add_anded_exp(exp_word[var->right_word], rcexp);
 
     if (verbosity >= D_SEL) {
-      cout<< "Lexp[" <<left_xnode->word->subword <<"]: ";  print_expression(var->left_exp);
-      cout<< "Rexp[" <<right_xnode->word->subword <<"]: "; print_expression(var->right_exp);
+      //cout<< "Lexp[" <<left_xnode->word->subword <<"]: ";  print_expression(var->left_exp);
+      cout<< "LCexp[" <<left_xnode->word->subword <<"]: ";  print_expression(lcexp);
+      //cout<< "Rexp[" <<right_xnode->word->subword <<"]: "; print_expression(var->right_exp);
+      cout<< "RCexp[" <<right_xnode->word->subword <<"]: "; print_expression(rcexp);
       cout<< "L+L: "; print_expression(exp_word[var->left_word]);
       cout<< "R+R: "; print_expression(exp_word[var->right_word]);
     }
@@ -1622,7 +1644,6 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
   for (WordIdx wi = 0; wi < _sent->length; wi++) {
     Exp *de = exp_word[wi];
 
-    //cout<<"Exp "<<wi<<": "<<endl; print_expression(de);
     // Skip empty words
     if (xnode_word[wi] == NULL)
       continue;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -239,7 +239,8 @@ void SATEncoder::build_word_tags()
     int dfs_position = 0;
 
     if (_sent->word[w].x == NULL) {
-      cerr << "Error: Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << ": NULL X_node" <<  endl;
+      // Most probably everything got pruned. There will be no linkage.
+      lgdebug(+0, "Word%zu %s: NULL X_node\n", w, N(_sent->word[w].unsplit_word));
       continue;
     }
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1662,6 +1662,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     word_record_in_disjunct(xnode_word[wi]->word, d);
     lkg->chosen_disjuncts[wi] = d;
     _sent->word[wi].d = d; // for free_disjuncts()
+    free_Exp(de);
   }
 
   lkg->num_links = current_link;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -28,16 +28,14 @@ extern "C" {
 #ifdef DEBUG
 #include <dict-api.h>             // for print_expression()
 #endif
-#include "dict-common.h"          // for Exp_create()
 #include "dict-file/read-dict.h"
-#include "disjunct-utils.h"
 #include "extract-links.h"
 #include "linkage.h"
 #include "post-process.h"
 #include "preparation.h"
 #include "score.h"
-#include "utilities.h"
-#include "wordgraph.h"
+//#include "utilities.h"         // XXX do we need it?
+#include "wordgraph.h"           // for empty_word()
 }
 
 // Macro DEBUG_print is used to dump to stdout information while debugging
@@ -1536,17 +1534,7 @@ void SATEncoder::generate_linked_min_max_planarity()
   }
 }
 
-static Exp* null_exp()
-{
-  static Exp e;
-
-  if (e.type) return &e;
-  e.u.l = NULL;
-  e.type = AND_type;
-  return &e;
-}
-
-static Exp* PositionConnector2exp(const PositionConnector* pc)
+Exp* SATEncoderConjunctionFreeSentences::PositionConnector2exp(const PositionConnector* pc)
 {
     Exp* e = (Exp*)xalloc(sizeof(Exp));
     e->type = CONNECTOR_type;
@@ -1556,36 +1544,6 @@ static Exp* PositionConnector2exp(const PositionConnector* pc)
     e->cost = pc->cost;
 
     return e;
-}
-
-#if 0
-static bool is_multi(const Connector* c, const Exp *e)
-{
-}
-#endif
-
-static void add_anded_exp(Exp*& orig, Exp* addit)
-{
-    if (orig == NULL)
-    {
-      orig = addit;
-    } else {
-      // flist is orig
-      E_list* flist = (E_list*)xalloc(sizeof(E_list));
-      flist->e = orig;
-      flist->next = NULL;
-
-      // elist is addit, orig
-      E_list* elist = (E_list*)xalloc(sizeof(E_list));
-      elist->next = flist;
-      elist->e = addit;
-
-      // The updated orig is addit & orig
-      orig = (Exp*)xalloc(sizeof(Exp));
-      orig->type = AND_type;
-      orig->cost = 0.0;
-      orig->u.l = elist;
-    }
 }
 
 #define D_SEL 5

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1310,6 +1310,9 @@ Linkage SATEncoder::get_next_linkage()
     // Perform the post-processing
     sane_linkage_morphism(_sent, lkg, _opts);
     do_post_process(_sent->postprocessor, lkg, lkg->is_sent_long);
+    build_type_array(_sent->postprocessor);
+    linkage_set_domain_names(_sent->postprocessor, lkg);
+    post_process_free_data(&_sent->postprocessor->pp_data);
     linkage_score(lkg, _opts);
 
     if (0 == lkg->lifo.N_violations) {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -41,6 +41,9 @@ extern "C" {
 #define DEBUG_print(x)
 #endif
 
+// Convert a NULL C string pointer, for printing a possibly NULL string
+#define N(s) ((s) ? (s) : "(null)")
+
 /*-------------------------------------------------------------------------*
  *               C N F   C O N V E R S I O N                               *
  *-------------------------------------------------------------------------*/
@@ -234,7 +237,7 @@ void SATEncoder::build_word_tags()
     int dfs_position = 0;
 
     if (_sent->word[w].x == NULL) {
-      DEBUG_print("Word ." << w << ".: " << _sent->word[w].unsplit_word << " (null)" <<  endl);
+      DEBUG_print("Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << " (null)" <<  endl);
       continue;
     }
 
@@ -242,7 +245,7 @@ void SATEncoder::build_word_tags()
     Exp* exp = join ? join_alternatives(w) : _sent->word[w].x->exp;
 
 #ifdef _DEBUG
-    cout << "Word ." << w << ".: " << _sent->word[w].unsplit_word << endl;
+    cout << "Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << endl;
     //print_expression(exp);
     cout << endl;
 #endif
@@ -298,7 +301,7 @@ void SATEncoder::generate_satisfaction_conditions()
 {
   for (size_t w = 0; w < _sent->length; w++) {
     if (_sent->word[w].x == NULL) {
-      DEBUG_print("Word: " << _sent->word[w].unsplit_word << " : " << "(null)" << endl);
+      DEBUG_print("Word: " << N(_sent->word[w].unsplit_word) << " : " << "(null)" << endl);
       handle_null_expression(w);
       continue;
     }
@@ -307,7 +310,7 @@ void SATEncoder::generate_satisfaction_conditions()
     Exp* exp = join ? join_alternatives(w) : _sent->word[w].x->exp;
 
 #ifdef _DEBUG
-    cout << "Word: " << _sent->word[w].unsplit_word << endl;
+    cout << "Word: " << N(_sent->word[w].unsplit_word) << endl;
     //print_expression(exp);
     cout << endl;
 #endif

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -510,12 +510,12 @@ void SATEncoder::generate_link_cw_ordinary_definition(size_t wi, int pi,
     if (dir == '+') {
       rhs.push(Lit(_variables->link_cost(wi, pi, Ci, e,
                                          (*i)->word, (*i)->position,
-                                         (*i)->connector->string,
+                                         (*i)->connector.string,
                                          (*i)->exp,
                                          cost + (*i)->cost)));
     } else if (dir == '-'){
       rhs.push(Lit(_variables->link((*i)->word, (*i)->position,
-                                    (*i)->connector->string,
+                                    (*i)->connector.string,
                                     (*i)->exp,
                                     wi, pi, Ci, e)));
     }
@@ -709,8 +709,8 @@ void SATEncoder::generate_conjunct_order_constraints(int w, Exp *e1, Exp* e2, in
           for (mw2i = mw2.begin(); mw2i != mw2.end(); mw2i++) {
             if (*mw1i >= *mw2i) {
               clause.growTo(2);
-              clause[0] = ~Lit(_variables->link_cw(*mw1i, w, (*i)->position, (*i)->connector->string));
-              clause[1] = ~Lit(_variables->link_cw(*mw2i, w, (*j)->position, (*j)->connector->string));
+              clause[0] = ~Lit(_variables->link_cw(*mw1i, w, (*i)->position, (*i)->connector.string));
+              clause[1] = ~Lit(_variables->link_cw(*mw2i, w, (*j)->position, (*j)->connector.string));
               add_clause(clause);
             }
           }
@@ -755,8 +755,8 @@ void SATEncoder::generate_conjunct_order_constraints(int w, Exp *e1, Exp* e2, in
           for (mw2i = mw2.begin(); mw2i != mw2.end(); mw2i++) {
             if (*mw1i <= *mw2i) {
               clause.growTo(2);
-              clause[0] = ~Lit(_variables->link_cw(*mw1i, w, (*i)->position, (*i)->connector->string));
-              clause[1] = ~Lit(_variables->link_cw(*mw2i, w, (*j)->position, (*j)->connector->string));
+              clause[0] = ~Lit(_variables->link_cw(*mw1i, w, (*i)->position, (*i)->connector.string));
+              clause[1] = ~Lit(_variables->link_cw(*mw2i, w, (*j)->position, (*j)->connector.string));
               add_clause(clause);
             }
           }
@@ -1089,16 +1089,16 @@ void SATEncoder::power_prune()
     const std::vector<PositionConnector>& rc = _word_tags[wl].get_right_connectors();
     std::vector<PositionConnector>::const_iterator rci;
     for (rci = rc.begin(); rci != rc.end(); rci++) {
-      if (!(*rci).leading_right || (*rci).connector->multi)
+      if (!(*rci).leading_right || (*rci).connector.multi)
         continue;
 
       const std::vector<PositionConnector*>& matches = rci->matches;
       for (std::vector<PositionConnector*>::const_iterator lci = matches.begin(); lci != matches.end(); lci++) {
-        if (!(*lci)->leading_left || (*lci)->connector->multi || (*lci)->word <= wl + 2)
+        if (!(*lci)->leading_left || (*lci)->connector.multi || (*lci)->word <= wl + 2)
           continue;
 
-        //        printf("LR: .%d. .%d. %s\n", wl, rci->position, rci->connector->string);
-        //        printf("LL: .%d. .%d. %s\n", (*lci)->word, (*lci)->position, (*lci)->connector->string);
+        //        printf("LR: .%d. .%d. %s\n", wl, rci->position, rci->connector.string);
+        //        printf("LL: .%d. .%d. %s\n", (*lci)->word, (*lci)->position, (*lci)->connector.string);
 
         vec<Lit> clause;
         for (std::vector<int>::const_iterator i = rci->eps_right.begin(); i != rci->eps_right.end(); i++) {
@@ -1112,8 +1112,8 @@ void SATEncoder::power_prune()
         add_additional_power_pruning_conditions(clause, wl, (*lci)->word);
 
         clause.push(~Lit(_variables->link(
-               wl, rci->position, rci->connector->string, rci->exp,
-               (*lci)->word, (*lci)->position, (*lci)->connector->string, (*lci)->exp)));
+               wl, rci->position, rci->connector.string, rci->exp,
+               (*lci)->word, (*lci)->position, (*lci)->connector.string, (*lci)->exp)));
         add_clause(clause);
       }
     }
@@ -1133,8 +1133,8 @@ void SATEncoder::power_prune()
       for (std::vector<PositionConnector*>::const_iterator lci = matches.begin(); lci != matches.end(); lci++) {
         if (!(*lci)->leading_left || (*lci)->word != wl + 1)
           continue;
-        int link = _variables->link(wl, rci->position, rci->connector->string,
-                                    (*lci)->word, (*lci)->position, (*lci)->connector->string);
+        int link = _variables->link(wl, rci->position, rci->connector.string,
+                                    (*lci)->word, (*lci)->position, (*lci)->connector.string);
         std::vector<int> clause(2);
         clause[0] = -link;
 
@@ -1178,8 +1178,8 @@ void SATEncoder::power_prune()
       for (j = matches.begin(); j != matches.end(); j++) {
         if (std::find(certainly_deep_left[(*j)->word].begin(), certainly_deep_left[(*j)->word].end(),
                       *j) != certainly_deep_left[(*j)->word].end()) {
-          generate_literal(-_variables->link((*i)->word, (*i)->position, (*i)->connector->string,
-                                             (*j)->word, (*j)->position, (*j)->connector->string));
+          generate_literal(-_variables->link((*i)->word, (*i)->position, (*i)->connector.string,
+                                             (*j)->word, (*j)->position, (*j)->connector.string));
         }
       }
     }
@@ -1416,7 +1416,7 @@ void SATEncoderConjunctionFreeSentences::generate_linked_definitions()
       for (c = w1_connectors.begin(); c != w1_connectors.end(); c++) {
         assert(c->word == w1, "Connector word must match");
         if (_word_tags[w2].match_possible(c->word, c->position)) {
-          rhs.push(Lit(_variables->link_cw(w2, c->word, c->position, c->connector->string)));
+          rhs.push(Lit(_variables->link_cw(w2, c->word, c->position, c->connector.string)));
         }
       }
 
@@ -1522,8 +1522,8 @@ static Exp* PositionConnector2exp(const PositionConnector* pc)
     Exp* e = (Exp*)xalloc(sizeof(Exp));
     e->type = CONNECTOR_type;
     e->dir = pc->dir;
-    e->multi = pc->connector->multi;
-    e->u.string = pc->connector->string;
+    e->multi = pc->connector.multi;
+    e->u.string = pc->connector.string;
     e->cost = pc->cost;
 
     return e;
@@ -1591,8 +1591,13 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     PositionConnector* lpc = _word_tags[var->left_word].get(var->left_position);
     PositionConnector* rpc = _word_tags[var->right_word].get(var->right_position);
 
-    clink.lc = lpc->connector;
-    clink.rc = rpc->connector;
+    // Allocate memory for the connectors, because they should persist
+    // beyond the lifetime of the sat-solver data structures.
+    clink.lc = connector_new();
+    clink.rc = connector_new();
+
+    *clink.lc = lpc->connector;
+    *clink.rc = rpc->connector;
 
     const X_node *left_xnode = lpc->word_xnode;
     const X_node *right_xnode = rpc->word_xnode;
@@ -1707,4 +1712,15 @@ extern "C" void sat_sentence_delete(Sentence sent)
   SATEncoder* encoder = (SATEncoder*) sent->hook;
   if (!encoder) return;
   delete encoder;
+
+  Linkage lkgs = sent->lnkages;
+  if (!lkgs) return;
+
+  for (LinkIdx li = 0; li < sent->num_linkages_alloced; li++) {
+    Linkage lkg = &lkgs[li];
+    for(size_t lai = 0; lai < lkg->num_links; lai++) {
+      free(lkg->link_array[lai].rc);
+      free(lkg->link_array[lai].lc);
+    }
+  }
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -239,7 +239,7 @@ void SATEncoder::build_word_tags()
     int dfs_position = 0;
 
     if (_sent->word[w].x == NULL) {
-      cerr << "Error: Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << "NULL X_node" <<  endl;
+      cerr << "Error: Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << ": NULL X_node" <<  endl;
       continue;
     }
 
@@ -1544,8 +1544,8 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 // all teh exp flow through this code could be removed. Arghhh.
     Disjunct *d;
 
-    const X_node *left_xnode = lpc->w_xnode;
-    const X_node *right_xnode = rpc->w_xnode;
+    const X_node *left_xnode = lpc->word_xnode;
+    const X_node *right_xnode = rpc->word_xnode;
 
     // For empty words, only create a dummy disjunct - for remove_empty_word()
     if (left_xnode->word->morpheme_type == MT_EMPTY ||

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1661,7 +1661,6 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     d = build_disjuncts_for_exp(de, xnode_word[wi]->string, UNLIMITED_LEN);
     word_record_in_disjunct(xnode_word[wi]->word, d);
     lkg->chosen_disjuncts[wi] = d;
-    _sent->word[wi].d = d; // for free_disjuncts()
     free_Exp(de);
   }
 
@@ -1719,9 +1718,14 @@ extern "C" void sat_sentence_delete(Sentence sent)
 
   for (LinkIdx li = 0; li < sent->num_linkages_alloced; li++) {
     Linkage lkg = &lkgs[li];
+    // Free the connectors
     for(size_t lai = 0; lai < lkg->num_links; lai++) {
       free(lkg->link_array[lai].rc);
       free(lkg->link_array[lai].lc);
+    }
+    // Free the disjuncts
+    for (size_t cdi = 0; cdi < lkg->num_words; cdi++) {
+      free_disjuncts(lkg->chosen_disjuncts[cdi]);
     }
   }
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -237,7 +237,7 @@ void SATEncoder::build_word_tags()
     int dfs_position = 0;
 
     if (_sent->word[w].x == NULL) {
-      DEBUG_print("Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << " (null)" <<  endl);
+      cerr << "Error: Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << "NULL X_node" <<  endl;
       continue;
     }
 
@@ -257,7 +257,7 @@ void SATEncoder::build_word_tags()
     std::vector<int> eps_right, eps_left;
 
     _word_tags[w].insert_connectors(exp, dfs_position, leading_right,
-         leading_left, eps_right, eps_left, name, true, 0, NULL);
+         leading_left, eps_right, eps_left, name, true, 0, NULL, _sent->word[w].x);
 
     if (join)
       free_alternatives(exp);

--- a/link-grammar/sat-solver/sat-encoder.h
+++ b/link-grammar/sat-solver/sat-encoder.h
@@ -6,6 +6,6 @@ Linkage sat_create_linkage(int k, Sentence sent, Parse_Options  opts);
 void sat_sentence_delete(Sentence sent);
 #else
 static inline int sat_parse(Sentence sent, Parse_Options  opts) { return -1; }
-static inline Linkage sat_create_linkage(int k, Sentence sent, Parse_Options  opts) { return NULL; }
+static inline Linkage sat_create_linkage(LinkageIdx k, Sentence sent, Parse_Options  opts) { return NULL; }
 static inline void sat_sentence_delete(Sentence sent) {}
 #endif

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -291,6 +291,9 @@ class SATEncoderConjunctionFreeSentences : public SATEncoder
 public:
   SATEncoderConjunctionFreeSentences(Sentence sent, Parse_Options  opts)
     : SATEncoder(sent, opts) {
+    verbosity = opts->verbosity;
+    debug = opts->debug;
+    test = opts->test;
   }
 
   virtual void handle_null_expression(int w);
@@ -304,5 +307,9 @@ public:
   virtual bool sat_extract_links(Linkage);
 
   virtual void generate_encoding_specific_clauses();
+
+  int verbosity;
+  const char *debug;
+  const char *test;
 };
 

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -190,7 +190,7 @@ protected:
 
   // Add the specified clause to the solver
   void add_clause(vec<Lit>& clause) {
-#ifdef _DEBUG
+#ifdef SAT_DEBUG
     print_clause(clause);
 #endif
     for (int i = 0; i < clause.size(); i++) {

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -19,6 +19,11 @@ public:
       _sent(sent), _opts(opts)
   {
     _cost_cutoff = parse_options_get_disjunct_cost(opts);
+
+    verbosity = opts->verbosity;
+    debug = opts->debug;
+    test = opts->test;
+
     // Preprocess word tags of the sentence
     build_word_tags();
   }
@@ -34,6 +39,11 @@ public:
 
   // Solve the formula, returning the next linkage.
   Linkage get_next_linkage();
+
+private:
+  int verbosity;
+  const char *debug;
+  const char *test;
 
 protected:
 

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -1,9 +1,5 @@
 #include "link-includes.h"
 
-extern "C" int sat_encode(Sentence sent, Parse_Options  opts);
-extern "C" Linkage sat_create_linkage(int k, Sentence sent, Parse_Options  opts);
-extern "C" void sat_sentence_delete(Sentence sent);
-
 #include "word-tag.hpp"
 
 /**

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -315,6 +315,7 @@ public:
 
   virtual void generate_linked_definitions();
   virtual bool sat_extract_links(Linkage);
+  virtual Exp* PositionConnector2exp(const PositionConnector*);
 
   virtual void generate_encoding_specific_clauses();
 

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -116,7 +116,7 @@ protected:
   virtual void generate_linked_definitions() = 0;
 
   // In order to reduce the number of clauses, some linked(wi, wj)
-  // variables can apriori be eliminated. The information about pairs
+  // variables can a priori be eliminated. The information about pairs
   // of words that can be linked is kept in this matrix.
   MatrixUpperTriangle<int> _linked_possible;
 
@@ -137,7 +137,7 @@ protected:
 #ifdef _CONNECTIVITY_
   // Generate clauses that encode the connectivity requirement of the
   // linkage. Experiments showed that it is better to check the
-  // connectivity aposteriori and this method has been excised.
+  // connectivity a posteriori and this method has been excised.
   void generate_connectivity();
 #endif
 
@@ -179,7 +179,7 @@ protected:
   // Power pruning
   void power_prune();
   // auxiliary method that extends power pruning clauses with additional literals
-  // (e.g., link should not be power-prunned if there words are fat-linked)
+  // (e.g., link should not be power-pruned if there words are fat-linked)
   virtual void add_additional_power_pruning_conditions(vec<Lit>& clause, int wl, int wr)
   {}
 
@@ -237,7 +237,7 @@ protected:
   /*
    *   Word tags of the words in a sentence kept in a preprocessed
    *   form. This enables users to get information about the
-   *   connectors in a very eficient way.
+   *   connectors in a very efficient way.
    */
   // Word tags
   std::vector<WordTag> _word_tags;

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -12,7 +12,7 @@ public:
   // Construct the encoder based on given sentence
   SATEncoder(Sentence sent, Parse_Options  opts)
     : _variables(new Variables(sent)), _solver(new Solver()),
-      _sent(sent), _opts(opts)
+      _opts(opts), _sent(sent)
   {
     _cost_cutoff = parse_options_get_disjunct_cost(opts);
 
@@ -280,12 +280,12 @@ protected:
   // The MiniSAT solver instance. The solver keeps the set of clauses.
   Solver* _solver;
 
-  // Sentence that is being parsed.
-  Sentence _sent;
-
   // Parse options.
   Parse_Options  _opts;
 
+public:
+  // Sentence that is being parsed.
+  Sentence _sent;
 };
 
 

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -318,6 +318,7 @@ public:
 
   virtual void generate_encoding_specific_clauses();
 
+private:
   int verbosity;
   const char *debug;
   const char *test;

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -3,7 +3,24 @@
 extern "C" {
 #include "api-structures.h"
 #include "structures.h"
+#include "disjunct-utils.h"
 };
+
+/**
+ * Free all the connectors and disjuncts of a specific linkage.
+ */
+void free_linkage(Linkage lkg)
+{
+  // Free the connectors
+  for(size_t i = 0; i < lkg->num_links; i++) {
+    free(lkg->link_array[i].rc);
+    free(lkg->link_array[i].lc);
+  }
+  // Free the disjuncts
+  for (size_t i = 0; i < lkg->num_words; i++) {
+    free_disjuncts(lkg->chosen_disjuncts[i]);
+  }
+}
 
 bool isEndingInterpunction(const char* str)
 {

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -3,7 +3,6 @@
 extern "C" {
 #include "api-structures.h"
 #include "structures.h"
-#include "disjunct-utils.h"
 };
 
 /**
@@ -20,6 +19,40 @@ void free_linkage(Linkage lkg)
   for (size_t i = 0; i < lkg->num_words; i++) {
     free_disjuncts(lkg->chosen_disjuncts[i]);
   }
+}
+
+Exp* null_exp()
+{
+  static Exp e;
+
+  if (e.type) return &e;
+  e.u.l = NULL;
+  e.type = AND_type;
+  return &e;
+}
+
+void add_anded_exp(Exp*& orig, Exp* addit)
+{
+    if (orig == NULL)
+    {
+      orig = addit;
+    } else {
+      // flist is orig
+      E_list* flist = (E_list*)xalloc(sizeof(E_list));
+      flist->e = orig;
+      flist->next = NULL;
+
+      // elist is addit, orig
+      E_list* elist = (E_list*)xalloc(sizeof(E_list));
+      elist->next = flist;
+      elist->e = addit;
+
+      // The updated orig is addit & orig
+      orig = (Exp*)xalloc(sizeof(Exp));
+      orig->type = AND_type;
+      orig->cost = 0.0;
+      orig->u.l = elist;
+    }
 }
 
 bool isEndingInterpunction(const char* str)

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -8,7 +8,7 @@ extern "C" {
 /**
  * Free all the connectors and disjuncts of a specific linkage.
  */
-void free_linkage(Linkage lkg)
+void free_linkage_connectors_and_disjuncts(Linkage lkg)
 {
   // Free the connectors
   for(size_t i = 0; i < lkg->num_links; i++) {

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -4,7 +4,7 @@
 #include "link-includes.h"
 
 bool isEndingInterpunction(const char* str);
-
 const char* word(Sentence sent, int w);
+void free_linkage(Linkage);
 
 #endif

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -10,7 +10,7 @@ extern "C" {
 
 bool isEndingInterpunction(const char* str);
 const char* word(Sentence sent, int w);
-void free_linkage(Linkage);
+void free_linkage_connectors_and_disjuncts(Linkage);
 Exp* null_exp();
 void add_anded_exp(Exp*&, Exp*);
 

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -1,10 +1,17 @@
 #ifndef __UTIL_HPP__
 #define __UTIL_HPP__
 
+extern "C" {
 #include "link-includes.h"
+#include "api-structures.h"
+#include "structures.h"
+#include "disjunct-utils.h"
+}
 
 bool isEndingInterpunction(const char* str);
 const char* word(Sentence sent, int w);
 void free_linkage(Linkage);
+Exp* null_exp();
+void add_anded_exp(Exp*&, Exp*);
 
 #endif

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -75,6 +75,10 @@ public:
         delete *i;
       }
     }
+
+    for (size_t i = 0; i < _linked_variables.size(); i++)
+      delete _linked_variables[i];
+
     delete _guiding;
   }
 

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -13,10 +13,10 @@
 #define  MAX_VARIABLE_NAME 256
 
 
-// #define _DEBUG
+// #define SAT_DEBUG
 // #define _VARS
 
-#ifdef _DEBUG
+#ifdef SAT_DEBUG
 #define _VARS
 #endif
 

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -101,7 +101,7 @@ public:
     return var;
   }
 
-  // If the cost is explicitely given, guiding params are calculated
+  // If the cost is explicitly given, guiding params are calculated
   // using the cost. Any params set earlier are overridden.
   int string_cost(const char* name, double cost)
   {
@@ -308,7 +308,7 @@ public:
     return var;
   }
 
-  // Auxilary variables used for connectivity encoding
+  // Auxiliary variables used for connectivity encoding
   int l_con(int i, int j, int k) {
     int var;
     if (!get_lcon_variable(i, j, k, var))

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -19,7 +19,6 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
     dfs_position++;
 
     const char* name = exp->u.string;
-    const Gword *x_node_gword =  w_xnode ?  w_xnode->word : NULL;
 
     Connector* connector = connector_new();
     connector->multi = exp->multi;
@@ -33,7 +32,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _right_connectors.push_back(
            PositionConnector(parent_exp, connector, '+', _word, dfs_position,
                              exp->cost, cost, leading_right, false,
-                             eps_right, eps_left, x_node_gword));
+                             eps_right, eps_left, w_xnode));
       leading_right = false;
       break;
     case '-':
@@ -42,7 +41,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _left_connectors.push_back(
            PositionConnector(parent_exp, connector, '-', _word, dfs_position,
                              exp->cost, cost, false, leading_left,
-                             eps_right, eps_left, x_node_gword));
+                             eps_right, eps_left, w_xnode));
       leading_left = false;
       break;
     default:

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -20,17 +20,17 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
 
     const char* name = exp->u.string;
 
-    Connector* connector = connector_new();
-    connector->multi = exp->multi;
-    connector->string = name;
-    set_connector_length_limit(connector);
+    Connector connector;
+    connector.multi = exp->multi;
+    connector.string = name;
+    set_connector_length_limit(&connector);
 
     switch (exp->dir) {
     case '+':
       _position.push_back(_right_connectors.size());
       _dir.push_back('+');
       _right_connectors.push_back(
-           PositionConnector(parent_exp, connector, '+', _word, dfs_position,
+           PositionConnector(parent_exp, &connector, '+', _word, dfs_position,
                              exp->cost, cost, leading_right, false,
                              eps_right, eps_left, word_xnode));
       leading_right = false;
@@ -39,7 +39,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _position.push_back(_left_connectors.size());
       _dir.push_back('-');
       _left_connectors.push_back(
-           PositionConnector(parent_exp, connector, '-', _word, dfs_position,
+           PositionConnector(parent_exp, &connector, '-', _word, dfs_position,
                              exp->cost, cost, false, leading_left,
                              eps_right, eps_left, word_xnode));
       leading_left = false;
@@ -165,7 +165,7 @@ void WordTag::find_matches(int w, const char* C, char dir, std::vector<PositionC
 
   std::vector<PositionConnector>::iterator i;
   for (i = connectors->begin(); i != connectors->end(); i++) {
-    if (WordTag::match(w, search_cntr, dir, (*i).word, *((*i).connector))) {
+    if (WordTag::match(w, search_cntr, dir, (*i).word, ((*i).connector))) {
       matches.push_back(&(*i));
     }
   }
@@ -176,7 +176,7 @@ void WordTag::add_matches_with_word(WordTag& tag)
   std::vector<PositionConnector>::iterator i;
   for (i = _right_connectors.begin(); i != _right_connectors.end(); i++) {
     std::vector<PositionConnector*> connector_matches;
-    tag.find_matches(_word, (*i).connector->string, '+', connector_matches);
+    tag.find_matches(_word, (*i).connector.string, '+', connector_matches);
     std::vector<PositionConnector*>::iterator j;
     for (j = connector_matches.begin(); j != connector_matches.end(); j++) {
       i->matches.push_back(*j);

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -1,6 +1,12 @@
 #include "word-tag.hpp"
 #include "fast-sprintf.hpp"
 
+extern "C" {
+#include "error.h"
+#include "utilities.h"
+}
+
+#define D_IC 6
 void WordTag::insert_connectors(Exp* exp, int& dfs_position,
                                 bool& leading_right, bool& leading_left,
                                 std::vector<int>& eps_right,
@@ -105,7 +111,9 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
         *s++ = 'd';
         fast_sprintf(s, i);
 
-        assert(w_xnode != NULL);
+        lgdebug(+D_IC, "Word%d: var: %s; exp%d; X_node: %s\n",
+                _word, var, i, w_xnode ? w_xnode->word->subword : "NULL X_node");
+        assert(w_xnode != NULL, "NULL X_node for var %s", new_var);
         if (root && parent_exp == NULL && l->e != w_xnode->exp) {
           E_list *we = NULL;
 
@@ -117,13 +125,10 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
             }
           }
           if (we == NULL) {
-            //cout << ">>>>>> NEXT W_XNODE" << endl;
+            lgdebug(+D_IC, "Next w_xnode for word %d is needed\n", _word);
             w_xnode = w_xnode->next;
-            assert(w_xnode != NULL);
+            assert(w_xnode != NULL, "NULL next X_node for var %s", new_var);
           }
-        }
-        if (0 && root && parent_exp == NULL) {
-          cout << "Word"<<_word<<"; var:" << var << "; ALT " << i << ": " << (w_xnode ? w_xnode->word->subword : "NULL X_node") << ' ' << endl;
         }
         insert_connectors(l->e, dfs_position, lr, ll, er, el, new_var, false, cost, l->e, w_xnode);
 
@@ -137,8 +142,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
     }
   }
 }
-
-
+#undef D_IC
 
 void WordTag::find_matches(int w, const char* C, char dir, std::vector<PositionConnector*>& matches)
 {

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -12,7 +12,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
                                 std::vector<int>& eps_right,
                                 std::vector<int>& eps_left,
                                 char* var, bool root, double parent_cost,
-                                Exp* parent_exp, const X_node *w_xnode)
+                                Exp* parent_exp, const X_node *word_xnode)
 {
   double cost = parent_cost + exp->cost;
   if (exp->type == CONNECTOR_type) {
@@ -32,7 +32,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _right_connectors.push_back(
            PositionConnector(parent_exp, connector, '+', _word, dfs_position,
                              exp->cost, cost, leading_right, false,
-                             eps_right, eps_left, w_xnode));
+                             eps_right, eps_left, word_xnode));
       leading_right = false;
       break;
     case '-':
@@ -41,7 +41,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _left_connectors.push_back(
            PositionConnector(parent_exp, connector, '-', _word, dfs_position,
                              exp->cost, cost, false, leading_left,
-                             eps_right, eps_left, w_xnode));
+                             eps_right, eps_left, word_xnode));
       leading_left = false;
       break;
     default:
@@ -54,7 +54,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       if (exp->u.l != NULL && exp->u.l->next == NULL) {
         /* unary and - skip */
         insert_connectors(exp->u.l->e, dfs_position, leading_right,
-             leading_left, eps_right, eps_left, var, root, cost, parent_exp, w_xnode);
+             leading_left, eps_right, eps_left, var, root, cost, parent_exp, word_xnode);
       } else {
         int i;
         E_list* l;
@@ -73,7 +73,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
           fast_sprintf(s, i);
 
           insert_connectors(l->e, dfs_position, leading_right, leading_left,
-                eps_right, eps_left, new_var, false, cost, parent_exp, w_xnode);
+                eps_right, eps_left, new_var, false, cost, parent_exp, word_xnode);
 
           if (leading_right && var != NULL) {
             eps_right.push_back(_variables->epsilon(new_var, '+'));
@@ -87,7 +87,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
     if (exp->u.l != NULL && exp->u.l->next == NULL) {
       /* unary or - skip */
       insert_connectors(exp->u.l->e, dfs_position, leading_right, leading_left,
-          eps_right, eps_left, var, root, cost, exp->u.l->e, w_xnode);
+          eps_right, eps_left, var, root, cost, exp->u.l->e, word_xnode);
     } else {
       int i;
       E_list* l;
@@ -111,25 +111,25 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
         fast_sprintf(s, i);
 
         lgdebug(+D_IC, "Word%d: var: %s; exp%d; X_node: %s\n",
-                _word, var, i, w_xnode ? w_xnode->word->subword : "NULL X_node");
-        assert(w_xnode != NULL, "NULL X_node for var %s", new_var);
-        if (root && parent_exp == NULL && l->e != w_xnode->exp) {
+                _word, var, i, word_xnode ? word_xnode->word->subword : "NULL X_node");
+        assert(word_xnode != NULL, "NULL X_node for var %s", new_var);
+        if (root && parent_exp == NULL && l->e != word_xnode->exp) {
           E_list *we = NULL;
 
-          if (w_xnode->exp->type == OR_type) {
-            for (we = w_xnode->exp->u.l; we != NULL; we = we-> next)
+          if (word_xnode->exp->type == OR_type) {
+            for (we = word_xnode->exp->u.l; we != NULL; we = we-> next)
             {
               if (l->e == we->e)
                 break;
             }
           }
           if (we == NULL) {
-            lgdebug(+D_IC, "Next w_xnode for word %d is needed\n", _word);
-            w_xnode = w_xnode->next;
-            assert(w_xnode != NULL, "NULL next X_node for var %s", new_var);
+            lgdebug(+D_IC, "Next word_xnode for word %d is needed\n", _word);
+            word_xnode = word_xnode->next;
+            assert(word_xnode != NULL, "NULL next X_node for var %s", new_var);
           }
         }
-        insert_connectors(l->e, dfs_position, lr, ll, er, el, new_var, false, cost, l->e, w_xnode);
+        insert_connectors(l->e, dfs_position, lr, ll, er, el, new_var, false, cost, l->e, word_xnode);
 
         if (lr)
           lr_true = true;

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -21,11 +21,16 @@ struct PositionConnector
   PositionConnector(Exp* e, Connector* c, char d, int w, int p, 
                     double cst, double pcst, bool lr, bool ll,
                     const std::vector<int>& er, const std::vector<int>& el, const X_node *w_xnode)
-    : exp(e), connector(c), dir(d), word(w), position(p),
+    : exp(e), dir(d), word(w), position(p),
       cost(cst), parent_cost(pcst),
       leading_right(lr), leading_left(ll),
       eps_right(er), eps_left(el), word_xnode(w_xnode)
   {
+    // Initialize some fields in the connector struct.
+    connector.string = c->string;
+    connector.multi = c->multi;
+    connector.length_limit = c->length_limit;
+
     if (word_xnode == NULL) {
        cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
     }
@@ -48,7 +53,7 @@ struct PositionConnector
   Exp* exp;
 
   // Connector itself
-  Connector* connector;
+  Connector connector;
   // Direction
   char dir;
   // word in a sentence that this connector belongs to

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -24,10 +24,10 @@ struct PositionConnector
     : exp(e), connector(c), dir(d), word(w), position(p),
       cost(cst), parent_cost(pcst),
       leading_right(lr), leading_left(ll),
-      eps_right(er), eps_left(el), w_xnode(w_xnode)
+      eps_right(er), eps_left(el), word_xnode(w_xnode)
   {
-    if (w_xnode == NULL) {
-       cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; X_node: " << (w_xnode?w_xnode->string: "(null)") << endl;
+    if (word_xnode == NULL) {
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
     }
 
     /*
@@ -67,7 +67,7 @@ struct PositionConnector
 
 
   // The corresponding X_node - chosen-disjuncts[]
-  const X_node *w_xnode;
+  const X_node *word_xnode;
 
   // Matches with other words
   std::vector<PositionConnector*> matches;
@@ -157,7 +157,7 @@ public:
                          std::vector<int>& eps_right,
                          std::vector<int>& eps_left,
                          char* var, bool root, double parent_cost,
-                         Exp* parent, const X_node *w_xnode);
+                         Exp* parent, const X_node *word_xnode);
 
   // Caches information about the found matches to the _matches vector, and also
   // updates the _matches vector of all connectors in the given tag.

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -102,6 +102,9 @@ public:
   WordTag(int word, Variables* variables, Sentence sent, Parse_Options opts)
     : _word(word), _variables(variables), _sent(sent), _opts(opts) {
     _match_possible.resize(_sent->length);
+    verbosity = opts->verbosity;
+    debug = opts->debug;
+    test = opts->test;
   }
 
   const std::vector<PositionConnector>& get_left_connectors() const {
@@ -172,6 +175,9 @@ public:
     return _match_possible[wi].find(pi) != _match_possible[wi].end();
   }
 
+  int verbosity;
+  const char *debug;
+  const char *test;
 };
 
 #endif

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -20,14 +20,14 @@ struct PositionConnector
 {
   PositionConnector(Exp* e, Connector* c, char d, int w, int p, 
                     double cst, double pcst, bool lr, bool ll,
-                    const std::vector<int>& er, const std::vector<int>& el, const Gword *gw)
+                    const std::vector<int>& er, const std::vector<int>& el, const X_node *w_xnode)
     : exp(e), connector(c), dir(d), word(w), position(p),
       cost(cst), parent_cost(pcst),
       leading_right(lr), leading_left(ll),
-      eps_right(er), eps_left(el), gword(gw)
+      eps_right(er), eps_left(el), w_xnode(w_xnode)
   {
-    if (gw == NULL) {
-       cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; gword: " << (gw ? gw->subword : "(null)") << endl;
+    if (w_xnode == NULL) {
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; X_node: " << (w_xnode?w_xnode->string: "(null)") << endl;
     }
 
     /*
@@ -65,8 +65,9 @@ struct PositionConnector
   std::vector<int> eps_right;
   std::vector<int> eps_left;
 
-  // The corresponding wordgraph word
-  const Gword *gword;
+
+  // The corresponding X_node - chosen-disjuncts[]
+  const X_node *w_xnode;
 
   // Matches with other words
   std::vector<PositionConnector*> matches;

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -176,6 +176,7 @@ public:
     return _match_possible[wi].find(pi) != _match_possible[wi].end();
   }
 
+private:
   int verbosity;
   const char *debug;
   const char *test;

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -20,12 +20,16 @@ struct PositionConnector
 {
   PositionConnector(Exp* e, Connector* c, char d, int w, int p, 
                     double cst, double pcst, bool lr, bool ll,
-                    const std::vector<int>& er, const std::vector<int>& el)
+                    const std::vector<int>& er, const std::vector<int>& el, const Gword *gw)
     : exp(e), connector(c), dir(d), word(w), position(p),
       cost(cst), parent_cost(pcst),
       leading_right(lr), leading_left(ll),
-      eps_right(er), eps_left(el)
+      eps_right(er), eps_left(el), gword(gw)
   {
+    if (gw == NULL) {
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; gword: " << (gw ? gw->subword : "(null)") << endl;
+    }
+
     /*
     cout << c->string << " : ." << w << ". : ." << p << ". ";
     if (leading_right) {
@@ -60,6 +64,9 @@ struct PositionConnector
   bool leading_left;
   std::vector<int> eps_right;
   std::vector<int> eps_left;
+
+  // The corresponding wordgraph word
+  const Gword *gword;
 
   // Matches with other words
   std::vector<PositionConnector*> matches;
@@ -146,7 +153,7 @@ public:
                          std::vector<int>& eps_right,
                          std::vector<int>& eps_left,
                          char* var, bool root, double parent_cost,
-                         Exp* parent);
+                         Exp* parent, const X_node *w_xnode);
 
   // Caches information about the found matches to the _matches vector, and also
   // updates the _matches vector of all connectors in the given tag.

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -45,6 +45,7 @@
 #define EMPTY_WORD_DOT   "EMPTY-WORD.zzz"  /* Has SUBSCRIPT_DOT in it! */
 #define EMPTY_WORD_MARK  "EMPTY-WORD\3zzz" /* Has SUBSCRIPT_MARK in it! */
 #define EMPTY_WORD_DISPLAY "∅"   /* Empty word representation for debug */
+#define EMPTY_CONNECTOR "ZZZ"
 
 /* Dictionary capitalization handling */
 #define CAP1st "1stCAP" /* Next word is capitalized */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -479,7 +479,7 @@ static void batch_process_some_linkages(Label label,
 	if (there_was_an_error(label, sent, opts))
 	{
 		/* If linkages were found, print them */
-		if (sentence_num_linkages_found(sent) > 0) {
+		if (sentence_num_linkages_found(sent) >= 0) {
 			Linkage linkage = NULL;
 			/* If we found at least one good linkage, print it. */
 			if (sentence_num_valid_linkages(sent) > 0) {

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -370,6 +370,14 @@ static int process_some_linkages(Sentence sent, Command_Options* copts)
 
 		linkage = linkage_create(i, sent, opts);
 
+		/* Currently, sat solver sets the linkage violation indication
+		 * only when it creates the linkage as a result of the above call. */
+		if ((sentence_num_violations(sent, i) > 0) &&
+			!copts->display_bad)
+		{
+			continue;
+		}
+
 		/* Currently, sat solver returns NULL when there ain't no more */
 		if (!linkage)
 		{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -371,7 +371,17 @@ static int process_some_linkages(Sentence sent, Command_Options* copts)
 		linkage = linkage_create(i, sent, opts);
 
 		/* Currently, sat solver returns NULL when there ain't no more */
-		if (!linkage) break;
+		if (!linkage)
+		{
+			if (verbosity > 0)
+			{
+				if (0 == i)
+					fprintf(stdout, "No linkages found.\n");
+				else
+					fprintf(stdout, "No more linkages.\n");
+			}
+			break;
+		}
 
 		if (verbosity > 0)
 		{


### PR DESCRIPTION
Fixes:
1. Correctly (hopefully) reconstruct the disjunct connectors.
2. Put the appropriate wordgraph pointer in each of the disjuncts. This is a must for the wordgraph code.
3. Use the X_node strings (subscripted words) as the disjunct words.
4,. Discard empty words. This is also a must for the wordgraph code.
5. Improve the related Link-parser messages. Previously it was "too silent". Messages added:
- No linkages found.
- No more linkages.

Not as usual, I didn't clean the commits too much, so they contain intermediate versions of the changes (for example, reconstructing the disjuncts from the provided right/left expressions, a thing that proved to be a wrong idea).

Many problems still remained unresolved. For some I know the fix or a work round.
Some of the problems below are mentioned in the last commit, but I added more here.
- It crashes on !links, because the domain array doesn't exist. I need an advice on that.
- It doesn't work on Hebrew at all (but works on Russian).
- Batch runs are mostly meaningless, because the sat-solver code
  returns num-linkages=222 even when there are no linkages.
- The costs shown by !disjuncts are not always the same as those of the
  standard parser.
- In the cost vector, it always shows a disjunct costs of 0.
- It still checks alternative[0] in in guiding.cpp. It can be fixed, by much work, to check the wordgraph. However, if it is done only for solving speedup hints, it may not be urgent to improve it.
- It doesn't free all memory, and especially not the connectors.   This problem always existed.
It doesn't parse with null words. It seems possible and easy enough, so I don't know why it has not been done.
- The post-parsing code could be more similar to that of the standard parser. It can be rewritten so more code can be shared.

I guess there are even more problems. I will try to fix some of them.

EDIT:
I appended some more fixes. Please see #188 for a summary.