### PR TITLE
match_in_connector_set(): Remove the "dir" parameter

### DIFF
--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -32,7 +32,7 @@ set_connector_list_length_limit(Connector *c,
 		if (parse_options_get_all_short_connectors(opts)) {
 			c->length_limit = short_len;
 		}
-		else if (conset == NULL || match_in_connector_set(conset, c, '+')) {
+		else if (conset == NULL || match_in_connector_set(conset, c)) {
 			c->length_limit = UNLIMITED_LEN;
 		} else {
 			c->length_limit = short_len;

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -142,7 +142,7 @@ public:
     if (parse_options_get_all_short_connectors(_opts)) {
       c->length_limit = short_len;
     }
-    else if (conset == NULL || match_in_connector_set(conset, c, '+')) {
+    else if (conset == NULL || match_in_connector_set(conset, c)) {
       c->length_limit = UNLIMITED_LEN;
     } else {
       c->length_limit = short_len;

--- a/link-grammar/word-utils.c
+++ b/link-grammar/word-utils.c
@@ -294,15 +294,15 @@ void connector_set_delete(Connector_set * conset)
  * d='-' means this connector is on the left side of the disjunct.
  */
 
-bool match_in_connector_set(Connector_set *conset, Connector * c, int dir)
+bool match_in_connector_set(Connector_set *conset, Connector * c)
 {
 	unsigned int h;
 	Connector * c1;
 	if (conset == NULL) return false;
-	h = connector_set_hash(conset, c->string, dir);
+	h = connector_set_hash(conset, c->string, '+');
 	for (c1 = conset->hash_table[h]; c1 != NULL; c1 = c1->next)
 	{
-		if (easy_match(c1->string, c->string) && (dir == c1->word)) return true;
+		if (easy_match(c1->string, c->string)) return true;
 	}
 	return false;
 }

--- a/link-grammar/word-utils.h
+++ b/link-grammar/word-utils.h
@@ -42,7 +42,7 @@ Connector_set * connector_set_create(Exp *e);
 void connector_set_delete(Connector_set * conset);
 bool word_has_connector(Dict_node *, const char *, char);
 const char * word_only_connector(Dict_node *);
-bool match_in_connector_set(Connector_set*, Connector*, int dir);
+bool match_in_connector_set(Connector_set*, Connector*);
 
 
 /**


### PR DESCRIPTION
(Issue #201.)

Notes:
connector_set_hash() still has a "dir" parameter.
However, it is useless, since match_in_connector_set() calls connector_set_hash() only with dir=='+'. Hence the code in build_connector_set_from_expression() which allows UNLIMITED-CONNECTORS with "-" is useless too.

So can "dir" be omitted also from connector_set_hash() and build_connector_set_from_expression()?