### PR TITLE
SAT: Bug fix - preallocate linkages memory

### DIFF
--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -36,6 +36,9 @@ public:
   // Solve the formula, returning the next linkage.
   Linkage get_next_linkage();
 
+  // Next linkage index in the linkage array
+  LinkageIdx _next_linkage_index;
+
 private:
   int verbosity;
   const char *debug;

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -25,16 +25,16 @@ void free_linkage_connectors_and_disjuncts(Linkage lkg)
 /**
  * Free all the connectors and disjuncts of all the linkages.
  */
-void sat_free_linkages(Sentence sent)
+void sat_free_linkages(Sentence sent, LinkageIdx next_linkage_index)
 {
   Linkage lkgs = sent->lnkages;
 
-  for (LinkageIdx li = 0; li < sent->num_linkages_alloced; li++) {
+  for (LinkageIdx li = 0; li < next_linkage_index; li++) {
     free_linkage_connectors_and_disjuncts(&lkgs[li]);
     free_linkage(&lkgs[li]);
   }
   free(lkgs);
-  sent->lnkages = 0;
+  sent->lnkages = NULL;
   sent->num_linkages_alloced = 0;
 }
 

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -11,6 +11,7 @@ extern "C" {
 bool isEndingInterpunction(const char* str);
 const char* word(Sentence sent, int w);
 void free_linkage_connectors_and_disjuncts(Linkage);
+void sat_free_linkages(Sentence, LinkageIdx);
 void sat_free_linkages(Sentence);
 Exp* null_exp();
 void add_anded_exp(Exp*&, Exp*);


### PR DESCRIPTION
Currently the linkage array in the SAT parser is allocated on demand -
for each new linkage it is enlarged by one element, using realloc().

The problem is that realloc() may return a pointer to another block of
memory, and since the API uses linkage pointers, such pointers would
become invalid.

This fix allocates the linkage array in advance, according to the
linkage_limit option.