### PR TITLE
Python test fixes

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -6,7 +6,7 @@
 
 # Run tests.py if the user says 'make check'
 TESTS = tests.py
-TESTS_ENVIRONMENT = PYTHONPATH=$(srcdir)/../python:../python/.libs LINK_GRAMMAR_DATA=$(srcdir)/../../data
+TESTS_ENVIRONMENT = PYTHONPATH=$(srcdir)/../python:../python:../python/.libs LINK_GRAMMAR_DATA=$(srcdir)/../../data
 
 EXTRA_DIST =         \
    AUTHORS           \

--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -6,7 +6,14 @@
 
 # Run tests.py if the user says 'make check'
 TESTS = tests.py
-TESTS_ENVIRONMENT = PYTHONPATH=$(srcdir)/../python:../python:../python/.libs LINK_GRAMMAR_DATA=$(srcdir)/../../data
+AM_TESTS_ENVIRONMENT = python=$(PYTHON) \
+   PYTHONPATH=$(srcdir)/../python:../$${python\#\#*/}:../$${python\#\#*/}/.libs \
+   LINK_GRAMMAR_DATA=$(srcdir)/../../data; \
+   export PYTHONPATH LINK_GRAMMAR_DATA;
+
+TEST_EXTENSIONS = .py
+PY_LOG_COMPILER = $(PYTHON)
+#AM_PY_LOG_FLAGS = -v
 
 EXTRA_DIST =         \
    AUTHORS           \

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -575,10 +575,13 @@ def linkage_testfile(self, dict, popt, desc = ''):
     """
     if '' != desc:
         desc = desc + '-'
-    parses = open(clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(dict._obj) + ".txt")
+    testfile = clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(dict._obj) + ".txt"
+    parses = open(testfile)
     diagram = None
     sent = None
+    lineno = 0
     for line in parses:
+        lineno += 1
         # Lines starting with I are the input sentences
         if 'I' == line[0]:
             sent = line[1:]
@@ -591,7 +594,9 @@ def linkage_testfile(self, dict, popt, desc = ''):
         if 'N' == line[0]:
             diagram = ""
             constituents = ""
-            linkage = linkages.next()
+            linkage = next(linkages, None)
+            if not linkage:
+                assert False, "{}:{}: Sentence has too few linkages".format(testfile, lineno)
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -7,8 +7,28 @@ import sys, os
 import locale
 import unittest
 
+# Show information on this program run
+print('Running by:', sys.executable)
+print('Running {} in:'.format(sys.argv[0]), os.getcwd())
+for v in 'PYTHONPATH', 'srcdir', 'LINK_GRAMMAR_DATA':
+    print('{}={}'.format(v, os.environ.get(v)))
+#===
+
+
 from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary, \
                         Clinkgrammar as clg
+
+
+# Show the location and version of the bindings modules
+for module in 'linkgrammar', '_clinkgrammar':
+    if module in sys.modules:
+        print("Using", sys.modules[module], end='')
+        if hasattr(sys.modules[module], '__version__'):
+            print(' version', sys.modules[module].__version__, end='')
+        print()
+    else:
+        print("Warning: Module", module,  "not loaded.")
+#===
 
 def setUpModule():
     datadir = os.getenv("LINK_GRAMMAR_DATA", "")
@@ -591,5 +611,6 @@ def linkage_testfile(self, dict, popt, desc = ''):
 def warning(*msg):
     progname = os.path.basename(sys.argv[0])
     print("{}: Warning:".format(progname), *msg, file=sys.stderr)
+
 
 unittest.main()

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -196,7 +196,7 @@ class DBasicParsingTestCase(unittest.TestCase):
         return list(Sentence(text, self.d, self.po).parse())
 
     def test_that_parse_returns_empty_iterator_on_no_linkage(self):
-        result = self.parse_sent("This this doesn't parse");
+        result = self.parse_sent("This this doesn't parse")
         for _ in result:
             assert False, "Unexpected linkage iteration"
 
@@ -212,7 +212,7 @@ class DBasicParsingTestCase(unittest.TestCase):
         self.assertTrue(isinstance(result[1], Linkage))
 
         # def test_unicode_encoded_string(self):
-        if (sys.version_info > (3, 0)):
+        if sys.version_info > (3, 0):
             result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.")
         else:
             result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.".encode('utf8'))

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -218,8 +218,10 @@ class DBasicParsingTestCase(unittest.TestCase):
 
     def test_that_parse_returns_empty_iterator_on_no_linkage(self):
         result = self.parse_sent("This this doesn't parse")
+        linkage_exists = False
         for _ in result:
-            assert False, "Unexpected linkage iteration"
+            linkage_exists = True
+            self.assertFalse(linkage_exists, "Unparsable sentence has linkages.")
 
     def test_that_parse_sent_returns_list_of_linkage_objects_for_valid_sentence(self):
         result = self.parse_sent("This is a relatively simple sentence.")
@@ -597,7 +599,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             constituents = ""
             linkage = next(linkages, None)
             if not linkage:
-                assert False, "{}:{}: Sentence has too few linkages".format(testfile, lineno)
+                self.assertTrue(linkage, "{}:{}: Sentence has too few linkages".format(testfile, lineno))
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -203,6 +203,7 @@ class CParseOptionsTestCase(unittest.TestCase):
         that parsers can be created and deleted without regard for
         the existence of PYTHON Linkage objects
         """
+        #pylint: disable=unused-variable
         s = Sentence('This is a sentence.', Dictionary(), ParseOptions())
         linkages = s.parse()
         del s

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # coding: utf8
-#
-# Python link-grammar test script
-#
+"""Python link-grammar test script"""
+
 from __future__ import print_function
 import sys, os
 import locale

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -568,14 +568,14 @@ class ZRULangTestCase(unittest.TestCase):
              'облачк.=', '=а.ndnpi',
              '.', 'RIGHT-WALL'])
 
-def linkage_testfile(self, dict, popt, desc = ''):
+def linkage_testfile(self, lgdict, popt, desc = ''):
     """
     Reads sentences and their corresponding
     linkage diagrams / constituent printings.
     """
     if '' != desc:
         desc = desc + '-'
-    testfile = clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(dict._obj) + ".txt"
+    testfile = clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(lgdict._obj) + ".txt"
     parses = open(testfile)
     diagram = None
     sent = None
@@ -587,7 +587,7 @@ def linkage_testfile(self, dict, popt, desc = ''):
             sent = line[1:]
             diagram = ""
             constituents = ""
-            linkages = Sentence(sent, dict, popt).parse()
+            linkages = Sentence(sent, lgdict, popt).parse()
             linkage = linkages.next()
 
         # Generate the next linkage of the last input sentence

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -245,10 +245,11 @@ class DBasicParsingTestCase(unittest.TestCase):
         self.assertEqual([len(l) for l in linkage.links()], [6,2,1,1,3,2,1,1,1])
 
     def test_dictionary_locale_definition(self):
-        oldlocale = locale.setlocale(locale.LC_CTYPE, "tr_TR.UTF-8")
+        tr_locale = 'tr_TR.UTF-8' if os.name != 'nt' else 'Turkish'
+        oldlocale = locale.setlocale(locale.LC_CTYPE, tr_locale)
         self.assertEqual(list(self.parse_sent('Is it fine?')[0].words()),
              ['LEFT-WALL', 'is.v', 'it', 'fine.a', '?', 'RIGHT-WALL'])
-        locale.setlocale(locale.LC_CTYPE, oldlocale);
+        locale.setlocale(locale.LC_CTYPE, oldlocale)
 
 class ESATsolverTestCase(unittest.TestCase):
     def setUp(self):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -10,8 +10,6 @@ import unittest
 from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary, \
                         Clinkgrammar as clg
 
-locale.setlocale(locale.LC_CTYPE, "en_US.UTF-8")
-
 def setUpModule():
     datadir = os.getenv("LINK_GRAMMAR_DATA", "")
     if datadir:

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -7,12 +7,8 @@ import sys, os
 import locale
 import unittest
 
-from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary
-
-try:
-    import linkgrammar._clinkgrammar as clg
-except ImportError:
-    import _clinkgrammar as clg
+from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary, \
+                        Clinkgrammar as clg
 
 locale.setlocale(locale.LC_CTYPE, "en_US.UTF-8")
 

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -332,6 +332,9 @@ class Linkage(object):
     def link_cost(self):
         return clg.linkage_link_cost(self._obj)
 
+    def disjunct_cost(self):
+        return clg.linkage_disjunct_cost(self._obj)
+
     def link(self, i):
         return Link(self, i, self.word(clg.linkage_get_link_lword(self._obj, i)),
                     clg.linkage_get_link_llabel(self._obj, i),

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -265,6 +265,9 @@ class Dictionary(object):
             clg.dictionary_delete(self._obj)
             del self._obj
 
+    def linkgrammar_get_dict_version(self):
+        return clg.linkgrammar_get_dict_version(self._obj)
+
 
 class Link(object):
     def __init__(self, linkage, index, left_word, left_label, right_label, right_word):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -11,7 +11,8 @@ try:
 except ImportError:
     import clinkgrammar as clg
 
-__all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence']
+Clinkgrammar = clg
+__all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence', 'Clinkgrammar']
 
 
 class ParseOptions(object):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -404,7 +404,7 @@ class Sentence(object):
             clg.sentence_parse(sent._obj, sent.parse_options._obj)
 
         def __iter__(self):
-            if (0 == clg.sentence_num_valid_linkages(self.sent._obj)):
+            if 0 == clg.sentence_num_valid_linkages(self.sent._obj):
                 return iter(())
             return self
 

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -370,10 +370,6 @@ class Sentence(object):
         for linkage in linkages:
             print linkage.diagram()
     """
-    text = None
-    dict = None
-    parse_options = None
-
     def __init__(self, text, dict, parse_options):
         self.text, self.dict, self.parse_options = text, dict, parse_options  # keep all args passed into clg.* fn
         self._obj = clg.sentence_create(self.text, self.dict._obj)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -5,8 +5,6 @@
 # See http://www.abisource.com/projects/link-grammar/api/index.html to get
 # more information about C API
 
-import sys
-
 # In Python3, importing just _clinkgrammar raises exception that the
 # module is not found.
 try:

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -265,8 +265,6 @@ class Dictionary(object):
             clg.dictionary_delete(self._obj)
             del self._obj
 
-    def get_max_cost(self):
-        return clg.dictionary_get_max_cost(self._obj)
 
 class Link(object):
     def __init__(self, linkage, index, left_word, left_label, right_label, right_word):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -370,8 +370,8 @@ class Sentence(object):
         for linkage in linkages:
             print linkage.diagram()
     """
-    def __init__(self, text, dict, parse_options):
-        self.text, self.dict, self.parse_options = text, dict, parse_options  # keep all args passed into clg.* fn
+    def __init__(self, text, lgdict, parse_options):
+        self.text, self.dict, self.parse_options = text, lgdict, parse_options  # keep all args passed into clg.* fn
         self._obj = clg.sentence_create(self.text, self.dict._obj)
 
     def __del__(self):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -6,6 +6,7 @@ See http://www.abisource.com/projects/link-grammar/api/index.html to get
 more information about C API
 """
 
+#pylint: disable=no-name-in-module,import-error
 try:
     import linkgrammar.clinkgrammar as clg
 except ImportError:

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -1,16 +1,15 @@
 # -*- coding: utf8 -*-
-#
-# High-level Python bindings build on top of the low-level
-# C API (clinkgrammar)
-# See http://www.abisource.com/projects/link-grammar/api/index.html to get
-# more information about C API
+"""
+High-level Python bindings build on top of the low-level
+C API (clinkgrammar)
+See http://www.abisource.com/projects/link-grammar/api/index.html to get
+more information about C API
+"""
 
-# In Python3, importing just _clinkgrammar raises exception that the
-# module is not found.
 try:
-    import linkgrammar._clinkgrammar as clg
+    import linkgrammar.clinkgrammar as clg
 except ImportError:
-    import _clinkgrammar as clg
+    import clinkgrammar as clg
 
 __all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence']
 

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -50,10 +50,6 @@ class ParseOptions(object):
             del self._obj
 
     @property
-    def version(self):
-        return clg.linkgrammar_get_version()
-
-    @property
     def verbosity(self):
         """
         This is the level of description printed to stderr/stdout about the

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -268,6 +268,9 @@ class Dictionary(object):
     def linkgrammar_get_dict_version(self):
         return clg.linkgrammar_get_dict_version(self._obj)
 
+    def linkgrammar_get_dict_locale(self):
+        return clg.linkgrammar_get_dict_locale(self._obj)
+
 
 class Link(object):
     def __init__(self, linkage, index, left_word, left_label, right_label, right_word):

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -49,6 +49,7 @@ const char * dictionary_get_lang(Dictionary dict);
 
 void dictionary_delete(Dictionary dict);
 void dictionary_set_data_dir(const char * path);
+%newobject dictionary_get_data_dir;
 char * dictionary_get_data_dir(void);
 
 /**********************************************************************

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -35,6 +35,7 @@ typedef enum
 
 const char * linkgrammar_get_version(void);
 const char * linkgrammar_get_dict_version(Dictionary dict);
+const char * linkgrammar_get_dict_locale(Dictionary dict);
 
 /**********************************************************************
 *


### PR DESCRIPTION
These changes were extracted from my current work (yet unfinished - it needs polishing) on tests.py involving same-cost linkage order independence.

Main changes here:
- Remove dead code.
- Fixes for Windows.
- Hide _clingrammar importing. (Issue #358.)
- Better IDE interaction, including much less pylint warnings and importing of clinkgrammar instead of _clinkgrammar for better pylint checks. (Issue #358.)
- Code cleanup.
- Print program info to validate that the intended locations are tested.
- "make check" now uses python3 is configured.
- Fix minor memory leak.
- Use assertTrue() instead of assert.
- Add several binding calls.
- Convert some comments to docstrings.

