### PR TITLE
Fixes for "to be ..." and "so", and kill the CC link.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Version 5.3.10: (XXX 2016?)
  * Fix SAT parser crashes.
  * Expand default list of Java JDK search paths.
  * Fix python bindings: after timeout, no further parsing is performed.
+ * Fix various adverbial, conjunctive uses of "so".
 
 Version 5.3.9: (27 August 2016)
  * Pull req #354: Major changes to support Cygwin.

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Version 5.3.10: (XXX 2016?)
  * Expand default list of Java JDK search paths.
  * Fix python bindings: after timeout, no further parsing is performed.
  * Fix various adverbial, conjunctive uses of "so".
+ * Extended list of exclamations.
 
 Version 5.3.9: (27 August 2016)
  * Pull req #354: Major changes to support Cygwin.

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Version 5.3.10: (XXX 2016?)
  * Fix python bindings: after timeout, no further parsing is performed.
  * Fix various adverbial, conjunctive uses of "so".
  * Extended list of exclamations.
+ * Remove CC link, add VC link, for clauses to coordinating conjunctions.
 
 Version 5.3.9: (27 August 2016)
  * Pull req #354: Major changes to support Cygwin.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -8097,7 +8097,7 @@ ending_up: (<vc-end-up> & <verb-pg,ge>) or <verb-ge-d>;
 %     insane?", "Are you the one?"
 % XXX everywhere where Ws+ is used, should probably be <wi-wall>!?
 <wo-wall>: Wa+ or Wi+ or Ww+ or Qd+;
-<wi-wall>: (Wd+ or Wp+ or Wr+ or Wq+ or Ws+ or Wj+ or Wc+ or We+ or Wt+) & <WALL>;
+<wi-wall>: (Wd+ or Wp+ or Wr+ or Wq+ or Ws+ or Wj+ or Wc+ or We+ or Wt+ or Wo+) & <WALL>;
 
 % Paraphrasing, quotational complements:
 <paraph-null>: [()];
@@ -8513,7 +8513,7 @@ of_them: (ND- or MF-) & (J+ or Pa+) & Xd- & (MX*x- or MVx-) & Xc+;
 %            This is where landmark transitivity could fix things,
 %            by placing a link between "what" and "do".
 to.r:
-  ({@E-} & {N+} & I*t+ & TO-)
+  ({@E-} & {N+} & I*t+ & (TO- or Wo-))
   or ({@E-} & {NT-} & I+ &
     (<MX-PHRASE>
     or (SFsx+ & <S-CLAUSE>)

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3103,9 +3103,9 @@ is_less_than_or_equal_to is_gretr_than_or_equal_to:
 %
 % accrue.v ache.v acquiesce.v ad-lib.v adhere.v adjoin.v alight.v
 /en/words/words.v.1.1: 
-  ((<verb-pl,i> & (({[[O+]]} & <vc-intrans>))) or
-  (<verb-and-pl-> & ((({[[O+]]} & <vc-intrans>)) or ())) or
-  ((({[[O+]]} & <vc-intrans>)) & <verb-and-pl+>));
+  ((<verb-pl,i> & ({[[O+]]} & <vc-intrans>)) or
+  (<verb-and-pl-> & (({[[O+]]} & <vc-intrans>) or ())) or
+  (({[[O+]]} & <vc-intrans>) & <verb-and-pl+>));
 
 % accounts.v accrues.v aches.v acquiesces.v ad-libs.v adheres.v
 % <verb-si>: Locative subj-obj inversion "far out in the sea lives a fish"
@@ -3121,9 +3121,9 @@ is_less_than_or_equal_to is_gretr_than_or_equal_to:
 % accounted.v accrued.v ached.v acquiesced.v ad-libbed.v adhered.v
 /en/words/words.v.1.3:
   
-  ((<verb-sp,pp> & (({[[O+]]} & <vc-intrans>))) or
-  (<verb-and-sp-i-> & ([({[[O+]]} & <vc-intrans>)] or ())) or
-  ((({[[O+]]} & <vc-intrans>)) & <verb-and-sp-i+>))
+  ((<verb-sp,pp> & ({[[O+]]} & <vc-intrans>)) or
+  (<verb-and-sp-i-> & ([{[[O+]]} & <vc-intrans>] or ())) or
+  (({[[O+]]} & <vc-intrans>) & <verb-and-sp-i+>))
   or <verb-si>;
 
 % <verb-pv>: "It was rusted closed"

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -1319,7 +1319,7 @@ mine.p yours theirs hers ours:
 
 % yisser yousser ye'r: Irish English second-person possessive --
 % https://en.wikipedia.org/wiki/Irish_English
-its my.p your their our thy yisser.p yousser ye'r:
+its my.p me.p your their our thy yisser.p yousser ye'r:
   DP+
   or ({AL-} & {@L+} & (D+ or DD+));
 
@@ -4054,6 +4054,7 @@ appeared.v-d:
 appearing.v: (<vc-appear> & <verb-x-pg,ge>) or <verb-ge-d>;
 
 % XXX Why is there a cost on Pv+ ?? "John seemed vindicated"
+% N+: "It seems not"
 <vc-seem>:
   {@MV+} & ((Pa+ & <verb-wall>) or <tof-verb> or LI+ or THi+ or AF- or N+ or [Pv+]);
 seem.v: 
@@ -11018,30 +11019,76 @@ statewide.e world-wide.e nation-wide.e state-wide.e industrywide.e
 instead.e maybe.e:
   ({Xc+ & {Xd-}} & CO+);
 
+% Argumentatives (children gain-saying).
+not.intj is_too is_not is_so unh_unh: Wa-;
+
 % Openers to directives, commands (Ic+ connection to infinitives)
 % or single-word interjections. These are semantically important,
 % so they've got to parse!
+% Wa- & Wa+: "Oh my God"
 no.ij nope.ij nah.ij no_way never.ij not_possible
 yes.ij yeah.ij yep.ij yup.ij
 ok.ij okay.ij OK.ij fine.ij exactly.ij sure.ij
 good.ij good_enough fair_enough whatever.ij
 hah.ij hey.ij well.ij wtf.ij hell_yes hell_no of_course
-oh_no oh_my oh_dear dear.ij Lordy
-yikes ouch my.ij my_oh_my my_my my_my_my tsk tsk_tsk tsk_tsk_tsk:
+gesundheit
+oh_no oh_my oh_my_days
+ohmigod OMG oh_em_gee omigosh
+oh_dear dear_me dearie_me deary_me dear.ij
+dear_Lord dear_Lordy Lord_be_praised
+Lordy my_Lord
+fuck_me fucking_hell
+uh_huh uh uhh uuh unh
+my.ij my_oh_my my_my my_my_my
+tsk tsk_tsk tsk_tsk_tsk:
   <directive-opener>
-  or Wa-;
+  or (Wa- & {Wa+});
 
 % Like above, but also used as plain-old interjections, so treat
 % as adjectives, as well.
+% A- & Wa-: "Holy Mother of God"
+howdy phew psst pssst ahem
+ah ahh eh ehh hmm hmmm huh
+oops eep egad egads ermahgerd ouch alas whoa whoah
 oh.ij ohh doh dohh woo_hoo
-gee gosh wow.ij ah ahh eh ehh hmm hmmm
-goody.ij jeepers Jee-sus oops amen.ij huh
-howdy dammit shucks.ij golly
-sonuvabitch aw aww awww oh_great oh_wow:
+boo.ij booo boooo phooey pooh
+wow.ij wowie wowee wowzers whoopee hurray hurrah rah rahh hooray
+ooo oo hoo hoowee hoo-wee who-wee hubba whammo wammo
+yikes yowza yowzah zoiks zoinks zounds zowie
+goody.ij
+amen.ij alrighty
+jeepers Jee-sus
+Kee-reist Christ Christ_almighty JHC
+Jesus_Christ Jesus_fucking_Christ Jesus_H_Christ
+Christ_alive crikey cripes Jiminy_Cricket
+Jaysus Jeebus Jehoshaphat sweet_Jesus
+jeez jeez_Louise jimminy geez geez_Louise geeminy
+God_Almighty God_almighty God_in_heaven
+drat.ij shoot.ij blast.ij doggone doggone_it rats.ij
+dammit god_dammit goddammit damn_it damn_it_all
+dang dagnabit dagnabbit dag-nabbit dag_nabbit dagnabbit_all darn.ij
+shucks.ij golly golly_gee golly_gee_willikers good_golly
+golly_gosh gosh gee gee_whiz gee_willikers my_gosh blimey
+gadzooks ye_gods
+gracious_sakes good_gracious goodness_gracious goodness_gracious_me
+goodness_me great_googly_moogly great_Ceasar great_Scott
+good_heavens good_gravy land_sakes sakes_alive snakes_alive
+heavens_to_Betsy heavens_above
+by_God by_golly by_Jove by_jingo
+dear_God
+sacre_bleu
+ay caramba kamoley kamoly moley moly
+holy_Moses mother_of_God Mother_of_God
+mother_of_God mama_mia mamma_mia
+sonuvabitch son_of_a_bitch
+heck sodding_hell
+aw aww awww oh_great oh_wow
+er err.ij errr um.ij umm
+anyways honey.ij man.ij baby.ij hush.ij:
   <ordinary-adj>
-  or ({{Ic-} & [[Wi-]]} & {{Xd-} & Xc+} & Ic+)
+  or ({{Ic-} & Wi-} & {{Xd-} & Xc+} & Ic+)
   or <directive-opener>
-  or Wa-;
+  or (({A-} or {E-} or {EE-}) & Wa-);
 
 % A single plain hello all by itself.  Costly, because these days,
 % its not normally a sentence opener.
@@ -11198,12 +11245,6 @@ so_on the_like vice_versa v.v.:
   <noun-and-x> or
   ((<verb-i> or <verb-sp,pp> or <verb-pg,ge> or <verb-pv>) & {@MV+}) or
   M- or MV-;
-
-% Assorted interjections, treat like unknown adjectives.
-er err.ij errr um.ij umm uh uhh ooo hoo zowie hubba Kee-reist whammo
-heck anyways honey.ij man.ij baby.ij hush.ij:
-  <ordinary-adj> or
-  ({{Ic-} & [[Wa-]]} & {{Xd-} & Xc+} & Ic+);
 
 % Emoticons ... at start or end of sentences ...
 EMOTICON :

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11286,6 +11286,7 @@ so:
     & (<subcl-verb> or [<sent-start>]0.5))
   or <fronted>
   or (Wq- & CQ+)
+  or Wa-
   or MVp-
   or Pv-
   or O-

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11283,7 +11283,7 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & <sent-start>)
   or <fronted>
   or (Wq- & CQ+)
   or MVp-

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11216,7 +11216,7 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & <coord>) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
@@ -11265,12 +11265,14 @@ EMOTICON :
 % The WV+ after the Xx+ allows the root verb after the punct to attach
 % to the wall.  e.g. "A woman lives next door, who is a nurse."
 % The naked WV+ without any W+ allows "that I did not know."
-% Xy is for new sentences. "Who is Obama? Where was he born?"
+% Xp+ is for new sentences. "Who is Obama? Where was he born?"
+% Xs+ is for dependent clauses starting with "so".
+%       "I stayed so I could see you."
 % XXX TODO: afer all WV's work, the WV link should no longer be optional...
 % XXX that is, change <WALL> to just WV+.
 %
 <sent-start>:
-  (<wo-wall> or <wi-wall>) & {CP+} & {(Xx+ or Xp+) & {hWV+}} & {RW+ or Xp+};
+  (<wo-wall> or <wi-wall>) & {CP+} & {(Xx+ or Xp+ or Xs+) & {hWV+}} & {RW+ or Xp+};
 
 % QU+ links to quoted phrases.
 % ZZZ+ is a "temporary" addition for randomly-quoted crap, and

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11374,9 +11374,11 @@ so:
   or (SJl- & SJr+ & SJl+);
 
 % :.j
-% Should we be using <sent-start> here? why or why not?
+% <sent-start> is needed for a wall-connection to the subsequent verb.
+% Should we also use a VC link here, similar to "so" ??
 <colon>:
-  {@Xca-} & ((Xx- & (W+ or J+ or Qd+ or TH+ or <ton-verb>) & {Xx+}) or Xe-);
+  {@Xca-} &
+    ((Xx- & (<sent-start> or J+ or Qd+ or TH+ or <ton-verb>) & {Xx+}) or Xe-);
 
 % Put a cost on this, because  we want to find other uses first ...
 ":.j":

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2237,6 +2237,9 @@ per "/.per": Us+ & Mp-;
 <MX-PHRASE>: Xd- & (Xc+ or <costly-null>) & (MX*p- or MVg-);
 <OPENER>: {Xd-} & Xc+ & COp+;
 
+% <coord>: connects to coordinating conjunction.
+<coord>: CC-;
+
 % These are the verb-form expressions for ordinary verbs.
 %
 % The general patterns here are:
@@ -8600,7 +8603,7 @@ lest:
 
 albeit:
   (<subcl-verb> & {Xc+ & {Xd-}} & CO*s+)
-  or ({Xd-} & CC- & Wd+);
+  or ({Xd-} & <coord> & Wd+);
 
 no_matter:
   QI+ & ((Xc+ & {Xd-} & CO+) or ({Xd- & Xc+} & MVs-));
@@ -9221,7 +9224,7 @@ whence whither:
 
 although in_as_much_as whilst whereas whereof wherein:
   (<subcl-verb> & (({Xc+ & {Xd-}} & CO*s+) or ({Xd- & Xc+} & MVs-)))
-  or ({Xd-} & CC- & (Wd+ or Wp+ or Wr+));
+  or ({Xd-} & <coord> & (Wd+ or Wp+ or Wr+));
 
 % QI- & (): "I do not know when"
 % (Mv- & Cs+): "an examination when it happened revealed chicanery"
@@ -9424,7 +9427,7 @@ once.e:
 % usages below.
 %
 
-and/or: [(({Xd-} & CC-) or Wc-) & (Wdc+ or Qd+ or Ws+ or Wq+)];
+and/or: [(({Xd-} & <coord>) or Wc-) & (Wdc+ or Qd+ or Ws+ or Wq+)];
 
 % and used as a conjunction in proper names:
 % The Great Southern and Western Railroad
@@ -9703,11 +9706,11 @@ neither.r:
   or [[<noun-main-x>]]
   or (Wa- & {OF+});
 
-nor.r: ((Xd- & CC-) or Wd-) & Qd+;
-for.r: [[(({Xd-} & CC-) or Wc-) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+)]];
-yet.r: ((({Xd-} & CC-) or Wc-) & (Wd+ or Wp+ or Wr+)) or E+ or MVa- or ({Xd-} & Xc+ & CO+);
+nor.r: ((Xd- & <coord>) or Wd-) & Qd+;
+for.r: [[(({Xd-} & <coord>) or Wc-) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+)]];
+yet.r: ((({Xd-} & <coord>) or Wc-) & (Wd+ or Wp+ or Wr+)) or E+ or MVa- or ({Xd-} & Xc+ & CO+);
 
-thus therefore: ({Xc+ & {Xd-}} & CO+) or ({Xd-} & CC- & Wd+) or
+thus therefore: ({Xc+ & {Xd-}} & CO+) or ({Xd-} & <coord> & Wd+) or
 ({Xd- & Xc+} & (E+ or EB-)) or (Xd- & Xc+ & MVa-);
 
 % EBy+ link is for "verbed not X but Y" "I saw not Mary, but John"
@@ -11004,7 +11007,7 @@ in_fact of_course in_effect for_example for_instance e.g. i.e. :
   or ({Xc+ & {Xd-}} & CO+)
   or (EB- & {Xc+})
   or (Xd- & EB- & Xc+)
-  or ({Xd-} & CC- & (Wd+ or Wp+ or Wr+));
+  or ({Xd-} & <coord> & (Wd+ or Wp+ or Wr+));
 
 % -----------------------------------------------------------
 % ADVERBS USABLE POST_VERBALLY OR AS OPENERS
@@ -11208,7 +11211,7 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or ((({Xd-} & <coord>) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
@@ -11381,7 +11384,7 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 % head-verb crossing, the way that CC is.  Basically, CC is deprecated!
 % Wc-: "But my efforts to win his heart have failed"
 but.ij and.ij or.ij not.ij also.ij but_not and_not and_yet:
-  [{Xd-} & ([CC-] or Xx- or Wc-) & {Xc+}
+  [{Xd-} & ([<coord>] or Xx- or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>];
 
 % (NI- & WV- & W+): Optionally numbered, bulleted lists

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11385,11 +11385,13 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 % connect whole clauses.  Should wee use <sent-start> here? Why not?
 %
 % not.ij seems to result in bad parses quite often, do we need it?
-% [Xx-]0.1: provides coordination to the wall. Has a cost, so that
-%           VC- is prefered way of coordinating.
+% Xx-: provides coordination to the wall.
+%      The cost on [<coord>] is to use the Xx when possible, because
+%      the VC link often does not go leftwards far enough.
+%      (e.g. "John screamed when I arrived but Sue left")
 % Wc-: "But my efforts to win his heart have failed"
 but.ij and.ij or.ij not.ij also.ij but_not and_not and_yet:
-  [{Xd-} & (<coord> or [Xx-]0.1 or Wc-) & {Xc+}
+  [{Xd-} & ([<coord>] or Xx- or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>];
 
 % (NI- & WV- & W+): Optionally numbered, bulleted lists

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -4036,8 +4036,9 @@ hoping.v agreeing.v pretending.v swearing.v praying.v vowing.v voting.v:
 (<vc-hope> & <verb-pg,ge>) or <verb-ge-d>;
 
 % XXX Why is there a cost on Pv+ ?? "John appeared vindicated"
+% N+: "It appears not"
 <vc-appear>:
-  {@MV+} & {(Pa+ & <verb-wall>) or <tof-verb> or THi+ or AF- or [Pv+]};
+  {@MV+} & {(Pa+ & <verb-wall>) or <tof-verb> or THi+ or AF- or N+ or [Pv+]};
 appear.v: 
   ((<verb-y-pl,i> & (<vc-appear>)) or
   (<verb-and-sp-i-> & ([<vc-appear>] or ())) or
@@ -4054,7 +4055,7 @@ appearing.v: (<vc-appear> & <verb-x-pg,ge>) or <verb-ge-d>;
 
 % XXX Why is there a cost on Pv+ ?? "John seemed vindicated"
 <vc-seem>:
-  {@MV+} & ((Pa+ & <verb-wall>) or <tof-verb> or LI+ or THi+ or AF- or [Pv+]);
+  {@MV+} & ((Pa+ & <verb-wall>) or <tof-verb> or LI+ or THi+ or AF- or N+ or [Pv+]);
 seem.v: 
   ((<verb-y-pl,i> & (<vc-seem>)) or
   (<verb-and-sp-i-> & ([<vc-seem>] or ())) or
@@ -10988,10 +10989,11 @@ though.e:
 
 % Nearly identical to words.adv.2, but do not force the EBm-
 % Wt-: single-word sentence: "Evidently"
+% Wt- & Pv+: "Evidently so"
 still.e presumably undoubtedly evidently apparently usually typically perhaps:
   E+
   or (Xd- & Xc+ & (E+ or MVa-))
-  or (Wt- & {Xc+})
+  or (Wt- & ({Xc+} or Pv+ or N+))
   or ({Xc+ & {Xd-}} & CO+)
   or EB-;
 
@@ -11152,15 +11154,18 @@ too:
 % Wi+: "So, don't do it!"
 % Em+: "That is so not going to happen"
 % EExk+: "That is so very beautiful"
+% EBb- & EAxk+: "It tastes bitter and so good"
 % MVp-: "Hold the brush so"
+% Pv-: "It seems so"
 so:
-  (EAxk+ & {HA+})
+  ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
   or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
+  or Pv-
   or O-
   or Js-;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11270,7 +11270,9 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 <sent-split>: Xp- & <sent-start>;
 
 % In many ways, "so" acts as a synonym for a semicolon...
-% Wi+: "So, don't do it!"
+% <sent-start>: "So, don't do it!"
+%    The cost on sent-start is to force preference for CV over WV,
+%    whenever possible.
 % Em+: "That is so not going to happen"
 % EExk+: "That is so very beautiful"
 % EBb- & EAxk+: "It tastes bitter and so good"
@@ -11280,7 +11282,8 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & <sent-start>)
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-))
+    & (<subcl-verb> or [<sent-start>]0.5))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
@@ -11288,6 +11291,8 @@ so:
   or O-
   or Js-;
 
+% Is <sent-start> ever needed here?
+% Should we be using <coord> instead of MVs- ??
 so_that such_that:
   <subcl-verb> & {Xd- & Xc+} & MVs-;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11206,24 +11206,6 @@ too:
     or ({Xd- & Xc+} & MVa-)
     or (Xd- & Xc+ & E+));
 
-% Wi+: "So, don't do it!"
-% Em+: "That is so not going to happen"
-% EExk+: "That is so very beautiful"
-% EBb- & EAxk+: "It tastes bitter and so good"
-% MVp-: "Hold the brush so"
-% Pv-: "It seems so"
-so:
-  ({EBb-} & EAxk+ & {HA+})
-  or ({EZ-} & EExk+)
-  or Em+
-  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
-  or <fronted>
-  or (Wq- & CQ+)
-  or MVp-
-  or Pv-
-  or O-
-  or Js-;
-
 % original
 % sufficiently: {EE-} & (EAxk+ or EExk+ or MVak-);
 % modified
@@ -11289,6 +11271,25 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 
 % mid-text period, question mark. Splits into two sentences.
 <sent-split>: Xp- & <sent-start>;
+
+% In many ways, "so" acts as a synonym for a semicolon...
+% Wi+: "So, don't do it!"
+% Em+: "That is so not going to happen"
+% EExk+: "That is so very beautiful"
+% EBb- & EAxk+: "It tastes bitter and so good"
+% MVp-: "Hold the brush so"
+% Pv-: "It seems so"
+so:
+  ({EBb-} & EAxk+ & {HA+})
+  or ({EZ-} & EExk+)
+  or Em+
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or <fronted>
+  or (Wq- & CQ+)
+  or MVp-
+  or Pv-
+  or O-
+  or Js-;
 
 % Quotation marks.
 % TODO: Add ' as quotation mark.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11023,8 +11023,8 @@ instead.e maybe.e:
 not.intj is_too is_not is_so unh_unh: Wa-;
 
 % Openers to directives, commands (Ic+ connection to infinitives)
-% or single-word interjections. These are semantically important,
-% so they've got to parse!
+% or single-word interjections, exclamations.
+% These are semantically important, so they've got to parse!
 % Wa- & Wa+: "Oh my God"
 no.ij nope.ij nah.ij no_way never.ij not_possible
 yes.ij yeah.ij yep.ij yup.ij

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2286,16 +2286,12 @@ per "/.per": Us+ & Mp-;
 % Pvp+ on to-be, using Pvv for the others, and demaninds the wall only for Pvp.
 % XXX FIXME, the above needs fixing.
 %
-% Pg- is naked, no verb-wall: "I like eating bass."
+% <verb-pp>: PP- & WV-: "I have seen it".
+% <verb-pg>: Pg- is naked, no verb-wall: "I like eating bass."
 %
 % XXX FIXME: for certain transitive verbs, we really want verb-ico to be
 % in the form (I- & B- & <verb-wall>)  for example: "that I did not know".
 %
-% XXX FIXME: <verb-pp> is almost surely wrong; it should be a plain PP-
-% and the wall, if any, should ride with something else.
-% Example: " Joan made sure to thank Susan for all the help she had given."
-% The PP on "given" can't take a wall, it should take a B-.
-
 <verb-s>:    {@E-} & ((Ss- & <verb-wall>) or (RS- & Bs-));
 <verb-pl>:   {@E-} & ((Sp- & <verb-wall>) or (RS- & Bp-));
 <verb-sp>:   {@E-} & ((S- & <verb-wall>) or (RS- & B-));

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11211,9 +11211,6 @@ too:
 % modified
 sufficiently: {EE-} & (EAxk+ or EExk+ or ({Xd- & Xc+} & MVa-) or E+);
 
-so_that such_that:
-  <subcl-verb> & {Xd- & Xc+} & MVs-;
-
 % much like an ordinary adverb, except even more commas allowed
 % please.e: <ordinary-adv>;
 please.e:
@@ -11290,6 +11287,9 @@ so:
   or Pv-
   or O-
   or Js-;
+
+so_that such_that:
+  <subcl-verb> & {Xd- & Xc+} & MVs-;
 
 % Quotation marks.
 % TODO: Add ' as quotation mark.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -8512,6 +8512,7 @@ of_them: (ND- or MF-) & (J+ or Pa+) & Xd- & (MX*x- or MVx-) & Xc+;
 %            but also incorrectly allows: "He is going to do"
 %            This is where landmark transitivity could fix things,
 %            by placing a link between "what" and "do".
+% I*t+ & Wo-: "To be continued"
 to.r:
   ({@E-} & {N+} & I*t+ & (TO- or Wo-))
   or ({@E-} & {NT-} & I+ &
@@ -8631,12 +8632,14 @@ then.r:
   or (S+ & Xd- & Xc+ & MVs-)
   or [[Mp-]];
 
+% Wt-: "Later."  (all by itself) but also: "Later, he left"
 later earlier:
   ({ECa- or Yt-} &
     (E+ or
     Mp- or
     Pp- or
     MVb- or
+    (Wt- & {Xc+}) or
     [({Xc+ & {Xd-}} & CO+)] or
     (Xd- & Xc+ & (MX*x- or MVx-)) or
     ({[[@Ec-]]} & {Xc+} & A+) or
@@ -10981,9 +10984,11 @@ though.e:
   or ({Xc+ & {Xd-}} & CO+);
 
 % Nearly identical to words.adv.2, but do not force the EBm-
+% Wt-: single-word sentence: "Evidently"
 still.e presumably undoubtedly evidently apparently usually typically perhaps:
   E+
   or (Xd- & Xc+ & (E+ or MVa-))
+  or (Wt- & {Xc+})
   or ({Xc+ & {Xd-}} & CO+)
   or EB-;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11150,9 +11150,12 @@ too:
     or (Xd- & Xc+ & E+));
 
 % Wi+: "So, don't do it!"
+% Em+: "That is so not going to happen"
+% EExk+: "That is so very beautiful"
 so:
   (EAxk+ & {HA+})
   or ({EZ-} & EExk+)
+  or Em+
   or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -97,7 +97,7 @@ nonCAP.zzz: ZZZ-;
 <clause-conjoin>: RJrc- or RJlc+;
 
 % {@COd-} : "That is the man who, in Joe's opinion, we should hire"
-<CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or [Rn-]};
+<CLAUSE>:   {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or [Rn-]};
 <S-CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-)};
 <CLAUSE-E>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or Re-};
 
@@ -2691,7 +2691,7 @@ had.v-d:
     (<to-verb> or
     ((O+ or <b-minus>) & {@MV+} & {[I*j+ or Pv+]}) or
     (([[@MV+ & O*n+]] or CX-) & {@MV+}))) or
-  [[(SI*j+ or SFI**j+) & PP+ & {{Xd-} & Xc+} & COp+]];
+  [[(SI*j+ or SFI**j+) & PP+ & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
 %we'd they'd I'd he'd she'd you'd: (PP+ or ({Vw+} & I+)) & <CLAUSE>;
 ’d 'd: S- & (PP+ or I+);
@@ -2891,7 +2891,7 @@ were.v-d:
   or (<verb-rq> & (SIpx+ or SFIp+) & {<vc-be>} & <verb-wall>)
   or (<verb-and-sp-> & <vc-be-and>)
   or (<vc-be-and> & <verb-and-sp+>)
-  or [[(SI*j+ or SFI**j+) & <vc-be> & {{Xd-} & Xc+} & COp+]];
+  or [[(SI*j+ or SFI**j+) & <vc-be> & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
 % Ss*w-: allows Wh subjets: "Who am I?"
 am.v:
@@ -2981,7 +2981,7 @@ should.v:
   ((SI+ or SFI+) & ((<verb-rq> & I+) or CQ-)) or
   ({N+} & <verb-x-sp> & (I+ or (CX- & {@MV+}) or <verb-wall> or [[()]])) or
   (<verb-and-sp-> & I+) or (I+ & <verb-and-sp+>) or
-  [[(SI*j+ or SFI**j+) & I+ & {{Xd-} & Xc+} & COp+]];
+  [[(SI*j+ or SFI**j+) & I+ & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
 % <verb-wall>: "I sure wish he would."
 would.v:

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11152,6 +11152,7 @@ too:
 % Wi+: "So, don't do it!"
 % Em+: "That is so not going to happen"
 % EExk+: "That is so very beautiful"
+% MVp-: "Hold the brush so"
 so:
   (EAxk+ & {HA+})
   or ({EZ-} & EExk+)
@@ -11159,6 +11160,7 @@ so:
   or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
+  or MVp-
   or O-
   or Js-;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -263,6 +263,9 @@ nonCAP.zzz: ZZZ-;
 <too-verb>: TOo+ & IV+;
 <tot-verb>: TOt+ & B+;
 
+% Connects verb to coordinating conjunction.
+<coord-verb>: VC+;
+
 <subord-verb>: CV+;
 <embed-verb>: Ce+ & CV+;
 <subcl-verb>: Cs+ & CV+;
@@ -2238,7 +2241,7 @@ per "/.per": Us+ & Mp-;
 <OPENER>: {Xd-} & Xc+ & COp+;
 
 % <coord>: connects to coordinating conjunction.
-<coord>: CC-;
+<coord>: ([[CC-]] or VC-);
 
 % These are the verb-form expressions for ordinary verbs.
 %
@@ -2258,6 +2261,7 @@ per "/.per": Us+ & Mp-;
 % WV connects the wall to the head-verb,
 % CV connects the dominating clause to the head verb of the dependent clause.
 % IV connects infinitives to the head-verb
+% VC connects the head-word to a subsequent coordinating conjunction.
 %
 % There are some other such connectors that don't quite fit this patten:
 % AF, and in many cases B (for example TOt+ & B+) for this reason, we
@@ -2268,8 +2272,8 @@ per "/.per": Us+ & Mp-;
 % Also: CP-, Eq+ and COq+ all connect to verbs, and are so disjoined
 % with <verb-wall>
 %
-<verb-wall>: dWV- or dCV- or dIV- or [[()]];
-% <verb-wall>: dWV- or dCV- or dIV-;
+<verb-wall>: ((dWV- or dCV- or dIV-) & {VC+}) or [[()]];
+% <verb-wall>: (dWV- or dCV- or dIV-) & {VC+};
 
 % When we are done, remove the option costly NULL below.
 <WALL>: hWV+ or [[()]];
@@ -11380,11 +11384,11 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 % connect whole clauses.  Should wee use <sent-start> here? Why not?
 %
 % not.ij seems to result in bad parses quite often, do we need it?
-% Xx-: provides a better way of doing coordination, since it is not
-% head-verb crossing, the way that CC is.  Basically, CC is deprecated!
+% [Xx-]0.1: provides coordination to the wall. Has a cost, so that
+%           VC- is prefered way of coordinating.
 % Wc-: "But my efforts to win his heart have failed"
 but.ij and.ij or.ij not.ij also.ij but_not and_not and_yet:
-  [{Xd-} & ([<coord>] or Xx- or Wc-) & {Xc+}
+  [{Xd-} & (<coord> or [Xx-]0.1 or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>];
 
 % (NI- & WV- & W+): Optionally numbered, bulleted lists

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10,8 +10,8 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.3.8 (formatted as V5v3v8+)
-<dictionary-version-number>: V5v3v8+;
+% Dictionary version number is 5.3.10 (formatted as V5v3v10+)
+<dictionary-version-number>: V5v3v10+;
 <dictionary-locale>: EN4us+;
 
  % _ORGANIZATION OF THE DICTIONARY_
@@ -2264,10 +2264,10 @@ per "/.per": Us+ & Mp-;
 % VC connects the head-word to a subsequent coordinating conjunction.
 %
 % There are some other such connectors that don't quite fit this patten:
-% AF, and in many cases B (for example TOt+ & B+) for this reason, we
+% AF, Z, and in many cases B (for example TOt+ & B+) for this reason, we
 % have to have a costly null [[()]] below, although we would really really
-% like to get rid of it.  But that would take a lot of B and AF link fiddling
-% about, so we have to live with this for now.
+% like to get rid of it.  But that would take a lot of Z and B and AF link
+% fiddling about, so we have to live with this for now.
 %
 % Also: CP-, Eq+ and COq+ all connect to verbs, and are so disjoined
 % with <verb-wall>
@@ -2612,7 +2612,7 @@ did.v-d:
 % <verb-pv-b> & <vc-done>: Pv- & B-: "he fixed what damage there had been done"
 done.v:
   
-  ((<verb-pp> & (<vc-done>)) or
+  (((<vc-done>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-done>] or ())) or
   ((<vc-done>) & <verb-and-had+>))
   or <verb-phrase-opener>
@@ -3174,7 +3174,7 @@ lay.v-d:
   ((<vc-bulge>) & <verb-and-sp-i+>)) or <verb-si>;
 
 lain.v: 
-  ((<verb-pp> & (<vc-bulge>)) or
+  (((<vc-bulge>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-bulge>] or ())) or
   ((<vc-bulge>) & <verb-and-had+>));
 /en/words/words.v.5.4:
@@ -3194,7 +3194,7 @@ come.v:
   (<verb-and-pl-> & ((<vc-come>) or ())) or
   ((<vc-come>) & <verb-and-pl+>))
   or 
-  ((<verb-pp> & (<vc-come>)) or
+  (((<vc-come>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-come>] or ())) or
   ((<vc-come>) & <verb-and-had+>))
   or ({@E-} & Ix- & O*t+)
@@ -3263,7 +3263,7 @@ spoilt.v-d unbent.v-d overfed.v-d:
 
 shrunk.v withdrawn.v sunk.v forgiven.v:
   
-  ((<verb-pp> & (<vc-tr,intr>)) or
+  (((<vc-tr,intr>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-tr,intr>] or ())) or
   ((<vc-tr,intr>) & <verb-and-had+>)) or
   <verb-pv> or
@@ -3355,13 +3355,13 @@ rose.v-d fell.v-d:
   ((<vc-rise>) & <verb-and-sp-i+>)) or <verb-si>;
 
 risen.v: 
-  ((<verb-pp> & (<vc-rise>)) or
+  (((<vc-rise>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-rise>] or ())) or
   ((<vc-rise>) & <verb-and-had+>));
 
 fallen.v:
   
-  ((<verb-pp> & (<vc-rise>)) or
+  (((<vc-rise>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-rise>] or ())) or
   ((<vc-rise>) & <verb-and-had+>)) or
   <verb-adj>;
@@ -3461,7 +3461,7 @@ begotten.v sown.v sewn.v sawn.v hewn.v cloven.v
 foreknown.v overthrown.v strewn.v awoken.v bidden.v
 stridden.v slain_dead:
   
-  ((<verb-pp> & (<vc-fill>)) or
+  (((<vc-fill>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-fill>] or ())) or
   ((<vc-fill>) & <verb-and-had+>))
   or <verb-pvk>
@@ -3532,7 +3532,7 @@ run.v:
   (<verb-and-pl-> & ((<vc-run>) or ())) or
   ((<vc-run>) & <verb-and-pl+>))
   or 
-  ((<verb-pp> & (<vc-run>)) or
+  (((<vc-run>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-run>] or ())) or
   ((<vc-run>) & <verb-and-had+>))
   or <verb-pvk>
@@ -3575,7 +3575,7 @@ beat.v-d:
 % Pa+: "He was driven green with envy"
 beaten.v driven.v stricken.v:
   
-  ((<verb-pp> & (<vc-run>)) or
+  (((<vc-run>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-run>] or ())) or
   ((<vc-run>) & <verb-and-had+>))
   or (<verb-pvk> & {Pa+})
@@ -3680,7 +3680,7 @@ overrun.v-d upset.v-d undercut.v-d:
 forsaken.v overridden.v overtaken.v rewritten.v undone.v
 beset.v mistaken.v underwritten.v:
   
-  ((<verb-pp> & (<vc-trans>)) or
+  (((<vc-trans>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-trans>] or ())) or
   ((<vc-trans>) & <verb-and-had+>)) or
   <verb-pv> or
@@ -3841,7 +3841,7 @@ shaken.v thrown.v torn.v worn.v
 forgone.v curretted.v forsworn.v oversewn.v over-eaten.v
  foresworn.v overeaten.v:
   
-  ((<verb-pp> & (<vc-kick>)) or
+  (((<vc-kick>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-kick>] or ())) or
   ((<vc-kick>) & <verb-and-had+>)) or
   (<verb-pv-b> & {K+} & {@MV+}) or
@@ -3998,7 +3998,10 @@ wishing.g: (<vc-wish> & <verb-ge>) or <verb-ge-d>;
 % The O+ target is to handle "I hope so", but really, we should have
 % a special-case for this (i.e. a new minor letter).
 % See also <vc-think> for the same problem.
-<vc-hope>: ({@MV+} & {TH+ or <embed-verb> or RSe+ or <to-verb>}) or [[O+ & {@MV+}]];
+<vc-hope>:
+  ({@MV+} & {TH+ or <embed-verb> or RSe+ or <to-verb>})
+  or [[O+ & {@MV+}]];
+
 hope.v agree.v pretend.v swear.v pray.v vow.v vote.v: 
   ((<verb-pl,i> & (<vc-hope>)) or
   (<verb-and-pl-> & ((<vc-hope>) or ())) or
@@ -4032,7 +4035,7 @@ swore.v-d:
   ((<vc-hope>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 sworn.v: 
-  ((<verb-pp> & (<vc-hope>)) or
+  (((<vc-hope>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-hope>] or ())) or
   ((<vc-hope>) & <verb-and-had+>)) or <verb-adj>;
 hoping.v agreeing.v pretending.v swearing.v praying.v vowing.v voting.v:
@@ -4334,7 +4337,7 @@ went.v-d:
   or <verb-si>;
 
 gone.v: 
-  ((<verb-pp> & (<vc-go>)) or
+  (((<vc-go>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-go>] or ())) or
   ((<vc-go>) & <verb-and-had+>));
 
@@ -4603,7 +4606,7 @@ undertook.v-d:
   ((<vc-attempt>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 undertaken.v: 
-  ((<verb-pp> & (<vc-attempt>)) or
+  (((<vc-attempt>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-attempt>] or ())) or
   ((<vc-attempt>) & <verb-and-had+>)) or <verb-pv>;
 attempting.g undertaking.g deserving.g
@@ -4804,7 +4807,7 @@ forgot.v-d:
   <verb-and-sp-t>);
 forgotten.v:
   
-  ((<verb-pp> & (<vc-forget>)) or
+  (((<vc-forget>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-forget>] or ())) or
   ((<vc-forget>) & <verb-and-had+>)) or
   <verb-pv> or
@@ -4909,7 +4912,7 @@ bore.v-d:
   <verb-and-sp-t>);
 born.v:
   
-  ((<verb-pp> & (<vc-bear>)) or
+  (((<vc-bear>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-bear>] or ())) or
   ((<vc-bear>) & <verb-and-had+>))
   or <verb-pv>
@@ -4984,7 +4987,7 @@ began.v-d:
   <verb-and-sp-t>);
 
 begun.v: 
-  ((<verb-pp> & (<vc-begin>)) or
+  (((<vc-begin>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-begin>] or ())) or
   ((<vc-begin>) & <verb-and-had+>)) or <verb-pv> or <verb-phrase-opener>;
 beginning.g ceasing.g:
@@ -5209,9 +5212,11 @@ imagining.g: (<vc-imagine> & <verb-ge>) or <verb-ge-d>;
 imagining.v: <verb-pg> & <vc-imagine>;
 
 % Pa**j link: The doctor declared him insane.
-<vc-declare>: <vc-trans> or
+<vc-declare>:
+  <vc-trans> or
   ({@MV+} & (<embed-verb> or TH+ or RSe+ or Pg+ or Z-)) or
   ((O+ or <b-minus>) & ({@MV+} & Pa**j+));
+
 declare.v fear.v conclude.v suspect.v concede.v presume.v foresee.v
 emphasize.v maintain.v acknowledge.v note.v confirm.v stress.v assume.v:
   
@@ -5244,7 +5249,7 @@ foresaw.v-d:
   <verb-and-sp-t>);
 foreseen.v:
   
-  ((<verb-pp> & (<vc-declare>)) or
+  (((<vc-declare>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-declare>] or ())) or
   ((<vc-declare>) & <verb-and-had+>)) or
   (<verb-s-pv> & {@MV+ or THi+}) or
@@ -5460,7 +5465,7 @@ knew.v-d:
 
 known.v:
   
-  ((<verb-pp> & (<vc-know>)) or
+  (((<vc-know>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-know>] or ())) or
   ((<vc-know>) & <verb-and-had+>)) or
   (<verb-s-pv> & {THi+ or <tof-verb> or QIi+}) or
@@ -5745,7 +5750,7 @@ grew.v-d:
   <verb-and-sp-t>) or <verb-si>;
 grown.v:
   
-  ((<verb-pp> & (<vc-grow>)) or
+  (((<vc-grow>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-grow>] or ())) or
   ((<vc-grow>) & <verb-and-had+>)) or
   (<verb-pv-b> & {K+} & {@MV+}) or
@@ -5816,7 +5821,7 @@ spoke.v-d:
   <verb-and-sp-t>);
 spoken.v:
   
-  ((<verb-pp> & (<vc-speak>)) or
+  (((<vc-speak>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-speak>] or ())) or
   ((<vc-speak>) & <verb-and-had+>)) or
   (<verb-pv-b> & {K+} & {@MV+}) or
@@ -6018,7 +6023,7 @@ gotta.v-d:
 
 gotten.v:
   
-  ((<verb-pp> & (<vc-get>)) or
+  (((<vc-get>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-get>] or ())) or
   ((<vc-get>) & <verb-and-had+>)) or
   (<verb-pv-b> & {K+ or Pp+} & {@MV+}) or
@@ -6316,7 +6321,7 @@ chose.v-d:
   <verb-and-sp-t>);
 chosen.v:
   
-  ((<verb-pp> & (<vc-choose>)) or
+  (((<vc-choose>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-choose>] or ())) or
   ((<vc-choose>) & <verb-and-had+>)) or
   (<verb-pv> & {<to-verb>}) or
@@ -6571,7 +6576,7 @@ saw.v-d:
 
 seen.v:
   
-  ((<verb-pp> & (<vc-see>)) or
+  (((<vc-see>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-see>] or ())) or
   ((<vc-see>) & <verb-and-had+>)) or
   (<verb-pv> & {Pg+ or AZ+}) or
@@ -6681,7 +6686,7 @@ gave.v-d:
   <verb-and-sp-t>);
 given.v:
   
-  ((<verb-pp> & (<vc-give>)) or
+  (((<vc-give>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-give>] or ())) or
   ((<vc-give>) & <verb-and-had+>)) or
   <verb-adj> or
@@ -6852,7 +6857,7 @@ charged.v-d:
   ({O+ or K+ or [[@MV+ & O*n+]]} & <verb-phrase-opener>);
 written.v-d drawn.v-d w/o.v-d:
   
-  ((<verb-pp> & (<vc-write>)) or
+  (((<vc-write>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-write>] or ())) or
   ((<vc-write>) & <verb-and-had+>)) or
   (<verb-pv-b> & {O+ or <b-minus> or K+ or [[@MV+ & O*n+]]} & {@MV+}) or
@@ -6981,7 +6986,7 @@ showed.v-d:
   <verb-and-sp-t>);
 shown.v:
   
-  ((<verb-pp> & (<vc-show>)) or
+  (((<vc-show>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-show>] or ())) or
   ((<vc-show>) & <verb-and-had+>)) or
   (<verb-s-pv-b> &
@@ -7122,7 +7127,7 @@ forbade.v-d:
   <verb-and-sp-t>);
 forbidden.v:
   
-  ((<verb-pp> & (<vc-design>)) or
+  (((<vc-design>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-design>] or ())) or
   ((<vc-design>) & <verb-and-had+>)) or
   (<verb-pv> & {<to-verb>}) or
@@ -7934,7 +7939,7 @@ broke_free took_over saw_fit took_note came_true came_clean came_of_age:
 done_so taken_place shown_up taken_office done_battle given_way
 taken_part taken_off broken_free taken_over seen_fit taken_note:
   
-  ((<verb-pp> & (<vc-intrans>)) or
+  (((<vc-intrans>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-intrans>] or ())) or
   ((<vc-intrans>) & <verb-and-had+>));
 
@@ -7944,7 +7949,7 @@ come_true come_clean come_of_age:
   (<verb-and-pl-> & ((<vc-intrans>) or ())) or
   ((<vc-intrans>) & <verb-and-pl+>)) or
   
-  ((<verb-pp> & (<vc-intrans>)) or
+  (((<vc-intrans>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-intrans>] or ())) or
   ((<vc-intrans>) & <verb-and-had+>));
 
@@ -7981,7 +7986,7 @@ allowed_for brought_about got_rid_of took_note_of:
   ((<vc-trans>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 gotten_rid_of taken_note_of: 
-  ((<verb-pp> & (<vc-trans>)) or
+  (((<vc-trans>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-trans>] or ())) or
   ((<vc-trans>) & <verb-and-had+>));
 putting_up_with allowing_for bringing_about getting_rid_of letting_go_of
@@ -8007,7 +8012,7 @@ took_it gave_notice:
   (<verb-and-sp-i-> & ([<vc-take-it>] or ())) or
   ((<vc-take-it>) & <verb-and-sp-i+>));
 taken_it given_notice: 
-  ((<verb-pp> & (<vc-take-it>)) or
+  (((<vc-take-it>) & <verb-pp>) or
   (<verb-and-had-> & ([<vc-take-it>] or ())) or
   ((<vc-take-it>) & <verb-and-had+>));
 taking_it making_out pointing_out giving_notice serving_notice:

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -97,9 +97,9 @@ nonCAP.zzz: ZZZ-;
 <clause-conjoin>: RJrc- or RJlc+;
 
 % {@COd-} : "That is the man who, in Joe's opinion, we should hire"
-<CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & (Wd- & {CC+})) or [Rn-]};
-<S-CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & (Wd- & {CC+}))};
-<CLAUSE-E>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & (Wd- or {CC+})) or Re-};
+<CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or [Rn-]};
+<S-CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-)};
+<CLAUSE-E>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or Re-};
 
 % Post-nominal qualifiers, complete with commas, etc.
 % We give these a small cost, so that they don't hide quotational
@@ -2241,7 +2241,7 @@ per "/.per": Us+ & Mp-;
 <OPENER>: {Xd-} & Xc+ & COp+;
 
 % <coord>: connects to coordinating conjunction.
-<coord>: ([[CC-]] or VC-);
+<coord>: VC-;
 
 % These are the verb-form expressions for ordinary verbs.
 %
@@ -2380,7 +2380,7 @@ per "/.per": Us+ & Mp-;
   {@E-} & {@MV+} & (
     <MX-PHRASE>
     or <OPENER>
-    or [<fronted> & {@MV+} & {CC+}]);
+    or [<fronted> & {@MV+}]);
 
 % Relative clause, or question.
 % Qw- & <verb-wall>: "Where are they?" -- verb must connect to wall.
@@ -2691,7 +2691,7 @@ had.v-d:
     (<to-verb> or
     ((O+ or <b-minus>) & {@MV+} & {[I*j+ or Pv+]}) or
     (([[@MV+ & O*n+]] or CX-) & {@MV+}))) or
-  [[(SI*j+ or SFI**j+) & PP+ & ((Xd- & CCq- & Xc+) or CCq- or ({{Xd-} & Xc+} & COp+))]];
+  [[(SI*j+ or SFI**j+) & PP+ & {{Xd-} & Xc+} & COp+]];
 
 %we'd they'd I'd he'd she'd you'd: (PP+ or ({Vw+} & I+)) & <CLAUSE>;
 ’d 'd: S- & (PP+ or I+);
@@ -2891,7 +2891,7 @@ were.v-d:
   or (<verb-rq> & (SIpx+ or SFIp+) & {<vc-be>} & <verb-wall>)
   or (<verb-and-sp-> & <vc-be-and>)
   or (<vc-be-and> & <verb-and-sp+>)
-  or [[(SI*j+ or SFI**j+) & <vc-be> & ((Xd- & CCq- & Xc+) or CCq- or ({{Xd-} & Xc+} & COp+))]];
+  or [[(SI*j+ or SFI**j+) & <vc-be> & {{Xd-} & Xc+} & COp+]];
 
 % Ss*w-: allows Wh subjets: "Who am I?"
 am.v:
@@ -2981,7 +2981,7 @@ should.v:
   ((SI+ or SFI+) & ((<verb-rq> & I+) or CQ-)) or
   ({N+} & <verb-x-sp> & (I+ or (CX- & {@MV+}) or <verb-wall> or [[()]])) or
   (<verb-and-sp-> & I+) or (I+ & <verb-and-sp+>) or
-  [[(SI*j+ or SFI**j+) & I+ & ((Xd- & CCq- & Xc+) or CCq- or ({{Xd-} & Xc+} & COp+))]];
+  [[(SI*j+ or SFI**j+) & I+ & {{Xd-} & Xc+} & COp+]];
 
 % <verb-wall>: "I sure wish he would."
 would.v:
@@ -8125,9 +8125,9 @@ ending_up: (<vc-end-up> & <verb-pg,ge>) or <verb-ge-d>;
 % QU+ & <embed-verb> & QU+: He said, "This is it."
 % Xc+ or Xe+ or [[()]]: punctuation is commonly missing.
 <vc-paraph>:
-  ({@MV+} & (Xc+ or Xp+) & CP- & {CC+})
+  ({@MV+} & (Xc+ or Xp+) & CP-)
   or ({@MV+} & ((Xd- or Xq-) & (Xc+ or Xp+ or <paraph-null>)
-      & (COq+ or (CP- & {CC+}) or Eq+ or <verb-wall>)))
+      & (COq+ or CP- or Eq+ or <verb-wall>)))
   or [{@MV+} & (Xc+ or Xe+ or [[()]]) & <embed-verb>]
   or ({@MV+} & (Xc+ or Xe+ or [[()]])
     & QUd+ & (<wi-wall> or <wo-wall>) & {X+} & QUc+);
@@ -8135,14 +8135,14 @@ ending_up: (<vc-end-up> & <verb-pg,ge>) or <verb-ge-d>;
 % Xd- & Xc+: "If I'm right, he thought, this will work."
 <vc-paraph-inv>:
   {@MV+} & (((Xd- or Xq-) & (Xc+ or Xp+ or <paraph-null>)
-      & (COq+ or (CPx- & {CC+}) or Eq+ or <verb-wall>))
+      & (COq+ or CPx- or Eq+ or <verb-wall>))
     or [(Xc+ or Xe+) & <embed-verb>]);
 
 % filler-it: "The President is busy, it seems."
 % The (Xd- or Xq-) links to the previous comma.
 <vc-it-paraph>:
   {@MV+} & (Xd- or Xq-) & (Xc+ or Xp+ or <paraph-null>)
-    & (COqi+ or (CPi- & {CC+}) or Eqi+ or <verb-wall>);
+    & (COqi+ or CPi- or Eqi+ or <verb-wall>);
 
 % paraphrasing verbs like "say", "reply"
 % acknowledge.q add.q admit.q affirm.q agree.q announce.q argue.q
@@ -9747,7 +9747,7 @@ n't n’t: N- or EB-;
 
 % Common disjuncts shared by virtually all adjectives.
 <adj-op>:
-  [{@E-} & {@MV+} & <fronted> & {@MV+} & {CC+}]
+  [{@E-} & {@MV+} & <fronted> & {@MV+}]
   or (AJra- & {@MV+})
   or ({@MV+} & AJla+)
   or ({@E-} & {@MV+} & ([[<OPENER>]] or (Xd- & Xc+ & MX*a-)));
@@ -11183,10 +11183,10 @@ only:
   or (MVp+ & Wq- & Q+);
 
 never.i at_no_time not_once rarely.i since_when:
-  {MVp+} & Wq- & Q+ & {CC+};
+  {MVp+} & Wq- & Q+;
 
 not_since:
-  (J+ or <subcl-verb>) & Wq- & Q+ & {CC+};
+  (J+ or <subcl-verb>) & Wq- & Q+;
 
 even.e:
   E+
@@ -11603,7 +11603,7 @@ UNKNOWN-WORD.a: [<ordinary-adj>]0.04;
 %    from "puts" to "object".
 %
 UNLIMITED-CONNECTORS:
-      S+ & O+ & CO+ & C+ & Xc+ & MV+ & CC+ & TH+ & W+
+      S+ & O+ & CO+ & C+ & Xc+ & MV+ & TH+ & W+
       & RW+ & Xp+ & Xx+ & CP+ & SFsx+ & WV+ & CV+;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -392,6 +392,9 @@ PL-CAPITALIZED-WORDS:
 /en/words/entities.gods:
   <marker-entity> or <given-names> or <directive-opener>;
 
+% Given name "So.f" interferes with adverb "so" -- give it a cost.
+So.f: [[<given-names>]];
+
 % Special handling for certain given names. These are words that have a
 % lower-case analog in the dictionary, and are also used in upper-case
 % form in an "idiomatic name" e.g. Vatican_City.  Without the below,
@@ -11146,10 +11149,11 @@ too:
     or ({Xd- & Xc+} & MVa-)
     or (Xd- & Xc+ & E+));
 
+% Wi+: "So, don't do it!"
 so:
   (EAxk+ & {HA+})
   or ({EZ-} & EExk+)
-  or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+))
+  or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or O-

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -401,6 +401,9 @@ PL-CAPITALIZED-WORDS:
 /en/words/entities.gods:
   <marker-entity> or <given-names> or <directive-opener>;
 
+% Given name "So.f" interferes with adverb "so" -- give it a cost.
+So.f: [[<given-names>]];
+
 % Special handling for certain given names. These are words that have a
 % lower-case analog in the dictionary, and are also used in upper-case
 % form in an "idiomatic name" e.g. Vatican_City.  Without the below,
@@ -9102,10 +9105,11 @@ too:
     or ({Xd- & Xc+} & MVa-)
     or (Xd- & Xc+ & E+));
 
+% Wi+: "So, don't do it!"
 so:
   (EAxk+ & {HA+})
   or ({EZ-} & EExk+)
-  or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+))
+  or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or O-

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9162,24 +9162,6 @@ too:
     or ({Xd- & Xc+} & MVa-)
     or (Xd- & Xc+ & E+));
 
-% Wi+: "So, don't do it!"
-% Em+: "That is so not going to happen"
-% EExk+: "That is so very beautiful"
-% EBb- & EAxk+: "It tastes bitter and so good"
-% MVp-: "Hold the brush so"
-% Pv-: "It seems so"
-so:
-  ({EBb-} & EAxk+ & {HA+})
-  or ({EZ-} & EExk+)
-  or Em+
-  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
-  or <fronted>
-  or (Wq- & CQ+)
-  or MVp-
-  or Pv-
-  or O-
-  or Js-;
-
 % original
 % sufficiently: {EE-} & (EAxk+ or EExk+ or MVak-);
 % modified
@@ -9245,6 +9227,25 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 
 % mid-text period, question mark. Splits into two sentences.
 <sent-split>: Xp- & <sent-start>;
+
+% In many ways, "so" acts as a synonym for a semicolon...
+% Wi+: "So, don't do it!"
+% Em+: "That is so not going to happen"
+% EExk+: "That is so very beautiful"
+% EBb- & EAxk+: "It tastes bitter and so good"
+% MVp-: "Hold the brush so"
+% Pv-: "It seems so"
+so:
+  ({EBb-} & EAxk+ & {HA+})
+  or ({EZ-} & EExk+)
+  or Em+
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or <fronted>
+  or (Wq- & CQ+)
+  or MVp-
+  or Pv-
+  or O-
+  or Js-;
 
 % Quotation marks.
 % TODO: Add ' as quotation mark.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9343,11 +9343,13 @@ changequote dnl
 % connect whole clauses.  Should wee use <sent-start> here? Why not?
 %
 % not.ij seems to result in bad parses quite often, do we need it?
-% [Xx-]0.1: provides coordination to the wall. Has a cost, so that
-%           VC- is prefered way of coordinating.
+% Xx-: provides coordination to the wall.
+%      The cost on [<coord>] is to use the Xx when possible, because
+%      the VC link often does not go leftwards far enough.
+%      (e.g. "John screamed when I arrived but Sue left")
 % Wc-: "But my efforts to win his heart have failed"
 but.ij and.ij or.ij not.ij also.ij but_not and_not and_yet:
-  [{Xd-} & (<coord> or [Xx-]0.1 or Wc-) & {Xc+}
+  [{Xd-} & ([<coord>] or Xx- or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>];
 
 % (NI- & WV- & W+): Optionally numbered, bulleted lists

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9167,9 +9167,6 @@ too:
 % modified
 sufficiently: {EE-} & (EAxk+ or EExk+ or ({Xd- & Xc+} & MVa-) or E+);
 
-so_that such_that:
-  <subcl-verb> & {Xd- & Xc+} & MVs-;
-
 % much like an ordinary adverb, except even more commas allowed
 % please.e: <ordinary-adv>;
 please.e:
@@ -9246,6 +9243,9 @@ so:
   or Pv-
   or O-
   or Js-;
+
+so_that such_that:
+  <subcl-verb> & {Xd- & Xc+} & MVs-;
 
 % Quotation marks.
 % TODO: Add ' as quotation mark.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -6586,12 +6586,14 @@ then.r:
   or (S+ & Xd- & Xc+ & MVs-)
   or [[Mp-]];
 
+% Wt-: "Later."  (all by itself) but also: "Later, he left"
 later earlier:
   ({ECa- or Yt-} &
     (E+ or
     Mp- or
     Pp- or
     MVb- or
+    (Wt- & {Xc+}) or
     [({Xc+ & {Xd-}} & CO+)] or
     (Xd- & Xc+ & (MX*x- or MVx-)) or
     ({[[@Ec-]]} & {Xc+} & A+) or
@@ -8938,9 +8940,11 @@ though.e:
   or ({Xc+ & {Xd-}} & CO+);
 
 % Nearly identical to words.adv.2, but do not force the EBm-
+% Wt-: single-word sentence: "Evidently"
 still.e presumably undoubtedly evidently apparently usually typically perhaps:
   E+
   or (Xd- & Xc+ & (E+ or MVa-))
+  or (Wt- & {Xc+})
   or ({Xc+ & {Xd-}} & CO+)
   or EB-;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9239,7 +9239,7 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & <sent-start>)
   or <fronted>
   or (Wq- & CQ+)
   or MVp-

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3714,16 +3714,18 @@ hoping.v agreeing.v pretending.v swearing.v praying.v vowing.v voting.v:
 (<vc-hope> & <verb-pg,ge>) or <verb-ge-d>;
 
 % XXX Why is there a cost on Pv+ ?? "John appeared vindicated"
+% N+: "It appears not"
 <vc-appear>:
-  {@MV+} & {(Pa+ & <verb-wall>) or <tof-verb> or THi+ or AF- or [Pv+]};
+  {@MV+} & {(Pa+ & <verb-wall>) or <tof-verb> or THi+ or AF- or N+ or [Pv+]};
 appear.v: VERB_Y_PLI(<vc-appear>);
 appears.v: VERB_Y_S(<vc-appear>);
 appeared.v-d: VERB_Y_SPPP(<vc-appear>);
 appearing.v: (<vc-appear> & <verb-x-pg,ge>) or <verb-ge-d>;
 
 % XXX Why is there a cost on Pv+ ?? "John seemed vindicated"
+% N+: "It seems not"
 <vc-seem>:
-  {@MV+} & ((Pa+ & <verb-wall>) or <tof-verb> or LI+ or THi+ or AF- or [Pv+]);
+  {@MV+} & ((Pa+ & <verb-wall>) or <tof-verb> or LI+ or THi+ or AF- or N+ or [Pv+]);
 seem.v: VERB_Y_PLI(<vc-seem>);
 seems.v: VERB_Y_S(<vc-seem>);
 seemed.v-d: VERB_Y_SPPP(<vc-seem>);
@@ -8944,10 +8946,11 @@ though.e:
 
 % Nearly identical to words.adv.2, but do not force the EBm-
 % Wt-: single-word sentence: "Evidently"
+% Wt- & Pv+: "Evidently so"
 still.e presumably undoubtedly evidently apparently usually typically perhaps:
   E+
   or (Xd- & Xc+ & (E+ or MVa-))
-  or (Wt- & {Xc+})
+  or (Wt- & ({Xc+} or Pv+ or N+))
   or ({Xc+ & {Xd-}} & CO+)
   or EB-;
 
@@ -9108,15 +9111,18 @@ too:
 % Wi+: "So, don't do it!"
 % Em+: "That is so not going to happen"
 % EExk+: "That is so very beautiful"
+% EBb- & EAxk+: "It tastes bitter and so good"
 % MVp-: "Hold the brush so"
+% Pv-: "It seems so"
 so:
-  (EAxk+ & {HA+})
+  ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
   or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
+  or Pv-
   or O-
   or Js-;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9108,6 +9108,7 @@ too:
 % Wi+: "So, don't do it!"
 % Em+: "That is so not going to happen"
 % EExk+: "That is so very beautiful"
+% MVp-: "Hold the brush so"
 so:
   (EAxk+ & {HA+})
   or ({EZ-} & EExk+)
@@ -9115,6 +9116,7 @@ so:
   or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
+  or MVp-
   or O-
   or Js-;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3115,7 +3115,7 @@ is_less_than_or_equal_to is_gretr_than_or_equal_to:
 % also could be sorted out.
 %
 % accrue.v ache.v acquiesce.v ad-lib.v adhere.v adjoin.v alight.v
-/en/words/words.v.1.1: VERB_PLI(({[[O+]]} & <vc-intrans>));
+/en/words/words.v.1.1: VERB_PLI({[[O+]]} & <vc-intrans>);
 
 % accounts.v accrues.v aches.v acquiesces.v ad-libs.v adheres.v
 % <verb-si>: Locative subj-obj inversion "far out in the sea lives a fish"
@@ -3127,7 +3127,7 @@ is_less_than_or_equal_to is_gretr_than_or_equal_to:
 
 % accounted.v accrued.v ached.v acquiesced.v ad-libbed.v adhered.v
 /en/words/words.v.1.3:
-  VERB_SPPP_I(({[[O+]]} & <vc-intrans>))
+  VERB_SPPP_I({[[O+]]} & <vc-intrans>)
   or <verb-si>;
 
 % <verb-pv>: "It was rusted closed"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -106,9 +106,9 @@ nonCAP.zzz: ZZZ-;
 <clause-conjoin>: RJrc- or RJlc+;
 
 % {@COd-} : "That is the man who, in Joe's opinion, we should hire"
-<CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & (Wd- & {CC+})) or [Rn-]};
-<S-CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & (Wd- & {CC+}))};
-<CLAUSE-E>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & (Wd- or {CC+})) or Re-};
+<CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or [Rn-]};
+<S-CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-)};
+<CLAUSE-E>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or Re-};
 
 % Post-nominal qualifiers, complete with commas, etc.
 % We give these a small cost, so that they don't hide quotational
@@ -2250,7 +2250,7 @@ per "/.per": Us+ & Mp-;
 <OPENER>: {Xd-} & Xc+ & COp+;
 
 % <coord>: connects to coordinating conjunction.
-<coord>: ([[CC-]] or VC-);
+<coord>: VC-;
 
 % These are the verb-form expressions for ordinary verbs.
 %
@@ -2389,7 +2389,7 @@ per "/.per": Us+ & Mp-;
   {@E-} & {@MV+} & (
     <MX-PHRASE>
     or <OPENER>
-    or [<fronted> & {@MV+} & {CC+}]);
+    or [<fronted> & {@MV+}]);
 
 % Relative clause, or question.
 % Qw- & <verb-wall>: "Where are they?" -- verb must connect to wall.
@@ -2704,7 +2704,7 @@ had.v-d:
     (<to-verb> or
     ((O+ or <b-minus>) & {@MV+} & {[I*j+ or Pv+]}) or
     (([[@MV+ & O*n+]] or CX-) & {@MV+}))) or
-  [[(SI*j+ or SFI**j+) & PP+ & ((Xd- & CCq- & Xc+) or CCq- or ({{Xd-} & Xc+} & COp+))]];
+  [[(SI*j+ or SFI**j+) & PP+ & {{Xd-} & Xc+} & COp+]];
 
 %we'd they'd I'd he'd she'd you'd: (PP+ or ({Vw+} & I+)) & <CLAUSE>;
 ’d 'd: S- & (PP+ or I+);
@@ -2904,7 +2904,7 @@ were.v-d:
   or (<verb-rq> & (SIpx+ or SFIp+) & {<vc-be>} & <verb-wall>)
   or (<verb-and-sp-> & <vc-be-and>)
   or (<vc-be-and> & <verb-and-sp+>)
-  or [[(SI*j+ or SFI**j+) & <vc-be> & ((Xd- & CCq- & Xc+) or CCq- or ({{Xd-} & Xc+} & COp+))]];
+  or [[(SI*j+ or SFI**j+) & <vc-be> & {{Xd-} & Xc+} & COp+]];
 
 % Ss*w-: allows Wh subjets: "Who am I?"
 am.v:
@@ -2994,7 +2994,7 @@ should.v:
   ((SI+ or SFI+) & ((<verb-rq> & I+) or CQ-)) or
   ({N+} & <verb-x-sp> & (I+ or (CX- & {@MV+}) or <verb-wall> or [[()]])) or
   (<verb-and-sp-> & I+) or (I+ & <verb-and-sp+>) or
-  [[(SI*j+ or SFI**j+) & I+ & ((Xd- & CCq- & Xc+) or CCq- or ({{Xd-} & Xc+} & COp+))]];
+  [[(SI*j+ or SFI**j+) & I+ & {{Xd-} & Xc+} & COp+]];
 
 % <verb-wall>: "I sure wish he would."
 would.v:
@@ -6099,9 +6099,9 @@ ending_up: (<vc-end-up> & <verb-pg,ge>) or <verb-ge-d>;
 % QU+ & <embed-verb> & QU+: He said, "This is it."
 % Xc+ or Xe+ or [[()]]: punctuation is commonly missing.
 <vc-paraph>:
-  ({@MV+} & (Xc+ or Xp+) & CP- & {CC+})
+  ({@MV+} & (Xc+ or Xp+) & CP-)
   or ({@MV+} & ((Xd- or Xq-) & (Xc+ or Xp+ or <paraph-null>)
-      & (COq+ or (CP- & {CC+}) or Eq+ or <verb-wall>)))
+      & (COq+ or CP- or Eq+ or <verb-wall>)))
   or [{@MV+} & (Xc+ or Xe+ or [[()]]) & <embed-verb>]
   or ({@MV+} & (Xc+ or Xe+ or [[()]])
     & QUd+ & (<wi-wall> or <wo-wall>) & {X+} & QUc+);
@@ -6109,14 +6109,14 @@ ending_up: (<vc-end-up> & <verb-pg,ge>) or <verb-ge-d>;
 % Xd- & Xc+: "If I'm right, he thought, this will work."
 <vc-paraph-inv>:
   {@MV+} & (((Xd- or Xq-) & (Xc+ or Xp+ or <paraph-null>)
-      & (COq+ or (CPx- & {CC+}) or Eq+ or <verb-wall>))
+      & (COq+ or CPx- or Eq+ or <verb-wall>))
     or [(Xc+ or Xe+) & <embed-verb>]);
 
 % filler-it: "The President is busy, it seems."
 % The (Xd- or Xq-) links to the previous comma.
 <vc-it-paraph>:
   {@MV+} & (Xd- or Xq-) & (Xc+ or Xp+ or <paraph-null>)
-    & (COqi+ or (CPi- & {CC+}) or Eqi+ or <verb-wall>);
+    & (COqi+ or CPi- or Eqi+ or <verb-wall>);
 
 % paraphrasing verbs like "say", "reply"
 % acknowledge.q add.q admit.q affirm.q agree.q announce.q argue.q
@@ -7703,7 +7703,7 @@ n't n’t: N- or EB-;
 
 % Common disjuncts shared by virtually all adjectives.
 <adj-op>:
-  [{@E-} & {@MV+} & <fronted> & {@MV+} & {CC+}]
+  [{@E-} & {@MV+} & <fronted> & {@MV+}]
   or (AJra- & {@MV+})
   or ({@MV+} & AJla+)
   or ({@E-} & {@MV+} & ([[<OPENER>]] or (Xd- & Xc+ & MX*a-)));
@@ -9139,10 +9139,10 @@ only:
   or (MVp+ & Wq- & Q+);
 
 never.i at_no_time not_once rarely.i since_when:
-  {MVp+} & Wq- & Q+ & {CC+};
+  {MVp+} & Wq- & Q+;
 
 not_since:
-  (J+ or <subcl-verb>) & Wq- & Q+ & {CC+};
+  (J+ or <subcl-verb>) & Wq- & Q+;
 
 even.e:
   E+
@@ -9553,7 +9553,7 @@ UNKNOWN-WORD.a: [<ordinary-adj>]0.04;
 %    from "puts" to "object".
 %
 UNLIMITED-CONNECTORS:
-      S+ & O+ & CO+ & C+ & Xc+ & MV+ & CC+ & TH+ & W+
+      S+ & O+ & CO+ & C+ & Xc+ & MV+ & TH+ & W+
       & RW+ & Xp+ & Xx+ & CP+ & SFsx+ & WV+ & CV+;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9106,9 +9106,12 @@ too:
     or (Xd- & Xc+ & E+));
 
 % Wi+: "So, don't do it!"
+% Em+: "That is so not going to happen"
+% EExk+: "That is so very beautiful"
 so:
   (EAxk+ & {HA+})
   or ({EZ-} & EExk+)
+  or Em+
   or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9332,9 +9332,11 @@ changequote dnl
   or (SJl- & SJr+ & SJl+);
 
 % :.j
-% Should we be using <sent-start> here? why or why not?
+% <sent-start> is needed for a wall-connection to the subsequent verb.
+% Should we also use a VC link here, similar to "so" ??
 <colon>:
-  {@Xca-} & ((Xx- & (W+ or J+ or Qd+ or TH+ or <ton-verb>) & {Xx+}) or Xe-);
+  {@Xca-} &
+    ((Xx- & (<sent-start> or J+ or Qd+ or TH+ or <ton-verb>) & {Xx+}) or Xe-);
 
 % Put a cost on this, because  we want to find other uses first ...
 ":.j":

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2295,16 +2295,12 @@ per "/.per": Us+ & Mp-;
 % Pvp+ on to-be, using Pvv for the others, and demaninds the wall only for Pvp.
 % XXX FIXME, the above needs fixing.
 %
-% Pg- is naked, no verb-wall: "I like eating bass."
+% <verb-pp>: PP- & WV-: "I have seen it".
+% <verb-pg>: Pg- is naked, no verb-wall: "I like eating bass."
 %
 % XXX FIXME: for certain transitive verbs, we really want verb-ico to be
 % in the form (I- & B- & <verb-wall>)  for example: "that I did not know".
 %
-% XXX FIXME: <verb-pp> is almost surely wrong; it should be a plain PP-
-% and the wall, if any, should ride with something else.
-% Example: " Joan made sure to thank Susan for all the help she had given."
-% The PP on "given" can't take a wall, it should take a B-.
-
 <verb-s>:    {@E-} & ((Ss- & <verb-wall>) or (RS- & Bs-));
 <verb-pl>:   {@E-} & ((Sp- & <verb-wall>) or (RS- & Bp-));
 <verb-sp>:   {@E-} & ((S- & <verb-wall>) or (RS- & B-));

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9242,6 +9242,7 @@ so:
     & (<subcl-verb> or [<sent-start>]0.5))
   or <fronted>
   or (Wq- & CQ+)
+  or Wa-
   or MVp-
   or Pv-
   or O-

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8979,8 +8979,8 @@ instead.e maybe.e:
 not.intj is_too is_not is_so unh_unh: Wa-;
 
 % Openers to directives, commands (Ic+ connection to infinitives)
-% or single-word interjections. These are semantically important,
-% so they've got to parse!
+% or single-word interjections, exclamations.
+% These are semantically important, so they've got to parse!
 % Wa- & Wa+: "Oh my God"
 no.ij nope.ij nah.ij no_way never.ij not_possible
 yes.ij yeah.ij yep.ij yup.ij

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9226,7 +9226,9 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 <sent-split>: Xp- & <sent-start>;
 
 % In many ways, "so" acts as a synonym for a semicolon...
-% Wi+: "So, don't do it!"
+% <sent-start>: "So, don't do it!"
+%    The cost on sent-start is to force preference for CV over WV,
+%    whenever possible.
 % Em+: "That is so not going to happen"
 % EExk+: "That is so very beautiful"
 % EBb- & EAxk+: "It tastes bitter and so good"
@@ -9236,7 +9238,8 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & <sent-start>)
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-))
+    & (<subcl-verb> or [<sent-start>]0.5))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
@@ -9244,6 +9247,8 @@ so:
   or O-
   or Js-;
 
+% Is <sent-start> ever needed here?
+% Should we be using <coord> instead of MVs- ??
 so_that such_that:
   <subcl-verb> & {Xd- & Xc+} & MVs-;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -19,8 +19,8 @@ changecom(`%')
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.3.8 (formatted as V5v3v8+)
-<dictionary-version-number>: V5v3v8+;
+% Dictionary version number is 5.3.10 (formatted as V5v3v10+)
+<dictionary-version-number>: V5v3v10+;
 <dictionary-locale>: EN4us+;
 
  % _ORGANIZATION OF THE DICTIONARY_
@@ -2273,10 +2273,10 @@ per "/.per": Us+ & Mp-;
 % VC connects the head-word to a subsequent coordinating conjunction.
 %
 % There are some other such connectors that don't quite fit this patten:
-% AF, and in many cases B (for example TOt+ & B+) for this reason, we
+% AF, Z, and in many cases B (for example TOt+ & B+) for this reason, we
 % have to have a costly null [[()]] below, although we would really really
-% like to get rid of it.  But that would take a lot of B and AF link fiddling
-% about, so we have to live with this for now.
+% like to get rid of it.  But that would take a lot of Z and B and AF link
+% fiddling about, so we have to live with this for now.
 %
 % Also: CP-, Eq+ and COq+ all connect to verbs, and are so disjoined
 % with <verb-wall>
@@ -2533,7 +2533,7 @@ define(`VERB_SP_T',`'VERB_x_T(<verb-sp>, $1))
 
 % as above but for past participles
 define(`VERB_PP',`'
-  ((<verb-pp> & ($1)) or
+  ((($1) & <verb-pp>) or
   (<verb-and-had-> & ([$1] or ())) or
   (($1) & <verb-and-had+>)))
 
@@ -3700,7 +3700,10 @@ wishing.g: (<vc-wish> & <verb-ge>) or <verb-ge-d>;
 % The O+ target is to handle "I hope so", but really, we should have
 % a special-case for this (i.e. a new minor letter).
 % See also <vc-think> for the same problem.
-<vc-hope>: ({@MV+} & {TH+ or <embed-verb> or RSe+ or <to-verb>}) or [[O+ & {@MV+}]];
+<vc-hope>:
+  ({@MV+} & {TH+ or <embed-verb> or RSe+ or <to-verb>})
+  or [[O+ & {@MV+}]];
+
 hope.v agree.v pretend.v swear.v pray.v vow.v vote.v: VERB_PLI(<vc-hope>);
 hopes.v agrees.v pretends.v swears.v prays.v vows.v votes.v: VERB_S_I(<vc-hope>);
 pretended.v-d prayed.v-d: VERB_SPPP_I(<vc-hope>);
@@ -4366,9 +4369,11 @@ imagining.g: (<vc-imagine> & <verb-ge>) or <verb-ge-d>;
 imagining.v: <verb-pg> & <vc-imagine>;
 
 % Pa**j link: The doctor declared him insane.
-<vc-declare>: <vc-trans> or
+<vc-declare>:
+  <vc-trans> or
   ({@MV+} & (<embed-verb> or TH+ or RSe+ or Pg+ or Z-)) or
   ((O+ or <b-minus>) & ({@MV+} & Pa**j+));
+
 declare.v fear.v conclude.v suspect.v concede.v presume.v foresee.v
 emphasize.v maintain.v acknowledge.v note.v confirm.v stress.v assume.v:
   VERB_PLI(<vc-declare>);

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2246,6 +2246,9 @@ per "/.per": Us+ & Mp-;
 <MX-PHRASE>: Xd- & (Xc+ or <costly-null>) & (MX*p- or MVg-);
 <OPENER>: {Xd-} & Xc+ & COp+;
 
+% <coord>: connects to coordinating conjunction.
+<coord>: CC-;
+
 % These are the verb-form expressions for ordinary verbs.
 %
 % The general patterns here are:
@@ -6554,7 +6557,7 @@ lest:
 
 albeit:
   (<subcl-verb> & {Xc+ & {Xd-}} & CO*s+)
-  or ({Xd-} & CC- & Wd+);
+  or ({Xd-} & <coord> & Wd+);
 
 no_matter:
   QI+ & ((Xc+ & {Xd-} & CO+) or ({Xd- & Xc+} & MVs-));
@@ -7175,7 +7178,7 @@ whence whither:
 
 although in_as_much_as whilst whereas whereof wherein:
   (<subcl-verb> & (({Xc+ & {Xd-}} & CO*s+) or ({Xd- & Xc+} & MVs-)))
-  or ({Xd-} & CC- & (Wd+ or Wp+ or Wr+));
+  or ({Xd-} & <coord> & (Wd+ or Wp+ or Wr+));
 
 % QI- & (): "I do not know when"
 % (Mv- & Cs+): "an examination when it happened revealed chicanery"
@@ -7380,7 +7383,7 @@ once.e:
 % usages below.
 %
 
-and/or: [(({Xd-} & CC-) or Wc-) & (Wdc+ or Qd+ or Ws+ or Wq+)];
+and/or: [(({Xd-} & <coord>) or Wc-) & (Wdc+ or Qd+ or Ws+ or Wq+)];
 
 % and used as a conjunction in proper names:
 % The Great Southern and Western Railroad
@@ -7659,11 +7662,11 @@ neither.r:
   or [[<noun-main-x>]]
   or (Wa- & {OF+});
 
-nor.r: ((Xd- & CC-) or Wd-) & Qd+;
-for.r: [[(({Xd-} & CC-) or Wc-) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+)]];
-yet.r: ((({Xd-} & CC-) or Wc-) & (Wd+ or Wp+ or Wr+)) or E+ or MVa- or ({Xd-} & Xc+ & CO+);
+nor.r: ((Xd- & <coord>) or Wd-) & Qd+;
+for.r: [[(({Xd-} & <coord>) or Wc-) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+)]];
+yet.r: ((({Xd-} & <coord>) or Wc-) & (Wd+ or Wp+ or Wr+)) or E+ or MVa- or ({Xd-} & Xc+ & CO+);
 
-thus therefore: ({Xc+ & {Xd-}} & CO+) or ({Xd-} & CC- & Wd+) or
+thus therefore: ({Xc+ & {Xd-}} & CO+) or ({Xd-} & <coord> & Wd+) or
 ({Xd- & Xc+} & (E+ or EB-)) or (Xd- & Xc+ & MVa-);
 
 % EBy+ link is for "verbed not X but Y" "I saw not Mary, but John"
@@ -8960,7 +8963,7 @@ in_fact of_course in_effect for_example for_instance e.g. i.e. :
   or ({Xc+ & {Xd-}} & CO+)
   or (EB- & {Xc+})
   or (Xd- & EB- & Xc+)
-  or ({Xd-} & CC- & (Wd+ or Wp+ or Wr+));
+  or ({Xd-} & <coord> & (Wd+ or Wp+ or Wr+));
 
 % -----------------------------------------------------------
 % ADVERBS USABLE POST_VERBALLY OR AS OPENERS
@@ -9164,7 +9167,7 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & CC-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or ((({Xd-} & <coord>) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
@@ -9339,7 +9342,7 @@ changequote dnl
 % head-verb crossing, the way that CC is.  Basically, CC is deprecated!
 % Wc-: "But my efforts to win his heart have failed"
 but.ij and.ij or.ij not.ij also.ij but_not and_not and_yet:
-  [{Xd-} & ([CC-] or Xx- or Wc-) & {Xc+}
+  [{Xd-} & ([<coord>] or Xx- or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>];
 
 % (NI- & WV- & W+): Optionally numbered, bulleted lists

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -9172,7 +9172,7 @@ so:
   ({EBb-} & EAxk+ & {HA+})
   or ({EZ-} & EExk+)
   or Em+
-  or ((({Xd-} & <coord>) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
+  or ((({Xd-} & <coord> & Xs-) or ({Xc+} & Wc-)) & (Wd+ or Wp+ or Wr+ or Qd+ or Ws+ or Wq+ or Wi+))
   or <fronted>
   or (Wq- & CQ+)
   or MVp-
@@ -9221,12 +9221,14 @@ EMOTICON :
 % The WV+ after the Xx+ allows the root verb after the punct to attach
 % to the wall.  e.g. "A woman lives next door, who is a nurse."
 % The naked WV+ without any W+ allows "that I did not know."
-% Xy is for new sentences. "Who is Obama? Where was he born?"
+% Xp+ is for new sentences. "Who is Obama? Where was he born?"
+% Xs+ is for dependent clauses starting with "so".
+%       "I stayed so I could see you."
 % XXX TODO: afer all WV's work, the WV link should no longer be optional...
 % XXX that is, change <WALL> to just WV+.
 %
 <sent-start>:
-  (<wo-wall> or <wi-wall>) & {CP+} & {(Xx+ or Xp+) & {hWV+}} & {RW+ or Xp+};
+  (<wo-wall> or <wi-wall>) & {CP+} & {(Xx+ or Xp+ or Xs+) & {hWV+}} & {RW+ or Xp+};
 
 % QU+ links to quoted phrases.
 % ZZZ+ is a "temporary" addition for randomly-quoted crap, and

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -1328,7 +1328,7 @@ mine.p yours theirs hers ours:
 
 % yisser yousser ye'r: Irish English second-person possessive --
 % https://en.wikipedia.org/wiki/Irish_English
-its my.p your their our thy yisser.p yousser ye'r:
+its my.p me.p your their our thy yisser.p yousser ye'r:
   DP+
   or ({AL-} & {@L+} & (D+ or DD+));
 
@@ -8975,30 +8975,76 @@ statewide.e world-wide.e nation-wide.e state-wide.e industrywide.e
 instead.e maybe.e:
   ({Xc+ & {Xd-}} & CO+);
 
+% Argumentatives (children gain-saying).
+not.intj is_too is_not is_so unh_unh: Wa-;
+
 % Openers to directives, commands (Ic+ connection to infinitives)
 % or single-word interjections. These are semantically important,
 % so they've got to parse!
+% Wa- & Wa+: "Oh my God"
 no.ij nope.ij nah.ij no_way never.ij not_possible
 yes.ij yeah.ij yep.ij yup.ij
 ok.ij okay.ij OK.ij fine.ij exactly.ij sure.ij
 good.ij good_enough fair_enough whatever.ij
 hah.ij hey.ij well.ij wtf.ij hell_yes hell_no of_course
-oh_no oh_my oh_dear dear.ij Lordy
-yikes ouch my.ij my_oh_my my_my my_my_my tsk tsk_tsk tsk_tsk_tsk:
+gesundheit
+oh_no oh_my oh_my_days
+ohmigod OMG oh_em_gee omigosh
+oh_dear dear_me dearie_me deary_me dear.ij
+dear_Lord dear_Lordy Lord_be_praised
+Lordy my_Lord
+fuck_me fucking_hell
+uh_huh uh uhh uuh unh
+my.ij my_oh_my my_my my_my_my
+tsk tsk_tsk tsk_tsk_tsk:
   <directive-opener>
-  or Wa-;
+  or (Wa- & {Wa+});
 
 % Like above, but also used as plain-old interjections, so treat
 % as adjectives, as well.
+% A- & Wa-: "Holy Mother of God"
+howdy phew psst pssst ahem
+ah ahh eh ehh hmm hmmm huh
+oops eep egad egads ermahgerd ouch alas whoa whoah
 oh.ij ohh doh dohh woo_hoo
-gee gosh wow.ij ah ahh eh ehh hmm hmmm
-goody.ij jeepers Jee-sus oops amen.ij huh
-howdy dammit shucks.ij golly
-sonuvabitch aw aww awww oh_great oh_wow:
+boo.ij booo boooo phooey pooh
+wow.ij wowie wowee wowzers whoopee hurray hurrah rah rahh hooray
+ooo oo hoo hoowee hoo-wee who-wee hubba whammo wammo
+yikes yowza yowzah zoiks zoinks zounds zowie
+goody.ij
+amen.ij alrighty
+jeepers Jee-sus
+Kee-reist Christ Christ_almighty JHC
+Jesus_Christ Jesus_fucking_Christ Jesus_H_Christ
+Christ_alive crikey cripes Jiminy_Cricket
+Jaysus Jeebus Jehoshaphat sweet_Jesus
+jeez jeez_Louise jimminy geez geez_Louise geeminy
+God_Almighty God_almighty God_in_heaven
+drat.ij shoot.ij blast.ij doggone doggone_it rats.ij
+dammit god_dammit goddammit damn_it damn_it_all
+dang dagnabit dagnabbit dag-nabbit dag_nabbit dagnabbit_all darn.ij
+shucks.ij golly golly_gee golly_gee_willikers good_golly
+golly_gosh gosh gee gee_whiz gee_willikers my_gosh blimey
+gadzooks ye_gods
+gracious_sakes good_gracious goodness_gracious goodness_gracious_me
+goodness_me great_googly_moogly great_Ceasar great_Scott
+good_heavens good_gravy land_sakes sakes_alive snakes_alive
+heavens_to_Betsy heavens_above
+by_God by_golly by_Jove by_jingo
+dear_God
+sacre_bleu
+ay caramba kamoley kamoly moley moly
+holy_Moses mother_of_God Mother_of_God
+mother_of_God mama_mia mamma_mia
+sonuvabitch son_of_a_bitch
+heck sodding_hell
+aw aww awww oh_great oh_wow
+er err.ij errr um.ij umm
+anyways honey.ij man.ij baby.ij hush.ij:
   <ordinary-adj>
-  or ({{Ic-} & [[Wi-]]} & {{Xd-} & Xc+} & Ic+)
+  or ({{Ic-} & Wi-} & {{Xd-} & Xc+} & Ic+)
   or <directive-opener>
-  or Wa-;
+  or (({A-} or {E-} or {EE-}) & Wa-);
 
 % A single plain hello all by itself.  Costly, because these days,
 % its not normally a sentence opener.
@@ -9155,12 +9201,6 @@ so_on the_like vice_versa v.v.:
   <noun-and-x> or
   ((<verb-i> or <verb-sp,pp> or <verb-pg,ge> or <verb-pv>) & {@MV+}) or
   M- or MV-;
-
-% Assorted interjections, treat like unknown adjectives.
-er err.ij errr um.ij umm uh uhh ooo hoo zowie hubba Kee-reist whammo
-heck anyways honey.ij man.ij baby.ij hush.ij:
-  <ordinary-adj> or
-  ({{Ic-} & [[Wa-]]} & {{Xd-} & Xc+} & Ic+);
 
 % Emoticons ... at start or end of sentences ...
 EMOTICON :

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -106,7 +106,7 @@ nonCAP.zzz: ZZZ-;
 <clause-conjoin>: RJrc- or RJlc+;
 
 % {@COd-} : "That is the man who, in Joe's opinion, we should hire"
-<CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or [Rn-]};
+<CLAUSE>:   {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or [Rn-]};
 <S-CLAUSE>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-)};
 <CLAUSE-E>: {({@COd-} & (C- or <clause-conjoin>)) or ({@CO-} & Wd-) or Re-};
 
@@ -2704,7 +2704,7 @@ had.v-d:
     (<to-verb> or
     ((O+ or <b-minus>) & {@MV+} & {[I*j+ or Pv+]}) or
     (([[@MV+ & O*n+]] or CX-) & {@MV+}))) or
-  [[(SI*j+ or SFI**j+) & PP+ & {{Xd-} & Xc+} & COp+]];
+  [[(SI*j+ or SFI**j+) & PP+ & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
 %we'd they'd I'd he'd she'd you'd: (PP+ or ({Vw+} & I+)) & <CLAUSE>;
 ’d 'd: S- & (PP+ or I+);
@@ -2904,7 +2904,7 @@ were.v-d:
   or (<verb-rq> & (SIpx+ or SFIp+) & {<vc-be>} & <verb-wall>)
   or (<verb-and-sp-> & <vc-be-and>)
   or (<vc-be-and> & <verb-and-sp+>)
-  or [[(SI*j+ or SFI**j+) & <vc-be> & {{Xd-} & Xc+} & COp+]];
+  or [[(SI*j+ or SFI**j+) & <vc-be> & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
 % Ss*w-: allows Wh subjets: "Who am I?"
 am.v:
@@ -2994,7 +2994,7 @@ should.v:
   ((SI+ or SFI+) & ((<verb-rq> & I+) or CQ-)) or
   ({N+} & <verb-x-sp> & (I+ or (CX- & {@MV+}) or <verb-wall> or [[()]])) or
   (<verb-and-sp-> & I+) or (I+ & <verb-and-sp+>) or
-  [[(SI*j+ or SFI**j+) & I+ & {{Xd-} & Xc+} & COp+]];
+  [[(SI*j+ or SFI**j+) & I+ & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
 % <verb-wall>: "I sure wish he would."
 would.v:

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -6071,7 +6071,7 @@ ending_up: (<vc-end-up> & <verb-pg,ge>) or <verb-ge-d>;
 %     insane?", "Are you the one?"
 % XXX everywhere where Ws+ is used, should probably be <wi-wall>!?
 <wo-wall>: Wa+ or Wi+ or Ww+ or Qd+;
-<wi-wall>: (Wd+ or Wp+ or Wr+ or Wq+ or Ws+ or Wj+ or Wc+ or We+ or Wt+) & <WALL>;
+<wi-wall>: (Wd+ or Wp+ or Wr+ or Wq+ or Ws+ or Wj+ or Wc+ or We+ or Wt+ or Wo+) & <WALL>;
 
 % Paraphrasing, quotational complements:
 <paraph-null>: [()];
@@ -6466,8 +6466,9 @@ of_them: (ND- or MF-) & (J+ or Pa+) & Xd- & (MX*x- or MVx-) & Xc+;
 %            but also incorrectly allows: "He is going to do"
 %            This is where landmark transitivity could fix things,
 %            by placing a link between "what" and "do".
+% I*t+ & Wo-: "To be continued"
 to.r:
-  ({@E-} & {N+} & I*t+ & TO-)
+  ({@E-} & {N+} & I*t+ & (TO- or Wo-))
   or ({@E-} & {NT-} & I+ &
     (<MX-PHRASE>
     or (SFsx+ & <S-CLAUSE>)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -272,6 +272,9 @@ nonCAP.zzz: ZZZ-;
 <too-verb>: TOo+ & IV+;
 <tot-verb>: TOt+ & B+;
 
+% Connects verb to coordinating conjunction.
+<coord-verb>: VC+;
+
 <subord-verb>: CV+;
 <embed-verb>: Ce+ & CV+;
 <subcl-verb>: Cs+ & CV+;
@@ -2247,7 +2250,7 @@ per "/.per": Us+ & Mp-;
 <OPENER>: {Xd-} & Xc+ & COp+;
 
 % <coord>: connects to coordinating conjunction.
-<coord>: CC-;
+<coord>: ([[CC-]] or VC-);
 
 % These are the verb-form expressions for ordinary verbs.
 %
@@ -2267,6 +2270,7 @@ per "/.per": Us+ & Mp-;
 % WV connects the wall to the head-verb,
 % CV connects the dominating clause to the head verb of the dependent clause.
 % IV connects infinitives to the head-verb
+% VC connects the head-word to a subsequent coordinating conjunction.
 %
 % There are some other such connectors that don't quite fit this patten:
 % AF, and in many cases B (for example TOt+ & B+) for this reason, we
@@ -2277,8 +2281,8 @@ per "/.per": Us+ & Mp-;
 % Also: CP-, Eq+ and COq+ all connect to verbs, and are so disjoined
 % with <verb-wall>
 %
-<verb-wall>: dWV- or dCV- or dIV- or [[()]];
-% <verb-wall>: dWV- or dCV- or dIV-;
+<verb-wall>: ((dWV- or dCV- or dIV-) & {VC+}) or [[()]];
+% <verb-wall>: (dWV- or dCV- or dIV-) & {VC+};
 
 % When we are done, remove the option costly NULL below.
 <WALL>: hWV+ or [[()]];
@@ -9338,11 +9342,11 @@ changequote dnl
 % connect whole clauses.  Should wee use <sent-start> here? Why not?
 %
 % not.ij seems to result in bad parses quite often, do we need it?
-% Xx-: provides a better way of doing coordination, since it is not
-% head-verb crossing, the way that CC is.  Basically, CC is deprecated!
+% [Xx-]0.1: provides coordination to the wall. Has a cost, so that
+%           VC- is prefered way of coordinating.
 % Wc-: "But my efforts to win his heart have failed"
 but.ij and.ij or.ij not.ij also.ij but_not and_not and_yet:
-  [{Xd-} & ([<coord>] or Xx- or Wc-) & {Xc+}
+  [{Xd-} & (<coord> or [Xx-]0.1 or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>];
 
 % (NI- & WV- & W+): Optionally numbered, bulleted lists

--- a/data/en/4.0.knowledge
+++ b/data/en/4.0.knowledge
@@ -32,7 +32,7 @@ DOMAIN_STARTER_LINKS:
 ;W   Ce   Cs   Ca   Cc   Ci   R*   Rn   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd  
  W   Ce   Cs   Ca   Cc   Ci   R*   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd  
  TOn   TOi   Mg*   MVi  Ss#d   Bsd   ER   Z  Ma#*   SIs#g  BIqx   MX#p   MX#a  
- MX#r   MX#j   MV#o   MV#p  Eq   COq   CCq  AFd   PFc 
+ MX#r   MX#j   MV#o   MV#p  Eq   COq  VC  AFd   PFc 
 
 
 
@@ -175,7 +175,7 @@ STARTING_LINK_TYPE_TABLE:
  MX#a  e  
  Eq    e  
  COq   e  
- CCq   s  
+ VC    s  
  MX#r  r 
 
 

--- a/data/en/4.0.knowledge
+++ b/data/en/4.0.knowledge
@@ -2,18 +2,18 @@
 ; 6/96
 
 ; ----------------------------------------------------------------------------
-; This file contains the knowledge related to post-processing, in the 
-; form of lists and rules. This file is read by post-process.c at run-time. 
+; This file contains the knowledge related to post-processing, in the
+; form of lists and rules. This file is read by post-process.c at run-time.
 ; Syntax of file:
 ;           line starting with ";" is a comment
-;           commas are field delimiters 
+;           commas are field delimiters
 ;           any token beginning with the character @ is expanded to the set
 ;               of symbols it defined. e.g. one could write
 ; FOO: blah1 blah2 blah3
 ; thus defining a set FOO containing three strings. Then one could later write
 ; BAR: blah5 @FOO blah8
-; which defines a set BAR containing 5 strings. 
-; 
+; which defines a set BAR containing 5 strings.
+;
 ; Capitalized tokens are *required*, though if you feel like providing an
 ; empty list afterwards, that's your right.
 ; ----------------------------------------------------------------------------
@@ -25,13 +25,13 @@
 ; Removed Rn as a starter link, since it doesn't seem to be needed,
 ; and also because it interferes with a verb-wall link for sentences
 ; like: "only you would say that" and "that I did not know". When Rn is
-; allowed to start an r domain, the above sentences then hit the 
+; allowed to start an r domain, the above sentences then hit the
 ; "unbounded r domain" rule below, on the WV link.
-  
-DOMAIN_STARTER_LINKS: 
-;W   Ce   Cs   Ca   Cc   Ci   R*   Rn   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd  
- W   Ce   Cs   Ca   Cc   Ci   R*   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd  
- TOn   TOi   Mg*   MVi  Ss#d   Bsd   ER   Z  Ma#*   SIs#g  BIqx   MX#p   MX#a  
+
+DOMAIN_STARTER_LINKS:
+;W   Ce   Cs   Ca   Cc   Ci   R*   Rn   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd
+ W   Ce   Cs   Ca   Cc   Ci   R*   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd
+ TOn   TOi   Mg*   MVi  Ss#d   Bsd   ER   Z  Ma#*   SIs#g  BIqx   MX#p   MX#a
  MX#r   MX#j   MV#o   MV#p  Eq   COq   VCq  AFd   PFc
 
 
@@ -52,22 +52,22 @@ URFL_DOMAIN_STARTER_LINKS:  TOo   I#j  Pa##j   CP
 ; reachable from the root word, tracing to the right. They aren't
 ; included in the domain
 
-URFL_ONLY_DOMAIN_STARTER_LINKS:  SFsx   Ss#g   COp    
+URFL_ONLY_DOMAIN_STARTER_LINKS:  SFsx   Ss#g   COp
 
 
 
 ; ----------------------------------------------------------------------
-; Links which start a domain and are also part of the domain. This must be 
-; a sublist of the domain_starter_list 
+; Links which start a domain and are also part of the domain. This must be
+; a sublist of the domain_starter_list
 
-DOMAIN_CONTAINS_LINKS: 
- Mg*   Mx   Bsd   MX#a   Ma#*   Mv*   MX#r   Ss#d   Ws   Wq  Qd   Mj   Wj 
+DOMAIN_CONTAINS_LINKS:
+ Mg*   Mx   Bsd   MX#a   Ma#*   Mv*   MX#r   Ss#d   Ws   Wq  Qd   Mj   Wj
  Wi  MX#j   AFd   PFc   Jr   Wd   Wp   Mr
 
 
 
 ; ----------------------------------------------------------------------
-; These links are not put in the word/link graph. They also cannot be the 
+; These links are not put in the word/link graph. They also cannot be the
 ; starter links for a domain. (These links may also only be used in cycles.)
 
 IGNORE_THESE_LINKS: Xca
@@ -82,7 +82,7 @@ IGNORE_THESE_LINKS: Xca
 ; WV must form a cycle with W links: WV links to the root verb to the wall,
 ; and W links the leading noun to the wall. Both verb and noun must be in
 ; the same phrase, forming a cycle, as otherwise, nonsense happens, such as
-; *He stated the fact that there be an investigation 
+; *He stated the fact that there be an investigation
 ; with W linking to "he" and WV linking to "be" (instead of "stated")
 ; ---
 ; CV: similar to WV above, must form a loop along with Ce (typically).
@@ -90,7 +90,7 @@ IGNORE_THESE_LINKS: Xca
 ; CV links the verb of the subordinate clause to the dominating phrase.
 ; Both the linked noun and verb must be in the same subordinate clause.
 ; Example: "I wish I could see him 100 times a day"
- 
+
 MUST_FORM_A_CYCLE_LINKS:  R#*  TOt  EXx  HA  SFsic  Jd  Jr  JQ  OFd Xca  WV CV IV
 
 
@@ -102,7 +102,7 @@ MUST_FORM_A_CYCLE_LINKS:  R#*  TOt  EXx  HA  SFsic  Jd  Jr  JQ  OFd Xca  WV CV I
 ; prevent the (e) domain, started by Ce, from extending around through
 ; the Rw link.
 ; Reverted the B#m thing ...
-; This breaks parsing of 
+; This breaks parsing of
 ;    How fast a program does he think it is
 ;    I wonder how fast a program he thinks it is
 ;    I wonder how much money you earned
@@ -115,8 +115,8 @@ MUST_FORM_A_CYCLE_LINKS:  R#*  TOt  EXx  HA  SFsic  Jd  Jr  JQ  OFd Xca  WV CV I
 ; Meanwhile, I can't find the Ce problem mentioned ... this needs more
 ; documentation!
 
-RESTRICTED_LINKS: 
-   B#*  D##w   B#w   B#d   AFh  MVt   Xx   HL   SFsic  AFd   Bc   CX  EAh  
+RESTRICTED_LINKS:
+   B#*  D##w   B#w   B#d   AFh  MVt   Xx   HL   SFsic  AFd   Bc   CX  EAh
    H   HA   PFc   B#j   Wd   PF   Z
 
 ;   H   HA   PFc   B#j   Wd   PF   Z  B#m
@@ -131,52 +131,52 @@ RESTRICTED_LINKS:
 ;
 ; Rn commented out, as per above.
 
-STARTING_LINK_TYPE_TABLE: 
- Ce    e  
- R*    r  
+STARTING_LINK_TYPE_TABLE:
+ Ce    e
+ R*    r
 ; Rn    r
- Re    r  
- W     m  
- RSe   e  
- Cs    s  
- Ca    s  
- Jr    e  
- Mr    r  
- Cc    s  
- Mv*   e  
- QI#d  s  
- BIqx  s  
- TOn   e  
- TOi   e  
- MVi   e  
- MV#o  s  
- MV#p  s  
- AFd   s  
- PFc   s  
- Mg*   e  
- Mj    j  
- Qd    m  
- MX#j  j  
- TOo   x  
- I#j   x  
- Pa##j x  
+ Re    r
+ W     m
+ RSe   e
+ Cs    s
+ Ca    s
+ Jr    e
+ Mr    r
+ Cc    s
+ Mv*   e
+ QI#d  s
+ BIqx  s
+ TOn   e
+ TOi   e
+ MVi   e
+ MV#o  s
+ MV#p  s
+ AFd   s
+ PFc   s
+ Mg*   e
+ Mj    j
+ Qd    m
+ MX#j  j
+ TOo   x
+ I#j   x
+ Pa##j x
  CP    x
- COp   d  
- SFsx  d  
- Ss#g  d  
- SIs#g s  
- Ss#d  s  
- Bsd   s  
- ER    s  
- Z     s  
- Ma#*  e  
- MX#p  e  
- Ci    e  
- MX#a  e  
- Eq    e  
- COq   e  
+ COp   d
+ SFsx  d
+ Ss#g  d
+ SIs#g s
+ Ss#d  s
+ Bsd   s
+ ER    s
+ Z     s
+ Ma#*  e
+ MX#p  e
+ Ci    e
+ MX#a  e
+ Eq    e
+ COq   e
  VCq   s
- MX#r  r 
+ MX#r  r
 
 
 ; ----------------------------------------------------------------------
@@ -187,21 +187,21 @@ STARTING_LINK_TYPE_TABLE:
 ; ----------------------------------------------------------------------
 ; ----------------- RULES ----------------------------------------------
 ; ----------------------------------------------------------------------
-; Explanation of syntax: as usual, each stanza begins with a label 
-; terminated by a colon. The interpretation of the rule depends on 
+; Explanation of syntax: as usual, each stanza begins with a label
+; terminated by a colon. The interpretation of the rule depends on
 ; the label, as specified in each stanza.
 
-; The following rule asserts that the linkage must *still* be connected 
+; The following rule asserts that the linkage must *still* be connected
 ; when the specified set(s) of links are removed from the linkage.
 
 FORM_A_CYCLE_RULES:
         @MUST_FORM_A_CYCLE_LINKS  ,  "'must form a cycle' violation0"
 
 
-; For the following rules, if a domain contains a link matching the 1st 
-; column, it must also contain a linkage matching one of the members of the 
+; For the following rules, if a domain contains a link matching the 1st
+; column, it must also contain a linkage matching one of the members of the
 ; set in the 2nd column. The individual rules are demarcated by semicolons and
-; the fields within a rule are demarcated by commas. 
+; the fields within a rule are demarcated by commas.
 
 ; XXX fixme -- Qd should be replaced by Qw in first four.
 CONTAINS_ONE_RULES:
@@ -246,27 +246,27 @@ CONTAINS_ONE_RULES:
  SFIst ,  O*t   Ost   Omt    Bs#t    B*#t    Bc#t    , "Bad use of 'there'34"           ,
  SFIp  ,  O*t   Opt   Omt    Bp#t    B*#t    Bc#t    , "Bad use of 'there'35"           ,
  OXt   ,  O#t   B##t                     ,   "Bad use of 'there'36"           ,
- SFsi* ,  TOi    THi   QIi    TSi    O#i    Ci    THb   CPi   
+ SFsi* ,  TOi    THi   QIi    TSi    O#i    Ci    THb   CPi
           COqi    CPi    Eqi    AFdi    BIh , "Bad use of 'it'37"           ,
- SFIsi ,  TOi    THi   QIi    TSi    O#i    Ci    THb   CPi   
+ SFIsi ,  TOi    THi   QIi    TSi    O#i    Ci    THb   CPi
           COqi    CPi    Eqi    AFdi    BIh , "Bad use of 'it'38"           ,
- OXi   ,  TOi    THi   QIi    TSi    O#i    Ci    THb   CPi   
+ OXi   ,  TOi    THi   QIi    TSi    O#i    Ci    THb   CPi
           COqi    CPi    Eqi    AFdi    BIh , "Bad use of 'it'39"           ,
  THb   ,  S##t    SI##t  SFsi  SFIsi        , "Bad use of predicate40"      ,
  BIh   ,  Ss#b    SIs#b  SFsi  SFIsi        , "Bad use of predicate41"      ,
- BIq   ,  S##q    SI##q  SFsi  Ss#b    SFIsi SIs#b 
+ BIq   ,  S##q    SI##q  SFsi  Ss#b    SFIsi SIs#b
                                             , "Bad use of predicate42"      ,
  MVt   ,  Dm#m   EAm   EEm   MVm  Pam   Pafm   AFm   EB#m   MVb AJrc
           Om   Mam  Am  Jm  Ds*m   MX#m     , "Bad comparative43"    ,
  MVz   ,  D##y    EAy    EEy    MVy    EB#y , "Bad comparative44"    ,
- MV#a  ,  Pam    Pafm    EAm   Ds*m   EAy   AFm   Mam   Am  
+ MV#a  ,  Pam    Pafm    EAm   Ds*m   EAy   AFm   Mam   Am
 					    , "Bad comparative45"    ,
- MV#i  ,  Pam    Pafm    EAm   Ds*m   EAy   AFm   Mam   Am  
+ MV#i  ,  Pam    Pafm    EAm   Ds*m   EAy   AFm   Mam   Am
 					    , "Bad comparative46"    ,
- MV#o  ,  D##m    D##y    Om    Oy    Jm    Jy   Am   MX#m  
+ MV#o  ,  D##m    D##y    Om    Oy    Jm    Jy   Am   MX#m
 					    , "Bad comparative47"    ,
- MV#p  ,  EEm   MVb   Dm#m   EEy   D##y  MVm   Om   Oy 
-                            Jm   Jy   Am   MX#m         
+ MV#p  ,  EEm   MVb   Dm#m   EEy   D##y  MVm   Om   Oy
+                            Jm   Jy   Am   MX#m
 					    , "Bad comparative48"    ,
  Pafc  ,  EB#m    EB#y                      , "Bad comparative49"    ,
  Pafc  ,  Pa*    Paf*                       , "Bad comparative50"    ,
@@ -274,24 +274,24 @@ CONTAINS_ONE_RULES:
  MVpt  ,  MVm                               , "Bad comparative52"    ,
  MVat  ,  MVa   MVp                         , "Bad comparative53"    ,
  MVpt  ,  MVa   MVp                         , "Bad comparative54"    ,
- U#t   ,  D##m    D##y    Om    Oy    Jm    Jy   Am   MX#m           
+ U#t   ,  D##m    D##y    Om    Oy    Jm    Jy   Am   MX#m
 				            , "Bad comparative55"    ,
- Cc    ,  EEm    EEy    MVm    MVb    MVy              
+ Cc    ,  EEm    EEy    MVm    MVb    MVy
 	                                    , "Bad comparative56"    ,
- Sp#c  ,  Dmcm    Dmcy    Om    Oy    Jm    Jy  MX#m         
+ Sp#c  ,  Dmcm    Dmcy    Om    Oy    Jm    Jy  MX#m
 	 				    , "Bad comparative57"    ,
- Ss#c  ,  Dmum    Dmuy    Om    Oy    Jm    Jy    Ds*y  MX#m        
+ Ss#c  ,  Dmum    Dmuy    Om    Oy    Jm    Jy    Ds*y  MX#m
 					    , "Bad comparative58"    ,
- S##c  ,  Dm#m    D##y    Om    Oy    Jm    Jy   MX#m         
+ S##c  ,  Dm#m    D##y    Om    Oy    Jm    Jy   MX#m
 					    , "Bad comparative59"    ,
  THc   ,  TH                                , "Bad comparative60"    ,
  TOc   ,  TO**   TOf*   TOi*                , "Bad comparative61"    ,
  TOtc  ,  TOt  ,                              "Bad comparative62"    ,
- Ma**  ,  TO   TOf   TH   MVp   TOt   QI   OF  MVt   MVz   MVh   Ytm   Ya             
+ Ma**  ,  TO   TOf   TH   MVp   TOt   QI   OF  MVt   MVz   MVh   Ytm   Ya
 					    , "Bad use of adjective63"    ,
- Mam   ,  TO   TOf   TH   MVp   TOt   QI   OF  MVt   MVz   MVh   Ytm   Ya              
+ Mam   ,  TO   TOf   TH   MVp   TOt   QI   OF  MVt   MVz   MVh   Ytm   Ya
 					    , "Bad use of adjective64"    ,
- MX#a  ,  TO   TOf   TH   MVp   TOt   QI   OF  MVt   MVz   MVh   Ytm   Ya  MJ 
+ MX#a  ,  TO   TOf   TH   MVp   TOt   QI   OF  MVt   MVz   MVh   Ytm   Ya  MJ
 			                    , "Bad use of adjective65"    ,
 
 ; There's no JUNK connector, which means that Oxn is
@@ -299,20 +299,20 @@ CONTAINS_ONE_RULES:
  Oxn   ,  JUNK                              , "Bad use of pronoun66" ,
  MVh   ,  EExk   EAxk   D##k                , "Incorrect use of that67" ,
 
-; The Rw link necessitated commenting out 68, because we had to make B#m 
+; The Rw link necessitated commenting out 68, because we had to make B#m
 ; a restricted link(see above) xxx reverted .. this is needed ...
 ;
-B#m  ,   D##w   H   HA                     , "Bad use of gerund68"   
+B#m  ,   D##w   H   HA                     , "Bad use of gerund68"
 
 CONTAINS_NONE_RULES:
  S     ,  Spxi                             , "Bad n-v agreement69" ,
  SI     , SIpxi                            , "Bad n-v agreement70" ,
  Ws    ,  B#m   Ca   BT                    , "Question inversion violated71" ,
- SF    ,  I*   PP*   TO*   Pa*   Pam  Pg*   Pv*   LE*   AFd*  MVta         
+ SF    ,  I*   PP*   TO*   Pa*   Pam  Pg*   Pv*   LE*   AFd*  MVta
                                            , "Bad use of 'filler' subject72" ,
- SFI   ,  I*   PP*   TO*   Pa*   Pam  Pg*   Pv*   LE*   AFd*  MVta        
+ SFI   ,  I*   PP*   TO*   Pa*   Pam  Pg*   Pv*   LE*   AFd*  MVta
                                            , "Bad use of 'filler' subject73" ,
- OX    ,  I*   PP*   TO*   Pa*   Pam  Pg*   Pv*   LE*   AFd*  MVta        
+ OX    ,  I*   PP*   TO*   Pa*   Pam  Pg*   Pv*   LE*   AFd*  MVta
                                            , "Bad use of 'filler' subject74" ,
  MXsr  ,  Sp#w                             , "Bad n-v agreement75" ,
  MXpr  ,  Ss#w   S#iw                      , "Bad n-v agreement76" ,
@@ -328,4 +328,4 @@ CONTAINS_NONE_RULES:
 
 BOUNDED_RULES:
  s                               , "Unbounded s domain78" ,
- r                               , "Unbounded r domain79" 
+ r                               , "Unbounded r domain79"

--- a/data/en/4.0.knowledge
+++ b/data/en/4.0.knowledge
@@ -32,15 +32,15 @@ DOMAIN_STARTER_LINKS:
 ;W   Ce   Cs   Ca   Cc   Ci   R*   Rn   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd  
  W   Ce   Cs   Ca   Cc   Ci   R*   Re   RSe  Mr   QI#d   Mv*   Jr  Mj   Qd  
  TOn   TOi   Mg*   MVi  Ss#d   Bsd   ER   Z  Ma#*   SIs#g  BIqx   MX#p   MX#a  
- MX#r   MX#j   MV#o   MV#p  Eq   COq  VC  AFd   PFc 
+ MX#r   MX#j   MV#o   MV#p  Eq   COq   VCq  AFd   PFc
 
 
 
 ; ----------------------------------------------------------------------
-; The following links start a urfl domain.  They are also included in the 
+; The following links start a urfl domain.  They are also included in the
 ; domain, as opposed to regular starter links (above), which are not. A
 ; urfl domain includes links accessible from the root word, tracing to
-; the right (as well as everything accessible from the left end of the 
+; the right (as well as everything accessible from the left end of the
 ; starter link).
 
 URFL_DOMAIN_STARTER_LINKS:  TOo   I#j  Pa##j   CP
@@ -175,7 +175,7 @@ STARTING_LINK_TYPE_TABLE:
  MX#a  e  
  Eq    e  
  COq   e  
- VC    s  
+ VCq   s
  MX#r  r 
 
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3634,6 +3634,7 @@ Do not fail!
 % "To be" constructions
 To be continued
 Soon to be continued
+Apparently, to be continued.
 To not be continued
 To not be continued, it seems.
 Not to be continued, it seems.
@@ -3642,6 +3643,13 @@ To be decided
 to be determined
 to be done later
 to be avoided
+
+% Single-word "topic" responses, taking the Wt link.
+Apparently.
+Apparently so.
+Perhaps.
+Evidently.
+Usually.
 
 Hey, of course!
 Why, of course!

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3572,6 +3572,12 @@ Do it like this.
 It must be done exactly like so.
 How could it be so?
 
+% "so" as conjunction.
+John left so I stayed.
+I stayed so I could see you.
+He failed to appear, so we went on without him.
+This is the easiest way to get there, so don't argue.
+
 % "So" as adverbial modifier
 That is so not going to happen.
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3598,6 +3598,9 @@ So be that way.
 So stick it up yor ass.
 So arrange it nicely.
 
+So! You thought I would fail!
+So!
+
 % "so" as a conjunction.
 
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3572,6 +3572,8 @@ Do it like this.
 It must be done exactly like so.
 How could it be so?
 
+That is so not going to happen.
+
 % "so" as sentence opener (... mild hostility)
 So, don't do it!
 So don't argue

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3572,6 +3572,18 @@ Do it like this.
 It must be done exactly like so.
 How could it be so?
 
+% "so" as sentence opener (... mild hostility)
+So, don't do it!
+So don't argue
+So be unhappy
+So be unhappy, see if I care!
+So go home.
+So be that way.
+So stick it up yor ass.
+So arrange it nicely.
+
+% "so" as a conjunction.
+
 
 % Requests, directives, commands, imperatives.
 Do not be wise in your own estimation.

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3748,6 +3748,14 @@ Not much.
 Did you get what you wanted?
 Not enough.
 
+% Children's gain-saying.
+Is too.
+Is not.
+Is so.
+Not.
+Uh huh.
+Unh unh.
+Liar.
 
 % short greetings
 Hello!

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3577,6 +3577,17 @@ That is so not going to happen.
 
 Hold the brush so.
 
+It seems so
+It seems not
+It appears so
+It appears not
+It appeared not.
+It appeared not to be so.
+Apparently so
+Apparently not
+Evidently so
+Evidently not
+
 % "so" as sentence opener (... mild hostility)
 So, don't do it!
 So don't argue

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3631,6 +3631,18 @@ Do not do that!
 Do not open!
 Do not fail!
 
+% "To be" constructions
+To be continued
+Soon to be continued
+To not be continued
+To not be continued, it seems.
+Not to be continued, it seems.
+That is not to be continued.
+To be decided
+to be determined
+to be done later
+to be avoided
+
 Hey, of course!
 Why, of course!
 Why, of course it will!

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -3572,7 +3572,10 @@ Do it like this.
 It must be done exactly like so.
 How could it be so?
 
+% "So" as adverbial modifier
 That is so not going to happen.
+
+Hold the brush so.
 
 % "so" as sentence opener (... mild hostility)
 So, don't do it!

--- a/data/en/words/entities.given-female.sing
+++ b/data/en/words/entities.given-female.sing
@@ -3584,7 +3584,6 @@ Siu.f
 Sixta.f
 Skye.f
 Slyvia.f
-So.f
 Socorro.f
 Sofia.f
 Soila.f


### PR DESCRIPTION
The "to be" fixes resolve issue #355.

There are numerous "so" fixes.

The CC link is killed, the VC link is introduced.  The CC link has been a thorn for a while. 