### PR TITLE
Manual page: Fix warning

### DIFF
--- a/man/link-parser.man1
+++ b/man/link-parser.man1
@@ -381,7 +381,7 @@ The directory search order for these files is:
 .br
 .I "../data/"
 .br
-.R A custom path, as set by the API call \%\fBdictionary_set_data_dir()\fP.
+A custom path, as set by the API call \%\fBdictionary_set_data_dir()\fP.
 .br
 .\" A tricky adaptation for man2html (1.6.15) and grohtml (1.22.2),
 .\" to prevent an extra blank line.


### PR DESCRIPTION
Debian has an automated package check tool called lintian which discovered this warning in the manpage:

```
$ LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings \
-E UTF-8 -l -Tutf8 -Z link-parser.man1 >/dev/null
```

> `R' is a string (producing the registered sign), not a macro.

The manpage seems to display fine without it.