### PR TITLE
Add basic install check

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -25,3 +25,15 @@ EXTRA_DIST =         \
    parses-quotes-en.txt \
    parses-sat-en.txt \
    tests.py
+
+
+# Installation checks, to be manually done after "make install".
+# 1. Check the usability of Python's linkgrammar module directory.
+# 2  Check the usability of the link-grammar system language directory.
+#
+# To run these checks, issue "make installcheck" from a regular user.
+installcheck-local:
+	for d in . .. ../data ./data; do \
+		[ ! -d $$d/en ] ||  { echo "Unexpected dictionary $$d/en"; exit 1; }; \
+	done
+	PYTHONPATH=$(pythondir) srcdir=$(srcdir) $(PYTHON) $(srcdir)/tests.py ${TESTSFLAGS}

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -34,3 +34,18 @@ if WITH_VITERBI
 link_parser_LDADD += $(top_builddir)/viterbi/libvitacog.la
 link_parser_LDADD += $(LIBGC_LIBS)
 endif
+
+
+# Installation checks, to be manually done after "make install".
+# link-parser checks:
+# 1. Show the location of its binary.
+# 2. Check that it can find the system link-grammar dictionary directory.
+# Note the "cd .libs" - it ensures that it will not find "../data".
+# To run these checks, issue "make installcheck" from a regular user.
+installcheck-local:
+	echo; echo -n 'Location of '; whereis -b link-parser; echo
+	[ "`which link-parser`" == $(bindir)/link-parser ] # Validate binary location
+	cd .libs; for d in . .. ../data ./data; do \
+		[ ! -d $$d/en ] ||  { echo "Unexpected dictionary $$d/en"; exit 1; }; \
+	done
+	cd .libs; echo "This is a test" | link-parser


### PR DESCRIPTION
Usage: make installcheck

This install check generally doesn't try check that "make install" has installed stuff at the needed places.  Instead, it checks that tests.py and link-parser can work independently of the installation directory. However, to validate that the correct link-parser command is invoked, its location is validated.

This change adds two checks - by using tests.py and by using link-parser. They check the  **usability** of the installed Python linkgrammar module and link-grammar dictionary directory.

__** If any of these checks fail, the "make" command will fail. **__

The output of the check can also be inspected: A recent tests.py modification shows info about its PYTHONPATH and module location. In addition, link-parser reports the dictionary location, and the link-parser check includes printing its binary location.