### PR TITLE
Fast matcher: Fix length-limit check of the match-list connectors

### DIFF
--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -534,20 +534,12 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	if ((lc != NULL) && ((w - lw) <= lc->length_limit))
 	{
 		mxp = get_match_table_entry(ctxt->l_table_size[w], ctxt->l_table[w], lc, -1);
-		if ((NULL != mxp) && (NULL != *mxp) &&
-		    ((w - lw) <= (*mxp)->d->left->length_limit))
-		{
-			ml = *mxp;
-		}
+		if (NULL != mxp) ml = *mxp;
 	}
 	if ((rc != NULL) && ((rw - w) <= rc->length_limit))
 	{
 		mxp = get_match_table_entry(ctxt->r_table_size[w], ctxt->r_table[w], rc, 1);
-		if ((NULL != mxp) && (NULL != *mxp) &&
-		    ((rw - w) <= (*mxp)->d->right->length_limit))
-		{
-			mr = *mxp;
-		}
+		if (NULL != mxp) mr = *mxp;
 	}
 
 	for (mx = mr; mx != NULL; mx = mx->next)
@@ -563,6 +555,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	for (mx = ml; mx != NULL; mx = mx->next)
 	{
 		if (mx->d->left->word < lw) break;
+		if ((w - lw) > mx->d->left->length_limit) continue;
 
 		mx->d->match_left = do_match_with_cache(mx->d->left, lc, &mc);
 		if (!mx->d->match_left) continue;
@@ -585,6 +578,8 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	mc.string = NULL;
 	for (mx = mr; mx != mr_end; mx = mx->next)
 	{
+		if ((rw - w) > mx->d->right->length_limit) continue;
+
 		mx->d->match_right = do_match_with_cache(mx->d->right, rc, &mc);
 		if (!mx->d->match_right || mx->d->match_left) continue;
 


### PR DESCRIPTION
A match-list contains only connectors with the same UC prefix.  However,
some connectors may have the same UC prefix but a different
length_limit, e.g. X and Xc which have unlimited length, and Xd which
have short_length.

If lc or rc would be an unlimited-length connector (e.g. X)
and the match-list would contain matching connectors with different
length-limit, e.g. Xc and Xd, the whole match-list could be missed
if the first connector is a short_length one. (If lc or rc would be
a short_length connector then we don't care.)

Such a thing has not been observed by a debug print. In addition,
absolutely no linkage in all the languages got changed due to this fix
(in English the fixes.batch has been verified too).

However, the code seems wrong in principle and in order to be on the safe
side it is fixed here. (This is a very subtle issue.)

EDIT: If connectors with the same UC prefix could have more than 2 different values of length_limit, then the remaining global length_limit check would need to move to the mach-lists traversing code.