### PR TITLE
Fix buffer overflow on #include of an empty file

### DIFF
--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -792,13 +792,14 @@ char *get_file_contents(const char * dict_name)
 
 	/* Now, read the whole file. */
 	p = contents;
+	*p = '\0';
 	left = tot_size + 7;
 	while (1)
 	{
 		char *rv = fgets(p, left, fp);
 		if (NULL == rv || feof(fp))
 			break;
-		while (*p != 0x0) { p++; left--; }
+		while (*p != '\0') { p++; left--; }
 		if (left < 0)
 			 break;
 	}


### PR DESCRIPTION
When reading an empty file, fgets returns NULL without writing to the
buffer. So the buffer contains garbage.

The get_file_contents() function then just returns a pointer to the
buffer, and the caller tries to analyze this garbage. The result
depends on actual garbage.

Fix it by assigning '\0' to the first character of the buffer.
(Also change 0x0 to '\0' for local code consistency.)