### PR TITLE
Adapt Wordgraph display for OSX+Win

### DIFF
--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -955,6 +955,16 @@ void wordgraph_show(Sentence sent, const char *modestr)
 		}
 	}
 
+#if _WIN32
+#define EXITKEY "ALT-F4"
+#elif __APPLE__
+#define EXITKEY "⌘-Q"
+#endif
+
+#ifdef EXITKEY
+	printf("Press "EXITKEY" in the graphical display window to continue\n");
+#endif
+
 #if !defined HAVE_FORK || defined POPEN_DOT
 	x_popen((mode & WGR_X11)? POPEN_DOT_CMD : POPEN_DOT_CMD_NATIVE, wgds);
 #else

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -29,6 +29,10 @@
 #include "print-util.h"
 #include "wordgraph.h"
 
+#ifdef __APPLE__
+#define POPEN_DOT
+#endif /* __APPLE__ */
+
 /* === Gword utilities === */
 /* Many more Gword utilities, that are used only in particular files,
  * are defined in these files statically. */
@@ -758,6 +762,13 @@ static void wordgraph_show_cancel(void)
 #    define WGJPG "%TEMP%\\lg-wg.jpg"
 #    define POPEN_DOT_CMD_NATIVE \
 				DOT_COMMAND" -Tjpg>"WGJPG"&"IMAGE_VIEWER" "WGJPG"&del "WGJPG
+#  elif __APPLE__
+#    ifndef IMAGE_VIEWER
+#      define IMAGE_VIEWER "open -W"
+#    endif
+#    define WGJPG "$TMPDIR/lg-wg.jpg"
+#    define POPEN_DOT_CMD_NATIVE \
+				DOT_COMMAND" -Tjpg>"WGJPG";"IMAGE_VIEWER" "WGJPG";rm "WGJPG
 #  else
 #    define POPEN_DOT_CMD_NATIVE POPEN_DOT_CMD
 #  endif

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -750,16 +750,16 @@ static void wordgraph_show_cancel(void)
 #define DOT_FILENAME "lg-wg.vg"
 
 #define POPEN_DOT_CMD DOT_COMMAND" "DOT_DRIVER
-#ifndef POPEN_DOT_CMD_WINDOWS
+#ifndef POPEN_DOT_CMD_NATIVE
 #  ifdef _WIN32
 #    ifndef IMAGE_VIEWER
 #      define IMAGE_VIEWER "rundll32 PhotoViewer,ImageView_Fullscreen"
 #    endif
 #    define WGJPG "%TEMP%\\lg-wg.jpg"
-#    define POPEN_DOT_CMD_WINDOWS \
+#    define POPEN_DOT_CMD_NATIVE \
 				DOT_COMMAND" -Tjpg>"WGJPG"&"IMAGE_VIEWER" "WGJPG"&del "WGJPG
 #  else
-#    define POPEN_DOT_CMD_WINDOWS POPEN_DOT_CMD
+#    define POPEN_DOT_CMD_NATIVE POPEN_DOT_CMD
 #  endif
 #endif
 
@@ -945,7 +945,7 @@ void wordgraph_show(Sentence sent, const char *modestr)
 	}
 
 #if !defined HAVE_FORK || defined POPEN_DOT
-	x_popen((mode & WGR_X11)? POPEN_DOT_CMD : POPEN_DOT_CMD_WINDOWS, wgds);
+	x_popen((mode & WGR_X11)? POPEN_DOT_CMD : POPEN_DOT_CMD_NATIVE, wgds);
 #else
 	{
 		assert(NULL != gvf_name, "DOT filename not initialized (#define mess?)");


### PR DESCRIPTION
Currently, it doesn't work on OS X because uses X11 driver. This fix makes it working without X11, because it is not installed by default.

The usage is the same as on Linux and Windows:
```
link-parser -test=wg
```
(The intention is that -test=wg:x will use the X11 driver - as on Windows, but this has not been tested).

As on Windows, there is a need to install **graphviz**.

Like on Windows, when displaying the Wordgraph, link-parser stalls until the graphical display window is closed. A message "To continue, press ... in the graphical display window" has been added  for both OS X and Windows (when "..." is the key to press).