### PR TITLE
Bug fix in the test_enabled macro (issue #255)

### DIFF
--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -75,6 +75,6 @@ const char *feature_enabled(const char *, const char *);
  * (a comma-separated feature list).
  */
 #define test_enabled(feature) \
-	(('\0' != test) ? feature_enabled(test, feature) : NULL)
+	(('\0' != test[0]) ? feature_enabled(test, feature) : NULL)
 
 #endif


### PR DESCRIPTION
The intention was to test the first character of this variable.
The variable itself is never NULL.

This problem caused the following on OS X El Capitan:
sat-encoder.cpp:1320:38: error: comparison between pointer and integer ('int' and 'const char *')
      display_linkage_disconnected = test_enabled("linkage-disconnected");
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../link-grammar/error.h:57:9: note: expanded from macro 'test_enabled'
        (('\0' != test) ? feature_enabled(test, feature) : NULL)

It was also an inefficiency bug: The feature_enabled() function was
called always instead of only when a test is set.