### PR TITLE
Add support for static linking on windows

### DIFF
--- a/README
+++ b/README
@@ -243,6 +243,13 @@ BUILDING on Windows
    See also:
    http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/regex.README
 
+   By default, the library is configured to create a DLL. If you want
+   to instead build a static library, the macro LINK_GRAMMAR_STATIC must
+   be defined before the inclusion of any header files for both the compiling
+   of the link-grammar library and for the application that uses it. Other
+   compiler settings will also have to be changed to create a static library
+   of course.
+
    The different build methods below are NOT regularly tested, and
    some link-grammar versions may have build issues.  If you are an
    experienced Windows developer who knows how to make things work

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -20,7 +20,7 @@
 #include "structures.h"
 #include "api-structures.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(LINK_GRAMMAR_STATIC)
 #define DLLEXPORT __declspec(dllexport)
 #else
 #define DLLEXPORT

--- a/link-grammar/link-features.h.in
+++ b/link-grammar/link-features.h.in
@@ -14,7 +14,7 @@
 #endif
 
 #ifndef link_public_api
-# ifdef _MSC_VER
+# if defined(_MSC_VER) && !defined(LINK_GRAMMAR_STATIC)
 #  if !defined LINK_GRAMMAR_DLL_EXPORT
 #   error !defined LINK_GRAMMAR_DLL_EXPORT
 #  endif


### PR DESCRIPTION
I recently tweaked some of the link-grammar headers in order to compile as static library for windows, and I thought others who want to do the same might benefit from the changes I made. I added the explanation below for how to build a static library to the README:

By default, the library is configured to create a DLL. If you want to instead build a static library, the macro LINK_GRAMMAR_STATIC must be defined before the inclusion of any header files for both the compiling of the link-grammar library and for the application that uses it. Other compiler settings will also have to be changed to create a static library of course.