### PR TITLE
Debug enhancement: Move command-line variable setting to the start of link-parser

### DIFF
--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -37,6 +37,8 @@
 
 #include "anysplit.h"
 
+#define D_AS 10          /* verbosity level for this file */
+
 extern const char * const afdict_classname[];
 
 typedef int p_start;     /* partition start in a word */
@@ -351,8 +353,7 @@ bool anysplit_init(Dictionary afdict)
 
 	if (0 == regparts->length)
 	{
-		/* FIXME: Early assignment of verbosity by -v=x argument. */
-		if (verbosity > 1)
+		if (debug_level(+D_AS))
 			prt_error("Warning: File %s: Anysplit disabled (%s not defined)",
 		             afdict->name, afdict_classname[AFDICT_REGPARTS]);
 		return true;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -271,6 +271,7 @@ static int cmplen(const void *a, const void *b)
  * needed - especially to first free memory and initialize the affix dict
  * structure.).
  */
+#define D_AI 10
 static bool afdict_init(Dictionary dict)
 {
 	Afdict_class * ac;
@@ -324,7 +325,7 @@ static bool afdict_init(Dictionary dict)
 		affix_list_add(afdict, &afdict->afdict_class[AFDICT_INFIXMARK], "");
 	}
 
-	if (0 || 4 < verbosity) /* debug - !verbosity is not set so early for now */
+	if (debug_level(+D_AI))
 	{
 		size_t l;
 
@@ -339,6 +340,7 @@ static bool afdict_init(Dictionary dict)
 				lgdebug(0, "\n");
 		}
 	}
+#undef D_AI
 
 	/* Store the SANEMORPHISM regex in the unused (up to now)
 	 * regex_root element of the affix dictionary, and precompile it */

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -140,21 +140,34 @@ void prt_error(const char *fmt, ...)
  * This list, if not empty, has a leading and a trailing commas.
  * Return NULL if not enabled, else ",". If the feature appears
  * as "feature:param", return a pointer to param.
+ * @param    list Comma delimited list of features (start/end commas too).
+ * @param    ... List of features to check.
+ * @return   If not enabled - NULL; Else "," or the feature param if exists.
  */
-const char *feature_enabled(const char * list, const char * feature)
+const char *feature_enabled(const char * list, ...)
 {
-	size_t len = strlen(feature);
-	char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
 
-	buff[0] = ',';
-	strcpy(buff+1, feature);
-	strcat(buff, ",");
+	const char *feature;
+	va_list given_features;
+	va_start(given_features, feature);
 
-	if (NULL != strstr(list, buff)) return ",";
-	buff[len+1] = ':'; /* check for "feature:param" */
-	if (NULL != strstr(list, buff)) return strstr(list, buff) + len + 1;
+	while (NULL != (feature = va_arg(given_features, char *)))
+	{
+		size_t len = strlen(feature);
+		char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
+
+		if ('/' == feature[0]) feature = strrchr(feature, '/') + 1;
+		buff[0] = ',';
+		strcpy(buff+1, feature);
+		strcat(buff, ",");
+
+		if (NULL != strstr(list, buff)) return ",";
+		buff[len+1] = ':'; /* check for "feature:param" */
+		if (NULL != strstr(list, buff)) return strstr(list, buff) + len + 1;
+	}
+	va_end(given_features);
+
 	return NULL;
 }
-
 
 /* ============================================================ */

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -136,22 +136,22 @@ void prt_error(const char *fmt, ...)
 
 /**
  * Check whether the given feature is enabled. It is considered
- * enabled if it is found in the comma-separated list of features.
- * This list, if not empty, has a leading and a trailing comma.
- * Return NULL if not enabled, else non-NULL. If the feature appears
- * as "feature=val", return pointer to val.
+ * enabled if it is found in the comma delimited list of features.
+ * This list, if not empty, has a leading and a trailing commas.
+ * Return NULL if not enabled, else ",". If the feature appears
+ * as "feature:param", return a pointer to param.
  */
 const char *feature_enabled(const char * list, const char * feature)
 {
 	size_t len = strlen(feature);
-	char *buff = alloca(len + 2 + 1); /* leading comma + comma/eq + NUL */
+	char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
 
 	buff[0] = ',';
 	strcpy(buff+1, feature);
 	strcat(buff, ",");
 
 	if (NULL != strstr(list, buff)) return ",";
-	buff[len+1] = ':'; /* check for "feature:..." */
+	buff[len+1] = ':'; /* check for "feature:param" */
 	if (NULL != strstr(list, buff)) return strstr(list, buff) + len + 1;
 	return NULL;
 }

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -30,7 +30,7 @@ typedef enum
 } severity;
 
 void err_msg(err_ctxt *, severity, const char *fmt, ...) GNUC_PRINTF(3,4);
-const char *feature_enabled(const char *, const char *);
+const char *feature_enabled(const char *, ...);
 
 #ifdef _WIN32
 # define __func__ __FUNCTION__
@@ -45,7 +45,8 @@ const char *feature_enabled(const char *, const char *);
  */
 #define lgdebug(level, ...) \
 (((verbosity >= (level)) && \
-	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
+	(('\0' == debug[0]) || \
+	feature_enabled(debug, __func__, __FILE__, NULL))) \
 	? ((STRINGIFY(level)[0] == '+' ? (void)printf("%s: ", __func__) : (void)0), \
 	(void)printf(__VA_ARGS__)) : (void)0)
 
@@ -66,7 +67,8 @@ const char *feature_enabled(const char *, const char *);
  */
 #define debug_level(level) \
 (((verbosity >= (level)) && \
-	(('\0' == debug[0]) || feature_enabled(debug, __func__))) \
+	(('\0' == debug[0]) || \
+	feature_enabled(debug, __func__, __FILE__, NULL))) \
 	? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : 0), true)  \
 	: false)
 
@@ -75,6 +77,6 @@ const char *feature_enabled(const char *, const char *);
  * (a comma-separated feature list).
  */
 #define test_enabled(feature) \
-	(('\0' != test[0]) ? feature_enabled(test, feature) : NULL)
+	(('\0' != test[0]) ? feature_enabled(test, feature, NULL) : NULL)
 
 #endif

--- a/link-grammar/pp_knowledge.c
+++ b/link-grammar/pp_knowledge.c
@@ -30,11 +30,12 @@
 
 /****************** non-exported functions ***************************/
 
-static void check_domain_is_legal(const char *p)
+static void check_domain_is_legal(pp_knowledge *k, const char *p)
 {
   if (0x0 != p[1])
   {
-    prt_error("Fatal Error: post_process(): Domain (%s) must be a single character", p);
+    prt_error("Fatal Error: post_process(): File %s: Domain (%s) must be a single character",
+              k->path, p);
     exit(1);
   }
 }
@@ -84,7 +85,7 @@ static void read_starting_link_table(pp_knowledge *k)
 
       /* read the domain type of the link */
       p = pp_lexer_get_next_token_of_label(k->lt);
-      check_domain_is_legal(p);
+      check_domain_is_legal(k, p);
       k->starting_link_lookup_table[i].domain = (int) p[0];
   }
 
@@ -102,7 +103,8 @@ static pp_linkset *read_link_set(pp_knowledge *k,
   pp_linkset *ls;
   if (!pp_lexer_set_label(k->lt, label)) {
     if (1 < verbosity)
-      printf("PP warning: Link set %s not defined: assuming empty.\n",label);
+      printf("PP warning: File %s: Link set %s not defined: assuming empty.\n",
+             k->path, label);
     n_strings = 0;
   }
   else n_strings = pp_lexer_count_tokens_of_label(k->lt);
@@ -148,7 +150,8 @@ static void read_form_a_cycle_rules(pp_knowledge *k, const char *label)
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_form_a_cycle_rules = 0;
       if (1 < verbosity)
-          printf("PP warning: Not using any 'form a cycle' rules\n");
+          printf("PP warning: File %s: Not using any 'form a cycle' rules\n",
+                 k->path);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -162,7 +165,7 @@ static void read_form_a_cycle_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens <= 0)
       {
-        prt_error("Fatal Error: syntax error in knowledge file");
+        prt_error("Fatal Error: Syntax error in knowledge file %s", k->path);
         exit(1);
       }
       lsHandle = pp_linkset_open(n_tokens);
@@ -174,7 +177,8 @@ static void read_form_a_cycle_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens > 1)
       {
-         prt_error("Fatal Error: post_process: Invalid syntax (rule %zu of %s)",r+1,label);
+         prt_error("Fatal Error: File %s: post_process: Invalid syntax (rule %zu of %s)",
+                   k->path, r+1,label);
          exit(1);
       }
       k->form_a_cycle_rules[r].msg = string_set_add(tokens[0], k->string_set);
@@ -193,7 +197,8 @@ static void read_bounded_rules(pp_knowledge *k, const char *label)
   size_t r;
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_bounded_rules = 0;
-      if (1 < verbosity) printf("PP warning: Not using any 'bounded' rules\n");
+      if (1 < verbosity)
+        printf("PP warning: File %s: Not using any 'bounded' rules\n", k->path);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -206,7 +211,8 @@ static void read_bounded_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens!=1)
       {
-        prt_error("Fatal Error: post_process: Invalid syntax: rule %zu of %s",r+1,label);
+        prt_error("Fatal Error: post_process: File %s: Invalid syntax: rule %zu of %s",
+                  k->path, r+1,label);
         exit(1);
       }
       k->bounded_rules[r].domain = (int) tokens[0][0];
@@ -215,7 +221,8 @@ static void read_bounded_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens!=1)
       {
-        prt_error("Fatal Error: post_process: Invalid syntax: rule %zu of %s",r+1,label);
+        prt_error("Fatal Error: post_process File %s:: Invalid syntax: rule %zu of %s",
+                  k->path, r+1,label);
         exit(1);
       }
       k->bounded_rules[r].msg = string_set_add(tokens[0], k->string_set);
@@ -237,7 +244,8 @@ static void read_contains_rules(pp_knowledge *k, const char *label,
   const char **tokens;
   if (!pp_lexer_set_label(k->lt, label)) {
       *nRules = 0;
-      if (1 < verbosity) printf("PP warning: Not using any %s rules\n", label);
+      if (1 < verbosity)
+        printf("PP warning: File %s: Not using any %s rules\n", k->path, label);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -249,7 +257,8 @@ static void read_contains_rules(pp_knowledge *k, const char *label,
       /* first read link */
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       assert ((n_tokens <= 1),
-        "Fatal Error: post_process: Invalid syntax in %s (rule %zu)", label, r+1);
+        "Fatal Error: post_process: File %s: Invalid syntax in %s (rule %zu)",
+        k->path, label, r+1);
 
       (*rules)[r].selector = string_set_add(tokens[0], k->string_set);
 

--- a/link-grammar/pp_knowledge.c
+++ b/link-grammar/pp_knowledge.c
@@ -26,6 +26,7 @@
 #include "string-set.h"
 #include "utilities.h"
 
+#define D_PPK 10                       /* verbosity level for this file */
 #define PP_MAX_UNIQUE_LINK_NAMES 1024  /* just needs to be approximate */
 
 /****************** non-exported functions ***************************/
@@ -102,7 +103,7 @@ static pp_linkset *read_link_set(pp_knowledge *k,
   int n_strings,i;
   pp_linkset *ls;
   if (!pp_lexer_set_label(k->lt, label)) {
-    if (1 < verbosity)
+    if (debug_level(+D_PPK))
       printf("PP warning: File %s: Link set %s not defined: assuming empty.\n",
              k->path, label);
     n_strings = 0;
@@ -149,7 +150,7 @@ static void read_form_a_cycle_rules(pp_knowledge *k, const char *label)
   const char **tokens;
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_form_a_cycle_rules = 0;
-      if (1 < verbosity)
+      if (debug_level(+D_PPK))
           printf("PP warning: File %s: Not using any 'form a cycle' rules\n",
                  k->path);
   }
@@ -197,7 +198,7 @@ static void read_bounded_rules(pp_knowledge *k, const char *label)
   size_t r;
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_bounded_rules = 0;
-      if (1 < verbosity)
+      if (debug_level(+D_PPK))
         printf("PP warning: File %s: Not using any 'bounded' rules\n", k->path);
   }
   else {
@@ -244,7 +245,7 @@ static void read_contains_rules(pp_knowledge *k, const char *label,
   const char **tokens;
   if (!pp_lexer_set_label(k->lt, label)) {
       *nRules = 0;
-      if (1 < verbosity)
+      if (debug_level(+D_PPK))
         printf("PP warning: File %s: Not using any %s rules\n", k->path, label);
   }
   else {

--- a/link-grammar/pp_knowledge.c
+++ b/link-grammar/pp_knowledge.c
@@ -104,7 +104,7 @@ static pp_linkset *read_link_set(pp_knowledge *k,
   pp_linkset *ls;
   if (!pp_lexer_set_label(k->lt, label)) {
     if (debug_level(+D_PPK))
-      printf("PP warning: File %s: Link set %s not defined: assuming empty.\n",
+      prt_error("Warning: File %s: Link set %s not defined: assuming empty.",
              k->path, label);
     n_strings = 0;
   }
@@ -151,8 +151,8 @@ static void read_form_a_cycle_rules(pp_knowledge *k, const char *label)
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_form_a_cycle_rules = 0;
       if (debug_level(+D_PPK))
-          printf("PP warning: File %s: Not using any 'form a cycle' rules\n",
-                 k->path);
+          prt_error("Warning: File %s: Not using any 'form a cycle' rules",
+                    k->path);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -199,7 +199,7 @@ static void read_bounded_rules(pp_knowledge *k, const char *label)
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_bounded_rules = 0;
       if (debug_level(+D_PPK))
-        printf("PP warning: File %s: Not using any 'bounded' rules\n", k->path);
+        prt_error("Warning: File %s: Not using any 'bounded' rules", k->path);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -246,7 +246,7 @@ static void read_contains_rules(pp_knowledge *k, const char *label,
   if (!pp_lexer_set_label(k->lt, label)) {
       *nRules = 0;
       if (debug_level(+D_PPK))
-        printf("PP warning: File %s: Not using any %s rules\n", k->path, label);
+        prt_error("Warning: File %s: Not using any %s rules", k->path, label);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -889,7 +889,8 @@ void * object_open(const char *filename,
 		size_t i;
 
 		path_found = strdup((NULL != completename) ? completename : filename);
-		prt_error("Info: Dictionary found at %s", path_found);
+		if (0 < verbosity)
+			prt_error("Info: Dictionary found at %s", path_found);
 		for (i = 0; i < 2; i++)
 		{
 			char *root = strrchr(path_found, DIR_SEPARATOR[0]);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -693,6 +693,15 @@ int main(int argc, char * argv[])
 		i++;
 	}
 
+	for (; i<argc; i++)
+	{
+		if (argv[i][0] == '-' && strcmp("--version", argv[i]) == 0)
+		{
+			printf("Version: %s\n", linkgrammar_get_version());
+			exit(0);
+		}
+	}
+
 	copts = command_options_create();
 	opts = copts->popts;
 	if (copts == NULL || opts == NULL || copts->panic_opts == NULL)
@@ -735,15 +744,6 @@ int main(int argc, char * argv[])
 	    "%s: Warning: Windows console (cmd.exe) does not support unicode\n"
 	    "input!  Will attempt to convert from the native encoding!\n", argv[0]);
 #endif
-
-	for (; i<argc; i++)
-	{
-		if (argv[i][0] == '-' && strcmp("--version", argv[i]) == 0)
-		{
-			printf("Version: %s\n", linkgrammar_get_version());
-			exit(0);
-		}
-	}
 
 	if (language && *language)
 		dict = dictionary_create_lang(language);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -767,7 +767,7 @@ int main(int argc, char * argv[])
 		if (argv[i][0] == '-')
 		{
 			int rc;
-			if (argv[i][1] == '!' || argv[i][1] == '-')
+			if (argv[i][1] == '-')
 				rc = issue_special_command(argv[i]+2, copts, dict);
 			else
 				rc = issue_special_command(argv[i]+1, copts, dict);


### PR DESCRIPTION
Now it is possible to have debug messages in the dictionary reading code, which are controlled by command-line arguments of link-parser. The convention I used is verbosity>=10 for the dictionary reading code, so the dictionary debug messages are not seen when using verbosity levels 2-9.

BTW, in order to see messages only from a particular file, the file can be mention in the debug variable, e.g.:`link-parser -verbosity=10 -debug=pp_knowledge.c[,another_filename]`

In the same occasion of touching pp_knowledge.c, I fixed several things in the messages there.

The message `link-grammar: Info: Dictionary found at ...` is now printed only on verbosity>=1,
so it is still printed by default by link-parser.
OTOH, now **tests.py doesn't print this message**. This can be considered a desired effect or not, so a verbosity level of 1 can be set at the start of tests.py if desired.

**Possible farther changes**:
1. pp_knowledge.c emits seemingly bogus warnings (now at verbosity>=10).  If desired, a slight change can be introduced to print these messages only when they really indicate a problem. This is not urgent but looks easy to implement.
2. Maybe the default library verbosity should be changed to 1, to allow some default messages.
3. prt_error() can invoke a function hook (if defined) instead of directly printing the message, to allow a better control of message display (and eliminate the need to capturing output). However, I don't know how to enable defining such a hook per thread (in a simple way).
4. lgdebug() (maybe renamed to dprint()) can be changed to use prt_error() at a new level "Debug"
(when this "Debug" is maybe not printed to tty by default to prevent debug output clutter).