### PR TITLE
Fix comment rot

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -9327,7 +9327,6 @@ as_soon_as:
   <subcl-verb> & {Xc+ & {Xd-}} & CO*s+;
 
 % J+ & CO+: "Until yesterday, ..."
-% The double-back-tick becomes a single backtick after m4
 until 'til ’til ‘til `til til till.r:
    ((Mgp+ or J+ or JT+ or UN+)
     & (({Xc+ & {Xd-}} & CO+) or ({Xd- & Xc+} & MVp-) or [Mp-]))
@@ -11374,7 +11373,6 @@ $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 
 "&": G- & {Xd- & G-} & G+;
 
-% The double-single-quote is converted to a single single quote by m4.
 "’" "'": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
 
 % Possessives

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -7284,7 +7284,6 @@ as_soon_as:
   <subcl-verb> & {Xc+ & {Xd-}} & CO*s+;
 
 % J+ & CO+: "Until yesterday, ..."
-% The double-back-tick becomes a single backtick after m4
 changequote(\,/)dnl
 until 'til ’til ‘til `til til till.r:
 changequote dnl
@@ -9335,7 +9334,6 @@ $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 
 "&": G- & {Xd- & G-} & G+;
 
-% The double-single-quote is converted to a single single quote by m4.
 "’" "'": YP- & (({AL-} & {@L+} & (D+ or DD+)) or [[<noun-main-x>]] or DP+);
 
 % Possessives


### PR DESCRIPTION
Remove comments about doubling m4 quotes, per issue #291.

The opening ` quote is now ignored using changequote.
The closing ' quote doesn't need any special handling since it doesn't have a special meaning for m4 unless it is in quoting mode.