### PR TITLE
Fast matcher etc.: "Cosmetic" changes

### DIFF
--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -290,7 +290,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 		int id = get_match_list_element(mchxt, mlb) ?
 		            get_match_list_element(mchxt, mlb)->match_id : 0;
 #endif
-		for (; mchxt->match_list[mle] != NULL; mle++)
+		for (; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{
 			unsigned int lnull_cnt, rnull_cnt;
 			Disjunct *d = get_match_list_element(mchxt, mle);

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -461,7 +461,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
  * the cost of each of the parses. The number and width of the bins
  * is adjustable in histogram.c. At this time, the histogram is not
  * used anywhere, and a 3-5% speedup is available if it is avoided.
- * We plan to use this historgram, later ....
+ * We plan to use this histogram, later ....
  */
 Count_bin do_parse(Sentence sent,
                    fast_matcher_t *mchxt,

--- a/link-grammar/extract-links.c
+++ b/link-grammar/extract-links.c
@@ -380,7 +380,7 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 		size_t mlb, mle;
 		mle = mlb = form_match_list(mchxt, w, le, lw, re, rw);
 		// if (mlist) mlist = sort_matchlist(mlist);
-		for (; mchxt->match_list[mle] != NULL; mle++)
+		for (; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{
 			unsigned int lnull_count, rnull_count;
 			Disjunct *d = get_match_list_element(mchxt, mle);

--- a/link-grammar/extract-links.c
+++ b/link-grammar/extract-links.c
@@ -242,7 +242,7 @@ static Match_node* sort_matchlist(Match_node* mlist)
 	for (mx = mlist; mx->next != NULL; mx = mx->next) len++;
 	if (1 == len) return mlist;
 
-	/* Avoid blowing out the stack. Its hopless. */
+	/* Avoid blowing out the stack. Its hopeless. */
 	if (100000 < len) return mlist;
 
 	marr = alloca(len * sizeof(Match_node*));
@@ -290,7 +290,7 @@ Parse_set * mk_parse_set(Sentence sent, fast_matcher_t *mchxt,
 	/* Perhaps we've already computed it; if so, return it. */
 	if (xt != NULL) return &xt->set;
 
-	/* Start it out with the empty set of parse chocies. */
+	/* Start it out with the empty set of parse choices. */
 	/* This entry must be updated before we return. */
 	xt = x_table_store(lw, rw, le, re, null_count, pi);
 
@@ -532,7 +532,7 @@ static bool set_overflowed(Parse_info pi)
 {
 	unsigned int i;
 
-	assert(pi->x_table != NULL, "called set_verflowed with x_table==NULL");
+	assert(pi->x_table != NULL, "called set_overflowed with x_table==NULL");
 	for (i=0; i<pi->x_table_size; i++)
 	{
 		X_table_connector *t;

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -63,7 +63,7 @@ static int right_disjunct_list_length(const Disjunct * d)
 }
 
 /**
- * Return a match-list element to be used by the caller.
+ * Push a match-list element into the match-list array.
  */
 static void push_match_list_element(fast_matcher_t *ctxt, Disjunct *d)
 {

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -41,7 +41,7 @@
 #define MATCH_LIST_SIZE_INC 2     /* match-list stack increase size factor */
 
 /**
- * returns the number of disjuncts in the list that have non-null
+ * Returns the number of disjuncts in the list that have non-null
  * left connector lists.
  */
 static int left_disjunct_list_length(const Disjunct * d)
@@ -219,7 +219,7 @@ static Match_node **get_match_table_entry(unsigned int size, Match_node **t,
 			/* Increment and try again. Every hash bucket MUST have
 			 * a unique upper-case part, since later on, we only
 			 * compare the lower-case parts, assuming upper-case
-			 * parts are already equal. So just look for teh next
+			 * parts are already equal. So just look for the next
 			 * unused hash bucket.
 			 */
 			h = (h + 1) & (size-1);


### PR DESCRIPTION
1. In the previous change I added match-list push/get functions, but forgot to change the a description and use the "get" function in two places in which the match-list array was directly accessed.
2. Also included here old-typo fixes which I found while working on these files.