### PR TITLE
Python bindings: after timeout, no more parsing.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 5.3.10: (XXX 2016?)
  * Pull #371: Simplification of API when handling disconnected words.
  * Fix SAT parser crashes.
  * Expand default list of Java JDK search paths.
+ * Fix python bindings: after timeout, no further parsing is performed.
 
 Version 5.3.9: (27 August 2016)
  * Pull req #354: Major changes to support Cygwin.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1503,10 +1503,7 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 
 	/* Initialize/free any leftover garbage */
 	free_sentence_disjuncts(sent);  /* Is this really needed ??? */
-	resources_reset_space(opts->resources);
-
-	if (resources_exhausted(opts->resources))
-		return 0;
+	resources_reset(opts->resources);
 
 	/* Expressions were previously set up during the tokenize stage. */
 	expression_prune(sent);


### PR DESCRIPTION
A very old bug failed to reset the parse resources!

Fix for bug #376