### PR TITLE
Parser utilities

### DIFF
--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -14,6 +14,7 @@ bin_PROGRAMS=link-parser
 link_parser_SOURCES = link-parser.c \
                       command-line.c \
                       lg_readline.c \
+		      parser-utilities.h \
                       command-line.h \
                       lg_readline.h
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -20,11 +20,6 @@
 #include "command-line.h"
 #include <link-grammar/link-includes.h>
 
-#ifdef _MSC_VER
-#define strcasecmp _stricmp
-#define strncasecmp(a,b,s) _strnicmp((a),(b),(s))
-#endif
-
 static struct
 {
 	int verbosity;

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -16,6 +16,7 @@
 #include <wchar.h>
 #include <wctype.h>
 
+#include "parser-utilities.h"
 #include "command-line.h"
 #include <link-grammar/link-includes.h>
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -66,10 +66,6 @@
 #define DISPLAY_MAX 1024
 #define COMMENT_CHAR '%'  /* input lines beginning with this are ignored */
 
-#if !defined(MIN)
-#define MIN(X,Y)  ( ((X) < (Y)) ? (X) : (Y))
-#endif
-
 static int batch_errors = 0;
 static bool input_pending = false;
 static int verbosity = 0;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -55,9 +55,7 @@
 #endif
 
 #include "../link-grammar/link-includes.h"
-#ifndef HAVE_EDITLINE
-  #include "../link-grammar/utilities.h" /* for lg_fgetc */
-#endif
+#include "parser-utilities.h"
 #include "command-line.h"
 #include "lg_readline.h"
 #ifdef USE_VITERBI

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -12,6 +12,10 @@
 #ifndef _PARSER_UTILITIES_
 #define _PARSER_UTILITIES_
 
+#if !defined(MIN)
+#define MIN(X,Y)  ( ((X) < (Y)) ? (X) : (Y))
+#endif
+
 #ifndef HAVE_EDITLINE
 
 /* This if/endif block is a copy from link-grammar/utilities.h. */
@@ -44,5 +48,10 @@ static inline int lg_ungetc(int c, FILE *stream)
 #endif
 
 #endif // HAVE_EDITLINE
+
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#define strncasecmp(a,b,s) _strnicmp((a),(b),(s))
+#endif
 
 #endif // _PARSER_UTILITIES_

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -1,0 +1,48 @@
+/***************************************************************************/
+/* Copyright (c) 2016 Linas Vepstas                                        */
+/* All rights reserved                                                     */
+/*                                                                         */
+/* Use of the link grammar parsing system is subject to the terms of the   */
+/* license set forth in the LICENSE file included with this software.      */
+/* This license allows free redistribution and use in source and binary    */
+/* forms, with or without modification, subject to certain conditions.     */
+/*                                                                         */
+/***************************************************************************/
+
+#ifndef _PARSER_UTILITIES_
+#define _PARSER_UTILITIES_
+
+#ifndef HAVE_EDITLINE
+
+/* This if/endif block is a copy from link-grammar/utilities.h. */
+#if __APPLE__
+/* It appears that fgetc on Mac OS 10.11.3 "El Capitan" has a weird
+ * or broken version of fgetc() that flubs reads of utf8 chars when
+ * the locale is not set to "C" -- in particular, it fails for the
+ * en_US.utf8 locale; see bug report #293
+ * https://github.com/opencog/link-grammar/issues/293
+ */
+static inline int lg_fgetc(FILE *stream)
+{
+	char c[4];  /* general overflow paranoia */
+	size_t nr = fread(c, 1, 1, stream);
+	if (0 == nr) return EOF;
+	return (int) c[0];
+}
+
+static inline int lg_ungetc(int c, FILE *stream)
+{
+	/* This should work, because we never unget past the newline char. */
+	int rc = fseek(stream, -1, SEEK_CUR);
+	if (rc) return EOF;
+	return c;
+}
+
+#else
+#define lg_fgetc   fgetc
+#define lg_ungetc  ungetc
+#endif
+
+#endif // HAVE_EDITLINE
+
+#endif // _PARSER_UTILITIES_


### PR DESCRIPTION
Create parser-utilities.h, per issue #299.
For now, I don't find a need to create parser-utilities.c.
Maybe more compatibility things can be moved to parser-utilities.h (and/or a future parser-utilities.c).

Building on Windows was not checked after this change.
A latter pull-request will address Windows.