### PR TITLE
afdict related fixes

### DIFF
--- a/bindings/python-examples/parses-quotes-en.txt
+++ b/bindings/python-examples/parses-quotes-en.txt
@@ -24,3 +24,15 @@ O    +--Wd--+--Ss-+-QUd+    +-Ss*b+  |       +----A----+   |
 O    |      |     |    |    |     |  |       |         |   |
 OLEFT-WALL he said.q-d ` this.p is.v a backtic[!].a test.n ` 
 O
+
+I“What are you doing?” she asked.
+O
+O    +---------------QUc--------------+                
+O    +--------------Xc--------------+ |                
+O    +----------->WV---------->+    | |                
+O    |         +------Bsw------+    | |                
+O    +----Wq---+    +---Pg*b---+    | +----CP---+      
+O    +-QUd-+   +-Rw-+SIpx+     |    | |  +--Ss--+--Xp-+
+O    |     |   |    |    |     |    | |  |      |     |
+OLEFT-WALL “ what are.v you doing.v ? ” she asked.q-d . 
+O 

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -1,12 +1,12 @@
-% 
-% Affixes get stripped off the left and right side of words 
+%
+% Affixes get stripped off the left and right side of words
 % i.e. spaces are inserted between the affix and the word itself.
 %
 % Some of the funky UTF-8 parenthesis are used in Asian texts.
 % In order to allow single straight quote ' and double straight quote ''
 % to be stripped off from both the left and the right, they are
 % distinguished by the suffix .x and .y (as as Mr.x Mrs.x or Jr.y Sr.y)
-% 
+%
 % 。is an end-of-sentence marker used in Japanese texts.
 
 % Punctuation appearing on the right-side of words.
@@ -14,8 +14,8 @@
 % splitting won't work right.
 ")" "}" "]" ">" "".y" » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" “ ''.y '.y `.y
 "%" "," ....y "." 。.y ‧ ":" ";" "?" "!" ‽ ؟ ？ ！ ….y "”" ━.y –.y ー.y ‐.y 、.y
-～ ¢ ₵ ™ ℠ 
-  : RPUNC+; 
+～ ¢ ₵ ™ ℠
+  : RPUNC+;
 
 % Punctuation appearing on the left-side of words.
 % Lots of styles of open-parenthesis
@@ -28,10 +28,10 @@
 % coffe w/milk
 "(" "{" "[" "<" "".x" « 〈 （ 〔 《 【 ［
 『 「 、.x `.x `` „ ‘ ''.x '.x ….x ....x
-¿ ¡ "$" US$ USD C$ 
+¿ ¡ "$" US$ USD C$
 £ ₤ € ¤ ₳ ฿ ₡ ₢ ₠ ₫ ৳ ƒ ₣ ₲ ₴ ₭ ₺  ℳ  ₥ ₦ ₧ ₱ ₰ ₹ ₨ ₪ ﷼ ₸ ₮ ₩ ¥ ៛ 호점
 † †† ‡ § ¶ © ® ℗ № "#"
-* • ⁂ ❧ ☞ ◊ ※  ○  。.x ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎ 
+* • ⁂ ❧ ☞ ◊ ※  ○  。.x ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎
 –.x ━.x ー.x -- - ‧.x
 y' w/
   : LPUNC+;

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -12,8 +12,8 @@
 % Punctuation appearing on the right-side of words.
 % Note: the ellipsis ....y must appear *before* the dot ".", else the
 % splitting won't work right.
-")" "}" "]" ">" "".y" » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" “ ''.y '.y `.y
-"%" "," ....y "." 。.y ‧ ":" ";" "?" "!" ‽ ؟ ？ ！ ….y "”" ━.y –.y ー.y ‐.y 、.y
+")" "}" "]" ">" "".y" » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" ” ''.y '.y `.y
+"%" "," ....y "." 。.y ‧ ":" ";" "?" "!" ‽ ؟ ？ ！ ….y ━.y –.y ー.y ‐.y 、.y
 ～ ¢ ₵ ™ ℠
   : RPUNC+;
 
@@ -27,7 +27,7 @@
 % Y'gotta Y'gonna
 % coffe w/milk
 "(" "{" "[" "<" "".x" « 〈 （ 〔 《 【 ［
-『 「 、.x `.x `` „ ‘ ''.x '.x ….x ....x
+『 「 、.x `.x `` „ ‘ “ ''.x '.x ….x ....x
 ¿ ¡ "$" US$ USD C$
 £ ₤ € ¤ ₳ ฿ ₡ ₢ ₠ ₫ ৳ ƒ ₣ ₲ ₴ ₭ ₺  ℳ  ₥ ₦ ₧ ₱ ₰ ₹ ₨ ₪ ﷼ ₸ ₮ ₩ ¥ ៛ 호점
 † †† ‡ § ¶ © ® ℗ № "#"
@@ -46,7 +46,7 @@ y' w/
 
 % The below is a quoted list, used during tokenization. Do NOT put
 % spaces in between the various quotation marks!!
-""«»《》【】『』`„“": QUOTES+;
+""«»《》【】『』`„“”": QUOTES+;
 
 % The below is a quoted list, used during tokenization. Do NOT put
 % spaces in between the various symbols!!

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11225,9 +11225,9 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 <post-quote>:
   QUc- & {<wo-wall> or <wi-wall> or CP+};
 
-« 《 【 『 „:
+« 《 【 『 „ “:
   QUd-;
-» 》 】 』 “:
+» 》 】 』 ”:
   <post-quote>;
 
 % For now, using ".x and ".y in the above definitions multiplies the number

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9181,9 +9181,9 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 <post-quote>:
   QUc- & {<wo-wall> or <wi-wall> or CP+};
 
-« 《 【 『 „:
+« 《 【 『 „ “:
   QUd-;
-» 》 】 』 “:
+» 》 】 』 ”:
   <post-quote>;
 
 % For now, using ".x and ".y in the above definitions multiplies the number

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -75,10 +75,7 @@ set_centers(const Linkage linkage, int center[], int word_offset[],
 		int len, center_t;
 
 		/* Centers obtained by counting the characters,
-		 * not the bytes in the string.
-		 * len = strlen(linkage->word[i]);
-		 * len = mbsrtowcs(NULL, &linkage->word[i], 0, &mbss);
-		 */
+		 * not the bytes in the string. */
 		len = utf8_strlen(linkage->word[i]);
 		center_t = tot + (len/2);
 #if 1 /* Long labels - disable in order to compare output with old versions. */

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -181,14 +181,12 @@ strndup (const char *str, size_t size)
 /* ============================================================= */
 /* UTF8 utilities */
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
-
 /** Returns length of UTF8 character.
  * Current algo is based on the first character only.
  * If pointer is not pointing at first char, no not a valid value, returns 0.
  * Returns 0 for NULL as well.
  */
-static int get_utf8_charlen(const char *xc)
+int utf8_charlen(const char *xc)
 {
 	unsigned char c;
 
@@ -201,6 +199,8 @@ static int get_utf8_charlen(const char *xc)
 	if ((c >= 0xf0) && (c <= 0xf4)) return 4; /* First byte of a code point U +10000 - U +10FFFF */
 	return -1; /* Fallthrough -- not the first byte of a code-point. */
 }
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 /**
  * (Experimental) Implementation of mbrtowc for Windows.
@@ -216,7 +216,7 @@ size_t lg_mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps)
 	if (0 == n) return -2;
 	if (0 == *s) { *pwc = 0; return 0; }
 
-	nb = get_utf8_charlen(s);
+	nb = utf8_charlen(s);
 	if (0 == nb) return 0;
 	if (0 > nb) return nb;
 	nb2 = MultiByteToWideChar(CP_UTF8, 0, s, nb, NULL, 0);

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -382,6 +382,7 @@ static inline bool utf8_upper_match(const char * s, const char * t)
 
 void downcase_utf8_str(char *to, const char * from, size_t usize);
 void upcase_utf8_str(char *to, const char * from, size_t usize);
+int utf8_charlen(const char *);
 
 size_t lg_strlcpy(char * dest, const char *src, size_t size);
 void safe_strcpy(char *u, const char * v, size_t usize);


### PR DESCRIPTION
1. Windows: Fix an encoding conversion bug by not doing an encoding conversion.
2. Fix a bug of handling English double quotation marks. Add a test.

English single quotation marks are still missing.