### PR TITLE
Prune length_limit shortcut + setting ZZZ length_limit=1

### DIFF
--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -50,7 +50,15 @@ set_connector_length_limits(Sentence sent, Parse_Options opts)
 	bool all_short = opts->all_short;
 	Connector_set * ucs = sent->dict->unlimited_connector_set;
 
-	if (len >= sent->length) return; /* No point to enforce short_length. */
+	if (0)
+	{
+		/* Not setting the length_limit saves observable time. However, if we
+		 * would like to set the ZZZ connector length_limit to 1 for all
+		 * sentences, we cannot do the following.
+		 * FIXME(?): Use a flag that the sentence contains an empty word. */
+		if (len >= sent->length) return; /* No point to enforce short_length. */
+	}
+
 	if (len > UNLIMITED_LEN) len = UNLIMITED_LEN;
 
 	for (i=0; i<sent->length; i++)

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -30,8 +30,12 @@ set_connector_list_length_limit(Connector *c,
 {
 	for (; c!=NULL; c=c->next)
 	{
-		if (all_short ||
-		    (conset != NULL && !match_in_connector_set(conset, c)))
+		if (0 == strncmp(c->string, "ZZZ", 3))
+		{
+			c->length_limit = 1;
+		}
+		else if (all_short ||
+		         (conset != NULL && !match_in_connector_set(conset, c)))
 		{
 			c->length_limit = short_len;
 		}

--- a/link-grammar/prune.c
+++ b/link-grammar/prune.c
@@ -1141,7 +1141,7 @@ right_connector_list_update(prune_context *pc, Sentence sent, Connector *c,
 
 	/* n is now the leftmost word we need to check */
 	foundmatch = false;
-	for (; n < ub ; n++)
+	for (; n <= ub ; n++)
 	{
 		pc->power_cost++;
 		if (left_table_search(pc, n, c, shallow, word_c))


### PR DESCRIPTION
These fixes were validated by a detailed batch runs of this version and the version before introducing the pruning length_limit shortcut (which is fixed here). 
There were no diff for the English basic and fixes batch.
I also compared a detailed parse of the sentence:
```
In vivo studies of the activity of four of the kinases, KinA, KinC, KinD (ykvD) and KinE (ykrQ), using abrB transcription as an indicator of Spo0A~P level, revealed that KinC and KinD were responsible for Spo0A~P production during the exponential phase of growth in the absence of KinA and KinB.
```
It was identical, and took about 50% less CPU in this fixed version.

In Russian there were diff in a few sentences, all of them with null count > 0.
My guess is that previously empty words could get linked with distance>1 in that case (I observed such a thing in a recent check), which causes printing of extra identical partial linkages.

This length_limit shortcut doesn't solve the whole pruning slowness that got introduced with the empty word. I continue to work on that problem (apparently in expression pruning).

BTW, it is possible to validate that the ZZZ length_limit=1 "does something" by observing the **power prune cost** message with -verbosity=3. Setting it for short sentences (< short_lenght), for which there was no need to set the length_limit otherwise, actually increase the processing time, but I think  it is more correct to do that. (I thought of a way to do this setup in a more efficient way but this is left for a future fix.)