### PR TITLE
Reduce MAX_SENTENCE size + Connector_struct changes

### DIFF
--- a/link-grammar/api-types.h
+++ b/link-grammar/api-types.h
@@ -26,7 +26,7 @@
  * should fit in two bytes (because the word field of a connector is an
  * unsigned short).
  */
-#define MAX_SENTENCE 65534      /* Maximum number of words in a sentence */
+#define MAX_SENTENCE 254        /* Maximum number of words in a sentence */
 
 /* Widely used private typedefs */
 typedef struct Connector_struct Connector;

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -14,6 +14,8 @@
 #ifndef _STRUCTURES_H_
 #define _STRUCTURES_H_
 
+#include "stdint.h"
+
 #include "api-types.h"
 #include "api-structures.h"
 #include "dict-structures.h"  /* For Exp, Exp_list */
@@ -91,11 +93,11 @@
  */
 struct Connector_struct
 {
-	int hash;
-	unsigned char word;
+	int16_t hash;
+	uint8_t word;
 	             /* The nearest word to my left (or right) that
 	                this could connect to.  Computed by power pruning */
-	unsigned char length_limit;
+	uint8_t length_limit;
 	             /* If this is a length limited connector, this
 	                gives the limit of the length of the link
 	                that can be used on this connector.  Since

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -92,7 +92,7 @@
 struct Connector_struct
 {
 	int hash;
-	unsigned short word;
+	unsigned char word;
 	             /* The nearest word to my left (or right) that
 	                this could connect to.  Computed by power pruning */
 	unsigned char length_limit;

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -93,7 +93,7 @@
  */
 struct Connector_struct
 {
-	int16_t hash;
+	int32_t hash;
 	uint8_t word;
 	             /* The nearest word to my left (or right) that
 	                this could connect to.  Computed by power pruning */
@@ -106,7 +106,7 @@ struct Connector_struct
 	                this.  If no limit, the value is set to 255. */
 	bool multi;  /* TRUE if this is a multi-connector */
 	Connector * next;
-	const char * string;  /* The connector name, e.g. AB+ */
+	const char * string; /* The connector name w/o the direction mark, e.g. AB */
 
 	/* Hash table next pointer, used only during pruning. */
 	Connector * tableNext;


### PR DESCRIPTION
One of the commits introduces using stdint sizes instead of int etc.
If this doesn't seem as a good idea I will resend the pull request without it.