### PR TITLE
sat-solver: Fix crashes in panic mode

### DIFF
--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1771,6 +1771,5 @@ extern "C" void sat_sentence_delete(Sentence sent)
   Linkage lkgs = sent->lnkages;
   if (!lkgs) return;
 
-  for (LinkageIdx li = 0; li < sent->num_linkages_alloced; li++)
-    free_linkage_connectors_and_disjuncts(&lkgs[li]);
+  sat_free_linkages(sent);
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -23,15 +23,13 @@ using std::endl;
 
 
 extern "C" {
-#include "analyze-linkage.h"
-#include "build-disjuncts.h"
+#include "analyze-linkage.h"      // for compute_link_names()
+#include "build-disjuncts.h"      // for build_disjuncts_for_exp()
 #include <dict-api.h>             // for print_expression()
-#include "dict-file/read-dict.h"
-#include "extract-links.h"
 #include "linkage.h"
 #include "post-process.h"
 #include "preparation.h"
-#include "score.h"
+#include "score.h"               // for linkage_score()
 //#include "utilities.h"         // XXX do we need it?
 #include "wordgraph.h"           // for empty_word()
 }

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -3,6 +3,7 @@
 extern "C" {
 #include "api-structures.h"
 #include "structures.h"
+#include "linkage.h"
 };
 
 /**
@@ -19,6 +20,22 @@ void free_linkage_connectors_and_disjuncts(Linkage lkg)
   for (size_t i = 0; i < lkg->num_words; i++) {
     free_disjuncts(lkg->chosen_disjuncts[i]);
   }
+}
+
+/**
+ * Free all the connectors and disjuncts of all the linkages.
+ */
+void sat_free_linkages(Sentence sent)
+{
+  Linkage lkgs = sent->lnkages;
+
+  for (LinkageIdx li = 0; li < sent->num_linkages_alloced; li++) {
+    free_linkage_connectors_and_disjuncts(&lkgs[li]);
+    free_linkage(&lkgs[li]);
+  }
+  free(lkgs);
+  sent->lnkages = 0;
+  sent->num_linkages_alloced = 0;
 }
 
 Exp* null_exp()

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -11,6 +11,7 @@ extern "C" {
 bool isEndingInterpunction(const char* str);
 const char* word(Sentence sent, int w);
 void free_linkage_connectors_and_disjuncts(Linkage);
+void sat_free_linkages(Sentence);
 Exp* null_exp();
 void add_anded_exp(Exp*&, Exp*);
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -941,6 +941,15 @@ int main(int argc, char * argv[])
 				/* print_total_time(opts); */
 				batch_errors++;
 				if (verbosity > 0) fprintf(stdout, "Entering \"panic\" mode...\n");
+				/* If the parser used was the SAT solver, set the panic parser to
+				 * it too.
+				 * FIXME? Currently, the SAT solver code is not too useful in
+				 * panic mode since it doesn't handle parsing with null words, so
+				 * using the regular parser in that case could be beneficial.
+				 * However, this currently causes a crash due to a memory
+				 * management mess. */
+				parse_options_set_use_sat_parser(copts->panic_opts,
+					parse_options_get_use_sat_parser(opts));
 				parse_options_reset_resources(copts->panic_opts);
 				parse_options_set_verbosity(copts->panic_opts, verbosity);
 				num_linkages = sentence_parse(sent, copts->panic_opts);


### PR DESCRIPTION
Also:
- Add comments about the sat-solver and panic mode.
- Remove unneeded include files.