### PR TITLE
Cygwin: Fix the module name of the Python bindings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,4 +46,6 @@ EXTRA_DIST =            \
 	msvc14/MSVC-common.props               \
 	msvc14/post-build.bat                  \
 	msvc14/README                          \
+	mingw/README.Cygwin
+	mingw/README.MSYS
 	TODO

--- a/README
+++ b/README
@@ -70,6 +70,7 @@ CONTENTS of this directory:
    configure                The GNU configuration script
    autogen.sh               Developer's configure maintenance tool
    msvc14                   Microsoft Visual-C project files
+   mingw                    Information on using MinGW under MSYS or Cygwin
 
 
 UNPACKING and signature verification:
@@ -237,7 +238,8 @@ BUILDING on Windows
    compatibility layer for Windows.  Unfortunately, the Cygwin system
    is not compatible with Java for Windows.  Another way is use the
    MSVC system.  A third way is to use the MinGW system, which uses the
-   Gnu toolset to compile windows programs.
+   Gnu toolset to compile windows programs. The source code supports
+   Windows systems from Vista on.
 
    Link-grammar requires a working version of POSIX-standard regex
    libraries.  Since these are not provided by Microsoft, a copy must
@@ -253,13 +255,6 @@ BUILDING on Windows
    http://gnuwin32.sourceforge.net/packages/regex.htm
    See also:
    http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/regex.README
-
-   By default, the library is configured to create a DLL. If you want
-   to instead build a static library, the macro LINK_GRAMMAR_STATIC must
-   be defined before the inclusion of any header files for both the compiling
-   of the link-grammar library and for the application that uses it. Other
-   compiler settings will also have to be changed to create a static library
-   of course.
 
    The different build methods below are NOT regularly tested, and
    some link-grammar versions may have build issues.  If you are an
@@ -277,57 +272,15 @@ BUILDING on Windows (Cygwin)
    Unfortunately, the Cygwin system is not compatible with Java, so if
    you need the Java bindings, you must use MSVC or MinGW, below.
 
-
 BUILDING on Windows (MinGW)
 ---------------------------
-   Another way to build link-grammar is to use the MinGW/MSYS, which
-   uses the Gnu toolset to compile Windows programs for Windows. This
-   is probably the easiest way to obtain workable Java bindings for
-   Windows.  Download and install MinGW, MSYS and MSYS-DTK from
-   http://mingw.org.
+   Another way to build link-grammar is to use MinGW, which uses the GNU
+   toolset to compile Windows programs for Windows. Using MinGW/MSYS is
+   probably the easiest way to obtain workable Java bindings for Windows.
+   Download and install MinGW, MSYS and MSYS-DTK from http://mingw.org.
 
-   Then build and install link-grammar with
-
-       ./configure
-       make
-       make install
-
-   If you used the standard installation paths, the directory /usr/ is
-   mapped to C:\msys\1.0, so after 'make install', the libraries and
-   executable will be found at C:\msys\1.0\local\bin and the dictionary
-   files at C:\msys\1.0\local\share\link-grammar.
-
-   In order to use the Java bindings you'll need to build two extra
-   DLLs, by running the following commands from the link-grammar base
-   directory:
-
-       cd link-grammar
-
-       gcc -g -shared -Wall -D_JNI_IMPLEMENTATION_ -Wl,--kill-at \
-       .libs/analyze-linkage.o .libs/and.o .libs/api.o \
-       .libs/build-disjuncts.o .libs/constituents.o \
-       .libs/count.o .libs/disjuncts.o .libs/disjunct-utils.o \
-       .libs/error.o .libs/expand.o .libs/extract-links.o \
-       .libs/fast-match.o .libs/idiom.o .libs/massage.o \
-       .libs/post-process.o .libs/pp_knowledge.o .libs/pp_lexer.o \
-       .libs/pp_linkset.o .libs/prefix.o .libs/preparation.o \
-       .libs/print-util.o .libs/print.o .libs/prune.o \
-       .libs/read-dict.o .libs/read-regex.o .libs/regex-morph.o \
-       .libs/resources.o .libs/spellcheck-aspell.o \
-       .libs/spellcheck-hun.o .libs/string-set.o .libs/tokenize.o \
-       .libs/utilities.o .libs/word-file.o .libs/word-utils.o \
-       -o /usr/local/bin/link-grammar.dll
-
-       gcc -g -shared -Wall -D_JNI_IMPLEMENTATION_ -Wl,--kill-at \
-       .libs/jni-client.o /usr/local/bin/link-grammar.dll \
-       -o /usr/local/bin/link-grammar-java.dll
-
-   This will create link-grammar.dll and link-grammar-java.dll in the
-   directory c:\msys\1.0\local\bin . These files, together with
-   link-grammar-*.jar, will be used by Java programs.
-
-   Make sure that this directory is in the %PATH setting, as otherwise,
-   the DLL's will not be found.
+   For more details see mingw/README.MSYS .
+   You can also build with MinGW under Cygwin. See mingw/README.Cygwin .
 
 
 BUILDING and RUNNING on Windows (MSVC)
@@ -337,25 +290,31 @@ BUILDING and RUNNING on Windows (MSVC)
 
 RUNNING the program:
 --------------------
-   To run the program issue the Unix command:
+   To run the program issue the command (supposing it is in your PATH):
 
-       ./link-parser
+       link-parser [arguments]
 
    This starts the program.  The program has many user-settable variables
    and options. These can be displayed by entering !var at the link-parser
    prompt.  Entering !help will display some additional commands.
 
-   The dictionaries contain some utf-8 punctuation. These may generate
-   errors for users in a non-utf-8 locale, such as the "C" locale.
-   The locale can be set, for example, by saying
+   The dictionaries are arranged in directories whose name is the 2-letter
+   language code. The link-parser program searches for such a language
+   directory in that order, directly or under a directory names "data":
 
-       export LANG=en_US.UTF-8
+   1. Under your current directory.
+   2. Unless compiled with MSVC or run under the Windows console:
+      At the installed location (typically in /usr/local/share/link-grammar).
+   3. If compiled on Windows: In the directory of the link-parser
+      executable (may be in a different location than the link-parser
+      command, which may be a script).
 
-   at the shell prompt.
+   If link-parser cannot find the desired dictionary, use verbosity
+   level 3 to debug the problem; for example:
 
-   By default, the parser will use dictionaries at the installed location
-   (typically in /usr/local/share). Other locations can be specified on
-   the command line; for example:
+      link-parser ru -verbosity=3
+
+   Other locations can be specified on the command line; for example:
 
       link-parser ../path/to-my/modified/data/en
 
@@ -365,7 +324,11 @@ RUNNING the program:
    The Russian dictionaries are in data/ru. Thus, the Russian parser
    can be started as:
 
-      link-parser data/ru
+      link-parser ru
+
+   If you don't supply an argument to link-parser, it searches for a
+   language according to your current locale setup. If it cannot find such
+   a language directory, it defaults to "en".
 
    If you see errors similar to this:
 
@@ -381,11 +344,6 @@ RUNNING the program:
    combinations or variants of these, depending on your operating
    system.
 
-   In order to debug dictionary search/opening, use verbosity level 3.
-   For example:
-
-      link-parser data/en -verbosity=3
-
 
 TESTING the program:
 --------------------
@@ -399,7 +357,7 @@ TESTING the program:
    on a large number of sentences.  The following command runs the
    parser on a file called corpus-basic.batch
 
-       ./link-parser < corpus-basic.batch
+       link-parser < corpus-basic.batch
 
    The line `!batch` near the top of corpus-basic.batch turns on batch
    mode.  In this mode, sentences labeled with an initial `*` should be
@@ -418,10 +376,10 @@ TESTING the program:
    number of errors one can expect to observe in each of these files
    are roughly as follows:
 
-   en/corpus-basic.batch:      61 errors
-   en/corpus-fixes.batch:     401 errors
-   lt/corpus-basic.batch:      17 errors
-   ru/corpus-basic.batch:      31 errors
+   en/corpus-basic.batch:      64 errors
+   en/corpus-fixes.batch:     407 errors
+   lt/corpus-basic.batch:      15 errors
+   ru/corpus-basic.batch:      47 errors
 
    The bindings/python directory contains a unit test for the python
    bindings. It also performs several basic checks that stress the
@@ -534,7 +492,7 @@ Spell Checking:
    aspell is used, else hunspell is used.
 
    Spell checking may be disabled at runtime, in the link-parser client
-   with the !spell flag.  Enter !help for more details.
+   with the !spell=0 flag.  Enter !help for more details.
 
 
 MULTI-THREADED USE:

--- a/bindings/perl/Makefile.am
+++ b/bindings/perl/Makefile.am
@@ -43,7 +43,7 @@ clinkgrammar_la_CPPFLAGS = \
    -I$(top_srcdir)         \
    -I$(top_builddir)
 
-clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PERL_LDFLAGS) -module
+clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PERL_LDFLAGS) -module -no-undefined
 clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la
 
 if HAVE_HUNSPELL

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -168,6 +168,8 @@ class BParseOptionsTestCase(unittest.TestCase):
 
     def test_setting_spell_guess(self):
         po = ParseOptions(spell_guess=True)
+        if po.spell_guess == 0:
+            raise unittest.SkipTest("Library is not configured with spell guess")
         self.assertEqual(po.spell_guess, 7)
         po = ParseOptions(spell_guess=5)
         self.assertEqual(po.spell_guess, 5)
@@ -300,6 +302,8 @@ class HEnglishLinkageTestCase(unittest.TestCase):
 
     def test_d_spell_guessing_on(self):
         self.po.spell_guess = 7
+        if self.po.spell_guess == 0:
+            raise unittest.SkipTest("Library is not configured with spell guess")
         result = self.parse_sent("I love going to shoop.")
         resultx = result[0] if result else []
         for resultx in result:

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -56,8 +56,7 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
-_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module
-_clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la
+_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module -no-undefined
 
 
 EXTRA_DIST =         \

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -57,6 +57,7 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_builddir)
 
 _clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module -no-undefined
+_clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
 
 
 EXTRA_DIST =         \

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -56,7 +56,13 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
-_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module -no-undefined
+# On Cygwin, a DLL with version is named name-major.dll with no symlink to
+# it of an unversioned name (at least up and including libtool 2.4.6).
+# This is bad for Python modules, as they must have an identifier name.
+if OS_CYGWIN
+AVOID_VERSION = -avoid-version
+endif
+_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(AVOID_VERSION) $(PYTHON_LDFLAGS) -module -no-undefined
 _clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
 
 

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -62,8 +62,11 @@ _clinkgrammar_la_CPPFLAGS =       \
 if OS_CYGWIN
 AVOID_VERSION = -avoid-version
 endif
-_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(AVOID_VERSION) $(PYTHON_LDFLAGS) -module -no-undefined
-_clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
+_clinkgrammar_la_LDFLAGS =                        \
+    -version-info @VERSION_INFO@ $(AVOID_VERSION) \
+    $(PYTHON_LDFLAGS) -module -no-undefined
+_clinkgrammar_la_LIBADD =                         \
+    $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
 
 
 EXTRA_DIST =         \

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -62,8 +62,17 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
-_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module -no-undefined
-_clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la
+# On Cygwin, a DLL with version is named name-major.dll with no symlink to
+# it of an unversioned name (at least up and including libtool 2.4.6).
+# This is bad for Python modules, as they must have an identifier name.
+if OS_CYGWIN
+AVOID_VERSION = -avoid-version
+endif
+_clinkgrammar_la_LDFLAGS =                        \
+    -version-info @VERSION_INFO@ $(AVOID_VERSION) \
+    $(PYTHON_LDFLAGS) -module -no-undefined
+_clinkgrammar_la_LIBADD =                         \
+    $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
 
 
 EXTRA_DIST =         \

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -62,7 +62,7 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
-_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module
+_clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PYTHON_LDFLAGS) -module -no-undefined
 _clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ AC_CHECK_FUNCS(prctl)
 dnl Check for types
 AC_CHECK_TYPES([locale_t], [], [], [[#include <locale.h>]])
 
+dnl Check for specific OSs
 # ====================================================================
 
 AC_MSG_CHECKING([for native Win32])
@@ -81,7 +82,17 @@ esac
 AC_MSG_RESULT([$native_win32])
 AM_CONDITIONAL(OS_WIN32, test "x$native_win32" = "xyes")
 
-# ====================================================================
+AC_MSG_CHECKING([for Cygwin])
+case "$host" in
+  *-*-cygwin*)
+    cygwin=yes
+    ;;
+  *)
+    cygwin=no
+    ;;
+esac
+AC_MSG_RESULT([$cygwin])
+AM_CONDITIONAL(OS_CYGWIN, test "x$cygwin" = "xyes")
 
 AC_MSG_CHECKING([for 64-bit Apple OSX])
 case "$host" in
@@ -95,6 +106,7 @@ esac
 AC_MSG_RESULT([$apple_osx])
 
 # ====================================================================
+
 CFLAGS="${CFLAGS} -O3"
 CXXFLAGS="${CXXFLAGS} -O3 -Wall"
 

--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ if test x${native_win32} = xyes; then
 
 	# Only running on Vista and on is supported.
 	AC_DEFINE(NTDDI_VERSION, NTDDI_VISTA)
-	AC_DEFINE(_WIN32_WINNT, NTDDI_VISTA)
+	AC_DEFINE(_WIN32_WINNT, _WIN32_WINNT_VISTA)
 
 
 else

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -118,10 +118,14 @@ Parse_Options parse_options_create(void)
 	po->min_null_count = 0;
 	po->max_null_count = 0;
 	po->islands_ok = false;
-	po->use_spell_guess = 7;
 	po->use_sat_solver = false;
 	po->use_viterbi = false;
 	po->linkage_limit = 100;
+#if defined HAVE_HUNSPELL || defined HAVE_ASPELL
+	po->use_spell_guess = 7;
+#else
+	po->use_spell_guess = 0;
+#endif /* defined HAVE_HUNSPELL || defined HAVE_ASPELL */
 
 #ifdef XXX_USE_CORPUS
 	/* Use the corpus cost model, if available.
@@ -325,7 +329,16 @@ bool parse_options_get_islands_ok(Parse_Options opts) {
 }
 
 void parse_options_set_spell_guess(Parse_Options opts, int dummy) {
+#if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 	opts->use_spell_guess = dummy;
+#else
+	if (dummy && (verbosity > D_USER_BASIC))
+	{
+		prt_error("Error: Cannot enable spell guess; "
+		        "this library was built without spell guess support.");
+	}
+
+#endif /* defined HAVE_HUNSPELL || defined HAVE_ASPELL */
 }
 
 int parse_options_get_spell_guess(Parse_Options opts) {

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -270,9 +270,11 @@ void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {
 #ifdef USE_SAT_SOLVER
 	opts->use_sat_solver = dummy;
 #else
-	if (dummy)
-		prt_error("Error: cannot enable the Boolean SAT parser; this"
-					 " library was built without SAT solver support.");
+	if (dummy && (verbosity > D_USER_BASIC))
+	{
+		prt_error("Error: Cannot enable the Boolean SAT parser; "
+		          "this library was built without SAT solver support.");
+	}
 #endif
 }
 

--- a/link-grammar/minisat/Makefile.am
+++ b/link-grammar/minisat/Makefile.am
@@ -2,7 +2,7 @@
 VERSION=2.0.0
 MINISAT_VERSION_INFO=2:0:0
 
-libminisat_la_LDFLAGS = -version-info $(MINISAT_VERSION_INFO)
+libminisat_la_LDFLAGS = -version-info $(MINISAT_VERSION_INFO) -no-undefined
 
 lib_LTLIBRARIES = libminisat.la
 

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -44,7 +44,7 @@
 #endif /*_WIN32 */
 
 #define IS_DIR_SEPARATOR(ch) (DIR_SEPARATOR[0] == (ch))
-#ifndef DICTIONARY_DIR
+#if !defined( DICTIONARY_DIR) || !defined(__MINGW32__)
 	#define DEFAULTPATH NULL
 #else
 	#define DEFAULTPATH DICTIONARY_DIR

--- a/mingw/README.Cygwin
+++ b/mingw/README.Cygwin
@@ -1,0 +1,108 @@
+Building on Windows using MinGW under Cygwin
+--------------------------------------------
+
+  Tested on an up-to-date Cygwin 2.5.2 under Windows 10,
+  with link-grammar version 5.3.8.
+
+
+Supported target versions
+-------------------------
+  The intention is to support versions from Vista on (some WIN32
+  functions which are used are not supported in earlier versions.)
+  The resulted link-parser executable is able to run under Cygwin too.
+
+  The system compatibility definitions:
+  In configure.ac:
+     AC_DEFINE(NTDDI_VERSION, NTDDI_VISTA)
+     AC_DEFINE(_WIN32_WINNT, _WIN32_WINNT_VISTA)
+
+
+Configuring
+-----------
+
+  $ LDFLAGS=-L$gnuregex/lib CPPFLAGS=-I$gnuregex/include \
+      configure -host=x86_64-w64-mingw32 \
+      --enable-wordgraph-display \
+      --disable-sat-solver \
+      --disable-python-bindings \
+      --disable-java-bindings
+
+  In the configure command above, $gnuregex points to the directory of the
+  POSIX regex for Windows. The library basename must b:e "libregex". The
+  -host value is for compiling for 64-bits.
+
+  The SAT solver cannot be enabled for now due to a missing definition in
+the build system. Python bindings fail because it currently tries to use the Cygwin Python
+  system. More development work is needed on these.
+
+  (The Java bindings has not been tested in this version. Most probably the
+  way described in README.MSYS can be used.)
+
+  $ make
+
+  $ make install
+
+  The dictionaries are installed by default under
+  /usr/local/share/link-grammar.
+
+
+Running
+-------
+
+  * From the sources directory, using cmd.exe Windows console:
+
+  Note: ^Z/^D/^C are not supported when running under Cygwin!
+  In particular, don't press ^Z - it may crash or stuck the window.
+  To exit, use the !exit command.
+
+      > PATH-TO-LG-CONF-DIRECTORY\link-parser\link-parser [arguments]
+
+  * Form the Cygwin shell:
+
+    Before installation:
+      $ PATH-TO-LG-CONF-DIRECTORY/link-parser/link-parser [args]
+
+    After "make install" (supposing /usr/local/bin is in the PATH):
+      $ link-parser [arguments]
+
+  To run the executable from other location, liblink-grammar-5.dll needs to be
+  in a directory in PATH (e.g. in the directory of the executable).
+
+  For more details, see "RUNNING the program" in the main README.
+
+Limitations
+-----------
+
+  Since MinGW currently doesn't support locale_t and the isw*() functions
+  that use it, the library doesn't support per-dictionary locale setting,
+  which just means that if several dictionaries are used, all of them share
+  the same global locale, so if they are used from different threads the
+  must use languages with the same codeset.  If the program is not
+  multi-threaded, dictionaries of several different languages can be created
+  and then used one by one, provided that the global locale is switched
+  (using setlocale()) to the locale of each dictionary just before using
+  this dictionary.
+
+  (To get a complete per-dictionary locale support, the library should be
+  compiled using MSVC.)
+
+
+Implementation Notes
+--------------------
+
+  MinGW uses by default a Windows STDIO from an unsupported Windows library
+  that just happens to be included even in Windows 10. This STDIO is not C99
+  compliant, and in particular doesn't support the %z formats (it crashes
+  when it encounters them).
+
+  Hence __USE_MINGW_ANSI_STDIO=1 is defined, so MinGW uses its own C99
+  compatible STDIO. However, the *printf() functions of these implementation
+  cannot print UTF-8 to the console (to files/pipe they print UTF-8 just
+  fine), because they use Windows' putchar(), which cannot write UTF-8 to
+  the console. A workaround is implemented in the LG library and in
+  link-parser.
+
+  If you write a C/C++ program (to be compiled with MinGW) that uses the
+  library and needs to print to the console, and this problem is not fixed
+  by then (in Windows or MinGW), then you need to copy this workaround
+  implementation. See utilities.c and/or parser_utilities.c.

--- a/mingw/README.MSYS
+++ b/mingw/README.MSYS
@@ -1,0 +1,57 @@
+BUILDING on Windows (MinGW/MSYS)
+--------------------------------
+   MinGW/MSYS uses the Gnu toolset to compile Windows programs for
+   Windows.  This is probably the easiest way to obtain workable Java
+   bindings for Windows.  Download and install MinGW, MSYS and MSYS-DTK
+   from http://mingw.org.
+
+      Then build and install link-grammar with
+
+          ./configure
+          make
+          make install
+
+   If you used the standard installation paths, the directory /usr/ is
+   mapped to C:\msys\1.0, so after 'make install', the libraries and
+   executable will be found at C:\msys\1.0\local\bin and the dictionary
+   files at C:\msys\1.0\local\share\link-grammar.
+
+Running
+-------
+  See "RUNNING the program" in the main README.
+
+
+Java bindings
+-------------
+
+   In order to use the Java bindings you'll need to build two extra
+   DLLs, by running the following commands from the link-grammar base
+   directory:
+
+       cd link-grammar
+
+       gcc -g -shared -Wall -D_JNI_IMPLEMENTATION_ -Wl,--kill-at \
+       .libs/analyze-linkage.o .libs/and.o .libs/api.o \
+       .libs/build-disjuncts.o .libs/constituents.o \
+       .libs/count.o .libs/disjuncts.o .libs/disjunct-utils.o \
+       .libs/error.o .libs/expand.o .libs/extract-links.o \
+       .libs/fast-match.o .libs/idiom.o .libs/massage.o \
+       .libs/post-process.o .libs/pp_knowledge.o .libs/pp_lexer.o \
+       .libs/pp_linkset.o .libs/prefix.o .libs/preparation.o \
+       .libs/print-util.o .libs/print.o .libs/prune.o \
+       .libs/read-dict.o .libs/read-regex.o .libs/regex-morph.o \
+       .libs/resources.o .libs/spellcheck-aspell.o \
+       .libs/spellcheck-hun.o .libs/string-set.o .libs/tokenize.o \
+       .libs/utilities.o .libs/word-file.o .libs/word-utils.o \
+       -o /usr/local/bin/link-grammar.dll
+
+       gcc -g -shared -Wall -D_JNI_IMPLEMENTATION_ -Wl,--kill-at \
+       .libs/jni-client.o /usr/local/bin/link-grammar.dll \
+       -o /usr/local/bin/link-grammar-java.dll
+
+   This will create link-grammar.dll and link-grammar-java.dll in the
+   directory c:\msys\1.0\local\bin . These files, together with
+   link-grammar-*.jar, will be used by Java programs.
+
+   Make sure that this directory is in the %PATH setting, as otherwise,
+   the DLL's will not be found.

--- a/msvc14/MSVC-common.props
+++ b/msvc14/MSVC-common.props
@@ -5,7 +5,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NTDDI_VERSION=NTDDI_VISTA;_WIN32_WINNT=_WIN32_WINNT_VISTA;WIN32_LEAN_AND_MEAN;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4068</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/msvc14/README
+++ b/msvc14/README
@@ -4,12 +4,20 @@ This directory contains project files for building Link Grammar with the
 Microsoft Visual Studio 2015 IDE (MSVC14). They were created and tested with
 the Community Edition of that product.
 
+Supported target versions
+-------------------------
+The intention is to support versions from Vista on (some WIN32
+functions which are used are not supported in earlier versions.)
+
+The definitions for that:
+In each project file - Target Platform version: 8.1
+In the MSVC-common property file - C/C++->Preprocessor:
+NTDDI_VERSION=NTDDI_VISTA;_WIN32_WINNT=_WIN32_WINNT_VISTA;
 
 Dependencies
 ------------
 The regex package, which includes libraries and header files, must be
 separately downloaded. Also see GNUREGEX_DIR below.
-
 
 Setup
 -----
@@ -30,7 +38,6 @@ sheet "Local" - GNUREGEX_DIR and (optionally) JAVA_HOME, as follows:
    Additional Include Directories.
    If your JAVA SDK/JDK installation has defined the JAVA_HOME environment
    variable (check it) then there is no need to define this User Macro.
-
 
 Compiling
 ---------

--- a/msvc14/README
+++ b/msvc14/README
@@ -9,9 +9,9 @@ Supported target versions
 The intention is to support versions from Vista on (some WIN32
 functions which are used are not supported in earlier versions.)
 
-The definitions for that:
+The system compatibility definitions:
 In each project file - Target Platform version: 8.1
-In the MSVC-common property file - C/C++->Preprocessor:
+In the MSVC-common property sheet - C/C++->Preprocessor:
 NTDDI_VERSION=NTDDI_VISTA;_WIN32_WINNT=_WIN32_WINNT_VISTA;
 
 Dependencies
@@ -52,9 +52,15 @@ Compiling
   You can do this at Build Menu->Configuration Manager.
 
 - The wordgraph-display feature is enabled when compiled with
-  USE_WORDGRAPH_DISPLAY (defined in the LGfeatures property sheet
-  Common properties->C/C++->Preprocessor/Preprocessor Definitions.
+  USE_WORDGRAPH_DISPLAY (already defined in the LGfeatures property sheet
+  Common properties->C/C++->Preprocessor/Preprocessor Definitions).
 
+- By default, the library is configured to create a DLL. If you want
+  to instead build a static library, the macro LINK_GRAMMAR_STATIC must
+  be defined before the inclusion of any header files for both the compiling
+  of the link-grammar library and for the application that uses it. Other
+  compiler settings will also have to be changed to create a static library
+  of course.
 
 Running
 -------


### PR DESCRIPTION
On Cygwin, a DLL with version is named name-major.dll with no symlink to it of an unversioned name (at least up and including libtool 2.4.6).  This is bad for Python modules, as they must have an identifier name.
    
Solve this by add the libtool flag -avoid-version (for Cygwin only).
