### PR TITLE
Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.deps
+.libs
 autom4te.cache
 autogen.err
 aclocal.m4
@@ -30,3 +32,4 @@ m4
 patches
 py-compile
 test-driver
+svn-commit.tmp*

--- a/bindings/.gitignore
+++ b/bindings/.gitignore
@@ -1,1 +1,0 @@
-Makefile.in

--- a/bindings/java-jni/.gitignore
+++ b/bindings/java-jni/.gitignore
@@ -1,1 +1,0 @@
-Makefile.in

--- a/bindings/java/.gitignore
+++ b/bindings/java/.gitignore
@@ -1,1 +1,0 @@
-Makefile.in

--- a/bindings/perl/.gitignore
+++ b/bindings/perl/.gitignore
@@ -1,1 +1,0 @@
-Makefile.in

--- a/bindings/python-examples/.gitignore
+++ b/bindings/python-examples/.gitignore
@@ -1,1 +1,0 @@
-Makefile.in

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -1,1 +1,1 @@
-Makefile.in
+__init__.py

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,0 @@
-Makefile.in
-Makefile

--- a/data/en/.gitignore
+++ b/data/en/.gitignore
@@ -1,3 +1,0 @@
-Makefile.in
-Makefile
-svn-commit.tmp*

--- a/data/en/words/.gitignore
+++ b/data/en/words/.gitignore
@@ -1,2 +1,0 @@
-Makefile.in
-Makefile

--- a/data/lt/.gitignore
+++ b/data/lt/.gitignore
@@ -1,3 +1,0 @@
-Makefile.in
-Makefile
-svn-commit.tmp*

--- a/link-grammar/.gitignore
+++ b/link-grammar/.gitignore
@@ -1,9 +1,2 @@
-Makefile
-Makefile.in
 link-parser
 link-features.h
-svn-commit.tmp*
-.deps
-.libs
-*.la
-*.lo

--- a/man/.gitignore
+++ b/man/.gitignore
@@ -1,2 +1,0 @@
-Makefile.in
-Makefile


### PR DESCRIPTION
Some files that should have been ignored got shown in "git status" after I made configuration tests in-place (usually I don't compile in the sources directory so I didn't notice it before). So I updated the .gitignore files, unified some content and removed the ones that got to be empty.
