### PR TITLE
Make the test suite insensitive to changed order of equal-cost linkages

### DIFF
--- a/README
+++ b/README
@@ -35,7 +35,9 @@ CONTENTS of this directory:
    bindings/lisp/*          Optional Common Lisp language bindings.
    bindings/ocaml/*         Optional OCaML language bindings.
    bindings/python/*        Optional Python2 language bindings.
-   bindings/python3/*       Optional Python3 language bindings.
+   bindings/python3/*       Optional Python3 languagSe bindings.
+   bindings/python-examples/* Link-grammar test suite and
+                            Python language binding usage example.
    bindings/swig/*          SWIG interface file, for other FFI interfaces.
 
    data/en/*                English language dictionaries.
@@ -355,6 +357,8 @@ TESTING the program:
    There are several ways to test the resulting build.  If the Python
    bindings are built, then a test program can be found in the file
    ./bindings/python-examples/tests.py -- When run, it should pass.
+   For more details see README.md in the bindings/python-examples
+   directory.
 
    There are also multiple batches of test/example sentences in the
    language data directories, generally having the names corpus-*.batch

--- a/bindings/python-examples/README.md
+++ b/bindings/python-examples/README.md
@@ -1,38 +1,103 @@
-# Python bindings for Link Grammar
+Python bindings for Link Grammar
+================================
 
 Description
-===========
-This directory contains a Python interface to the Link Grammar C library.
+-----------
+A Link Grammar library test is implemented in **tests.py**.
+An example program **example.py** is provided.
 
-
-Testing
-=======
-The test collection `tests.py` should run 47 tests, which should all
-pass. 
-
-**NOTE**: Neither the `tests.py` nor `example.py` will run until
-**after** `make install` is performed. If you do not wish to install,
-then you will have to manually set the PYTHONPATH environment variable
-to you build directory `.libs` subdirectory, so that `_clinkgrammar.la`
-can be found.
+Configuring (if needed)
+-----------------------
+### For Python2
+   $ configure --enable-python-bindings
+### For Python3
+   $ configure --enable-python4-bindings
 
 
 How to use
-==========
-Parsing simple sentences::
+----------
+(See below under **Testing the installation** for directions on how to set PYTHONPATH in case it is needed.)
 
-    >>> from linkgrammar import Parser
-    >>> p = Parser()
-    >>> linkages = p.parse_sent("This is a simple sentence.")
-    >>> len(linkages)
-    4
-    >>> print linkages[0].diagram
-    
-        +-------------------Xp------------------+
-        |              +--------Ost-------+     |
-        +------WV------+  +-------Ds------+     |
-        +---Wd---+-Ss*b+  |     +----A----+     |
-        |        |     |  |     |         |     |
-    LEFT-WALL this.p is.v a simple.a sentence.n . 
+Parsing simple sentences:
 
+```
+$ python
+
+>>> from linkgrammar import Sentence, ParseOptions, Dictionary
+>>> sent = Sentence("This is a simple sentence.", Dictionary(), ParseOptions())
+>>> linkages = sent.parse()
+>>> len(linkages)
+>>> for linkage in linkages:
+...    print linkage.diagram()
+...
+```
+```
+      +-------------------Xp------------------+
+      |              +--------Osm-------+     |
+      +----->WV----->+  +-----Ds**x-----+     |
+      +---Wd---+-Ss*b+  |     +----A----+     |
+      |        |     |  |     |         |     |
+  LEFT-WALL this.p is.v a simple.a sentence.n .
+```
 Additional examples can be found in `examples.py`.
+
+Testing
+-------
+The test collection **tests.py** should run 56 tests, none of them should fail.
+However, 3 tests will get skipped if the library is not configured with a speller, and one test will get skipped if the library is not configured with the SAT solver (this is the status for now on native Windows).
+
+**Issuing the tests on systems other then native Windows/MinGW**
+Note: For less verbosity of the **make** command output you can use the **-s** flag of make.
+
+### Testing the build directory
+The following is assumed:
+**$SRC_DIR** - Link Grammar source directory.
+**$BUILD_DIR** - Link Grammar build directory.
+
+#### By **make**
+```
+$ cd $BUILD_DIR/bindings/python-examples
+$ make [-s] check
+```
+The results of tests.py are in the current directory under in the file **tests.log**.
+
+Note: To run also the tests in the **$SRC_DIR/tests/** directory, issue **make check** directly from **$BUILD_DIR**.
+
+#### Manually
+To run tests.py manually, or to run **example.py**, you have to set the PYTHONPATH environment variable as follows:
+```
+PYTHONPATH=$SRC_DIR/bindings/python:$BUILD_DIR/bindings/python:$BUILD_DIR/bindings/python/.libs
+```
+(Export it, or prepend it it the **make** command.)
+```
+$ cd $SRC_DIR
+$ python tests.py [-v]
+```
+
+### Testing the installation
+This can be done only after **make install**.
+
+#### By **make**
+```
+$ cd $BUILD_DIR/bindings/python-examples
+$ make [-s] installcheck
+```
+To run the whole package installcheck, issue **make installcheck** from $BUILD_DIR.
+
+#### Manually
+Set the **PYTHONPATH** environment variable to the location of the installed Python's **linkgrammar** module, e.g.:
+
+```
+PYTHONPATH=/usr/local/lib/python2.7/site-packages
+```
+(Export it, or prepend it to the **python** command.)
+Note: This is not needed if the package has been configured to install to the OS standard system locations.
+```
+$ cd $SRC_DIR
+$ python bindings/python-examples/tests.py
+```
+From any directory:
+```
+$ LINK_GRAMMAR_DATA=dictionary_location python PATHTO/tests.py
+$ python PATHTO/example.py
+```

--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -1,19 +1,13 @@
 #! /usr/bin/env python
 # -*- coding: utf8 -*-
-#
-# Link Grammar example usage
-#
+"""Link Grammar example usage"""
+
 from __future__ import print_function, division  # We require Python 2.6 or later
-import locale
 
-from linkgrammar import Sentence, ParseOptions, Dictionary
-import linkgrammar._clinkgrammar as clg
-
-locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+from linkgrammar import Sentence, ParseOptions, Dictionary, Clinkgrammar as clg
 
 print ("Version:", clg.linkgrammar_get_version())
-po = ParseOptions()
-#po = ParseOptions(short_length=16)
+po = ParseOptions(verbosity=1)
 
 def desc(lkg):
     print (lkg.diagram())
@@ -44,17 +38,17 @@ sent = Sentence("This is a test.", Dictionary(), po)
 linkages = sent.parse()
 linkage_stat(sent, 'English')
 for linkage in linkages:
-        desc(linkage)
+    desc(linkage)
 
 # Russian
 sent = Sentence("Целью курса является обучение магистрантов основам построения и функционирования программного обеспечения сетей ЭВМ.", Dictionary('ru'), po)
 linkages = sent.parse()
 linkage_stat(sent, 'Russian')
 for linkage in linkages:
-        desc(linkage)
+    desc(linkage)
 
 # Turkish
-po = ParseOptions(islands_ok=True, max_null_count=1, display_morphology=True)
+po = ParseOptions(islands_ok=True, max_null_count=1, display_morphology=True, verbosity=1)
 sent = Sentence("Senin ne istediğini bilmiyorum", Dictionary('tr'), po)
 linkages = sent.parse()
 linkage_stat(sent, 'Turkish')

--- a/bindings/python-examples/lg_testutils.py
+++ b/bindings/python-examples/lg_testutils.py
@@ -1,0 +1,80 @@
+from operator import methodcaller # Used in sorted()
+
+def add_eqcost_linkage_order(original_class):
+    """
+    Decorate the parse method of class Sentence (to be given as argument)
+    with a new parse function, defined below, so equal-cost linkages will
+    be in a deterministic order.
+    Usage: lg_testutils.add_eqcost_linkage_order(Sentence)
+    """
+    class eqcost_soretd_parse(object):
+        """
+        Sort equal-cost linkages according to the alphabetic order of their
+        diagram string, on demand.  We need it because the order of linkages
+        with equal costs is not guaranteed and it may get changed due to subtle
+        changes in the parsing code and/or in the qsort() library function.
+        """
+        def __init__(self, linkages):
+            self.linkages = linkages
+            self.ok = bool(linkages)
+            self.linkage_list = [] # List of equal-cost linkages
+            self.num = 0
+            self.cost = None
+            self.saved_next = None
+
+        def __iter__(self):
+            return self
+
+        def __nonzero__(self):
+            """Return False if there was a split or parse error; else return True."""
+            return self.ok
+
+        __bool__ = __nonzero__      # Account python3
+
+        def next(self):
+            # If the list of equal-cost linkages has exhausted, fetch a new one.
+            if self.num >= len(self.linkage_list)-1:
+                if self.linkage_list and not self.saved_next:
+                    raise StopIteration()
+                self.linkage_list = []
+                self.cost = None
+                while True:
+                    if self.saved_next:
+                        linkage = self.saved_next
+                        self.saved_next = None
+                    else:
+                        try:
+                            linkage = self.linkages.next()
+                        except StopIteration:
+                            break
+                    cost = [linkage.unused_word_cost(),
+                            linkage.disjunct_cost(),
+                            linkage.link_cost()]
+                    if not self.cost:
+                        self.cost = cost
+                    else:
+                        if self.cost != cost:
+                            self.saved_next = linkage
+                            break
+                    self.linkage_list.append(linkage)
+
+                if not self.linkage_list:
+                    raise StopIteration()
+                # We have here a new list of equal-cost linkages.
+                self.num = -1
+                self.linkage_list.sort(key=methodcaller('diagram', screen_width=9999))
+
+            # Return the next linkage from the sorted list of equal-cost linkages.
+            self.num += 1
+            return self.linkage_list[self.num]
+
+        __next__ = next      # Account python3
+
+    original_class.original_parse = original_class.parse
+
+    def parse(self):
+        """A decoration for the original Sentence.parse"""
+        linkages = self.original_parse()
+        return eqcost_soretd_parse(linkages)
+
+    original_class.parse = parse

--- a/bindings/python-examples/parses-en.txt
+++ b/bindings/python-examples/parses-en.txt
@@ -4,7 +4,7 @@
 
 Ithis is a test
 O
-O    +----->WV----->+---Ost--+
+O    +----->WV----->+---Osm--+
 O    +---Wd---+-Ss*b+  +Ds**c+
 O    |        |     |  |     |
 OLEFT-WALL this.p is.v a  test.n 
@@ -15,7 +15,7 @@ C       (NP a test.n)))
 C
 N
 O
-O    +----->WV----->+---Osm--+
+O    +----->WV----->+---Ost--+
 O    +---Wd---+-Ss*b+  +Ds**c+
 O    |        |     |  |     |
 OLEFT-WALL this.p is.v a  test.n 

--- a/bindings/python-examples/parses-quotes-en.txt
+++ b/bindings/python-examples/parses-quotes-en.txt
@@ -10,7 +10,7 @@
 Ithey have told of the soldiers' fear
 O
 O    +--------->WV-------->+     +----------Jp----------+
-O    +---Wd--+--Sp-+---PP--+-OFw-+  +--Dmc--+--YP-+D*u*c+
+O    +---Wd--+--Sp-+---PP--+-OFj-+  +--Dmc--+--YP-+D*u*c+
 O    |       |     |       |     |  |       |     |     |
 OLEFT-WALL they have.v told.v-d of the soldiers.n '  fear.n 
 O
@@ -18,7 +18,7 @@ O
 Ihe said `this is a backtic test`
 O
 O                 +-------------------QUc------------------+
-O                 +------>WV----->+---------Ost--------+   |
+O                 +------>WV----->+---------Osm--------+   |
 O    +---->WV---->+----Wd---+     |  +------Ds**x------+   |
 O    +--Wd--+--Ss-+-QUd+    +-Ss*b+  |       +----A----+   |
 O    |      |     |    |    |     |  |       |         |   |

--- a/bindings/python-examples/parses-sat-en.txt
+++ b/bindings/python-examples/parses-sat-en.txt
@@ -6,7 +6,7 @@
 
 Ithis is a test
 O
-O    +----->WV----->+---Ost--+
+O    +----->WV----->+---Osm--+
 O    +---Wd---+-Ss*b+  +Ds**c+
 O    |        |     |  |     |
 OLEFT-WALL this.p is.v a  test.n 

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -35,11 +35,9 @@ def setUpModule():
     if datadir:
         clg.dictionary_set_data_dir(datadir)
 
-    clg.test_data_srcdir = os.getenv("srcdir")
+    clg.test_data_srcdir = os.getenv("srcdir", os.path.dirname(sys.argv[0]))
     if clg.test_data_srcdir:
         clg.test_data_srcdir += "/"
-    else:
-        clg.test_data_srcdir = ""
 
 # The tests are run in alphabetical order....
 #

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -7,6 +7,8 @@ import sys, os
 import locale
 import unittest
 
+import lg_testutils # Found in the same directory of this test script
+
 # Show information on this program run
 print('Running by:', sys.executable)
 print('Running {} in:'.format(sys.argv[0]), os.getcwd())
@@ -20,7 +22,7 @@ from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary, \
 
 
 # Show the location and version of the bindings modules
-for module in 'linkgrammar', '_clinkgrammar':
+for module in 'linkgrammar', '_clinkgrammar', 'lg_testutils':
     if module in sys.modules:
         print("Using", sys.modules[module], end='')
         if hasattr(sys.modules[module], '__version__'):
@@ -309,7 +311,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
         self.assertEqual(linkage.link(3),
                          Link(linkage, 3, 'this.p','Ss*b','Ss','is.v'))
         self.assertEqual(linkage.link(4),
-                         Link(linkage, 4, 'is.v','O*t','Os','sentence.n'))
+                         Link(linkage, 4, 'is.v','O*m','Os','sentence.n'))
         self.assertEqual(linkage.link(5),
                          Link(linkage, 5, 'a','Ds**c','Ds**c','sentence.n'))
         self.assertEqual(linkage.link(6),
@@ -362,7 +364,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
               '\'s.p', 'shoe.n', 'fell.v-d', 'off', '.', 'RIGHT-WALL'])
 
         self.assertEqual(list(self.parse_sent('Jumbo sat down.')[0].words()),
-             ['LEFT-WALL', 'Jumbo[!]', 'sat.v-d', 'down.a', '.', 'RIGHT-WALL'])
+             ['LEFT-WALL', 'Jumbo[!]', 'sat.v-d', 'down.r', '.', 'RIGHT-WALL'])
 
         # Red is in dict, lower-case, as noun, too.
         # There's no way to really know, syntactically, that Red
@@ -382,7 +384,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
              ['LEFT-WALL', 'May.f', '\'s.v', 'going.v', '?', 'RIGHT-WALL'])
 
         self.assertEqual(list(self.parse_sent('May sat down.')[0].words()),
-             ['LEFT-WALL', 'May.f', 'sat.v-d', 'down.e', '.', 'RIGHT-WALL'])
+             ['LEFT-WALL', 'May.f', 'sat.v-d', 'down.r', '.', 'RIGHT-WALL'])
 
         # McGyver is not in the dict, but is regex-matched.
         self.assertEqual(list(self.parse_sent('McGyver\'s going?')[0].words()),
@@ -393,7 +395,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
               '\'s.p', 'shoe.n', 'fell.v-d', 'off', '.', 'RIGHT-WALL'])
 
         self.assertEqual(list(self.parse_sent('McGyver sat down.')[0].words()),
-             ['LEFT-WALL', 'McGyver[!]', 'sat.v-d', 'down.a', '.', 'RIGHT-WALL'])
+             ['LEFT-WALL', 'McGyver[!]', 'sat.v-d', 'down.r', '.', 'RIGHT-WALL'])
 
         self.assertEqual(list(self.parse_sent('McGyver Industries stock declined.')[0].words()),
              ['LEFT-WALL', 'McGyver[!]', 'Industries[!]',
@@ -617,5 +619,8 @@ def warning(*msg):
     progname = os.path.basename(sys.argv[0])
     print("{}: Warning:".format(progname), *msg, file=sys.stderr)
 
+
+# Decorate Sentence.parse with eqcost_soretd_parse.
+lg_testutils.add_eqcost_linkage_order(Sentence)
 
 unittest.main()

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -429,6 +429,9 @@ class Sentence(object):
                 return iter(())
             return self
 
+        def __len__(self):
+            return clg.sentence_num_linkages_found(self.sent._obj)
+
         def next(self):
             if self.num == clg.sentence_num_valid_linkages(self.sent._obj):
                 raise StopIteration()


### PR DESCRIPTION
Changes:
- Make **tests.py** insensitive to to the particular order of equal-cost linkages (the problem is described in PR #353). It now runs fine on Windows too (a PR for Windows Python binding will be sent soon).
- Totally rewrite the **README.md** in the **binding/python-examples** directory.
- Add a missing binding that was already documented (existed in the old bindings).
- Fix example.py according to latest lib/binding changes.