### PR TITLE
Use the full set of C warning for C sources

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -701,7 +701,7 @@ MAYBE_WARN_CXX="-Wall -Wextra \
 -Wno-attributes -Wno-long-long -Winline"
 
 MAYBE_WARN_C="-Wstrict-prototypes -Wmissing-prototypes \
--Wnested-externs -Wdeclaration-after-statement -Wold-style-definition"
+-Wnested-externs -Wold-style-definition"
 
 MAYBE_WARN="$MAYBE_WARN_CXX $MAYBE_WARN_C"
 

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -27,7 +27,7 @@ endif
 DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir)\"
 
 # $(top_builddir) to pick up autogened link-grammar/link-features.h
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) $(WARN_CXXFLAGS) \
+AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) $(WARN_CFLAGS) \
 	$(HUNSPELL_CFLAGS)
 
 lib_LTLIBRARIES = liblink-grammar.la

--- a/link-grammar/sat-solver/Makefile.am
+++ b/link-grammar/sat-solver/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/link-grammar \
 	-I$(top_srcdir)/link-grammar/minisat \
 	-I$(top_builddir) -I$(top_builddir)/link-grammar \
-	$(WARN_CXXXFLAGS)
+	$(WARN_CXXFLAGS)
 
 noinst_LTLIBRARIES = libsat-solver.la
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -13,6 +13,9 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
+extern "C" {
+#include "sat-encoder.h"
+}
 #include "sat-encoder.hpp"
 #include "variables.hpp"
 #include "word-tag.hpp"

--- a/link-grammar/sat-solver/sat-encoder.h
+++ b/link-grammar/sat-solver/sat-encoder.h
@@ -2,7 +2,7 @@
 
 #ifdef USE_SAT_SOLVER
 int sat_parse(Sentence sent, Parse_Options  opts);
-Linkage sat_create_linkage(int k, Sentence sent, Parse_Options  opts);
+Linkage sat_create_linkage(LinkageIdx k, Sentence sent, Parse_Options  opts);
 void sat_sentence_delete(Sentence sent);
 #else
 static inline int sat_parse(Sentence sent, Parse_Options  opts) { return -1; }

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -49,6 +49,12 @@ struct PositionConnector
     */
   }
 
+  // Added only to suppress the warning:
+  // warning: inlining failed in call to ‘PositionConnector::~PositionConnector() noexcept’: call is unlikely and code size would grow [-Winline]
+  // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70328
+  // Can be removed when this GCC problem is fixed.
+  ~PositionConnector() {};
+
   // Original expression that this connector came from
   Exp* exp;
 
@@ -112,6 +118,12 @@ public:
     debug = opts->debug;
     test = opts->test;
   }
+
+  // Added only to suppress the warning:
+  // warning: inlining failed in call to ‘WordTag::~WordTag() noexcept’: call is unlikely and code size would grow [-Winline]
+  // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70328
+  // Can be removed when this GCC problem is fixed.
+  ~WordTag() {};
 
   const std::vector<PositionConnector>& get_left_connectors() const {
     return _left_connectors;


### PR DESCRIPTION
Use the full set of C warning for link-grammar/.
Remove declaration-after-statement from it.
Per issue #310.