### PR TITLE
Python bindings + more

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -18,13 +18,13 @@ def desc(lkg):
 def s(q):
     return '' if q == 1 else 's'
 
-def linkage_stat(psent, lang):
+def linkage_stat(psent, lang, sent_po):
     """
     This function mimics the linkage status report style of link-parser
     """
     random = ' of {0} random linkages'. \
              format(psent.num_linkages_post_processed()) \
-             if psent.num_valid_linkages() < psent.num_linkages_found() else ''
+             if psent.num_linkages_found() > sent_po.linkage_limit else ''
 
     print ('{0}: Found {1} linkage{2} ({3}{4} had no P.P. violations)'. \
           format(lang, psent.num_linkages_found(),
@@ -38,20 +38,21 @@ en_lines = [
 ]
 
 po = ParseOptions(min_null_count=0, max_null_count=999)
+#po.linkage_limit = 3
 
 # English is the default language
 en_dir = Dictionary() # open the dictionary only once
 for text in en_lines:
     sent = Sentence(text, en_dir, po)
     linkages = sent.parse()
-    linkage_stat(sent, 'English')
+    linkage_stat(sent, 'English', po)
     for linkage in linkages:
         desc(linkage)
 
 # Russian
 sent = Sentence("Целью курса является обучение магистрантов основам построения и функционирования программного обеспечения сетей ЭВМ.", Dictionary('ru'), po)
 linkages = sent.parse()
-linkage_stat(sent, 'Russian')
+linkage_stat(sent, 'Russian', po)
 for linkage in linkages:
     desc(linkage)
 
@@ -59,7 +60,7 @@ for linkage in linkages:
 po = ParseOptions(islands_ok=True, max_null_count=1, display_morphology=True, verbosity=1)
 sent = Sentence("Senin ne istediğini bilmiyorum", Dictionary('tr'), po)
 linkages = sent.parse()
-linkage_stat(sent, 'Turkish')
+linkage_stat(sent, 'Turkish', po)
 for linkage in linkages:
     desc(linkage)
 

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -294,6 +294,13 @@ class DBasicParsingTestCase(unittest.TestCase):
         linkage = self.parse_sent("This is a _regex_ive regex test")[0]
         self.assertEqual(linkage.word(4), '_regex_ive[!].a')
 
+    def test_timer_exhausted_exception(self):
+        self.po = ParseOptions(max_parse_time=1)
+        self.assertRaises(LG_TimerExhausted,
+                          self.parse_sent,
+                          "This should take more than one second to parse! " * 20,
+                          self.po)
+
 class ESATsolverTestCase(unittest.TestCase):
     def setUp(self):
         self.d, self.po = Dictionary(lang='en'), ParseOptions()

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -45,7 +45,7 @@ def setUpModule():
 # The tests are run in alphabetical order....
 #
 # First test: test the test framework itself ...
-class AAALinkTestCase(unittest.TestCase):
+class AALinkTestCase(unittest.TestCase):
     def test_link_display_with_identical_link_type(self):
         self.assertEqual(str(Link(None, 0, 'Left','Link','Link','Right')),
                          u'Left-Link-Right')
@@ -53,6 +53,10 @@ class AAALinkTestCase(unittest.TestCase):
     def test_link_display_with_identical_link_type2(self):
         self.assertEqual(str(Link(None, 0, 'Left','Link','Link*','Right')),
                          u'Left-Link-Link*-Right')
+
+class AAADictionaryTestCase(unittest.TestCase):
+    def test_open_nonexistent_dictionary(self):
+        self.assertRaises(LG_DictionaryError, Dictionary, 'No such language')
 
 class BParseOptionsTestCase(unittest.TestCase):
     def test_setting_verbosity(self):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -17,8 +17,9 @@ for v in 'PYTHONPATH', 'srcdir', 'LINK_GRAMMAR_DATA':
 #===
 
 
-from linkgrammar import Sentence, Linkage, ParseOptions, Link, Dictionary, \
-                        Clinkgrammar as clg
+from linkgrammar import (Sentence, Linkage, ParseOptions, Link, Dictionary,
+                         LG_DictionaryError, LG_TimerExhausted,
+                         Clinkgrammar as clg)
 
 
 # Show the location and version of the bindings modules

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -384,6 +384,10 @@ class Linkage(object):
     def constituent_tree(self, mode=1):
         return clg.linkage_print_constituent_tree(self._obj, mode)
 
+
+class LG_TimerExhausted(Exception):
+    pass
+
 class Sentence(object):
     """
     sent = Sentence("This is a test.", Dictionary(), ParseOptions())
@@ -436,6 +440,8 @@ class Sentence(object):
             self.sent = sent
             self.num = 0
             self.rc = clg.sentence_parse(sent._obj, sent.parse_options._obj)
+            if clg.parse_options_timer_expired(sent.parse_options._obj):
+                raise LG_TimerExhausted()
 
         def __nonzero__(self):
             """Return False if there was a split or parse error; else return True."""

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -264,6 +264,7 @@ class Dictionary(object):
     def __init__(self, lang='en'):
         self._obj = clg.dictionary_create_lang(lang)
         if not self._obj:
+            # We should get the error message from the library.
             raise LG_DictionaryError('Error: Failed to open dictionary {!r}'.format(lang))
 
     def __str__(self):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -13,7 +13,8 @@ except ImportError:
     import clinkgrammar as clg
 
 Clinkgrammar = clg
-__all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence', 'Clinkgrammar']
+__all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence',
+           'LG_DictionaryError', 'LG_TimerExhausted', 'Clinkgrammar']
 
 
 class ParseOptions(object):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -1,9 +1,8 @@
 # -*- coding: utf8 -*-
 """
-High-level Python bindings build on top of the low-level
-C API (clinkgrammar)
+High-level Python bindings build on top of the low-level C API (clinkgrammar)
 See http://www.abisource.com/projects/link-grammar/api/index.html to get
-more information about C API
+more information about C API.
 """
 
 try:
@@ -69,7 +68,11 @@ class ParseOptions(object):
     @property
     def linkage_limit(self):
         """
-        This parameter determines the maximum number of linkages that are considered in post-processing. If more than linkage_limit linkages found, then a random sample of linkage_limit is chosen for post-processing. When this happen a warning is displayed at verbosity levels bigger than 1.
+        This parameter determines the maximum number of linkages that are
+        considered in post-processing. If more than linkage_limit linkages
+        found, then a random sample of linkage_limit is chosen for
+        post-processing. When this happen a warning is displayed at verbosity
+        levels bigger than 1.
         """
         return clg.parse_options_get_linkage_limit(self._obj)
 
@@ -457,7 +460,7 @@ class Sentence(object):
             self.num += 1
             return linkage
 
-        __next__= next              # Account python3
+        __next__ = next             # Account python3
 
     def parse(self):
         return self.sentence_parse(self)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -449,7 +449,7 @@ class Sentence(object):
             return self
 
         def __len__(self):
-            return clg.sentence_num_linkages_found(self.sent._obj)
+            return clg.sentence_num_valid_linkages(self.sent._obj)
 
         def next(self):
             if self.num == clg.sentence_num_valid_linkages(self.sent._obj):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -9,7 +9,7 @@ try:
     #pylint: disable=no-name-in-module
     import linkgrammar.clinkgrammar as clg
 except ImportError:
-    #pylint: import-error
+    #pylint: disable=import-error
     import clinkgrammar as clg
 
 Clinkgrammar = clg

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -752,8 +752,10 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
 	      (int (*)(const void *, const void *))opts->cost_model.compare_fn);
 
 #ifdef DEBUG
-	/* num_linkages_post_processed sanity check (ONLY). */
+	/* Skip in case of a timeout - sent->lnkages may be inconsistent then. */
+	if (!resources_exhausted(opts->resources))
 	{
+		/* num_linkages_post_processed sanity check (ONLY). */
 		size_t in;
 		size_t N_linkages_post_processed = 0;
 		for (in=0; in < sent->num_linkages_alloced; in++)


### PR DESCRIPTION
Main fixes:
1. Add LG_TimerExpired exception.
2. Add tests for it and for the previously added LG_DictionaryError exception.
3. Avoid assertion failure in debug mode if a timeout happens during the PP.

Note that now tests.py prints
```
link-grammar: Error: Could not open dictionary No such language/4.0.dict
```
This is currently unavoidable because this error is printed unconditionally when a dict is not found.

Related comment:
In order that the library will be able to get embedded seamlessly in applications (like grammar checkers or GUIs) it should not print such error messages, but instead only provide an error indication, and put the error in a variable (a per-thread variable if multi-threaded), to be retrieved by a new function link-grammar_error(). Such an arrangement is found in other libraries,.

Linas, if implementing such an error mechanism seems to you fine, I will send a PR for that.
I can provide a compatibility feature to prevent the need to rewrite existing applications  in order to print the error messages. So link-parser.c will not need a rewrite in order to report such error messages.