### PR TITLE
Fix missing dictionary DEFAULTPATH

### DIFF
--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -44,7 +44,7 @@
 #endif /*_WIN32 */
 
 #define IS_DIR_SEPARATOR(ch) (DIR_SEPARATOR[0] == (ch))
-#if !defined( DICTIONARY_DIR) || !defined(__MINGW32__)
+#if !defined(DICTIONARY_DIR) || defined(__MINGW32__)
 	#define DEFAULTPATH NULL
 #else
 	#define DEFAULTPATH DICTIONARY_DIR


### PR DESCRIPTION
I had a rather bad typo!
Regretfully I don't usually make installation tests.
But just now I made and found this bug.

I will define the installcheck target (or equivalent) to run tests.py with the system pathes, and make sure I run it before sending any PR.

It may be a good idea to issue 5.3.9, and recall 5.3.8 if still possible.
Maybe an issue with a workaround should also be opened.