### PR TITLE
The SAT sparser doesn't cause these crashes any more

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1129,7 +1129,6 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			break;
 		}
 
-		/* This causes a crash when using !use-sat. It should be fixed. [ap] */
 		assert(MT_EMPTY != cdj->word[0]->morpheme_type); /* already discarded */
 
 		if (4 <= opts->verbosity) print_with_subscript_dot(cdj->string);

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -422,12 +422,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 			/* TODO: Suppress "virtual-morphemes", currently the dictcap ones. */
 			char *sm;
 
-			/* XXX FIXME: the assert below sometimes crashes, because
-			 * I guess cdj->word[0] is a null pointer, or something like
-			 * that.  Not sure, its hard to reproduce.
-			 *
-			 * This happens on !use-sat. It should be fixed. [ap] */
-			/* assert(MT_EMPTY != cdj->word[0]->morpheme_type); already discarded */
+			assert(MT_EMPTY != cdj->word[0]->morpheme_type);/* already discarded */
 
 			t = cdj->string;
 			/* Print the subscript, as in "dog.n" as opposed to "dog". */


### PR DESCRIPTION
Now that the SAT parser has pointers to wordgraph words in its
data structures, and it removes empty-word links, these asserts() are OK.

Remove the comments on this problem.
Re-enable an assert().