### PR TITLE
Additional significant speedup of long sentences

### DIFF
--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -93,19 +93,6 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 	memset(ctxt->table, 0, ctxt->table_size*sizeof(Table_connector*));
 }
 
-/*
- * Returns TRUE if s and t match according to the connector matching
- * rules.
- */
-bool do_match(Connector *a, Connector *b, int aw, int bw)
-{
-	int dist = bw - aw;
-	if (NULL == a || NULL == b) return false;
-	assert(aw < bw, "do_match() did not receive params in the natural order.");
-	if (dist > a->length_limit || dist > b->length_limit) return false;
-	return easy_match(a->string, b->string);
-}
-
 /**
  * Stores the value in the table.  Assumes it's not already there.
  */

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -286,10 +286,16 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 	{
 		Match_node *m, *m1;
 		m1 = m = form_match_list(mchxt, w, le, lw, re, rw);
+#ifdef VERIFY_MATCH_LIST
+		int id = m ? m->d->match_id : 0;
+#endif
 		for (; m != NULL; m = m->next)
 		{
 			unsigned int lnull_cnt, rnull_cnt;
 			Disjunct * d = m->d;
+#ifdef VERIFY_MATCH_LIST
+			assert(id == d->match_id, "Modified id (%d!=%d)\n", id, d->match_id);
+#endif
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
 

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -303,8 +303,8 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 		{
 			unsigned int lnull_cnt, rnull_cnt;
 			Disjunct * d = m->d;
-			bool Lmatch = do_match(le, d->left, lw, w);
-			bool Rmatch = do_match(d->right, re, w, rw);
+			bool Lmatch = d->match_left;
+			bool Rmatch = d->match_right;
 
 			/* _p1 avoids a gcc warning about unsafe loop opt */
 			unsigned int null_count_p1 = null_count + 1;

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -100,6 +100,7 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 bool do_match(Connector *a, Connector *b, int aw, int bw)
 {
 	int dist = bw - aw;
+	if (NULL == a || NULL == b) return false;
 	assert(aw < bw, "do_match() did not receive params in the natural order.");
 	if (dist > a->length_limit || dist > b->length_limit) return false;
 	return easy_match(a->string, b->string);
@@ -302,12 +303,14 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 		{
 			unsigned int lnull_cnt, rnull_cnt;
 			Disjunct * d = m->d;
+			bool Lmatch = do_match(le, d->left, lw, w);
+			bool Rmatch = do_match(d->right, re, w, rw);
+
 			/* _p1 avoids a gcc warning about unsafe loop opt */
 			unsigned int null_count_p1 = null_count + 1;
 
 			for (lnull_cnt = 0; lnull_cnt < null_count_p1; lnull_cnt++)
 			{
-				bool Lmatch, Rmatch;
 				bool leftpcount = false;
 				bool rightpcount = false;
 				bool pseudototal = false;
@@ -318,10 +321,6 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 
 				/* Now, we determine if (based on table only) we can see that
 				   the current range is not parsable. */
-				Lmatch = (le != NULL) && (d->left != NULL) &&
-				         do_match(le, d->left, lw, w);
-				Rmatch = (d->right != NULL) && (re != NULL) &&
-				         do_match(d->right, re, w, rw);
 
 				/* First, perform pseudocounting as an optimization. If
 				 * the pseudocount is zero, then we know that the true

--- a/link-grammar/count.h
+++ b/link-grammar/count.h
@@ -14,7 +14,6 @@
 #include "histogram.h" /* for s64 */
 
 Count_bin* table_lookup(count_context_t *, int, int, Connector *, Connector *, unsigned int);
-bool do_match(Connector *a, Connector *b, int wa, int wb);
 Count_bin do_parse(Sentence, fast_matcher_t*, count_context_t*, int null_count, Parse_Options);
 void delete_unmarked_disjuncts(Sentence sent);
 

--- a/link-grammar/extract-links.c
+++ b/link-grammar/extract-links.c
@@ -384,10 +384,12 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 		{
 			unsigned int lnull_count, rnull_count;
 			Disjunct* d = m->d;
+			bool Lmatch = do_match(le, d->left, lw, w);
+			bool Rmatch = do_match(d->right, re, w, rw);
+
 			for (lnull_count = 0; lnull_count <= null_count; lnull_count++)
 			{
 				int i, j;
-				bool Lmatch, Rmatch;
 				Parse_set *ls[4], *rs[4];
 
 				/* Here, lnull_count and rnull_count are the null_counts
@@ -396,11 +398,6 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 
 				/* Now, we determine if (based on table only) we can see that
 				   the current range is not parsable. */
-
-				Lmatch = (le != NULL) && (d->left != NULL)
-				         && do_match(le, d->left, lw, w);
-				Rmatch = (d->right != NULL) && (re != NULL)
-				         && do_match(d->right, re, w, rw);
 
 				for (i=0; i<4; i++) { ls[i] = rs[i] = NULL; }
 				if (Lmatch)

--- a/link-grammar/extract-links.c
+++ b/link-grammar/extract-links.c
@@ -384,8 +384,8 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 		{
 			unsigned int lnull_count, rnull_count;
 			Disjunct* d = m->d;
-			bool Lmatch = do_match(le, d->left, lw, w);
-			bool Rmatch = do_match(d->right, re, w, rw);
+			bool Lmatch = d->match_left;
+			bool Rmatch = d->match_right;
 
 			for (lnull_count = 0; lnull_count <= null_count; lnull_count++)
 			{

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -466,6 +466,11 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	Match_node *ml = NULL, *mr = NULL;
 	match_cache mc;
 
+#ifdef VERIFY_MATCH_LIST
+	static int id = 0;
+	int lid = ++id; /* A local copy, for multi-threading support. */
+#endif
+
 	/* Get the lists of candidate matching disjuncts of word w for lc and
 	 * rc.  Consider each of these lists only if the length_limit of lc
 	 * rc and also w, is not greater then the distance between their word
@@ -511,6 +516,9 @@ form_match_list(fast_matcher_t *ctxt, int w,
 		my->d = mx->d;
 		my->next = front;
 		front = my;
+#ifdef VERIFY_MATCH_LIST
+		mx->d->match_id = lid;
+#endif
 	}
 
 	/* Append the list of things that could match the right.
@@ -528,6 +536,9 @@ form_match_list(fast_matcher_t *ctxt, int w,
 		my->d = mx->d;
 		my->next = front;
 		front = my;
+#ifdef VERIFY_MATCH_LIST
+		mx->d->match_id = lid;
+#endif
 	}
 
 	return front;

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -417,9 +417,9 @@ static void print_match_list(int id, Match_node *m, int w,
  * This function uses shortcuts to speed up the comparison.
  * Especially, we know that the uc parts of the connectors are the same,
  * because we fetch the matching lists according to the uc part or the
- * connectors to be matched. So the uc parts are not checked here.
- * The head/dependent indications are not checked here, but in the
- * caller function, to save CPU when the connectors don't match
+ * connectors to be matched. So the uc parts are not checked here. The
+ * head/dependent indicators are in the caller function, and only when
+ * connectors match here, to save CPU when the connectors don't match
  * otherwise. This is because h/d mismatch is rare.
  * FIXME: Use connector enumeration.
  */

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -475,7 +475,13 @@ static bool do_match_with_cache(Connector *a, Connector *b, match_cache *c_con)
 	/* The following uses a string-set compare - string_set_cmp() cannot
 	 * be used here because c_con->string may be NULL. */
 	match_stats(c_con->string == a->string ? NULL : a, NULL);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+	/* The string field is initialized to NULL, and this is enough because
+	 * the connector string cannot be NULL, as it actually fetched a
+	 * non-empty match list. */
 	if (c_con->string == a->string) return c_con->match;
+#pragma GCC diagnostic pop
 
 	/* No cache exists. Check if the connectors match and cache the result. */
 	c_con->match = easy_match_list(a, b) && match_hd(a, b);

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -359,15 +359,27 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	Match_node *mx, *my, *mr_end, *front, **mxp;
 	Match_node *ml = NULL, *mr = NULL;
 
-	if (lc != NULL)
+	/* Get the lists of candidate matching disjuncts of word w for lc and
+	 * rc.  Consider each of these lists only if the length_limit of lc
+	 * rc and also w, is not greater then the distance between their word
+	 * and the word w. */
+	if ((lc != NULL) && ((w - lw) <= lc->length_limit))
 	{
 		mxp = get_match_table_entry(ctxt->l_table_size[w], ctxt->l_table[w], lc, -1);
-		if (NULL != mxp) ml = *mxp;
+		if ((NULL != mxp) && (NULL != *mxp) &&
+		    ((w - lw) <= (*mxp)->d->left->length_limit))
+		{
+			ml = *mxp;
+		}
 	}
-	if (rc != NULL)
+	if ((rc != NULL) && ((rw - w) <= rc->length_limit))
 	{
 		mxp = get_match_table_entry(ctxt->r_table_size[w], ctxt->r_table[w], rc, 1);
-		if (NULL != mxp) mr = *mxp;
+		if ((NULL != mxp) && (NULL != *mxp) &&
+		    ((rw - w) <= (*mxp)->d->right->length_limit))
+		{
+			mr = *mxp;
+		}
 	}
 
 	for (mx = mr; mx != NULL; mx = mx->next)

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -337,7 +337,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 #if 0
 /**
  * Print statistics on various connector matching aspects.
- * A summary can be found by the shell commans:
+ * A summary can be found by the shell commands:
  * link-parser < file.batch | grep match_stats: | sort | uniq -c
  */
 static void match_stats(Connector *c1, Connector *c2)

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -125,6 +125,9 @@ static inline const char * connector_get_string(Connector *c)
 	return c->string;
 }
 
+//#ifdef DEBUG
+#define VERIFY_MATCH_LIST
+//#endif
 struct Disjunct_struct
 {
 	Disjunct *next;
@@ -132,8 +135,12 @@ struct Disjunct_struct
 	Connector *left, *right;
 	double cost;
 	bool marked;               /* unmarked disjuncts get deleted */
-	bool match_left, match_right; /* used only during parsing */
 	const Gword **word;        /* NULL terminated list of originating words */
+	/* Used only during chart-parsing, for the match list. */
+	bool match_left, match_right;
+#ifdef VERIFY_MATCH_LIST
+	int match_id;              /* verify the match list integrity */
+#endif
 };
 
 typedef struct Match_node_struct Match_node;

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -132,6 +132,7 @@ struct Disjunct_struct
 	Connector *left, *right;
 	double cost;
 	bool marked;               /* unmarked disjuncts get deleted */
+	bool match_left, match_right; /* used only during parsing */
 	const Gword **word;        /* NULL terminated list of originating words */
 };
 

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -93,7 +93,7 @@
  */
 struct Connector_struct
 {
-	int32_t hash;
+	int16_t hash;
 	uint8_t word;
 	             /* The nearest word to my left (or right) that
 	                this could connect to.  Computed by power pruning */
@@ -105,6 +105,9 @@ struct Connector_struct
 	                name, efficiency is the only reason to store
 	                this.  If no limit, the value is set to 255. */
 	bool multi;  /* TRUE if this is a multi-connector */
+	uint8_t lc_start;     /* lc start position (or 0) - for match speedup. */
+	uint8_t uc_length;    /* uc part length - for match speedup. */
+	uint8_t uc_start;     /* uc start position - for match speedup. */
 	Connector * next;
 	const char * string; /* The connector name w/o the direction mark, e.g. AB */
 

--- a/link-grammar/word-utils.c
+++ b/link-grammar/word-utils.c
@@ -458,6 +458,7 @@ int calculate_connector_hash(Connector * c)
 	i = 0;
 	s = c->string;
 	if (islower((int) *s)) s++; /* ignore head-dependent indicator */
+	c->uc_start = s - c->string;
 	while (isupper((int) *s)) /* connector tables cannot contain UTF8, yet */
 	{
 		i += *s;
@@ -475,6 +476,7 @@ int calculate_connector_hash(Connector * c)
 	i = 0;
 	s = c->string;
 	if (islower((int) *s)) s++; /* ignore head-dependent indicator */
+	c->uc_start = s - c->string;
 	while (isupper((int) *s))
 	{
 		i = *s + (i << 6) + (i << 16) - i;
@@ -482,6 +484,8 @@ int calculate_connector_hash(Connector * c)
 	}
 #endif /* USE_SDBM */
 
+	c->lc_start = ('\0' == *s) ? 0 : s - c->string;
+	c->uc_length = s - c->string - c->uc_start;
 	c->hash = i;
 	return i;
 }


### PR DESCRIPTION
See the discussion at #244.

Speed up by these changes (comparing to the current master branch):

ru/corpus-fixes.batch: ~0%
en/corpus-basic.batch: ~0%
en/corpus-fixes.batch: ~10%
en/corpus-fix-long.batch [not including 3 last sentences, to shorten the benchmark]: 40+%

I tried it also on the following sentence which was not included above - it is currently the last one in en/corpus-fix-long.batch, and the result is consistent with the speed up as indicated above:

And yet he should be always ready to have a perfectly terrible scene, whenever we want one, and to become miserable, absolutely miserable, at a moment’s notice, and to overwhelm us with just reproaches in less than twenty minutes, and to be positively violent at the end of half an hour, and to leave us for ever at a quarter to eight, when we have to go and dress for dinner when, after that, one has seen him for really the last time, and he has refused to take back the little things he has given one, and promised never to communicate with one again, or to write one any foolish letters, he should be perfectly broken-hearted, and telegraph to one all day long, and send one little notes every half-hour by a private hansom, and dine quite alone at the club, so that every one should know how unhappy he was.

Results:
Current: 3966.762u 3.320s 1:06:16.47 99.8%  0+0k 192+128io 0pf+0w
After this modification: 2235.120u 2.471s 37:21.20 99.8%  0+0k 200+16io 8pf+0w
(Speed up of ~44%.)

A detailed run with **-limit=10000** of en/corpus-basic.batch, en/corpus-fixes.batch, ru/corpus-basic.batch and he/corpus-basic.batch, with the library before and after this modification gives **exactly the same results**, modulo order changes of linkages with the same cost - if any, which is not important and which my check is not sensitive to. At least with the sentences tested in the test suite, this order is preserved too.