### PR TITLE
Change the "s" wordgraph display to make a more readable subgraph

### DIFF
--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -570,6 +570,8 @@ static String *wordgraph2dot(Sentence sent, unsigned int mode, const char *modes
 
 	append_string(wgd, "# Mode: %s\n", modestr);
 	append_string(wgd, "digraph G {\nsize =\"30,20\";\nrankdir=LR;\n");
+	if ((mode & (WGR_SUB)) && !(mode & WGR_COMPACT))
+		append_string(wgd, "newrank=true;\n");
 	if (mode & WGR_LEGEND) wordgraph_legend(wgd, mode);
 	append_string(wgd, "\"%p\" [shape=box,style=filled,color=\".7 .3 1.0\"];\n",
 	              sent->wordgraph);

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -2,6 +2,7 @@
 /* Wordgraph display representation modes. */
 #define lo(l) (l-'a')
 #define WGR_SUB      (1<<lo('s')) /* Unsplit words as subgraphs */
+#define WGR_COMPACT  (1<<lo('c')) /* Compact. Just now applies only to 's'. */
 #define WGR_PREV     (1<<lo('p')) /* Prev links */
 #define WGR_UNSPLIT  (1<<lo('u')) /* Unsplit_word links */
 #define WGR_DBGLABEL (1<<lo('d')) /* Debug label addition */


### PR DESCRIPTION
... but less compact.

Usage:
link-parser -test=wg:s

![test wg s](https://cloud.githubusercontent.com/assets/879514/11630911/55031e84-9d08-11e5-923c-b49caff1bd40.gif)

The previous (more compact on the X axis) display is still possible by:
link-parser -test=wg:sc

![test wg sc](https://cloud.githubusercontent.com/assets/879514/11630926/5babaa80-9d08-11e5-9d94-a35ac2a7b87a.gif)

