### PR TITLE
SWIG now generates wrapper for Python 3.

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -32,7 +32,7 @@ DISTCLEANFILES =                                   \
 
 if HAVE_SWIG
 $(BUILT_SOURCES) $(pkgpython_PYTHON): $(SWIG_SOURCES)
-	$(SWIG) -python -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
+	$(SWIG) -python3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 endif
 
 # The la MUST have the same name as the pm,

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -32,7 +32,7 @@ DISTCLEANFILES =                                   \
 
 if HAVE_SWIG
 $(BUILT_SOURCES) $(pkgpython_PYTHON): $(SWIG_SOURCES)
-	$(SWIG) -python3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
+	$(SWIG) -python -py3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 endif
 
 # The la MUST have the same name as the pm,

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -31,7 +31,8 @@ DISTCLEANFILES =                                   \
    $(top_builddir)/bindings/python/__init__.py
 
 if HAVE_SWIG
-$(BUILT_SOURCES) $(pkgpython_PYTHON): $(SWIG_SOURCES)
+#$(BUILT_SOURCES) $(pkgpython_PYTHON): $(SWIG_SOURCES)
+$(BUILT_SOURCES) : $(SWIG_SOURCES)
 	$(SWIG) -python -py3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 endif
 
@@ -60,5 +61,5 @@ EXTRA_DIST =         \
    README.md
 
 if HAVE_SWIG
-EXTRA_DIST += __init__.py.in linkgrammar.py
+EXTRA_DIST += __init__.py.in linkgrammar.py ppp.py
 endif

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -357,6 +357,12 @@ class Linkage(object):
     def constituent_tree(self, mode=1):
         return clg.linkage_print_constituent_tree(self._obj, mode)
 
+    def pp_msgs(self):
+        return clg.linkage_print_pp_msgs(self._obj)
+
+    def disjuncts(self):
+        return clg.linkage_print_disjuncts(self._obj)
+
 class Sentence(object):
     """
     sent = Sentence("This is a test.", Dictionary(), ParseOptions())

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -134,8 +134,38 @@ int  sentence_link_cost(Sentence sent, int i);
 
 Linkage linkage_create(int index, Sentence sent, Parse_Options opts);
 void linkage_delete(Linkage linkage);
+
+%typemap(newfree) char * {
+   linkage_free_diagram($1);
+}
 char * linkage_print_diagram(Linkage linkage, bool display_walls, size_t screen_width);
+
+%typemap(newfree) char * {
+   linkage_free_postscript($1);
+}
 char * linkage_print_postscript(Linkage linkage, bool display_walls, bool print_ps_header);
+
+%typemap(newfree) char * {
+   linkage_free_links_and_domains($1);
+}
+char * linkage_print_links_and_domains(Linkage linkage);
+
+%typemap(newfree) char * {
+   linkage_free_senses($1);
+}
+char * linkage_print_senses(Linkage linkage);
+
+%typemap(newfree) char * {
+   linkage_free_constituent_tree_str($1);
+}
+char * linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle mode);
+
+
+
+// Reset to default
+%typemap(newfree) char * {
+   free($1);
+}
 
 int linkage_get_num_words(Linkage linkage);
 int linkage_get_num_links(Linkage linkage);
@@ -150,9 +180,7 @@ const char ** linkage_get_link_domain_names(Linkage linkage, int index);
 const char ** linkage_get_words(Linkage linkage);
 //const char *  linkage_get_disjunct(Linkage linkage, int w);
 const char *  linkage_get_word(Linkage linkage, int w);
-char * linkage_print_links_and_domains(Linkage linkage);
-char * linkage_print_senses(Linkage linkage);
-char * linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle mode);
+
 int linkage_unused_word_cost(Linkage linkage);
 double linkage_disjunct_cost(Linkage linkage);
 int linkage_link_cost(Linkage linkage);

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -132,6 +132,7 @@ int  sentence_link_cost(Sentence sent, int i);
 %newobject linkage_print_postscript;
 %newobject linkage_print_constituent_tree;
 
+
 Linkage linkage_create(int index, Sentence sent, Parse_Options opts);
 void linkage_delete(Linkage linkage);
 
@@ -160,13 +161,20 @@ char * linkage_print_senses(Linkage linkage);
 }
 char * linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle mode);
 
+%typemap(newfree) char * {
+   linkage_free_disjuncts($1);
+}
+char * linkage_print_disjuncts(const Linkage linkage);
 
+%typemap(newfree) char * {
+   linkage_free_pp_msgs($1);
+}
+char * linkage_print_pp_msgs(Linkage linkage);
 
-// Reset to default
+// Reset to default.
 %typemap(newfree) char * {
    free($1);
 }
-
 int linkage_get_num_words(Linkage linkage);
 int linkage_get_num_links(Linkage linkage);
 int linkage_get_link_lword(Linkage linkage, int index);

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -91,6 +91,20 @@ void parse_options_reset_resources(Parse_Options opts);
 void parse_options_set_use_sat_parser(Parse_Options opts, bool val);
 bool parse_options_get_use_sat_parser(Parse_Options opts);
 
+void parse_options_set_debug(Parse_Options opts, const char * debug);
+char * parse_options_get_debug(Parse_Options opts);
+void parse_options_set_test(Parse_Options opts, const char * test);
+char * parse_options_get_test(Parse_Options opts);
+void parse_options_set_use_viterbi(Parse_Options opts, bool use_viterbi);
+bool parse_options_get_use_viterbi(Parse_Options opts);
+void parse_options_set_use_cluster_disjuncts(Parse_Options opts, bool val);
+bool parse_options_get_use_cluster_disjuncts(Parse_Options opts);
+void parse_options_set_repeatable_rand(Parse_Options opts, bool val);
+bool parse_options_get_repeatable_rand(Parse_Options opts);
+
+
+
+
 /**********************************************************************
 *
 * Functions to manipulate Sentences

--- a/configure.ac
+++ b/configure.ac
@@ -651,7 +651,7 @@ fi
 
 PythonFound=no
 if test "x$enable_python_bindings" = "xyes"; then
-	AM_PATH_PYTHON(2.6, [PythonFound=yes], [PythonFound=no])
+	AM_PATH_PYTHON(3.0, [PythonFound=yes], [PythonFound=no])
 	AX_PYTHON_DEVEL
 	AM_CONDITIONAL(HAVE_PYTHON, test x${PythonFound} = xyes)
 else


### PR DESCRIPTION
Hi, Linas!

I've checked the ability switching to -python3 (for Python 3 only). It worked, I mean, all the tests are ok, examples too.

Addition: I've compared SWIG output for python2 and pyhon3, they are the same.

Best regards,
Evgeny