### PR TITLE
Mingw UTF-8

### DIFF
--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -895,7 +895,7 @@ void set_utf8_program_locale(void)
 			}
 		}
 	}
-#endif
+#endif /* !_WIN32 */
 }
 
 #ifdef _WIN32

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -243,7 +243,7 @@ static inline size_t utf8_strlen(const char *s)
  */
 static inline size_t utf8_next(const char *s)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
 	/* mbrlen does not work correctly on Windows. See issue #285 */
 	/* https://github.com/opencog/link-grammar/issues/285 */
 	size_t len = 0;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -234,7 +234,7 @@ static inline size_t utf8_strlen(const char *s)
 	return MultiByteToWideChar(CP_UTF8, 0, s, -1, NULL, 0)-1;
 #else
 	return mbsrtowcs(NULL, &s, 0, &mbss);
-#endif
+#endif /* _WIN32 */
 }
 
 /**
@@ -264,7 +264,7 @@ static inline size_t utf8_next(const char *s)
 		return 1;
 	}
 	return len;
-#endif
+#endif /* _WIN32 */
 }
 
 static inline int is_utf8_upper(const char *s, locale_t dict_locale)
@@ -432,4 +432,4 @@ static inline unsigned int next_power_of_two_up(unsigned int i)
    return j;
 }
 
-#endif
+#endif /* _LINK_GRAMMAR_UTILITIES_H_ */


### PR DESCRIPTION
An ifdef _MSV_VER has not been replaced by _WIN32.
However, this code is needed for native Windows, independent of the
compiler version.
Fix it by using _WIN32 instead.

FIXME:
However, it after this fix it prints fine only when running under
Cygwin.  It turns out the problem is triggered by the stdio implementation
of MinGW that is used (in order to handle `%z`) instead of the native
Windows library stdio - using the native stdio prints UTF-8 fine (but crashes on %z).

I still investigate how to solve this problem. One of the ways is to return the previous conversion of `%z` to `%I `in format strings - but I would like to avoid that.
