### PR TITLE
Improvements in the setting of length_limit

### DIFF
--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -29,10 +29,8 @@ set_connector_list_length_limit(Connector *c,
                                 Parse_Options opts)
 {
 	for (; c!=NULL; c=c->next) {
-		if (parse_options_get_all_short_connectors(opts)) {
-			c->length_limit = short_len;
-		}
-		else if (conset == NULL || match_in_connector_set(conset, c)) {
+		if (!opts->all_short &&
+		    (conset == NULL || match_in_connector_set(conset, c))) {
 			c->length_limit = UNLIMITED_LEN;
 		} else {
 			c->length_limit = short_len;
@@ -44,7 +42,7 @@ static void
 set_connector_length_limits(Sentence sent, Parse_Options opts)
 {
 	size_t i;
-	size_t len = opts->short_length;
+	unsigned int len = opts->short_length;
 	Connector_set * ucs = sent->dict->unlimited_connector_set;
 
 	if (len > UNLIMITED_LEN) len = UNLIMITED_LEN;

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -134,18 +134,16 @@ public:
 
   void set_connector_length_limit(Connector* c)
   {
-    int short_len = _opts->short_length;
-    if (short_len > UNLIMITED_LEN)
-      short_len = UNLIMITED_LEN;
+    unsigned int len = _opts->short_length;
+    Connector_set * conset = _sent->dict->unlimited_connector_set;
 
-    Connector_set *conset = _sent->dict->unlimited_connector_set;
-    if (parse_options_get_all_short_connectors(_opts)) {
-      c->length_limit = short_len;
-    }
-    else if (conset == NULL || match_in_connector_set(conset, c)) {
+    if (len > UNLIMITED_LEN) len = UNLIMITED_LEN;
+
+    if (!_opts->all_short &&
+        (conset == NULL || match_in_connector_set(conset, c))) {
       c->length_limit = UNLIMITED_LEN;
     } else {
-      c->length_limit = short_len;
+      c->length_limit = len;
     }
   }
 


### PR DESCRIPTION
- In the regular and SAT parsers:
  Avoid a very large number of calls (a call per connector) to the API
  call parse_options_get_all_short_connectors().  Instead, use
  opts->all_short.

- Simplify set_connector_list_length_limit() and in a similar way
  set_connector_length_limit().

- Use unsigned int instead of size_t for the temporary variable that is
  set to opts->short_length.
