### PR TITLE
en/4.0.dict: Restore a missing apostrophe

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11341,7 +11341,7 @@ $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 
 "&": G- & {Xd- & G-} & G+;
 
-"’" "": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
+"’" "'": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
 
 % Possessives
 "'s.p" "’s.p":


### PR DESCRIPTION
The problem was detected in this sentence from en/corpus-basic.batch:
The boys' bedrooms will be enlarged

This problem happened in commit 220b86f9510800d2d9cf2c6cf93692ec6ec6468c.