### PR TITLE
Fix a bad bug that apparently doesn't have any impact

### DIFF
--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -193,7 +193,7 @@ static bool con_uc_eq(const Connector *c1, const Connector *c2)
 {
 	if (string_set_cmp(c1->string, c2->string)) return true;
 	if (c1->hash != c2->hash) return false;
-	if (c1->uc_length != c1->uc_length) return false;
+	if (c1->uc_length != c2->uc_length) return false;
 
 	/* We arrive here for less than 50% of the cases for "en" and
 	 * less then 20% of the cases for "ru", and, in practice, the


### PR DESCRIPTION
The intention of the offending code line is to compares the lengths of the uppercase part of two connectors. If they are not the same, it means the connectors don't match.

However, there is a bug and a variable is compared to itself (gcc 6.2.0 detected that, while 5.3.1 didn't). This means that a non-equal uppercase connectors could leak to the rest of the code, which has a comparison assuming they have an equal length.

However, it turned out that in practice they always have an equal length. It seems this is because the  hashing is very good and it just happens that connectors with different uppercase length have never the same hash value.