### PR TITLE
Improve debug

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1047,6 +1047,7 @@ static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
  *
  * Return true if the linkage is good, else return false.
  */
+#define D_SLM 4
 bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 {
 	Wordgraph_pathpos *wp_new = NULL;
@@ -1076,11 +1077,11 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 	{
 		Disjunct *cdj;            /* chosen disjunct */
 
-		lgdebug(4, "%p Word %zu: ", lkg, i);
+		lgdebug(D_SLM, "%p Word %zu: ", lkg, i);
 
 		if (NULL == wp_new)
 		{
-			lgdebug(+4, "- No more words in the wordgraph\n");
+			lgdebug(+D_SLM, "- No more words in the wordgraph\n");
 			match_found = false;
 			break;
 		}
@@ -1097,7 +1098,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		/* Handle null words */
 		if (NULL == cdj)
 		{
-			lgdebug(4, "- Null word\n");
+			lgdebug(D_SLM, "- Null word\n");
 			/* A null word matches any word in the Wordgraph -
 			 * so, unconditionally proceed in all paths in parallel. */
 			match_found = false;
@@ -1124,7 +1125,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		if (!match_found)
 		{
 			const char *e = "Internal error: Too many words in the linkage\n";
-			lgdebug(4, "- %s", e);
+			lgdebug(D_SLM, "- %s", e);
 			prt_error("Error: %s.", e);
 			break;
 		}
@@ -1132,7 +1133,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		/* This causes a crash when using !use-sat. It should be fixed. [ap] */
 		assert(MT_EMPTY != cdj->word[0]->morpheme_type); /* already discarded */
 
-		if (4 <= opts->verbosity) print_with_subscript_dot(cdj->string);
+		if (debug_level(D_SLM)) print_with_subscript_dot(cdj->string);
 
 		match_found = false;
 		/* Proceed in all the paths in which the word is found. */
@@ -1158,10 +1159,10 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		{
 			/* FIXME? A message can be added here if there are too many words
 			 * in the linkage (can happen only if there is an internal error). */
-			lgdebug(4, "- No Wordgraph match\n");
+			lgdebug(D_SLM, "- No Wordgraph match\n");
 			break;
 		}
-		lgdebug(4, "\n");
+		lgdebug(D_SLM, "\n");
 	}
 
 	if (match_found)
@@ -1181,7 +1182,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			}
 		}
 		if (!match_found)
-		    lgdebug(4, "%p Missing word(s) at the end of the linkage.\n", lkg);
+		    lgdebug(D_SLM, "%p Missing word(s) at the end of the linkage.\n", lkg);
 	}
 
 #define DEBUG_morpheme_type 0
@@ -1229,7 +1230,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			}
 
 #if DEBUG_morpheme_type
-			lgdebug(4, "Word %zu: %s affixtype=%c\n",
+			lgdebug(D_SLM, "Word %zu: %s affixtype=%c\n",
 			     i, (*w)->subword,  *affix_types_p);
 #endif
 
@@ -1247,7 +1248,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			if (NULL != uw)
 			{
 				*affix_types_p++ = AFFIXTYPE_END;
-				lgdebug(4, "%p End of Gword %s\n", lkg, uw->subword);
+				lgdebug(D_SLM, "%p End of Gword %s\n", lkg, uw->subword);
 			}
 		}
 #endif
@@ -1274,9 +1275,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 	{
 		if ('\0' != affix_types[0])
 		{
-			lgdebug(4, "%p Morpheme type combination '%s'\n", lkg, affix_types);
+			lgdebug(D_SLM, "%p Morpheme type combination '%s'\n", lkg, affix_types);
 		}
-		lgdebug(+4, "%p SUCCEEDED\n", lkg);
+		lgdebug(+D_SLM, "%p SUCCEEDED\n", lkg);
 		lkg->wg_path = lwg_path;
 		return true;
 	}
@@ -1287,9 +1288,10 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 	lifo->pp_violation_msg = "Invalid morphism construction.";
 	lkg->wg_path = NULL;
 	lifo->discarded = true;
-	lgdebug(4, "%p FAILED\n", lkg);
+	lgdebug(D_SLM, "%p FAILED\n", lkg);
 	return false;
 }
+#undef D_SLM
 
 static void sane_morphism(Sentence sent, Parse_Options opts)
 {

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -50,6 +50,27 @@ const char *feature_enabled(const char *, const char *);
 	(void)printf(__VA_ARGS__)) : (void)0)
 
 /**
+ * Wrap-up a debug-messages block.
+ * Preceding the level number by a + (+level) adds printing of the
+ * function name.
+ * The !debug variable can be set to a comma-separated list of functions
+ * in order to restrict the debug messages to these functions only.
+ *
+ * Return true if the debug-messages block should be executed, else false.
+ *
+ * Usage example, for debug messages at verbosity V:
+ * if (debug_level(V))
+ * {
+ * 	print_disjunct(d);
+ * }
+ */
+#define debug_level(level) \
+(((verbosity >= (level)) && \
+	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
+	? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : 0), true)  \
+	: false)
+
+/**
  * Return TRUE if the given feature (a string) is set in the !test variable
  * (a comma-separated feature list).
  */

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -384,7 +384,7 @@ static void match_stats(Connector *c1, Connector *c2)
 
 /**
  * Print the match list, including connector match indications.
- * Usage: link-parser -v=5 [-debug=print_match_list]
+ * Usage: link-parser -verbosity=9 -debug=print_match_list
  * Output format:
  * MATCH_NODE list_id:  lw>lc   [=]   left<w>right   [=]    rc<rw
  *
@@ -405,7 +405,7 @@ static void print_match_list(int id, Match_node *m, int w,
                              Connector *lc, int lw,
                              Connector *rc, int rw)
 {
-	if (verbosity < 5) return;
+	if (!debug_level(9)) return;
 
 	for (; m != NULL; m = m->next)
 	{

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -392,14 +392,6 @@ static void match_stats(Connector *c1, Connector *c2)
  * used, and which nodes are from mr or ml or both (the full print version
  * clutters the source code very much, as it needs to be inserted in plenty
  * of places.)
- *
- * FIXME It is not clear to me why these printout are intermixed by stderr
- * printouts, as prt_error() flushes stdout. For example:
- *
- * MATCH_NODE    49: 02>O*t       =        Os<04>                     <06
- * link-grammar: Info: Total count with 0 null links:   4
- * ++++Counted parses                          0.00 seconds
- * MATCH_NODE    58: 00>RW        =        RW<05>                     <06
  */
 static void print_match_list(int id, Match_node *m, int w,
                              Connector *lc, int lw,

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -217,15 +217,16 @@ void remap_linkages(Linkage lkg, const int *remap)
  * XXX Should we remove here also the dict-cap tokens? In any case, for now they
  * are left for debug.
  */
+#define D_REE 3
 void remove_empty_words(Linkage lkg)
 {
 	size_t i, j;
 	Disjunct **cdj = lkg->chosen_disjuncts;
 	int *remap = alloca(lkg->num_words * sizeof(*remap));
 
-	if (4 <= verbosity)
+	if (debug_level(+D_REE))
 	{
-		lgdebug(0, "Info: chosen_disjuncts before removing empty words:\n");
+		printf("Info: chosen_disjuncts before:\n");
 		print_chosen_disjuncts_words(lkg);
 	}
 
@@ -245,14 +246,15 @@ void remove_empty_words(Linkage lkg)
 	lkg->num_words = j;
 	/* Unused memory not freed - all of it will be freed in free_linkages(). */
 
-	if (4 <= verbosity)
+	if (debug_level(+D_REE))
 	{
-		lgdebug(0, "Info: chosen_disjuncts after removing empty words:\n");
+		printf("Info: chosen_disjuncts after:\n");
 		print_chosen_disjuncts_words(lkg);
 	}
 
 	remap_linkages(lkg, remap); /* Update lkg->link_array and lkg->num_links. */
 }
+#undef D_REE
 
 /**
  * This takes the Wordgraph path array and uses it to


### PR DESCRIPTION
These changes only include improving debug, to reduce debug message volume and enable selecting the desired debug messages.
Current debug messages that are printed by a special print function are done something like that:
```
func1()
{
   ...
   f (verbosity >= X)
   {
      print_some_debug_messages();
   }
```

The problem:
When a verbosity Y>X is desired, these debug messages are printed too even if undesired, and if their volume is high it is annoying.

This fix enables to write this section as:
```
func1()
{
   ...
   if (debug_level(X))
   {
      print_some_debug_messages();
   }
```

Now if a debug from particular functions which uses this facility is desired, the following can be used:
`link-parser -verbosity=Y -debug=func2,func3`
and the debug output from other functions (e.g. func1) that use this facility will not be shown.
(This exact mechanism already works for lgdebug()).

Using these facility instead of  direct check of `verbosity` also allows easy future separation (if desired) of `verbosity` and `debug-level`.