### PR TITLE
Parse1step

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -32,13 +32,21 @@ def linkage_stat(psent, lang):
                  psent.num_valid_linkages(), random))
 
 
+en_lines = [
+    'This is a test.',
+    'I feel is the exciter than other things', # from issue #303 (10 linkages)
+]
+
+po = ParseOptions(min_null_count=0, max_null_count=999)
 
 # English is the default language
-sent = Sentence("This is a test.", Dictionary(), po)
-linkages = sent.parse()
-linkage_stat(sent, 'English')
-for linkage in linkages:
-    desc(linkage)
+en_dir = Dictionary() # open the dictionary only once
+for text in en_lines:
+    sent = Sentence(text, en_dir, po)
+    linkages = sent.parse()
+    linkage_stat(sent, 'English')
+    for linkage in linkages:
+        desc(linkage)
 
 # Russian
 sent = Sentence("Целью курса является обучение магистрантов основам построения и функционирования программного обеспечения сетей ЭВМ.", Dictionary('ru'), po)
@@ -54,3 +62,6 @@ linkages = sent.parse()
 linkage_stat(sent, 'Turkish')
 for linkage in linkages:
     desc(linkage)
+
+# Prevent interleaving "Dictionary close" messages
+po = ParseOptions(verbosity=0)

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -141,8 +141,10 @@ static bool disjuncts_equal(Disjunct * d1, Disjunct * d2)
 	}
 	if ((e1 != NULL) || (e2 != NULL)) return false;
 
-	/* Save cpu time by comparing this last, since this will
-	 * almost always be true. */
+	/* Save CPU time by comparing this last, since this will
+	 * almost always be true. Rarely, the strings are not from
+	 * the same string_set and hence the 2-step comparison. */
+	if (d1->string == d2->string) return true;
 	return (strcmp(d1->string, d2->string) == 0);
 }
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -24,5 +24,6 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * );
 char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
 void disjunct_word_print(Disjunct *);
+Disjunct * disjuncts_dup(Disjunct *origd);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -94,6 +94,7 @@ void free_fast_matcher(fast_matcher_t *mchxt)
 	size_t w;
 	unsigned int i;
 
+	if (NULL == mchxt) return;
 	for (w = 0; w < mchxt->size; w++)
 	{
 		for (i = 0; i < mchxt->l_table_size[w]; i++)

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -104,6 +104,5 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 
 	set_connector_length_limits(sent, opts);
-	pp_and_power_prune(sent, opts);
 }
 


### PR DESCRIPTION
This change fixes a problem that may be an obstacle for API users. See issue #303.
In verbosity>0, it mimics the current link-parser printing of "No complete linkages found."
when no parse is found with null_count==0.

A test for this fix is added, and python-examples/example.py is updated to make a 1-step parse.

Main changed functions:
- chart-parse
- prepare_to_parse

Added functions:
- connectors_dup
- disjuncts_dup

The following functions moved up in the source files:
- free_sentence_disjuncts
- disjuct_gwordlist_append