### PR TITLE
Python binding use-sat support

### DIFF
--- a/bindings/python-examples/parses-sat-en.txt
+++ b/bindings/python-examples/parses-sat-en.txt
@@ -1,0 +1,17 @@
+% This file contains test cases for the SAT solver,
+% to validate that it works.
+% Since the SAT solver doesn't order (for now) its solutions
+% according to cost, this is just the solution it omits first
+% for the given sentence.
+
+Ithis is a test
+O
+O    +----->WV----->+---Osm--+
+O    +---Wd---+-Ss*b+  +Ds**c+
+O    |        |     |  |     |
+OLEFT-WALL this.p is.v a  test.n 
+O
+C(S (NP this.p)
+C   (VP is.v
+C       (NP a test.n)))
+C

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -3,7 +3,8 @@
 #
 # Python link-grammar test script
 #
-import os
+from __future__ import print_function
+import sys, os
 import locale
 import unittest
 
@@ -242,8 +243,17 @@ class DBasicParsingTestCase(unittest.TestCase):
         linkage = self.parse_sent("This is a silly sentence.")[0]
         self.assertEqual([len(l) for l in linkage.links()], [6,2,1,1,3,2,1,1,1])
 
+class ESATsolverTestCase(unittest.TestCase):
+    def setUp(self):
+        self.d, self.po = Dictionary(lang='en'), ParseOptions()
+        self.po = ParseOptions(use_sat=True)
+        if self.po.use_sat != True:
+            raise unittest.SkipTest("Library not configured with SAT parser")
 
-class EEnglishLinkageTestCase(unittest.TestCase):
+    def test_SAT_getting_links(self):
+        linkage_testfile(self, self.d, self.po, 'sat')
+
+class HEnglishLinkageTestCase(unittest.TestCase):
     def setUp(self):
         self.d, self.po = Dictionary(), ParseOptions()
 
@@ -525,12 +535,14 @@ class ZRULangTestCase(unittest.TestCase):
              'облачк.=', '=а.ndnpi',
              '.', 'RIGHT-WALL'])
 
-def linkage_testfile(self, dict, popt):
+def linkage_testfile(self, dict, popt, desc = ''):
     """
     Reads sentences and their corresponding
     linkage diagrams / constituent printings.
     """
-    parses = open(clg.test_data_srcdir + "parses-" + clg.dictionary_get_lang(dict._obj) + ".txt")
+    if '' != desc:
+        desc = desc + '-'
+    parses = open(clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(dict._obj) + ".txt")
     diagram = None
     sent = None
     for line in parses:
@@ -562,5 +574,9 @@ def linkage_testfile(self, dict, popt):
                 self.assertEqual(linkage.constituent_tree(), constituents)
             constituents += line[1:]
     parses.close()
+
+def warning(*msg):
+    progname = os.path.basename(sys.argv[0])
+    print("{}: Warning:".format(progname), *msg, file=sys.stderr)
 
 unittest.main()

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -21,6 +21,7 @@ class ParseOptions(object):
                  all_short_connectors=False,
                  display_morphology=False,
                  spell_guess=False,
+                 use_sat=False,
                  max_parse_time=-1,
                  disjunct_cost=2.7):
 
@@ -34,6 +35,7 @@ class ParseOptions(object):
         self.all_short_connectors = all_short_connectors
         self.display_morphology = display_morphology
         self.spell_guess = spell_guess
+        self.use_sat = use_sat
         self.max_parse_time = max_parse_time
         self.disjunct_cost = disjunct_cost
 
@@ -218,6 +220,20 @@ class ParseOptions(object):
         if isinstance(value, bool):
             value = 7 if value else 0
         clg.parse_options_set_spell_guess(self._obj, value)
+
+    @property
+    def use_sat(self):
+        """
+        To be used after enabling the use of the SAT solver in order to
+        validate that it is supported by the LG library.
+        """
+        return clg.parse_options_get_use_sat_parser(self._obj)
+
+    @use_sat.setter
+    def use_sat(self, value):
+        if not isinstance(value, bool):
+            raise TypeError("use_sat must be set to a bool")
+        clg.parse_options_set_use_sat_parser(self._obj, value)
 
     @property
     def all_short_connectors(self):

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -82,6 +82,8 @@ int  parse_options_get_spell_guess(Parse_Options opts);
 void parse_options_set_all_short_connectors(Parse_Options opts, int val);
 int  parse_options_get_all_short_connectors(Parse_Options opts);
 void parse_options_reset_resources(Parse_Options opts);
+void parse_options_set_use_sat_parser(Parse_Options opts, bool val);
+bool parse_options_get_use_sat_parser(Parse_Options opts);
 
 /**********************************************************************
 *

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -262,8 +262,9 @@ void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {
 #ifdef USE_SAT_SOLVER
 	opts->use_sat_solver = dummy;
 #else
-	prt_error("Error: cannot enable the Boolean SAT parser; this "
-	          " library was built without SAT solver support.\n");
+	if (dummy)
+		prt_error("Error: cannot enable the Boolean SAT parser; this "
+					 " library was built without SAT solver support.\n");
 #endif
 }
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -263,7 +263,7 @@ void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {
 	opts->use_sat_solver = dummy;
 #else
 	if (dummy)
-		prt_error("Error: cannot enable the Boolean SAT parser; this "
+		prt_error("Error: cannot enable the Boolean SAT parser; this"
 					 " library was built without SAT solver support.\n");
 #endif
 }

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -264,7 +264,7 @@ void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {
 #else
 	if (dummy)
 		prt_error("Error: cannot enable the Boolean SAT parser; this"
-					 " library was built without SAT solver support.\n");
+					 " library was built without SAT solver support.");
 #endif
 }
 


### PR DESCRIPTION
SWIG + python use-sat support.
Also add a test for checking that the SAT parser is basically functional.
This test is skipped if the SAT parser is not configured.