### PR TITLE
Fix assert  strip_right: unexpected empty word

### DIFF
--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -43,24 +43,25 @@
  * Append an unmarked (i.e. without INFIXMARK) morpheme to join_buff.
  * join_buff is a zeroed-out buffer which has enough room for morpheme to be
  * added + terminating NUL.
- * In case INFIXMARK is not defined in the affix file, it is '\0'. However,
- * in that case there are no MT_PREFIX, MT_SUFFIX and MT_MIDDLE morpheme types.
+ * Note that MT_PREFIX or MT_SUFFIX can be without an INFIX_MARK, in case
+ * INFIX_MARK is not defined. XXX: What about MT_MIDDLE? (not in use yet).
  *
  * FIXME Combining contracted words is not handled yet, because combining
  * morphemes which have non-LL links to other words is not yet implemented.
  */
-static void add_morpheme_unmarked(char *join_buff, const char *wm,
-                                  Morpheme_type mt)
+static void add_morpheme_unmarked(Sentence sent, char *join_buff,
+                                  const char *wm, Morpheme_type mt)
 {
+	const char infix_mark = INFIX_MARK(sent->dict->affix_table);
 	const char *sm =  strrchr(wm, SUBSCRIPT_MARK);
 
 	if (NULL == sm) sm = (char *)wm + strlen(wm);
 
-	if (MT_PREFIX == mt)
+	if ((MT_PREFIX == mt) && (infix_mark == sm[-INFIX_MARK_L]))
 		strncat(join_buff, wm, sm-wm-INFIX_MARK_L);
-	else if (MT_SUFFIX == mt)
+	else if ((MT_SUFFIX == mt) && (infix_mark == wm[0]))
 		strncat(join_buff, INFIX_MARK_L+wm, sm-wm-INFIX_MARK_L);
-	else if (MT_MIDDLE == mt)
+	else if ((MT_MIDDLE == mt))
 		strncat(join_buff, INFIX_MARK_L+wm, sm-wm-2*INFIX_MARK_L);
 	else
 		strncat(join_buff, wm, sm-wm);
@@ -80,7 +81,8 @@ static const char *join_null_word(Sentence sent, Gword **wgp, size_t count)
 	memset(join_buff, '\0', join_len+1);
 
 	for (i = 0; i < count; i++)
-		add_morpheme_unmarked(join_buff, wgp[i]->subword, wgp[i]->morpheme_type);
+		add_morpheme_unmarked(sent, join_buff, wgp[i]->subword,
+		                      wgp[i]->morpheme_type);
 
 	s = string_set_add(join_buff, sent->string_set);
 
@@ -105,7 +107,7 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
 	usubword = calloc(join_len+1, 1); /* zeroed out */
 
 	for (w = start; w <= end; w++)
-		add_morpheme_unmarked(usubword, (*w)->subword, (*w)->morpheme_type);
+		add_morpheme_unmarked(sent, usubword, (*w)->subword, (*w)->morpheme_type);
 
 	new_word = gword_new(sent, usubword);
 	free(usubword);
@@ -500,7 +502,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 						/* 1. Join base words. (Could just use the unsplit_word.) */
 						for (wgaltp = wgp, m = 0; m < mcnt; wgaltp++, m++)
 						{
-							add_morpheme_unmarked(join, cdjp[i+m]->string,
+							add_morpheme_unmarked(sent, join, cdjp[i+m]->string,
 							                      (*wgaltp)->morpheme_type);
 						}
 

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -995,7 +995,8 @@ static bool add_alternative_with_subscr(Sentence sent,
 		}
 		else
 		{
-			/* This is a compound-word spell check. Reject unknown words. */
+			/* This is a compound-word spell check. Reject unknown words.
+			 * XXX: What if the word is capitalized? */
 			word_is_in_dict = boolean_dictionary_lookup(dict, word);
 		}
 	}

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1134,8 +1134,10 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 			for (j = 0; j < p_strippable; j++)
 			{
 				size_t prelen = strlen(prefix[j]);
-				/* The remaining w is too short for a possible match. */
-				if ((wend-w) - suflen < prelen) continue;
+				/* The remaining w is too short for a possible match.
+				 * NOTE: A zero length "stem" is not allowed here. In any
+				 * case, it cannot be handled (yet) by the rest of the code. */
+				if ((wend-w) - suflen <= prelen) continue;
 				if (strncmp(w, prefix[j], prelen) == 0)
 				{
 					size_t sz = MIN((wend-w) - suflen - prelen, MAX_WORD);

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -965,6 +965,8 @@ error:
  * If unsplit_word is null, this function actually only checks whether
  * the alternative is valid as described above. This is used for checking
  * is a spell guess result if valid if the word itself is not in the dict.
+ * FIXME: If a word can split it doesn't follow it is a "real" dictionary
+ * word, as there can still be no links between some of its parts.
  *
  * Return true if the alternative is valid, else false.
  */
@@ -1038,11 +1040,6 @@ static bool add_alternative_with_subscr(Sentence sent,
  * It can also split contracted words (like he's).
  * Alternatives are generated if issue_alternatives=true.
  * Return value:
- * If issue_alternatives=true: true only if the word can morpheme-split.
- * If issue_alternatives=false: true only if the word can split.
- *
- * FIXME: If a word can split it doesn't follow it is a "real" dictionary word,
- * as there can still be no links between some of its parts.
  *
  * The prefix code is only lightly validated by actual use.
  *
@@ -1101,10 +1098,6 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 				 * In case we try to split a contracted word, the first word
 				 * may match a regex. Hence find_word_in_dict() is used and
 				 * not boolean_dictionary_lookup().
-				 * However, if this is a check whether the word is a known one
-				 * (argument issue_alternatives=false), we shouldn't allow words
-				 * which are not in the dict file.
-				 *
 				 * Note: Not like a previous version, stems cannot match a regex
 				 * here, and stem capitalization need to be handled elsewhere. */
 				if ((is_contraction_word(w) &&


### PR DESCRIPTION
It was due to allowing a null-string "stem", which is not supported by the rest of the code.
So an empty string entered into the wordgraph (maybe we need an assert on that).
When separate_word() encountered this newly inserted empty string word, it aborted in strip_right() on this assert(), that was originally intended to guard against a miscalculation of the word end before calling the function.

In the same occasion I found and fixed another bug, which caused mis-displaying of linkage null-words which happen to be prefixes, when INFIX_MARK is not defined (their last character, in our case `/` or `'`, got stripped from the displayed word, as if it was an INFIX_MARK).