### PR TITLE
linkgrammar.py: Fix a syntax error from the last change

### DIFF
--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -46,7 +46,7 @@ class ParseOptions(object):
         self.disjunct_cost = disjunct_cost
 
     def __del__(self):
-        if hasattr(self, '_obj')
+        if hasattr(self, '_obj'):
             clg.parse_options_delete(self._obj)
             del self._obj
 
@@ -266,7 +266,7 @@ class Dictionary(object):
         return clg.dictionary_get_lang(self._obj)
 
     def __del__(self):
-        if hasattr(self, '_obj')
+        if hasattr(self, '_obj'):
             clg.dictionary_delete(self._obj)
             del self._obj
 
@@ -323,7 +323,7 @@ class Linkage(object):
         self._obj = clg.linkage_create(idx, sentence._obj, parse_options)
 
     def __del__(self):
-        if hasattr(self, '_obj')
+        if hasattr(self, '_obj'):
             clg.linkage_delete(self._obj)
             del self._obj
 
@@ -401,7 +401,7 @@ class Sentence(object):
         self._obj = clg.sentence_create(self.text, self.dict._obj)
 
     def __del__(self):
-        if hasattr(self, '_obj')
+        if hasattr(self, '_obj'):
             clg.sentence_delete(self._obj)
             del self._obj
 


### PR DESCRIPTION
Fix a syntax error in the previous PR.
(I don't have an idea how it bypassed my tests, I guess this is a result of too many open branches and merges between them.)