### PR TITLE
Set word_in_dict if there is any suffix split alternative

### DIFF
--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1132,7 +1132,7 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 				    boolean_dictionary_lookup(dict, newword))
 				{
 					did_split = true;
-					word_can_split =
+					word_can_split |=
 						add_alternative_with_subscr(sent, unsplit_word,
 						                            NULL, newword, *suffix);
 				}
@@ -1167,7 +1167,7 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 					/* ??? Do we need a regex match? */
 					if (boolean_dictionary_lookup(dict, newword))
 					{
-						word_can_split =
+						word_can_split |=
 							add_alternative_with_subscr(sent, unsplit_word, prefix[j],
 								                         newword, *suffix);
 					}


### PR DESCRIPTION
See the commit message for the detailed description of the problem.
EDIT: I forgot to write in it that in the described condition, a regex lookup happens, and this adds the said extra parses. I pushed it again with this added  description.

BTW, I'm going to send (hopefully in a few days) a pull request for a new affix-split function that can split multi-affix words, but there is a need to apply this fix anyway so the batch baseline for comparisons will be as expected.