### PR TITLE
Python3 binding adaptation.

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -4,6 +4,7 @@
 # Link Grammar example usage
 #
 import locale
+from __future__ import print_function, division  # We require Python 2.6 or later
 
 from linkgrammar import Sentence, ParseOptions, Dictionary
 try:
@@ -13,15 +14,15 @@ except ImportError:
 
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
-print "Version:", clg.linkgrammar_get_version()
+print ("Version:", clg.linkgrammar_get_version())
 po = ParseOptions()
 #po = ParseOptions(short_length=16)
 
 def desc(lkg):
-    print lkg.diagram()
-    print 'Postscript:'
-    print lkg.postscript()
-    print '---'
+    print (lkg.diagram())
+    print ('Postscript:')
+    print (lkg.postscript())
+    print ('---')
 
 def s(q):
     return '' if q == 1 else 's'
@@ -34,10 +35,10 @@ def linkage_stat(psent, lang):
              format(psent.num_linkages_post_processed()) \
              if psent.num_valid_linkages() < psent.num_linkages_found() else ''
 
-    print '{0}: Found {1} linkage{2} ({3}{4} had no P.P. violations)'. \
+    print ('{0}: Found {1} linkage{2} ({3}{4} had no P.P. violations)'. \
           format(lang, psent.num_linkages_found(),
                  s(psent.num_linkages_found()),
-                 psent.num_valid_linkages(), random)
+                 psent.num_valid_linkages(), random))
 
 
 
@@ -46,14 +47,14 @@ sent = Sentence("This is a test.", Dictionary(), po)
 linkages = sent.parse()
 linkage_stat(sent, 'English')
 for linkage in linkages:
-    desc(linkage)
+        desc(linkage)
 
 # Russian
-sent = Sentence("это большой тест.", Dictionary('ru'), po)
+sent = Sentence("Целью курса является обучение магистрантов основам построения и функционирования программного обеспечения сетей ЭВМ.", Dictionary('ru'), po)
 linkages = sent.parse()
 linkage_stat(sent, 'Russian')
 for linkage in linkages:
-    desc(linkage)
+        desc(linkage)
 
 # Turkish
 po = ParseOptions(islands_ok=True, max_null_count=1, display_morphology=True)

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -17,6 +17,9 @@ except ImportError:
 
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
 
+if (sys.version_info > (3, 0)):
+    def unicode(x):
+        return str(x)
 
 def setUpModule():
     datadir = os.getenv("LINK_GRAMMAR_DATA", "")
@@ -35,11 +38,11 @@ def setUpModule():
 class AAALinkTestCase(unittest.TestCase):
     def test_link_display_with_identical_link_type(self):
         self.assertEqual(unicode(Link(None, 0, 'Left','Link','Link','Right')),
-                         u'Left-Link-Right')
+                         u'Link: Left-Link-Right')
 
     def test_link_display_with_identical_link_type2(self):
         self.assertEqual(unicode(Link(None, 0, 'Left','Link','Link*','Right')),
-                         u'Left-Link-Link*-Right')
+                         u'Link: Left-Link-Link*-Right')
 
 class BParseOptionsTestCase(unittest.TestCase):
     def test_setting_verbosity(self):
@@ -219,7 +222,10 @@ class DBasicParsingTestCase(unittest.TestCase):
         self.assertTrue(isinstance(result[1], Linkage))
 
         # def test_unicode_encoded_string(self):
-        result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.".encode('utf8'))
+        if (sys.version_info > (3, 0)):
+            result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.")
+        else:
+            result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.".encode('utf8'))
         self.assertTrue(1 < len(result))
         self.assertTrue(isinstance(result[0], Linkage))
         self.assertTrue(isinstance(result[1], Linkage))

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -6,7 +6,7 @@
 # more information about C API
 
 import linkgrammar._clinkgrammar as clg   # In Python3 just _clinkgrammar raises exception thst the module is not found.
-
+import sys
 
 __all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence']
 
@@ -263,6 +263,9 @@ class Dictionary(object):
     def get_max_cost(self):
         return clg.dictionary_get_max_cost(self._obj)
 
+if (sys.version_info > (3, 0)):
+    def unicode(x):
+        return x.__unicode__()
 
 class Link(object):
     def __init__(self, linkage, index, left_word, left_label, right_label, right_word):
@@ -312,7 +315,7 @@ class Linkage(object):
         return clg.linkage_get_num_links(self._obj)
 
     def words(self):
-        for i in xrange(self.num_of_words()):
+        for i in range(self.num_of_words()):
             yield self.word(i)
 
     def word(self, i):
@@ -331,7 +334,7 @@ class Linkage(object):
                     self.word(clg.linkage_get_link_rword(self._obj, i)))
 
     def links(self):
-        for i in xrange(self.num_of_links()):
+        for i in range(self.num_of_links()):
             yield self.link(i)
 
     def violation_name(self):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -5,7 +5,7 @@
 # See http://www.abisource.com/projects/link-grammar/api/index.html to get
 # more information about C API
 
-import _clinkgrammar as clg
+import linkgrammar._clinkgrammar as clg   # In Python3 just _clinkgrammar raises exception thst the module is not found.
 
 
 __all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence']
@@ -40,7 +40,7 @@ class ParseOptions(object):
         self.disjunct_cost = disjunct_cost
 
     def __del__(self):
-        if hasattr(self, '_obj'):
+        if hasattr(self, '_obj') and clg:
             clg.parse_options_delete(self._obj)
             del self._obj
 
@@ -407,6 +407,8 @@ class Sentence(object):
             linkage = Linkage(self.num, self.sent, self.sent.parse_options._obj)
             self.num += 1
             return linkage
+
+        __next__=next      # Account python3
 
     def parse(self):
         return self.sentence_parse(self)


### PR DESCRIPTION
Hi!

The following problems are fixed:
1. In my Arch Linux, compiled .so-module _clinkgrammar could not be loaded. Changed slightly the way of its loading.
2. Examples did not work in Pythin3 due to inconsistent syntax of examples and binding module itself. Fixed.
3. Test cases also fixed to run with Python3.

Best regards,
Evgeny Cherkashin