### PR TITLE
Further fix the long-irritating backtic bug

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -6,12 +6,16 @@
 import locale
 
 from linkgrammar import Sentence, ParseOptions, Dictionary
-# from linkgrammar import _clinkgrammar as clg
+try:
+    import linkgrammar._clinkgrammar as clg
+except ImportError:
+    import _clinkgrammar as clg
 
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
+print "Version:", clg.linkgrammar_get_version()
 po = ParseOptions()
-#po = ParseOptions(linkage_limit=3)
+#po = ParseOptions(short_length=16)
 
 def desc(lkg):
     print lkg.diagram()
@@ -36,12 +40,14 @@ def linkage_stat(psent, lang):
                  psent.num_valid_linkages(), random)
 
 
+
 # English is the default language
-sent = Sentence("This is a test.", Dictionary(), po)
+sent = Sentence("he said: `this is a backtic test`", Dictionary(), po)
 linkages = sent.parse()
 linkage_stat(sent, 'English')
 for linkage in linkages:
     desc(linkage)
+exit(0)
 
 # Russian
 sent = Sentence("это большой тест.", Dictionary('ru'), po)

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -435,6 +435,9 @@ class ZENLangTestCase(unittest.TestCase):
     def test_getting_links(self):
         linkage_testfile(self, self.d, self.po)
 
+    def test_quotes(self):
+        linkage_testfile(self, self.d, self.po, 'quotes')
+
 class ZENConstituentsCase(unittest.TestCase):
     def setUp(self):
         self.d, self.po = Dictionary(lang='en'), ParseOptions()

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -17,7 +17,7 @@ class ParseOptions(object):
                  min_null_count=0,
                  max_null_count=0,
                  islands_ok=False,
-                 short_length=6,
+                 short_length=16,
                  all_short_connectors=False,
                  display_morphology=False,
                  spell_guess=False,

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -401,6 +401,8 @@ class Sentence(object):
 
         def next(self):
             if self.num == clg.sentence_num_valid_linkages(self.sent._obj):
+                if 0 == self.num:
+                    return None
                 raise StopIteration()
             linkage = Linkage(self.num, self.sent, self.sent.parse_options._obj)
             self.num += 1

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -9329,7 +9329,7 @@ as_soon_as:
 % J+ & CO+: "Until yesterday, ..."
 % The double-back-tick becomes a single backtick after m4
 until 'til ’til ‘til `til til till.r:
-  ((Mgp+ or J+ or JT+ or UN+)
+   ((Mgp+ or J+ or JT+ or UN+)
     & (({Xc+ & {Xd-}} & CO+) or ({Xd- & Xc+} & MVp-) or [Mp-]))
   or (<subcl-verb> & (({Xc+ & {Xd-}} & CO*s+) or ({Xd- & Xc+} & MVs-)));
 
@@ -9523,7 +9523,7 @@ and.j-r or.j-r:
                    ({Xd-} & SJlp- & SJru+ & {[[Xc+]]}) or
                    ({Xd-} & SJls- & SJru+ & {[[Xc+]]});
 
-% Give AN+ a cost, because in general, we dont want to conjoin nouns,
+% Give AN+ a cost, because in general, we don't want to conjoin nouns,
 % and then use the resulting phrase to modify another noun ...
 <noun-conj-head>: Ju- or SJl+ or [[AN+]];
 
@@ -11375,7 +11375,7 @@ $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 "&": G- & {Xd- & G-} & G+;
 
 % The double-single-quote is converted to a single single quote by m4.
-"’" "''": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
+"’" "'": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
 
 % Possessives
 "'s.p" "’s.p":

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -7285,7 +7285,9 @@ as_soon_as:
 
 % J+ & CO+: "Until yesterday, ..."
 % The double-back-tick becomes a single backtick after m4
-until 'til ’til ‘til ``til til till.r:
+changequote(\,/)dnl
+until 'til ’til ‘til `til til till.r:
+changequote dnl
   ((Mgp+ or J+ or JT+ or UN+)
     & (({Xc+ & {Xd-}} & CO+) or ({Xd- & Xc+} & MVp-) or [Mp-]))
   or (<subcl-verb> & (({Xc+ & {Xd-}} & CO*s+) or ({Xd- & Xc+} & MVs-)));
@@ -9334,7 +9336,7 @@ $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 "&": G- & {Xd- & G-} & G+;
 
 % The double-single-quote is converted to a single single quote by m4.
-"’" "''": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
+"’" "'": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
 
 % Possessives
 "'s.p" "’s.p":


### PR DESCRIPTION
Just now an apostrophe is not a known word in the English dictionary.
This pull-request continues the fix introduced in f79d2492b0ef5c08cb08d26956713fc176a4bf57.
The commit message explains the reason of the problem and how to avoid such problems in the future.
(Issue #281.)