### PR TITLE
Fix printing expressions

### DIFF
--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -34,7 +34,7 @@
  *
  * Suffixes have the form =asdf.asdf or possibly just =asdf without
  * the dot (subscript mark). The "null" suffixes have the form
- * =.asdf (always with the ubscript mark, as there are several).
+ * =.asdf (always with the subscript mark, as there are several).
  * Ordinary equals signs appearing in regular text are either = or =[!].
  */
 bool is_suffix(const char infix_mark, const char* w)
@@ -272,7 +272,7 @@ int delete_dictionary_words(Dictionary dict, const char * s)
 /**
  * The following two functions free the Exp s and the
  * E_lists of the dictionary.  Not to be confused with
- * free_E_list in utilities.c
+ * free_E_list in word-utils.c.
  */
 static void free_Elist(E_list * l)
 {

--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -414,6 +414,7 @@ void print_expression(Exp * n)
 
 #else /* INFIX_NOTATION */
 
+#define COST_FMT "%.3f"
 /**
  * print the expression, in infix-style
  */
@@ -421,6 +422,7 @@ static void print_expression_parens(const Exp * n, int need_parens)
 {
 	E_list * el;
 	int i, icost;
+	double dcost;
 
 	if (n == NULL)
 	{
@@ -429,6 +431,17 @@ static void print_expression_parens(const Exp * n, int need_parens)
 	}
 
 	icost = (int) (n->cost);
+	dcost = n->cost - icost;
+	if (dcost > 10E-4)
+	{
+		dcost = n->cost;
+		icost = 1;
+	}
+	else
+	{
+		dcost = 0;
+	}
+
 	/* print the connector only */
 	if (n->type == CONNECTOR_type)
 	{
@@ -436,6 +449,7 @@ static void print_expression_parens(const Exp * n, int need_parens)
 		if (n->multi) printf("@");
 		printf("%s%c", n->u.string, n->dir);
 		for (i=0; i<icost; i++) printf("]");
+		if (0 != dcost) printf(COST_FMT, dcost);
 		return;
 	}
 
@@ -446,6 +460,7 @@ static void print_expression_parens(const Exp * n, int need_parens)
 		for (i=0; i<icost; i++) printf("[");
 		printf ("()");
 		for (i=0; i<icost; i++) printf("]");
+		if (0 != dcost) printf(COST_FMT, dcost);
 		return;
 	}
 
@@ -469,6 +484,7 @@ static void print_expression_parens(const Exp * n, int need_parens)
 	if ((n->type == AND_type) && (el->next == NULL))
 	{
 		for (i=0; i<icost; i++) printf("]");
+		if (0 != dcost) printf(COST_FMT, dcost);
 		if ((icost == 0) && need_parens) printf(")");
 		return;
 	}
@@ -497,6 +513,7 @@ static void print_expression_parens(const Exp * n, int need_parens)
 	}
 
 	for (i=0; i<icost; i++) printf("]");
+	if (0 != dcost) printf(COST_FMT, dcost);
 	if ((icost == 0) && need_parens) printf(")");
 }
 

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1210,8 +1210,9 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 	size_t wi;   /* Internal sentence word index */
 	size_t ai;   /* Index of a word alternative */
 	size_t sentlen = sent->length;     /* Shortened if there is a right-wall */
-	int first_sentence_word = 0;       /* Used for skipping a left-wall */
+	size_t first_sentence_word = 0;    /* Used for skipping a left-wall */
 	bool word_split = false;           /* !!word got split */
+	Dictionary dict = sent->dict;
 
 	if (0 == sentlen)
 	{
@@ -1227,10 +1228,12 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 	else
 	{
 		/* For analyzing words we need to ignore the left/right walls */
-		if (0 == strcmp(sent->word[0].unsplit_word, LEFT_WALL_WORD))
+		if (dict->left_wall_defined &&
+		    (0 == strcmp(sent->word[0].unsplit_word, LEFT_WALL_WORD)))
 			first_sentence_word = 1;
-		if ((NULL != sent->word[sentlen-1].unsplit_word) &&
-		 (0 == strcmp(sent->word[sentlen-1].unsplit_word, RIGHT_WALL_WORD)))
+		if (dict->right_wall_defined &&
+		    ((NULL != sent->word[sentlen-1].unsplit_word)) &&
+		    (0 == strcmp(sent->word[sentlen-1].unsplit_word, RIGHT_WALL_WORD)))
 			sentlen--;
 
 		/* Find if a word got split. This is indicated by:
@@ -1341,7 +1344,8 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 					struct tokenpos firstpos = { wt };
 
 					print_sentence_word_alternatives(sent, false, NULL, &firstpos);
-					if ((firstpos.wi != wi) || (firstpos.ai != ai))
+					if (((firstpos.wi != wi) || (firstpos.ai != ai)) &&
+					  firstpos.wi >= first_sentence_word) // allow !!LEFT_WORD
 					{
 						/* We encountered this token earlier */
 						if (NULL != display)


### PR DESCRIPTION
This patch fixes the following bugs:
1. Fractional costs are currently totally ignored when printing expressions.
I was somewhat paranoid in comparing to 0 and in printing, in order to prevent things like [...]0.09999999 and [...]0.00000001.

2. !!LEFT-WALL and !!RIGHT-WALL are mishandled.
The fix takes care to handle them like any other word.