### PR TITLE
Fix a bug due to an incompatible LC_NUMERIC

### DIFF
--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -725,7 +725,7 @@ int main(int argc, char * argv[])
 	/* Get the locale from the environment...
 	 * Perhaps we should someday get it from the dictionary ??
 	 */
-	locale = setlocale(LC_ALL, "");
+	locale = setlocale(LC_CTYPE, "");
 
 	/* Check to make sure the current locale is UTF8; if its not,
 	 * then force-set this to the english utf8 locale


### PR DESCRIPTION
If the LC NUMERIC convention is not compatible to the C locale (e.g. in
fr_FR.utf-8) then there is a malfunctions regarding costs.  This is
because the conversion from ASCII representation of floating-point
numbers in the dict is done by a system library function, and such
functions are locale dependent.

The example below supposes LC_NUMERIC is not defined in the environment.
Example sentence: `An income tax increase may be necessary`

```
$ LANG=en_US.utf-8 link-parser -disjuncts
...
            LEFT-WALL    0.000  Wd+ hWV+ RW+
                   an    0.000  PHv+ Ds**x+
           income.n-u    -0.100  PHv- AN+
                tax.n    0.000  AN+
           increase.n    0.100  @AN- Ds**x- Wd- Ss+
                may.v    0.000  S- I+
                 be.v    0.000  Ix- dWV- Pa+
          necessary.a    0.000  Paf-
           RIGHT-WALL    0.000  RW-
```
```
$ LANG=fr_FR.utf-8 link-parser -disjuncts
...
            LEFT-WALL    0,000  Wd+ hWV+ RW+
                   an    0,000  Ds**x+
             income.s    0,000  AN+
                tax.n    0,000  @AN- AN+
           increase.n    0,000  @AN- Ds**x- Wd- Ss+
                may.v    0,000  S- I+
                 be.v    0,000  Ix- dWV- Pa+
          necessary.a    0,000  Paf-
           RIGHT-WALL    0,000  RW-
```