### PR TITLE
Python  fixes

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -42,12 +42,11 @@ def linkage_stat(psent, lang):
 
 
 # English is the default language
-sent = Sentence("he said: `this is a backtic test`", Dictionary(), po)
+sent = Sentence("This is a test.", Dictionary(), po)
 linkages = sent.parse()
 linkage_stat(sent, 'English')
 for linkage in linkages:
     desc(linkage)
-exit(0)
 
 # Russian
 sent = Sentence("это большой тест.", Dictionary('ru'), po)

--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -56,7 +56,7 @@ for linkage in linkages:
     desc(linkage)
 
 # Turkish
-po = ParseOptions(islands_ok=True, max_null_count=1,display_morphology=True)
+po = ParseOptions(islands_ok=True, max_null_count=1, display_morphology=True)
 sent = Sentence("Senin ne istediğini bilmiyorum", Dictionary('tr'), po)
 linkages = sent.parse()
 linkage_stat(sent, 'Turkish')

--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -56,7 +56,8 @@ for linkage in linkages:
     desc(linkage)
 
 # Turkish
-sent = Sentence("çok şişman adam geldi", Dictionary('tr'), po)
+po = ParseOptions(islands_ok=True, max_null_count=1,display_morphology=True)
+sent = Sentence("Senin ne istediğini bilmiyorum", Dictionary('tr'), po)
 linkages = sent.parse()
 linkage_stat(sent, 'Turkish')
 for linkage in linkages:

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -202,6 +202,11 @@ class DBasicParsingTestCase(unittest.TestCase):
     def parse_sent(self, text):
         return list(Sentence(text, self.d, self.po).parse())
 
+    def test_that_parse_returns_empty_iterator_on_no_linkage(self):
+        result = self.parse_sent("This this doesn't parse");
+        for _ in result:
+            assert False, "Unexpected linkage iteration"
+
     def test_that_parse_sent_returns_list_of_linkage_objects_for_valid_sentence(self):
         result = self.parse_sent("This is a relatively simple sentence.")
         self.assertTrue(isinstance(result[0], Linkage))

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -397,12 +397,12 @@ class Sentence(object):
             clg.sentence_parse(sent._obj, sent.parse_options._obj)
 
         def __iter__(self):
+            if (0 == clg.sentence_num_valid_linkages(self.sent._obj)):
+                return iter(())
             return self
 
         def next(self):
             if self.num == clg.sentence_num_valid_linkages(self.sent._obj):
-                if 0 == self.num:
-                    return None
                 raise StopIteration()
             linkage = Linkage(self.num, self.sent, self.sent.parse_options._obj)
             self.num += 1


### PR DESCRIPTION
Fix example.py.
Fix parse() returned value when no linkages are found to be an empty iterator.
Add a test-suite validation for the no-linkages case.