### PR TITLE
Dictionary "UTF8 char is too long": Change exit to error indication

### DIFF
--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -608,9 +608,7 @@ dictionary_six_str(const char * lang,
 	return dict;
 
 failure:
-	string_set_delete(dict->string_set);
-	if (dict->affix_table) xfree(dict->affix_table, sizeof(struct Dictionary_s));
-	xfree(dict, sizeof(struct Dictionary_s));
+	dictionary_delete(dict);
 	return NULL;
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1915,7 +1915,12 @@ static bool read_entry(Dictionary dict)
 	return true;
 
 syntax_error:
-	free_lookup(dn);
+	while (dn != NULL)
+	{
+		dnx = dn->left;
+		free_dict_node(dn);
+		dn = dnx;
+	}
 	return false;
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -427,8 +427,8 @@ static utf8char get_character(Dictionary dict, int quote_mode)
 			uc[i] = c;
 			i++;
 		}
-		dict_error(dict, "Fatal Error: UTF8 char is too long");
-		exit(1);
+		dict_error(dict, "UTF8 char is too long");
+		return NULL;
 	}
 	uc[0] = 0x0;
 	return uc;
@@ -484,7 +484,12 @@ static bool link_advance(Dictionary dict)
 		return true;
 	}
 
-	do { c = get_character(dict, false); } while (lg_isspace(c[0]));
+	do
+	{
+		c = get_character(dict, false);
+		if (NULL == c) return false;
+	}
+	while (lg_isspace(c[0]));
 
 	quote_mode = false;
 
@@ -547,6 +552,7 @@ static bool link_advance(Dictionary dict)
 			}
 		}
 		c = get_character(dict, quote_mode);
+		if (NULL == c) return false;
 	}
 	return true;
 }


### PR DESCRIPTION
With this fix, instead of existing on this error, dictionary_create*() just fails, similarly to other dictionary errors.