### PR TITLE
Debug enhancement: Allow restricting messages by file name(s) too

### DIFF
--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -140,21 +140,34 @@ void prt_error(const char *fmt, ...)
  * This list, if not empty, has a leading and a trailing commas.
  * Return NULL if not enabled, else ",". If the feature appears
  * as "feature:param", return a pointer to param.
+ * @param    list Comma delimited list of features (start/end commas too).
+ * @param    ... List of features to check.
+ * @return   If not enabled - NULL; Else "," or the feature param if exists.
  */
-const char *feature_enabled(const char * list, const char * feature)
+const char *feature_enabled(const char * list, ...)
 {
-	size_t len = strlen(feature);
-	char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
 
-	buff[0] = ',';
-	strcpy(buff+1, feature);
-	strcat(buff, ",");
+	const char *feature;
+	va_list given_features;
+	va_start(given_features, feature);
 
-	if (NULL != strstr(list, buff)) return ",";
-	buff[len+1] = ':'; /* check for "feature:param" */
-	if (NULL != strstr(list, buff)) return strstr(list, buff) + len + 1;
+	while (NULL != (feature = va_arg(given_features, char *)))
+	{
+		size_t len = strlen(feature);
+		char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
+
+		if ('/' == feature[0]) feature = strrchr(feature, '/') + 1;
+		buff[0] = ',';
+		strcpy(buff+1, feature);
+		strcat(buff, ",");
+
+		if (NULL != strstr(list, buff)) return ",";
+		buff[len+1] = ':'; /* check for "feature:param" */
+		if (NULL != strstr(list, buff)) return strstr(list, buff) + len + 1;
+	}
+	va_end(given_features);
+
 	return NULL;
 }
-
 
 /* ============================================================ */

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -136,22 +136,22 @@ void prt_error(const char *fmt, ...)
 
 /**
  * Check whether the given feature is enabled. It is considered
- * enabled if it is found in the comma-separated list of features.
- * This list, if not empty, has a leading and a trailing comma.
- * Return NULL if not enabled, else non-NULL. If the feature appears
- * as "feature=val", return pointer to val.
+ * enabled if it is found in the comma delimited list of features.
+ * This list, if not empty, has a leading and a trailing commas.
+ * Return NULL if not enabled, else ",". If the feature appears
+ * as "feature:param", return a pointer to param.
  */
 const char *feature_enabled(const char * list, const char * feature)
 {
 	size_t len = strlen(feature);
-	char *buff = alloca(len + 2 + 1); /* leading comma + comma/eq + NUL */
+	char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
 
 	buff[0] = ',';
 	strcpy(buff+1, feature);
 	strcat(buff, ",");
 
 	if (NULL != strstr(list, buff)) return ",";
-	buff[len+1] = ':'; /* check for "feature:..." */
+	buff[len+1] = ':'; /* check for "feature:param" */
 	if (NULL != strstr(list, buff)) return strstr(list, buff) + len + 1;
 	return NULL;
 }

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -30,7 +30,7 @@ typedef enum
 } severity;
 
 void err_msg(err_ctxt *, severity, const char *fmt, ...) GNUC_PRINTF(3,4);
-const char *feature_enabled(const char *, const char *);
+const char *feature_enabled(const char *, ...);
 
 #ifdef _WIN32
 # define __func__ __FUNCTION__
@@ -45,7 +45,8 @@ const char *feature_enabled(const char *, const char *);
  */
 #define lgdebug(level, ...) \
 (((verbosity >= (level)) && \
-	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
+	(('\0' == debug[0]) || \
+	feature_enabled(debug, __func__, __FILE__, NULL))) \
 	? ((STRINGIFY(level)[0] == '+' ? (void)printf("%s: ", __func__) : (void)0), \
 	(void)printf(__VA_ARGS__)) : (void)0)
 
@@ -66,7 +67,8 @@ const char *feature_enabled(const char *, const char *);
  */
 #define debug_level(level) \
 (((verbosity >= (level)) && \
-	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
+	(('\0' == debug[0]) || \
+	feature_enabled(debug, __func__, __FILE__, NULL))) \
 	? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : 0), true)  \
 	: false)
 
@@ -75,6 +77,6 @@ const char *feature_enabled(const char *, const char *);
  * (a comma-separated feature list).
  */
 #define test_enabled(feature) \
-	(('\0' != test[0]) ? feature_enabled(test, feature) : NULL)
+	(('\0' != test[0]) ? feature_enabled(test, feature, NULL) : NULL)
 
 #endif


### PR DESCRIPTION
Example of usage:
link-parser -verbosity=7 -debug=tokenize.c

The value of the debug variable can be a comma delimited list of function and file names.

In order to get a full benefit of this enhancement, there is a need to convert all the debug messages to use lgdebug() / debug_level().