### PR TITLE
SAT-solver: Add a call to init_connectors

### DIFF
--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -21,6 +21,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
     const char* name = exp->u.string;
 
     Connector connector;
+    init_connector(&connector);
     connector.multi = exp->multi;
     connector.string = name;
     set_connector_length_limit(&connector);

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -141,11 +141,8 @@ public:
 
     if (_opts->all_short ||
         (conset != NULL && !match_in_connector_set(conset, c)))
-  {
+    {
       c->length_limit = len;
-    }
-    else {
-      c->length_limit = UNLIMITED_LEN;
     }
   }
 


### PR DESCRIPTION
Again make set_connector_length_limit() to be similar to
set_connector_list_length_limit().