### PR TITLE
Windows fixes

### DIFF
--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -518,14 +518,14 @@ dictionary_six_str(const char * lang,
 	/* If we didn't succeed to set the dictionary locale, the program will
 	 * SEGFAULT when it tries to use it with the isw*() functions.
 	 * So set it to the current program's locale as a last resort. */
-	if (NULL == dict->locale)
+	if (NULL == dict->locale_t)
 	{
 		dict->locale = setlocale(LC_CTYPE, NULL);
-		dict->locale_t = newlocale_LC_CTYPE(setlocale(LC_CTYPE, NULL));
+		dict->locale_t = newlocale_LC_CTYPE(dict->locale);
 		prt_error("Warning: Couldn't set dictionary locale! "
 		          "Using current program locale %s", dict->locale);
 	}
-	/* If dict->locale is still not set, there is a bug. */
+	/* If dict->locale_t is still not set, there is a bug. */
 	assert((locale_t)0 != dict->locale_t, "Dictionary locale is not set.");
 #else
 	/* We don't have a locale per dictionary - but anyway make sure
@@ -534,6 +534,9 @@ dictionary_six_str(const char * lang,
 	 * locale of this dictionary and the locale of the compiled regexs. */
 	dict->locale = setlocale(LC_CTYPE, NULL);
 #endif /* HAVE_LOCALE_T */
+
+	/* Previous setlocale() result is not valid after its next call. */
+	dict->locale = string_set_add(dict->locale, dict->string_set);
 
 	dict->affix_table = dictionary_six(lang, affix_name, NULL, NULL, NULL, NULL);
 	if (dict->affix_table == NULL)

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -523,7 +523,7 @@ dictionary_six_str(const char * lang,
 		dict->locale = setlocale(LC_CTYPE, NULL);
 		dict->locale_t = newlocale_LC_CTYPE(dict->locale);
 		prt_error("Warning: Couldn't set dictionary locale! "
-		          "Using current program locale %s", dict->locale);
+		          "Using current program locale \"%s\"", dict->locale);
 	}
 	/* If dict->locale_t is still not set, there is a bug. */
 	assert((locale_t)0 != dict->locale_t, "Dictionary locale is not set.");
@@ -557,7 +557,7 @@ dictionary_six_str(const char * lang,
 	const char *locale = setlocale(LC_CTYPE, NULL);
 	locale = strdupa(locale); /* setlocale() uses static memory. */
 	setlocale(LC_CTYPE, dict->locale);
-	lgdebug(+D_DICT, "Regexs locale %s\n", setlocale(LC_CTYPE, NULL));
+	lgdebug(+D_DICT, "Regexs locale \"%s\"\n", setlocale(LC_CTYPE, NULL));
 
 	if (compile_regexs(dict->regex_root, dict))
 	{

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -79,7 +79,7 @@ static const char * format_locale(Dictionary dict,
 	tmpbuf[LOCALE_NAME_MAX_LENGTH-1] = '\0';
 	if (0 == strncmp(tmpbuf, "Unknown", 7))
 	{
-		prt_error("Error: Unknown territory code in locale %s", locale);
+		prt_error("Error: Unknown territory code in locale \"%s\"", locale);
 		return NULL;
 	}
 	strcpy(locale_buf, tmpbuf);
@@ -101,7 +101,7 @@ static const char * format_locale(Dictionary dict,
 	tmpbuf[LOCALE_NAME_MAX_LENGTH-1] = '\0';
 	if (0 == strncmp(tmpbuf, "Unknown", 7))
 	{
-		prt_error("Error: Unknown territory code in locale %s", locale);
+		prt_error("Error: Unknown territory code in locale \"%s\"", locale);
 		return NULL;
 	}
 	locale = strcat(locale_buf, tmpbuf);
@@ -166,13 +166,13 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 
 		if (!try_locale(locale))
 		{
-			lgdebug(D_USER_FILES, "Debug: Dictionary locale %s unknown\n", locale);
+			lgdebug(D_USER_FILES, "Debug: Dictionary locale \"%s\" unknown\n", locale);
 			goto locale_error;
 		}
 	}
 
 	free_lookup(dn);
-	lgdebug(D_USER_FILES, "Debug: Dictionary locale: %s\n", locale);
+	lgdebug(D_USER_FILES, "Debug: Dictionary locale: \"%s\"\n", locale);
 	dict->locale = locale;
 	return locale;
 
@@ -184,11 +184,11 @@ locale_error:
 		if (NULL == locale) return NULL;
 		const char *sslocale = string_set_add(locale, dict->string_set);
 		free((void *)locale);
-		prt_error("Info: No dictionary locale definition - %s will be used.",
+		prt_error("Info: No dictionary locale definition - \"%s\" will be used.",
 		          sslocale);
 		if (!try_locale(sslocale))
 		{
-			lgdebug(D_USER_FILES, "Debug: Unknown locale %s...\n", sslocale);
+			lgdebug(D_USER_FILES, "Debug: Unknown locale \"%s\"...\n", sslocale);
 			return NULL;
 		}
 		return sslocale;

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -841,7 +841,7 @@ locale_t newlocale_LC_CTYPE(const char *locale)
  * Check that the given locale known by the system.
  * In case we don't have locale_t, actually set the locale
  * in order to find out if it is fine. This side effect doesn't cause
- * harm, as the local would be set up to that value anyway shortly.
+ * harm, as the locale would be set up to that value anyway shortly.
  * @param locale Locale string
  * @return True if known, false if unknown.
  */
@@ -852,7 +852,7 @@ bool try_locale(const char *locale)
 		if ((locale_t)0 == ltmp) return false;
 		freelocale(ltmp);
 #else
-		lgdebug(D_USER_FILES, "Debug: Setting program's locale %s", locale);
+		lgdebug(D_USER_FILES, "Debug: Setting program's locale \"%s\"", locale);
 		if (NULL == setlocale(LC_CTYPE, locale))
 		{
 			lgdebug(D_USER_FILES, " failed!\n");
@@ -882,7 +882,7 @@ void set_utf8_program_locale(void)
 		/* Avoid an initial spurious message. */
 		if ((0 != strcmp(locale, "C")) && (0 != strcmp(locale, "POSIX")))
 		{
-			prt_error("Warning: Program locale %s (codeset %s) was not UTF-8; "
+			prt_error("Warning: Program locale \"%s\" (codeset %s) was not UTF-8; "
 						 "force-setting to en_US.UTF-8", locale, codeset);
 		}
 		locale = setlocale(LC_CTYPE, "en_US.UTF-8");
@@ -946,7 +946,7 @@ char * get_default_locale(void)
 	if (NULL != *evname)
 	{
 		locale = ev;
-		lgdebug(D_USER_FILES, "Debug: Environment locale %s=%s\n", *evname, ev);
+		lgdebug(D_USER_FILES, "Debug: Environment locale \"%s=%s\"\n", *evname, ev);
 #ifdef _WIN32
 		/* If compiled with MSVC/MinGW, we still support running under Cygwin. */
 		const char *ostype = getenv("OSTYPE");
@@ -967,7 +967,7 @@ char * get_default_locale(void)
 		if (NULL == locale)
 			lgdebug(D_USER_FILES, "Debug: Cannot find user default locale\n");
 		else
-			lgdebug(D_USER_FILES, "Debug: User default locale %s\n", locale);
+			lgdebug(D_USER_FILES, "Debug: User default locale \"%s\"\n", locale);
 		return locale; /* Already strdup'ed */
 #endif /* _WIN32 */
 	}

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -147,13 +147,6 @@ int lg_isatty(int fd)
 	PFILE_NAME_INFO pfni = (PFILE_NAME_INFO)buf;
 	PWCHAR cp;
 
-	/* First check using _isatty.
-		Note that this returns the wrong result for NUL, for instance!
-		Workaround is not to use _isatty at all, but rather GetFileType
-		plus object name checking. */
-	if (_isatty(fd))
-		return 1;
-
 	/* Fetch the underlying HANDLE. */
 	fh = (HANDLE)_get_osfhandle(fd);
 	if (!fh || (INVALID_HANDLE_VALUE == fh))


### PR DESCRIPTION
The dictionary locale setting fix is general, but the garbage locale name printing was observed only on Windows.