### PR TITLE
add_empty_word(): Invoke only when needed

### DIFF
--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -14,7 +14,6 @@
 /* stuff for transforming a dictionary entry into a disjunct list */
 
 #include <math.h>
-#include "api-structures.h"
 #include "build-disjuncts.h"
 #include "dict-api.h"
 #include "dict-common.h"

--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -459,7 +459,7 @@ X_node * build_word_expressions(Sentence sent, const Gword *w, const char *s)
 		y = (X_node *) xalloc(sizeof(X_node));
 		y->next = x;
 		x = y;
-		x->exp = copy_Exp(add_empty_word(dict, &eli, dn));
+		x->exp = copy_Exp(dn->exp);
 		if (NULL == s)
 		{
 			x->string = dn->string;

--- a/link-grammar/dict-common.h
+++ b/link-grammar/dict-common.h
@@ -16,6 +16,7 @@
 
 #include "api-types.h"
 #include "dict-structures.h"
+#include "structures.h"
 
 /* The functions here are for link-grammar internal use only.
  * They are not part of the public API. */
@@ -24,7 +25,7 @@ bool find_word_in_dict(Dictionary dict, const char *);
 Afdict_class * afdict_find(Dictionary, const char *, bool);
 
 Exp * Exp_create(Exp_list *);
-Exp * add_empty_word(Dictionary const, Exp_list *, Dict_node *);
+void add_empty_word(Dictionary const, X_node *);
 void free_Exp_list(Exp_list *);
 
 void patch_subscript(char *);

--- a/link-grammar/dict-common.h
+++ b/link-grammar/dict-common.h
@@ -14,8 +14,6 @@
 #ifndef _LG_DICT_COMMON_H_
 #define  _LG_DICT_COMMON_H_
 
-#include "api-types.h"
-#include "dict-structures.h"
 #include "structures.h"
 
 /* The functions here are for link-grammar internal use only.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1021,6 +1021,21 @@ void add_empty_word(Dictionary const dict, X_node *x)
 	/* Replace plain-word-exp by {ZZZ+} & (plain-word-exp) in each X_node.  */
 	for(; NULL != x; x = x->next)
 	{
+		/* Ignore stems for now, decreases a little the overhead for
+       * stem-suffix languages.
+       * This line should be removed if these 2 conditions happen together:
+       * 1. Multi-stem splits are to be supported.
+       * 2. Affix splits are done by wordgraph splits.
+       *
+		 * FIXME: A more general solution instead of this line is to add
+		 * empty-word connectors only to the x-nodes that need them, instead
+		 * of adding them, like now, to all the x-nodes of the word that come
+		 * before the empty-word. This will support wordgraph affix splits (if
+		 * will ever be done) and will slightly increase the efficiency of
+		 * handling sentences with multi-suffix splits (less empty-word
+		 * connectors in the sentence). */
+		if (is_stem(x->string)) continue; /* Avoid an unneeded overhead. */
+
 		/* zn points at {ZZZ+} */
 		zn = Exp_create(&eli);
 		zn->dir = '+';

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1035,6 +1035,7 @@ void add_empty_word(Dictionary const dict, X_node *x)
 		 * handling sentences with multi-suffix splits (less empty-word
 		 * connectors in the sentence). */
 		if (is_stem(x->string)) continue; /* Avoid an unneeded overhead. */
+		//lgdebug(+0, "Processing '%s'\n", x->string);
 
 		/* zn points at {ZZZ+} */
 		zn = Exp_create(&eli);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -11,13 +11,10 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include <limits.h>
 #include <string.h>
 
 #include "build-disjuncts.h"
-#include "dict-api.h"
 #include "dict-common.h"
-#include "disjunct-utils.h"
 #include "error.h"
 #include "print.h"
 #include "externs.h"
@@ -25,11 +22,8 @@
 #include "read-dict.h"
 #include "regex-morph.h"
 #include "string-set.h"
-#include "tokenize.h"
 #include "utilities.h"
 #include "word-file.h"
-#include "word-utils.h"
-#include "utilities.h"
 
 const char * linkgrammar_get_version(void)
 {

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -989,15 +989,15 @@ static Exp * make_connector(Dictionary dict)
  * but can also be split into эт.= =о.mnsi. The problem arises because это.msi
  * is a single word, while эт.= =о.mnsi counts as two words, and there is no
  * pretty way to handle both during parsing. Thus a work-around is introduced:
- * add the empty word =.zzz: ZZZ+; to the dictionary.  This becomes a
- * pseudo-suffix that can attach to any plain word.  It can attach to any
- * plain word only because the routine below, add_empty_word(), adds the
- * corresponding connector ZZZ- to the plain word.  This is done "on the fly",
- * because we don't want to pollute the dictionary with this stuff.  Besides,
- * the Russian dictionary has more then 23K words that qualify for this
- * treatment (It has 22.5K words that appear both as plain words, and as
- * stems, and can thus attach to null suffixes. For non-null suffix splits,
- * there are clearly many more.)
+ * add the empty word EMPTY-WORD.zzz: ZZZ+; to the dictionary.  This becomes
+ * a pseudo-suffix that can attach to the previous word. It can attach to
+ * the previous word only because the routine below, add_empty_word(), adds
+ * the corresponding connector ZZZ- to the word.  This is done "on the
+ * fly", because we don't want to pollute the dictionary with this stuff.
+ * Besides, the Russian dictionary has more then 23K words that qualify for
+ * this treatment (It has 22.5K words that appear both as plain words, and
+ * as stems, and can thus attach to null suffixes. For non-null suffix
+ * splits, there are clearly many more.)
  *
  * The empty words are removed from the linkages after the parsing step.
  * FIXME However, the ZZZ connectors are still found in the chosen disjuncts

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2699,7 +2699,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	/* At last .. concatenate the word expressions we build for
 	 * this alternative. */
 	sent->word[wordpos].x = catenate_X_nodes(sent->word[wordpos].x, we);
-	if (D_X_NODE <= verbosity)
+	if (debug_level(D_X_NODE))
 	{
 		/* Print the X_node details for the word. */
 		printf("Tokenize word/alt=%zu/%zu '%s' re=%s\n",

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2631,7 +2631,6 @@ static Word *word_new(Sentence sent)
 #define D_X_NODE 8
 #define D_DWE 5
 static bool determine_word_expressions(Sentence sent, Gword *w,
-                                       Parse_Options opts,
                                        unsigned int *ZZZ_added)
 {
 	Dictionary dict = sent->dict;
@@ -2700,7 +2699,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	/* At last .. concatenate the word expressions we build for
 	 * this alternative. */
 	sent->word[wordpos].x = catenate_X_nodes(sent->word[wordpos].x, we);
-	if (D_X_NODE <= opts->verbosity)
+	if (D_X_NODE <= verbosity)
 	{
 		/* Print the X_node details for the word. */
 		printf("Tokenize word/alt=%zu/%zu '%s' re=%s\n",
@@ -2837,7 +2836,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 					if (!sent->dict->empty_word_defined)
 						prt_error("Error: %s must be defined!\n", EMPTY_WORD_DOT);
 
-					if (!determine_word_expressions(sent, empty_word(), opts, &ZZZ_added))
+					if (!determine_word_expressions(sent, empty_word(), &ZZZ_added))
 						error_encountered = true;
 					empty_word_encountered = true;
 				}
@@ -2851,7 +2850,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 				/* This is a new wordgraph word.
 				 */
 				assert(!right_wall_encountered, "Extra word");
-				if (!determine_word_expressions(sent, wg_word, opts, &ZZZ_added))
+				if (!determine_word_expressions(sent, wg_word, &ZZZ_added))
 					error_encountered = true;
 				if ((MT_WALL == wg_word->morpheme_type) &&
 				    0== strcmp(wg_word->subword, RIGHT_WALL_WORD))

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -33,7 +33,6 @@
 #include "utilities.h"
 #include "wordgraph.h"
 #include "word-utils.h"
-#include "stdarg.h"
 
 #define MAX_STRIP 10
 #define SYNTHETIC_SENTENCE_MARK '>' /* A marking of a synthetic sentence. */

--- a/link-grammar/word-utils.c
+++ b/link-grammar/word-utils.c
@@ -348,7 +348,7 @@ static bool exp_has_connector(Exp * e, const char * cs, char direction)
 	}
 	for (el = e->u.l; el != NULL; el = el->next)
 	{
-		if (exp_has_connector(el->e, cs, direction)) return false;
+		if (exp_has_connector(el->e, cs, direction)) return true;
 	}
 	return false;
 }

--- a/link-grammar/word-utils.c
+++ b/link-grammar/word-utils.c
@@ -337,25 +337,30 @@ bool word_has_connector(Dict_node * dn, const char * cs, char direction)
 }
 #else /* CRAZY_OBESE_CHECKING_AGLO */
 
-static bool exp_has_connector(Exp * e, const char * cs, char direction)
+/**
+ * Return true if the given expression has the given connector.
+ * The connector cs argument must originally be in the dictionary string set.
+ */
+static bool exp_has_connector(const Exp * e, const char * cs, char direction,
+                              bool smart_match)
 {
 	E_list * el;
 	if (e->type == CONNECTOR_type)
 	{
-		if (direction == e->dir)
-			return easy_match(e->u.string, cs);
-		return false;
+		if (direction != e->dir) return false;
+		return smart_match ? easy_match(e->u.string, cs)
+		                   : string_set_cmp(e->u.string, cs);
 	}
 	for (el = e->u.l; el != NULL; el = el->next)
 	{
-		if (exp_has_connector(el->e, cs, direction)) return true;
+		if (exp_has_connector(el->e, cs, direction, smart_match)) return true;
 	}
 	return false;
 }
 
 bool word_has_connector(Dict_node * dn, const char * cs, char direction)
 {
-	return exp_has_connector(dn->exp, cs, direction);
+	return exp_has_connector(dn->exp, cs, direction, /*smart_match*/true);
 }
 #endif /* CRAZY_OBESE_CHECKING_AGLO */
 

--- a/link-grammar/word-utils.c
+++ b/link-grammar/word-utils.c
@@ -15,12 +15,8 @@
  */
 
 #include <math.h>
-#include <stdio.h>
-#include <stdint.h>
 
-#include "count.h"
 #include "dict-api.h"
-#include "disjunct-utils.h"
 #include "string-set.h"
 #include "word-utils.h"
 

--- a/link-grammar/word-utils.c
+++ b/link-grammar/word-utils.c
@@ -365,6 +365,19 @@ bool word_has_connector(Dict_node * dn, const char * cs, char direction)
 #endif /* CRAZY_OBESE_CHECKING_AGLO */
 
 /**
+ * Find if an expression has a connector ZZZ- (that an empty-word has).
+ * FIXME: This is a costly way to find it. A cheaper way is to mark
+ * such words at dictionary read time (or to add a "shallow" flag to
+ * exp_has_connector()).
+ **/
+bool is_exp_like_empty_word(Dictionary dict, Exp *exp)
+{
+	const char *cs = string_set_lookup(EMPTY_CONNECTOR, dict->string_set);
+	if (NULL == cs) return false;
+	return exp_has_connector(exp, cs, '-', /*smart_match*/false);
+}
+
+/**
  * If word has a connector, return it.
  * If word has more than one connector, return NULL.
  */

--- a/link-grammar/word-utils.h
+++ b/link-grammar/word-utils.h
@@ -23,6 +23,7 @@ void free_Exp(Exp *);
 void free_E_list(E_list *);
 int  size_of_expression(Exp *);
 Exp * copy_Exp(Exp *);
+bool is_exp_like_empty_word(Dictionary dict, Exp *);
 /* int exp_compare(Exp * e1, Exp * e2); */
 /* int exp_contains(Exp * super, Exp * sub); */
 

--- a/link-grammar/word-utils.h
+++ b/link-grammar/word-utils.h
@@ -14,8 +14,6 @@
 #ifndef _LINK_GRAMMAR_WORD_UTILS_H_
 #define _LINK_GRAMMAR_WORD_UTILS_H_
 
-#include "api-types.h"
-#include "dict-structures.h"
 #include "structures.h"
 
 /* Exp utilities ... */


### PR DESCRIPTION
This is a step toward a multi-affix split.
See issue #276.
This change adds an empty-word connector on suffixes too, but only when needed.
It also significantly increases the speed of English processing, especially for long sentences.

The benchmark showed a very slight efficiency decrease for Russian, but a detailed inspection ensured that the new code never adds  the ZZZ+ connector to more words than before, and actually (on average) adds it to less than 50% of the words comparing to what the current code does. Also, the new `is_exp_like_empty_word()` doesn't seem to be a problem since replacing it by a simple variable comparison doesn't improve the speed my a noticeable amount.

In the same occasion, I cleaned up (from the files changed in these commits) unneeded include files that have been accumulated over time.
