### PR TITLE
Fix some MSVC warnings

### DIFF
--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -241,7 +241,7 @@ static int wctomb_check(char *s, wchar_t wc)
 	nr = WideCharToMultiByte(CP_UTF8, 0, &wc, 1, NULL, 0, NULL, NULL);
 	nr = WideCharToMultiByte(CP_UTF8, 0, &wc, 1, s, nr, NULL, NULL);
 	if (nr < 0) {
-		wprintf(L"Fatal Error: wctomb_check failed: %d %S\n", nr, &wc);
+		wprintf(L"Fatal Error: wctomb_check failed: %d %ls\n", nr, &wc);
 		exit(1);
 	}
 	/* XXX TODO Perhaps the below needs to be uncommented?  .. tucker says no ... */

--- a/link-grammar/word-utils.h
+++ b/link-grammar/word-utils.h
@@ -150,8 +150,18 @@ static inline unsigned int pair_hash(unsigned int table_size,
 	i = cost;
 	i = lw + (i << 6) + (i << 16) - i;
 	i = rw + (i << 6) + (i << 16) - i;
-	i = ((unsigned long) le) + (i << 6) + (i << 16) - i;
-	i = ((unsigned long) re) + (i << 6) + (i << 16) - i;
+#ifdef _MSC_VER
+	/* Prevent cluttering the compilation output with 32 such warnings:
+	* warning C4311: 'type cast': pointer truncation from 'const Connector *' to 'unsigned long'
+	*/
+	#pragma warning(push)
+	#pragma warning(disable: 4311)
+	#endif
+	i = ((unsigned long)le) + (i << 6) + (i << 16) - i;
+	i = ((unsigned long)re) + (i << 6) + (i << 16) - i;
+	#ifdef _MSC_VER
+	#pragma warning(pop)
+	#endif
 #endif
 
 	return i & (table_size-1);


### PR DESCRIPTION
The first commit fixes a real problem.
The second one just prevents cluttering the compilation output with 32 warnings.