### PR TITLE
Windows debug and more

### DIFF
--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -321,9 +321,7 @@ Dictionary dictionary_create_from_db(const char *lang)
 	t = strrchr (lang, '/');
 	t = (NULL == t) ? lang : t+1;
 	dict->lang = string_set_add(t, dict->string_set);
-#ifdef _DEBUG
-	prt_error("Info: Language: %s\n", dict->lang);
-#endif
+	lgdebug(D_USER_FILES, "Info: Language: %s\n", dict->lang);
 
 	/* To disable spell-checking, just set the checker to NULL */
 	dict->spell_checker = spellcheck_create(dict->lang);

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -147,7 +147,16 @@ const char *feature_enabled(const char * list, ...)
 		size_t len = strlen(feature);
 		char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
 
-		if ('/' == feature[0]) feature = strrchr(feature, '/') + 1;
+		/* The "feature" variable may contain a full/relative file path.
+		 * If so, extract the file name from it. On Windows first try the
+		 * native separator \, but also try /. */
+		const char *dir_sep = NULL;
+#ifdef _WIN32
+		dir_sep = strrchr(feature, '\\');
+#endif
+		if (NULL == dir_sep) dir_sep = strrchr(feature, '/');
+		if (NULL != dir_sep) feature = dir_sep + 1;
+
 		buff[0] = ',';
 		strcpy(buff+1, feature);
 		strcat(buff, ",");

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -35,10 +35,6 @@ typedef enum
 void err_msg(err_ctxt *, severity, const char *fmt, ...) GNUC_PRINTF(3,4);
 const char *feature_enabled(const char *, ...);
 
-#ifdef _WIN32
-# define __func__ __FUNCTION__
-#endif
-
 /**
  * Print a debug message at verbosity >= level.
  * Preceding the level number by a + (+level) adds printing of the

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -226,12 +226,6 @@ size_t lg_mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps)
 }
 #endif /* defined(_MSC_VER) || defined(__MINGW32__) */
 
-#if __APPLE__
-/* Junk, to keep the Mac OSX linker happy, because this is listed in
- * the link-grammar.def symbol export file.  */
-void lg_mbrtowc(void) {}
-#endif
-
 static int wctomb_check(char *s, wchar_t wc)
 {
 	int nr;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -108,7 +108,6 @@ char * strndup (const char *str, size_t size);
  * cygwin just doesn't work very well. So we use our own custom version,
  * instead.
  */
-link_public_api(size_t) lg_mbrtowc(wchar_t *, const char *, size_t, mbstate_t *);
 #ifdef mbrtowc
 #undef mbrtowc
 #endif
@@ -147,13 +146,6 @@ link_public_api(size_t) lg_mbrtowc(wchar_t *, const char *, size_t, mbstate_t *)
   #define lg_isspace(c) ((0 < c) && (c < 127) && isspace(c))
 #else
   #define lg_isspace isspace
-#endif
-
-
-#if __APPLE__
-/* Junk, to keep the Mac OSX linker happy, because this is listed in
- * the link-grammar.def symbol export file.  */
-void lg_mbrtowc(void);
 #endif
 
 #if __APPLE__
@@ -409,15 +401,6 @@ void * xalloc(size_t) GNUC_MALLOC;
 void * exalloc(size_t) GNUC_MALLOC;
 
 /* Tracking the space usage can help with debugging */
-#if defined(_WIN32) || __APPLE__
-  /* **MUST** define for win32, Mac OSX, because xfree is listed in
-   * link-grammar.def and the win/osx linker fails if there is no
-   * xfree. So, keep the linker happy. (xfree is used in both dict-file
-   * and sat solver.)
-   */
-  #define TRACK_SPACE_USAGE 1
-#endif /* defined(_WIN32) || __APPLE__ */
-
 #ifdef TRACK_SPACE_USAGE
 void xfree(void *, size_t);
 void exfree(void *, size_t);

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -79,12 +79,6 @@ void *alloca (size_t);
 #define vsnprintf _vsnprintf
 #endif
 
-/* MS Visual C does not have any function normally found in strings.h */
-/* In particular, be careful to avoid including strings.h */
-#define strcasecmp _stricmp
-#ifndef strdup
-#define strdup _strdup
-#endif
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 
 /* MS changed the name of rand_r to rand_s */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -84,6 +84,12 @@ void *alloca (size_t);
 /* MS changed the name of rand_r to rand_s */
 #define rand_r(seedp) rand_s(seedp)
 
+/* Avoid plenty of: warning C4090: 'function': different 'const' qualifiers.
+ * This happens, for example, when the argument is "const void **". */
+#define free(x) free((void *)x)
+#define realloc(x, s) realloc((void *)x, s)
+#define memcpy(x, y, s) memcpy((void *)x, (void *)y, s)
+#define qsort(x, y, z, w) qsort((void *)x, y, z, w)
 #endif /* _MSC_VER */
 
 /* Apparently, MinGW is also missing a variety of standard functions.

--- a/msvc14/LinkGrammar.vcxproj
+++ b/msvc14/LinkGrammar.vcxproj
@@ -94,7 +94,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(GNUREGEX_DIR)\include;..;..\link-grammar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <PrecompiledHeader />
@@ -125,7 +125,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(GNUREGEX_DIR)\include;..;..\link-grammar;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>

--- a/msvc14/LinkGrammarExe.vcxproj
+++ b/msvc14/LinkGrammarExe.vcxproj
@@ -94,7 +94,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -122,7 +122,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>


### PR DESCRIPTION
Mainly: 
- Windows debug-related fixes.
- Avoid all C4090 warnings (18).
- Avoid defining TRACK_SPACE_USAGE for Windows/Mac.