### PR TITLE
Trie speedup and dead code removal

### DIFF
--- a/link-grammar/sat-solver/fast-sprintf.cpp
+++ b/link-grammar/sat-solver/fast-sprintf.cpp
@@ -2,17 +2,14 @@
 
 char* fast_sprintf(char* buffer, int num)
 {
-  char* begin = buffer;
-  do {
-    *buffer++ = '0' + num % 10;
-    num /= 10;
-  } while (num > 0);
-  char* end = buffer - 1;
-
-  for (; begin < end; begin++, end--) {
-    char tmp = *begin;
-    *begin = *end;
-    *end = tmp;
+  // num is 0 or 1 most of the times
+  if (num < 16) {
+    *buffer++ = '0' + num;
+  } else {
+    do {
+      *buffer++ = '0' + num % 16;
+      num /= 16;
+    } while (num > 0);
   }
 
   *buffer = '\0';

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -254,7 +254,10 @@ void SATEncoder::build_word_tags()
 #endif
 
     char name[MAX_VARIABLE_NAME];
-    sprintf(name, "w%zu", w);
+    // sprintf(name, "w%zu", w);
+    name[0] = 'w';
+    fast_sprintf(name+1, w);
+
     bool leading_right = true;
     bool leading_left = true;
     std::vector<int> eps_right, eps_left;
@@ -319,7 +322,9 @@ void SATEncoder::generate_satisfaction_conditions()
 #endif
 
     char name[MAX_VARIABLE_NAME];
-    sprintf(name, "w%zu", w);
+    // sprintf(name, "w%zu", w);
+    name[0] = 'w';
+    fast_sprintf(name+1, w);
 
     determine_satisfaction(w, name);
     int dfs_position = 0;
@@ -489,9 +494,12 @@ void SATEncoder::generate_link_cw_ordinary_definition(size_t wi, int pi,
   double cost = e->cost;
   Lit lhs = Lit(_variables->link_cw(wj, wi, pi, Ci));
 
-  char str[MAX_VARIABLE_NAME];
-  sprintf(str, "w%zd", wj);
-  Lit condition = Lit(_variables->string(str));
+  char name[MAX_VARIABLE_NAME];
+  // sprintf(name, "w%zu", wj);
+  name[0] = 'w';
+  fast_sprintf(name+1, wj);
+
+  Lit condition = Lit(_variables->string(name));
 
   vec<Lit> rhs;
 
@@ -946,7 +954,9 @@ void SATEncoder::generate_epsilon_definitions()
     Exp* exp = join ? join_alternatives(w) : _sent->word[w].x->exp;
 
     char name[MAX_VARIABLE_NAME];
-    sprintf(name, "w%zu", w);
+    // sprintf(name, "w%zu", w);
+    name[0] = 'w';
+    fast_sprintf(name+1, w);
 
     int dfs_position;
 

--- a/link-grammar/sat-solver/trie.hpp
+++ b/link-grammar/sat-solver/trie.hpp
@@ -33,7 +33,7 @@ private:
   // Number of supported chars - digits + upper + lower + other + addition-for-hexadecimal-base
   const static int NUM_CHARS = 10 + 1 + 10 + 1 + 6;
   // hash chars
-  int char_to_pos(char c);
+  ssize_t char_to_pos(char c);
 
   bool _terminal;
   Trie* _next[NUM_CHARS];
@@ -57,8 +57,8 @@ Trie<T>::~Trie() {
 
 
 template <class T>
-int Trie<T>::char_to_pos(char c) {
-  static int pos[] = {
+ssize_t Trie<T>::char_to_pos(char c) {
+  static ssize_t pos[] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -94,7 +94,7 @@ template <class T>
 void Trie<T>::insert(const char* key, T value) {
   Trie* t = this;
   while(*key != '\0') {
-    int pos = char_to_pos(*key);
+    ssize_t pos = char_to_pos(*key);
     if (!t->_next[pos]) {
       t->_next[pos] = new Trie();
     }
@@ -109,7 +109,7 @@ template <class T>
 T Trie<T>::lookup(const char* key) {
   Trie* t = this;
   while(*key != '\0') {
-    int pos = char_to_pos(*key);
+    ssize_t pos = char_to_pos(*key);
     t = t->_next[pos];
     if (!t) {
       return NOT_FOUND;

--- a/link-grammar/sat-solver/trie.hpp
+++ b/link-grammar/sat-solver/trie.hpp
@@ -30,8 +30,8 @@ private:
 
 
 
-  // Number of supported chars - digits + upper + lower + other
-  const static int NUM_CHARS = 10 + 1 + 10 + 1;
+  // Number of supported chars - digits + upper + lower + other + addition-for-hexadecimal-base
+  const static int NUM_CHARS = 10 + 1 + 10 + 1 + 6;
   // hash chars
   int char_to_pos(char c);
 
@@ -63,7 +63,7 @@ int Trie<T>::char_to_pos(char c) {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-    -1, -1, -1, -1, -1, -1, -1,
+    22, 23, 24, 25, 26, 27, -1,
 //   A   B   C   D   E   F   G   H   I   J   K   L   M   N   O   P   Q   R   S   T   U   V   W   X   Y   Z
     -1, -1, -1, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, 11, -1,

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -272,6 +272,7 @@ public:
    * linked to a connector
    */
 
+#if 0
   // If guiding params for this variable are not set earlier, they are
   // now set to default
   int link_top_cw(int wi, int wj, int pj, const char* cj) {
@@ -289,6 +290,7 @@ public:
     assert(var != -1, "Var == -1");
     return var;
   }
+#endif
 
 
 #ifdef _CONNECTIVITY_
@@ -526,6 +528,7 @@ private:
   // Additional info about the link_top_cw(wi, wj, pj) variable with the given number
   std::vector<LinkTopCWVar*> _link_top_cw_variables;
 
+#if 0
   // Set this additional info
   void add_link_top_cw_variable(int i, int j, int pj, const char* cj, size_t var) {
     char name[MAX_VARIABLE_NAME];
@@ -548,6 +551,7 @@ private:
     _link_top_cw_variables[var] = new LinkTopCWVar(name, i, j, cj);
     _link_top_cw_variables_indices.push_back(var);
   }
+#endif
 
   /*
    *   Information about the link_cw(w, wj, pj) variables

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -449,6 +449,10 @@ private:
   void add_link_variable(int i, int pi, const char* ci, Exp* ei,
                          int j, int pj, const char* cj, Exp* ej, size_t var)
   {
+  /* The following variable is created but is never inserted to the trie,
+     and generating it has an observable performance impact.
+     The trie even doesn't have 'k'. */
+#if 0
     char name[MAX_VARIABLE_NAME];
     char* s = name;
     *s++ = 'l';    *s++ = 'i';     *s++ = 'n';     *s++ = 'k';
@@ -464,12 +468,14 @@ private:
     s = fast_sprintf(s, pj);
     *s++ = '_';
     s = fast_sprintf(s, cj);
+#endif
     char* label = construct_link_label(ci, cj);
 
     if (var >= _link_variables.size()) {
       _link_variables.resize(var + 1, 0);
     }
-    _link_variables[var] = new LinkVar(name, label, i, pi, j, pj, ci, cj, ei, ej);
+    // The first argument was the redundant variable eliminated above
+    _link_variables[var] = new LinkVar("", label, i, pi, j, pj, ci, cj, ei, ej);
     _link_variables_indices.push_back(var);
   }
 


### PR DESCRIPTION
1. Speed up the trie variables generation and lookup by
 - using base 16 instead of 10
 - not using divisions when the number < 16 (most of the cases) [generation only]
 - use ssize_t index instead of int

The observed performance increase was about 1-1.5% (of course averaging many runs was needed to find it out). BTW, trying to use base 128 caused a huge slowness. Other bases has not been tried.

2. "#if 0" code that has apparently no purpose but has an observable performance impact (more info in the commit comment).

3. "#if 0" of code that was used only from the already-removed FAT-linkages code. Maybe it can just been removed.