### PR TITLE
Improve installtests

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -33,7 +33,7 @@ EXTRA_DIST =         \
 #
 # To run these checks, issue "make installcheck" from a regular user.
 installcheck-local:
-	for d in . .. ../data ./data; do \
+	$(AM_V_at)for d in . .. ../data ./data; do \
 		[ ! -d $$d/en ] ||  { echo "Unexpected dictionary $$d/en"; exit 1; }; \
 	done
 	PYTHONPATH=$(pythondir) srcdir=$(srcdir) $(PYTHON) $(srcdir)/tests.py ${TESTSFLAGS}

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -43,9 +43,10 @@ endif
 # Note the "cd .libs" - it ensures that it will not find "../data".
 # To run these checks, issue "make installcheck" from a regular user.
 installcheck-local:
-	echo; echo -n 'Location of '; whereis -b link-parser; echo
-	[ "`which link-parser`" == $(bindir)/link-parser ] # Validate binary location
-	cd .libs; for d in . .. ../data ./data; do \
+	$(AM_V_at)echo; echo -n 'Location of '; cd .libs; whereis -b link-parser; echo
+	$(AM_V_at)cd .libs; [ "`which link-parser`" == $(bindir)/link-parser ] || \
+		{ echo "Incorrect location for link-parser: `which link-parser`"; exit 1; }
+	$(AM_V_at)cd .libs; for d in . .. ../data ./data; do \
 		[ ! -d $$d/en ] ||  { echo "Unexpected dictionary $$d/en"; exit 1; }; \
 	done
 	cd .libs; echo "This is a test" | link-parser


### PR DESCRIPTION
- Be less verbose by default.
- Add cooperation with make argument **V=**.
- If **link-parser** is found in an incorrect PATH location, notify this  instead of just failing the **make** command silently.
- For the link-parser check, also **cd** to **.libs** for the **which** and  **whereis** checks so failures due to '**.'** in front of PATH (a  strange setup) will be evident.