### PR TITLE
link-parser fixes: Fix  -max-cost  and allow  -panic-*

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1475,6 +1475,7 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 		/* If we are here, then no valid linkages were found.
 		 * If there was a parse overflow, give up now. */
 		if (PARSE_NUM_OVERFLOW < total) break;
+		//if (sent->num_linkages_found > 0 && nl>0) printf("NUM_LINKAGES_FOUND %d\n", sent->num_linkages_found);
 	}
 	sort_linkages(sent, opts);
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -489,9 +489,20 @@ static void put_local_vars_in_opts(Command_Options* copts)
 int issue_special_command(const char * line, Command_Options* opts, Dictionary dict)
 {
 	int rc;
+	Parse_Options save = NULL;
+
+	if (strncmp(line, "panic_", 6) == 0)
+	{
+		line += 6;
+		save = opts->popts;
+		opts->popts = opts->panic_opts;
+	}
+
 	put_opts_in_local_vars(opts);
 	rc = x_issue_special_command(line, opts, dict);
 	put_local_vars_in_opts(opts);
+
+	if (save) opts->popts = save;
 	return rc;
 }
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -666,12 +666,6 @@ int main(int argc, char * argv[])
 		}
 	}
 
-	/* The English and Russian dicts use a cost of 2.7, which allows
-	 * regexes with a fractional cost of less than 1 to be used with
-	 * rules that have a cost of 2.0.
-	 */
-	parse_options_set_disjunct_cost(opts, 2.7);
-
 	/* Process the command line '!' commands */
 	for (i = 1; i<argc; i++)
 	{


### PR DESCRIPTION
Fix the following:
1. max-cost cannot not be set from the command line.
2. No way to set -panic-* from the command line. 

After this fix, link-parser uses the disjunct_cost as set by the library.