### PR TITLE
Fix ifdef/endif indentation + a long comment

### DIFF
--- a/link-grammar/word-utils.h
+++ b/link-grammar/word-utils.h
@@ -152,8 +152,8 @@ static inline unsigned int pair_hash(unsigned int table_size,
 	i = rw + (i << 6) + (i << 16) - i;
 #ifdef _MSC_VER
 	/* Prevent cluttering the compilation output with 32 such warnings:
-	* warning C4311: 'type cast': pointer truncation from 'const Connector *' to 'unsigned long'
-	*/
+	 * warning C4311: 'type cast':
+	 *         pointer truncation from 'const Connector *' to 'unsigned long' */
 	#pragma warning(push)
 	#pragma warning(disable: 4311)
 #endif

--- a/link-grammar/word-utils.h
+++ b/link-grammar/word-utils.h
@@ -156,12 +156,12 @@ static inline unsigned int pair_hash(unsigned int table_size,
 	*/
 	#pragma warning(push)
 	#pragma warning(disable: 4311)
-	#endif
+#endif
 	i = ((unsigned long)le) + (i << 6) + (i << 16) - i;
 	i = ((unsigned long)re) + (i << 6) + (i << 16) - i;
-	#ifdef _MSC_VER
+#ifdef _MSC_VER
 	#pragma warning(pop)
-	#endif
+#endif
 #endif
 
 	return i & (table_size-1);

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -21,7 +21,7 @@
 
 #ifdef _MSC_VER
 #define strcasecmp _stricmp
-#define strncasecmp(a,b,s) strnicmp((a),(b),(s))
+#define strncasecmp(a,b,s) _strnicmp((a),(b),(s))
 #endif
 
 static struct


### PR DESCRIPTION
- Fix ifdef/endif indentation: see #301.
BTW, I have left the #pragma lines aligned with the C code, in a hope this is more readable.
- Also fold a long comment line.