### PR TITLE
Fast matcher: Return the match-list as an array instead of a linked list

### DIFF
--- a/bindings/python-examples/parses-en.txt
+++ b/bindings/python-examples/parses-en.txt
@@ -4,7 +4,7 @@
 
 Ithis is a test
 O
-O    +----->WV----->+---Osm--+
+O    +----->WV----->+---Ost--+
 O    +---Wd---+-Ss*b+  +Ds**c+
 O    |        |     |  |     |
 OLEFT-WALL this.p is.v a  test.n 
@@ -15,7 +15,7 @@ C       (NP a test.n)))
 C
 N
 O
-O    +----->WV----->+---Ost--+
+O    +----->WV----->+---Osm--+
 O    +---Wd---+-Ss*b+  +Ds**c+
 O    |        |     |  |     |
 OLEFT-WALL this.p is.v a  test.n 

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -280,7 +280,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
         self.assertEqual(linkage.link(3),
                          Link(linkage, 3, 'this.p','Ss*b','Ss','is.v'))
         self.assertEqual(linkage.link(4),
-                         Link(linkage, 4, 'is.v','O*m','Os','sentence.n'))
+                         Link(linkage, 4, 'is.v','O*t','Os','sentence.n'))
         self.assertEqual(linkage.link(5),
                          Link(linkage, 5, 'a','Ds**c','Ds**c','sentence.n'))
         self.assertEqual(linkage.link(6),

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -284,21 +284,22 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 
 	for (w = start_word; w < end_word; w++)
 	{
-		Match_node *m, *m1;
-		m1 = m = form_match_list(mchxt, w, le, lw, re, rw);
+		size_t mlb, mle;
+		mle = mlb = form_match_list(mchxt, w, le, lw, re, rw);
 #ifdef VERIFY_MATCH_LIST
-		int id = m ? m->d->match_id : 0;
+		int id = get_match_list_element(mchxt, mlb) ?
+		            get_match_list_element(mchxt, mlb)->match_id : 0;
 #endif
-		for (; m != NULL; m = m->next)
+		for (; mchxt->match_list[mle] != NULL; mle++)
 		{
 			unsigned int lnull_cnt, rnull_cnt;
-			Disjunct * d = m->d;
-#ifdef VERIFY_MATCH_LIST
-			assert(id == d->match_id, "Modified id (%d!=%d)\n", id, d->match_id);
-#endif
+			Disjunct *d = get_match_list_element(mchxt, mle);
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
 
+#ifdef VERIFY_MATCH_LIST
+			assert(id == d->match_id, "Modified id (%d!=%d)\n", id, d->match_id);
+#endif
 			/* _p1 avoids a gcc warning about unsafe loop opt */
 			unsigned int null_count_p1 = null_count + 1;
 
@@ -420,13 +421,13 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 						total = INT_MAX;
 #endif /* PERFORM_COUNT_HISTOGRAMMING */
 						t->count = total;
-						put_match_list(mchxt, m1);
+						pop_match_list(mchxt, mlb);
 						return total;
 					}
 				}
 			}
 		}
-		put_match_list(mchxt, m1);
+		pop_match_list(mchxt, mlb);
 	}
 	t->count = total;
 	return total;

--- a/link-grammar/extract-links.c
+++ b/link-grammar/extract-links.c
@@ -377,13 +377,13 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 	RECOUNT({xt->set.recount = 0;})
 	for (w = start_word; w < end_word; w++)
 	{
-		Match_node * m, *mlist;
-		mlist = form_match_list(mchxt, w, le, lw, re, rw);
+		size_t mlb, mle;
+		mle = mlb = form_match_list(mchxt, w, le, lw, re, rw);
 		// if (mlist) mlist = sort_matchlist(mlist);
-		for (m = mlist; m != NULL; m = m->next)
+		for (; mchxt->match_list[mle] != NULL; mle++)
 		{
 			unsigned int lnull_count, rnull_count;
-			Disjunct* d = m->d;
+			Disjunct *d = get_match_list_element(mchxt, mle);
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
 
@@ -505,7 +505,7 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 				}
 			}
 		}
-		put_match_list(mchxt, mlist);
+		pop_match_list(mchxt, mlb);
 	}
 	return &xt->set;
 }

--- a/link-grammar/fast-match.h
+++ b/link-grammar/fast-match.h
@@ -16,11 +16,42 @@
 #include "link-includes.h"
 #include "structures.h"
 
+struct fast_matcher_s
+{
+	size_t size;
+	unsigned int *l_table_size;  /* the sizes of the hash tables */
+	unsigned int *r_table_size;
+
+	/* the beginnings of the hash tables */
+	Match_node *** l_table;
+	Match_node *** r_table;
+
+	/* I'll pedantically maintain my own array of these cells */
+	Disjunct ** match_list;      /* match-list stack */
+	size_t match_list_end;       /* index to the match-list stack end */
+	size_t match_list_size;      /* number of allocated elements */
+};
+
 /* See the source file for documentation. */
 fast_matcher_t* alloc_fast_matcher(const Sentence);
 void free_fast_matcher(fast_matcher_t*);
 
-Match_node * form_match_list(fast_matcher_t *, int, Connector *, int, Connector *, int);
-void put_match_list(fast_matcher_t *, Match_node *);
+size_t form_match_list(fast_matcher_t *, int, Connector *, int, Connector *, int);
+
+/**
+ * Return the match-list element at the given index.
+ */
+static inline Disjunct *get_match_list_element(fast_matcher_t *ctxt, size_t mli)
+{
+	return ctxt->match_list[mli];
+}
+
+/**
+ * Pop up the match-list stack
+ */
+static inline void pop_match_list(fast_matcher_t *ctxt, size_t match_list_last)
+{
+	ctxt->match_list_end = match_list_last;
+}
 
 #endif

--- a/link-grammar/fast-match.h
+++ b/link-grammar/fast-match.h
@@ -10,6 +10,9 @@
 /*                                                                       */
 /*************************************************************************/
 
+#ifndef _FAST_MATCH_H_
+#define _FAST_MATCH_H_
+
 #include "link-includes.h"
 #include "structures.h"
 
@@ -19,3 +22,5 @@ void free_fast_matcher(fast_matcher_t*);
 
 Match_node * form_match_list(fast_matcher_t *, int, Connector *, int, Connector *, int);
 void put_match_list(fast_matcher_t *, Match_node *);
+
+#endif


### PR DESCRIPTION
This is the change I referred to in #263.
Two things to add:
**1.** I repeated the benchmarks several times, this time with RT priority (running current and new branches at once, as usual) in order to reduce fluctuations:
en/corpus-fixes.batch: ~>5%
en/corpus-basic.batch: ~<1%
Rest: ~0%
**2.** For now I took the short-range path of fixing tests.py to reflect the changed order of equal-cost linkages.