### PR TITLE
Restore lg_mbrtowc() definition (for Windows)

### DIFF
--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -115,6 +115,7 @@ char * strndup (const char *str, size_t size);
 #ifdef mbrtowc
 #undef mbrtowc
 #endif
+size_t lg_mbrtowc(wchar_t *, const char *, size_t n, mbstate_t *ps);
 #define mbrtowc(w,s,n,x) lg_mbrtowc(w,s,n,x)
 #endif /* _MSC_VER || __MINGW32__ */
 


### PR DESCRIPTION
A recent commit removed a link_public_api definition of lg_mbrtowc().
However, this removed the definition of lg_mbrtowc() for Windows.

Add it back.