### PR TITLE
OS X fixes

### DIFF
--- a/bindings/python-examples/parses-quotes-en.txt
+++ b/bindings/python-examples/parses-quotes-en.txt
@@ -15,14 +15,14 @@ O    |       |     |       |     |  |       |     |     |
 OLEFT-WALL they have.v told.v-d of the soldiers.n '  fear.n 
 O
 
-Ihe said `this is a backtic test`
+Ihe said `this is a backtick test`
 O
-O                 +-------------------QUc------------------+
-O                 +------>WV----->+---------Osm--------+   |
-O    +---->WV---->+----Wd---+     |  +------Ds**x------+   |
-O    +--Wd--+--Ss-+-QUd+    +-Ss*b+  |       +----A----+   |
-O    |      |     |    |    |     |  |       |         |   |
-OLEFT-WALL he said.q-d ` this.p is.v a backtic[!].a test.n ` 
+O                 +------------------QUc-----------------+
+O                 +------>WV----->+--------Osm-------+   |
+O    +---->WV---->+----Wd---+     |  +-----Ds**x-----+   |
+O    +--Wd--+--Ss-+-QUd+    +-Ss*b+  |      +---AN---+   |
+O    |      |     |    |    |     |  |      |        |   |
+OLEFT-WALL he said.q-d ` this.p is.v a backtick.n test.n ` 
 O
 
 I“What are you doing?” she asked.

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -287,6 +287,12 @@ class DBasicParsingTestCase(unittest.TestCase):
              ['LEFT-WALL', 'is.v', 'it', 'fine.a', '?', 'RIGHT-WALL'])
         locale.setlocale(locale.LC_CTYPE, oldlocale)
 
+    # If \w is supported, other \ shortcuts are hopefully supported too.
+    def test_regex_class_shortcut_support(self):
+        r"""Test that regexes support \w"""
+        linkage = self.parse_sent("This is a _regex_ive regex test")[0]
+        self.assertEqual(linkage.word(4), '_regex_ive[!].a')
+
 class ESATsolverTestCase(unittest.TestCase):
     def setUp(self):
         self.d, self.po = Dictionary(lang='en'), ParseOptions()

--- a/configure.ac
+++ b/configure.ac
@@ -787,6 +787,8 @@ LINK_CC_TRY_FLAG([-fno-strict-aliasing],
 
 AC_SUBST(LINK_CFLAGS)
 
+LINK_CC_TRY_FLAG([-Wmaybe-uninitialized -Werror], [AC_DEFINE(HAVE_MAYBE_UNINITIALIZED)])
+
 # ===================================================================
 
 AC_SUBST(CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -64,8 +64,21 @@ AC_FUNC_ALLOCA
 AC_FUNC_FORK
 AC_CHECK_FUNCS(prctl)
 
-dnl Check for types
-AC_CHECK_TYPES([locale_t], [], [], [[#include <locale.h>]])
+dnl For locale_t
+AC_MSG_CHECKING(for locale_t in locale.h)
+AC_LINK_IFELSE(
+[AC_LANG_PROGRAM([#include <locale.h>], [locale_t lt = NULL])],
+AC_MSG_RESULT(yes)
+AC_DEFINE([HAVE_LOCALE_T_IN_LOCALE_H], 1, [Define to 1 if locale_t is defined in locale.h]),
+AC_MSG_RESULT(no)
+  AC_MSG_CHECKING(for locale_t in xlocale.h)
+  AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM([#include <xlocale.h>], [locale_t lt = NULL])],
+  AC_MSG_RESULT(yes)
+  AC_DEFINE([HAVE_LOCALE_T_IN_XLOCALE_H], 1, [Define to 1 if locale_t is defined in xlocale.h]),
+  AC_MSG_RESULT(no)
+  )
+)
 
 dnl Check for specific OSs
 # ====================================================================

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -33,7 +33,13 @@
 #ifndef _API_STRUCTURESH_
 #define _API_STRUCTURESH_
 
-#include <locale.h>                /* for locale_t */
+/* For locale_t */
+#ifdef HAVE_LOCALE_T_IN_LOCALE_H
+#include <locale.h>
+#endif /* HAVE_LOCALE_T_IN_LOCALE_H */
+#ifdef HAVE_LOCALE_T_IN_XLOCALE_H
+#include <xlocale.h>
+#endif /* HAVE_LOCALE_T_IN_XLOCALE_H */
 
 #include "api-types.h"
 #include "dict-structures.h"

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -463,13 +463,17 @@ static bool do_match_with_cache(Connector *a, Connector *b, match_cache *c_con)
 	/* The following uses a string-set compare - string_set_cmp() cannot
 	 * be used here because c_con->string may be NULL. */
 	match_stats(c_con->string == a->string ? NULL : a, NULL);
+#ifdef HAVE_MAYBE_UNINITIALIZED
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif /* HAVE_MAYBE_UNINITIALIZED */
 	/* The string field is initialized to NULL, and this is enough because
 	 * the connector string cannot be NULL, as it actually fetched a
 	 * non-empty match list. */
 	if (c_con->string == a->string) return c_con->match;
+#ifdef HAVE_MAYBE_UNINITIALIZED
 #pragma GCC diagnostic pop
+#endif /* HAVE_MAYBE_UNINITIALIZED */
 
 	/* No cache exists. Check if the connectors match and cache the result. */
 	c_con->match = match_lower_case(a, b) && match_hd(a, b);

--- a/link-grammar/regex-morph.c
+++ b/link-grammar/regex-morph.c
@@ -64,7 +64,12 @@ int compile_regexs(Regex_node *re, Dictionary dict)
 			/* re->re = pcre_compile(re->pattern, 0, &error, &erroroffset, NULL); */
 			preg = (regex_t *) malloc (sizeof(regex_t));
 			re->re = preg;
-			rc = regcomp(preg, re->pattern, REG_EXTENDED);
+
+			/* REG_ENHANCED is needed for OS X to support \w etc. */
+#ifndef REG_ENHANCED
+#define REG_ENHANCED 0
+#endif
+			rc = regcomp(preg, re->pattern, REG_EXTENDED|REG_ENHANCED);
 			if (rc)
 			{
 				prt_regerror("Failed to compile regex", re, rc);

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -13,12 +13,15 @@
 
 #include <ctype.h>
 #include <limits.h>
-#include <locale.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdarg.h>
+#include <locale.h>
+#ifdef HAVE_LOCALE_T_IN_XLOCALE_H
+#include <xlocale.h>
+#endif /* HAVE_LOCALE_T_IN_XLOCALE_H */
 
 #ifndef _WIN32
 	#include <unistd.h>

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -29,6 +29,10 @@
 #include <string.h>
 #include <wchar.h>
 #include <wctype.h>
+#include <locale.h>
+#ifdef HAVE_LOCALE_T_IN_XLOCALE_H
+#include <xlocale.h>
+#endif /* HAVE_LOCALE_T_IN_XLOCALE_H */
 
 #include "error.h"
 
@@ -76,6 +80,10 @@ void *alloca (size_t);
 #define memcpy(x, y, s) memcpy((void *)x, (void *)y, s)
 #define qsort(x, y, z, w) qsort((void *)x, y, z, w)
 #endif /* _MSC_VER */
+
+#if defined(HAVE_LOCALE_T_IN_LOCALE_H) || defined(HAVE_LOCALE_T_IN_XLOCALE_H)
+#define HAVE_LOCALE_T 1
+#endif /* HAVE_LOCALE_T_IN_LOCALE_H || HAVE_LOCALE_T_IN_XLOCALE_H) */
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
1. A fix for issue #374 (locale_t in xlocale.h).
2. regcomp() flag fix (\w etc. were not recognized).
3. Added test for regex \w.
4. Avoid a clang warning on unknown warning in pragma.