### PR TITLE
Tokenization efficiency fixes

### DIFF
--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -465,18 +465,20 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 			token_ord++;
 			switch (at)
 			{
-				size_t sz;
-
 				/* Mark the token with INFIX_MARK if needed. */
 				case PREFIX: /* set to word= */
-					sz = strlen(*affix);
-					strncpy(buff, *affix, sz);
-					if ('\0' != infix_mark)
+					if ('\0' == infix_mark)
 					{
-						buff[sz++] = infix_mark;
+						buff = (char *)*affix;
+					}
+					else
+					{
+						size_t sz = strlen(*affix);
+						memcpy(buff, *affix, sz);
+						buff[sz] = infix_mark;
+						buff[sz+1] = '\0';
 						last_split = true;
 					}
-					buff[sz] = '\0';
 					if (is_contraction_word(unsplit_word->subword))
 						morpheme_type = MT_CONTR;
 					else
@@ -485,7 +487,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				case STEM:   /* already word, word.=, word.=x */
 					/* Stems are already marked with a stem subscript, if needed.
 					 * The possible marks are set in the affix class STEMSUBSCR. */
-					strcpy(buff, *affix);
+					buff = (char *)*affix;
 					if (is_stem(buff))
 					{
 						morpheme_type = MT_STEM;
@@ -501,7 +503,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					if ((('\0' != (*affix)[0]) && !is_utf8_alpha(*affix)) ||
 					    '\0' == infix_mark)
 					{
-						strcpy(buff, *affix);
+						buff = (char *)*affix;
 						if (is_contraction_word(unsplit_word->subword))
 							morpheme_type = MT_CONTR;
 						else

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -416,6 +416,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 	bool subword_eq_unsplit_word;
 	char *buff;
 	size_t maxword = 0;
+	bool last_split = false;        /* this is a final token */
 #ifdef DEBUG
 	Gword *sole_alternative_of_itself = NULL;
 #endif
@@ -470,8 +471,12 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				case PREFIX: /* set to word= */
 					sz = strlen(*affix);
 					strncpy(buff, *affix, sz);
-					buff[sz] = infix_mark;
-					buff[sz+1] = '\0';
+					if ('\0' != infix_mark)
+					{
+						buff[sz++] = infix_mark;
+						last_split = true;
+					}
+					buff[sz] = '\0';
 					if (is_contraction_word(unsplit_word->subword))
 						morpheme_type = MT_CONTR;
 					else
@@ -481,7 +486,15 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					/* Stems are already marked with a stem subscript, if needed.
 					 * The possible marks are set in the affix class STEMSUBSCR. */
 					strcpy(buff, *affix);
-					morpheme_type = is_stem(buff) ? MT_STEM : MT_WORD;
+					if (is_stem(buff))
+					{
+						morpheme_type = MT_STEM;
+						last_split = true;
+					}
+					else
+					{
+						morpheme_type = MT_WORD;
+					}
 					break;
 				case SUFFIX: /* set to =word */
 					/* If the suffix starts with an apostrophe, don't mark it */
@@ -495,6 +508,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 							morpheme_type = MT_WORD;
 						break;
 					}
+					last_split = true;
 					buff[0] = infix_mark;
 					strcpy(&buff[1], *affix);
 					morpheme_type = MT_SUFFIX;
@@ -587,6 +601,15 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				subword->unsplit_word = unsplit_word;
 				subword->split_counter = unsplit_word->split_counter + 1;
 				subword->morpheme_type = morpheme_type;
+				if (last_split)
+				{
+					/* This is a stem, or an affix which is marked by INFIX_MARK.
+					 * Hence it must be a dict word - regex/spell are not done
+					 * for stems/affixes. Also, it cannot split further.
+					 * Save resources by marking it accordingly. */
+					subword->status |= WS_INDICT;
+					subword->tokenizing_step = TS_DONE;
+				}
 				word_label(sent, subword, "+", label);
 
 				/* If the subword is equal to the unsplit_word (may happen when the


### PR DESCRIPTION
**1.** The tokenization code tries to further suffix-split stems and affixes. It always fails to do that, as
stems include a stem mark and affixes include an affix mark, and the dicts are not supporting splitting them further. Not only its slows down the program, but it also clutters the debug output.
This fix prevents further tokenization handling of such tokens - 4% saving on the ru batch.

**2.** In the same occasion I observed that there is a redundant buffer copy when the morphemes are not marked (mostly happens on English). The saving is relatively small and has not been benchmarked.

**3.** strncpy() has been replaced by memcpy(). This can be done in other places in which strncpy() is currently used, and there is no NUL character in the copied string.