### PR TITLE
fast-match: Fix a crash due to off-by-one in realloc condition

### DIFF
--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -67,7 +67,7 @@ static int right_disjunct_list_length(const Disjunct * d)
  */
 static void push_match_list_element(fast_matcher_t *ctxt, Disjunct *d)
 {
-	if (ctxt->match_list_end > ctxt->match_list_size)
+	if (ctxt->match_list_end >= ctxt->match_list_size)
 	{
 		ctxt->match_list_size *= MATCH_LIST_SIZE_INC;
 		ctxt->match_list = realloc(ctxt->match_list,


### PR DESCRIPTION
This sentence needs a realloc, and causes a crash:
Князь Андрей, невеселый и озабоченный соображениями о том, что и что ему нужно о делах спросить у предводителя, подъезжал по аллее сада к отрадненскому дому Ростовых.

Reported by Айгерим Еримбетова in the LG discussion group.

Linas,
There are some more fixes that can be done before issuing a new version, one of them is #299,
on which I need your opinion before I can send a fix.