### PR TITLE
Dual python by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,12 @@ lg_*_wrap.cc
 Makefile.in
 Makefile
 missing
-m4
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+m4/._*.m4
 .pc
 patches
 py-compile

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST =            \
 	docker/docker-parser/Dockerfile        \
 	docker/docker-python/Dockerfile        \
 	docker/docker-server/Dockerfile        \
+	m4/varcheckpoint.m4
 	msvc14/LGlib-features.props            \
 	msvc14/LinkGrammarExe.vcxproj          \
 	msvc14/LinkGrammarExe.vcxproj.filters  \

--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -18,14 +18,22 @@ if HAVE_PERL
 SUBDIRS += perl
 endif
 
-if HAVE_PYTHON
-SUBDIRS += python python-examples
+if HAVE_PYTHON2
+SUBDIRS += python
 endif
 
 if HAVE_PYTHON3
-SUBDIRS += python3 python-examples
+SUBDIRS += python3
 endif
 
+# Add python-examples only once - else make enters it twice.
+if HAVE_PYTHON2
+SUBDIRS += python-examples
+else !HAVE_PYTHON2
+if HAVE_PYTHON3
+SUBDIRS += python-examples
+endif HAVE_PYTHON3
+endif !HAVE_PYTHON2
 
 EXTRA_DIST =                              \
    README                                 \

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -13,8 +13,8 @@ BUILT_PY_SOURCES = $(top_builddir)/bindings/python/clinkgrammar.py
 # directory "link-grammar".  Turns out python cannot tolerate dashes.
 # Thus, typically, it will install into
 # /usr/local/lib/python2.7/dist-packages/linkgrammar (without the dash)
-pkgpythondir=$(pythondir)/linkgrammar
-pkgpyexecdir=$(pythondir)/linkgrammar
+pkgpythondir=$(python2dir)/linkgrammar
+pkgpyexecdir=$(python2dir)/linkgrammar
 
 # Files that get installed in $pkgpythondir
 pkgpython_PYTHON =                                 \
@@ -52,7 +52,7 @@ _clinkgrammar_la_SOURCES = $(BUILT_C_SOURCES) $(SWIG_SOURCES)
 # $(top_builddir) to pick up autogen'ed link-grammar/link-features.h
 _clinkgrammar_la_CPPFLAGS =       \
    $(SWIG_PYTHON_CPPFLAGS)        \
-   $(PYTHON_CPPFLAGS)             \
+   $(PYTHON2_CPPFLAGS)            \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
@@ -64,9 +64,9 @@ AVOID_VERSION = -avoid-version
 endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \
-    $(PYTHON_LDFLAGS) -module -no-undefined
+    $(PYTHON2_LDFLAGS) -module -no-undefined
 _clinkgrammar_la_LIBADD =                         \
-    $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
+    $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON2_LIBS)
 
 
 EXTRA_DIST =         \

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -13,11 +13,11 @@ BUILT_PY_SOURCES = $(top_builddir)/bindings/python3/clinkgrammar.py
 # directory "link-grammar".  Turns out python cannot tolerate dashes.
 # Thus, typically, it will install into
 # /usr/local/lib/python3.4/dist-packages/linkgrammar (without the dash)
-pkgpython3dir=$(pythondir)/linkgrammar
-pkgpyexecdir=$(pythondir)/linkgrammar
+pkgpythondir=$(python3dir)/linkgrammar
+pkgpyexecdir=$(python3dir)/linkgrammar
 
 # Files that get installed in $pkgpythondir
-pkgpython3_PYTHON =                                 \
+pkgpython_PYTHON =                                 \
    ../../bindings/python/linkgrammar.py             \
    $(top_builddir)/bindings/python3/__init__.py     \
    $(top_builddir)/bindings/python3/clinkgrammar.py
@@ -25,7 +25,7 @@ pkgpython3_PYTHON =                                 \
 
 # Apparently, anaconda does not work without this!?
 # This seems wrong and lme to me, but see issue #298
-pkgpypathdir=$(pythondir)
+pkgpypathdir=$(python3dir)
 pkgpypath_PYTHON =                                 \
    linkgrammar.pth
 
@@ -58,7 +58,7 @@ _clinkgrammar_la_SOURCES = $(BUILT_C_SOURCES) $(SWIG_SOURCES)
 # $(top_builddir) to pick up autogen'ed link-grammar/link-features.h
 _clinkgrammar_la_CPPFLAGS =       \
    $(SWIG_PYTHON_CPPFLAGS)        \
-   $(PYTHON_CPPFLAGS)             \
+   $(PYTHON3_CPPFLAGS)            \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
@@ -70,12 +70,12 @@ AVOID_VERSION = -avoid-version
 endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \
-    $(PYTHON_LDFLAGS) -module -no-undefined
+    $(PYTHON3_LDFLAGS) -module -no-undefined
 _clinkgrammar_la_LIBADD =                         \
-    $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON_LIBS)
+    $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON3_LIBS)
 
 
 EXTRA_DIST =         \
    README.md         \
-   linkgrammar.pth	\
+   linkgrammar.pth   \
    __init__.py.in

--- a/configure.ac
+++ b/configure.ac
@@ -736,19 +736,15 @@ PythonFound=no
 if test "x$enable_python_bindings" = "xyes"; then
 	AM_PATH_PYTHON(2.6, [PythonFound=yes], [PythonFound=no])
 	AX_PYTHON_DEVEL(>= '2.6')
-	AM_CONDITIONAL(HAVE_PYTHON, test x${PythonFound} = xyes)
-else
-	AM_CONDITIONAL(HAVE_PYTHON, false)
 fi
+AM_CONDITIONAL(HAVE_PYTHON, test x${PythonFound} = xyes)
 
 Python3Found=no
-if test "x$enable_python3_bindings" = "xyes"; then
+if test "x$enable_python_bindings" = "xyes"; then
 	AM_PATH_PYTHON(3.4, [Python3Found=yes], [Python3Found=no])
 	AX_PYTHON_DEVEL(>= '3.4')
-	AM_CONDITIONAL(HAVE_PYTHON3, test x${Python3Found} = xyes)
-else
-	AM_CONDITIONAL(HAVE_PYTHON3, false)
 fi
+AM_CONDITIONAL(HAVE_PYTHON3, test x${Python3Found} = xyes)
 
 # ====================================================================
 # check compiler flags

--- a/configure.ac
+++ b/configure.ac
@@ -247,16 +247,20 @@ AC_ARG_ENABLE( java-bindings,
   [],
   [enable_java_bindings=yes])
 
+# Python is now enabled by default
+define([PYTHON2_REQUIRED], [2.6])
+define([PYTHON3_REQUIRED], [3.4])
 AC_ARG_ENABLE( python-bindings,
-  [  --enable-python-bindings  create python 2.7 bindings to the link-grammar library],
-  [],
-  [enable_python_bindings=no]
-)
-
-AC_ARG_ENABLE( python3-bindings,
-  [  --enable-python3-bindings  create python 3.4 bindings to the link-grammar library],
-  [],
-  [enable_python3_bindings=no]
+	[  --disable-python-bindings  disable build of python bindings
+                          (default is enabled)
+  --enable-python-bindings[[=ARG]]
+                          create python bindings to the link-grammar library
+                          (minimum versions: PYTHON2_REQUIRED and PYTHON3_REQUIRED).
+                          ARG=yes (default): create both python 2 & 3 bindings
+                          ARG=2: create only python 2 bindings
+                          ARG=3: create only python 3 bindings],
+                          [enable_python_bindings="${enableval:-yes}"],
+                          [enable_python_bindings=yes]
 )
 
 # Perl now disabled by default

--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,7 @@ AC_ARG_ENABLE( perl-bindings,
 AC_ARG_ENABLE( sat-solver,
 
    [  --disable-sat-solver    disable use of the Boolean SAT parser (default is enabled)
-  --enable-sat-solver=ARG
+  --enable-sat-solver=[[ARG]]
                           enable use of the Boolean SAT parser
                           ARG=yes (default): Use the system minisat library if possible
                           ARG=bundled: Use the bundled minisat library],

--- a/configure.ac
+++ b/configure.ac
@@ -71,13 +71,13 @@ AC_LINK_IFELSE(
 AC_MSG_RESULT(yes)
 AC_DEFINE([HAVE_LOCALE_T_IN_LOCALE_H], 1, [Define to 1 if locale_t is defined in locale.h]),
 AC_MSG_RESULT(no)
-  AC_MSG_CHECKING(for locale_t in xlocale.h)
-  AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM([#include <xlocale.h>], [locale_t lt = NULL])],
-  AC_MSG_RESULT(yes)
-  AC_DEFINE([HAVE_LOCALE_T_IN_XLOCALE_H], 1, [Define to 1 if locale_t is defined in xlocale.h]),
-  AC_MSG_RESULT(no)
-  )
+	AC_MSG_CHECKING(for locale_t in xlocale.h)
+	AC_LINK_IFELSE(
+	[AC_LANG_PROGRAM([#include <xlocale.h>], [locale_t lt = NULL])],
+	AC_MSG_RESULT(yes)
+	AC_DEFINE([HAVE_LOCALE_T_IN_XLOCALE_H], 1, [Define to 1 if locale_t is defined in xlocale.h]),
+	AC_MSG_RESULT(no)
+	)
 )
 
 dnl Check for specific OSs
@@ -242,7 +242,6 @@ AM_CONDITIONAL(WITH_PTHREADS, test x${enable_pthreads} = xyes)
 
 # ====================================================================
 # Java now enabled by default
-
 AC_ARG_ENABLE( java-bindings,
   [  --disable-java-bindings disable build of java bindings (default is enabled)],
   [],
@@ -405,7 +404,7 @@ AC_CHECK_HEADER([sqlite3.h], [SQLiteFound=yes], SQLiteFound=no)
 # If sqlite3 and pkg-config are not found on MacOS, then
 # recommend that user install MacPorts http://www.macports.org/
 if test "x${SQLiteFound}" = "xyes"; then
- 	PKG_CHECK_MODULES(SQLITE3, sqlite3 >= 3.0.0, [SQLiteFound=yes], [SQLiteFound=no])
+	PKG_CHECK_MODULES(SQLITE3, sqlite3 >= 3.0.0, [SQLiteFound=yes], [SQLiteFound=no])
 fi
 
 # Don't set the CPPFLAGS unless we can find the library too.

--- a/configure.ac
+++ b/configure.ac
@@ -273,10 +273,12 @@ AC_ARG_ENABLE( perl-bindings,
 
 AC_ARG_ENABLE( sat-solver,
 
-   [  --disable-sat-solver    disable use of the Boolean SAT parser (default is enabled)
+   [  --disable-sat-solver    disable use of the Boolean SAT parser
+                          (default is enabled)
   --enable-sat-solver=[[ARG]]
                           enable use of the Boolean SAT parser
-                          ARG=yes (default): Use the system minisat library if possible
+                          ARG=yes (default): Use the system minisat library
+                          if possible
                           ARG=bundled: Use the bundled minisat library],
   [if test "x$enableval" = xbundled; then
 		use_minisat_bundled_library=yes

--- a/configure.ac
+++ b/configure.ac
@@ -734,23 +734,76 @@ fi
 
 # ===================================================================
 # Find python things.
-#
-# Since AX_PYTHON_DEVEL will hard-fail if python-devel is not installed,
-# it is up to the user to explicitly ask for python, if they want it.
 
-PythonFound=no
-if test "x$enable_python_bindings" = "xyes"; then
-	AM_PATH_PYTHON(2.6, [PythonFound=yes], [PythonFound=no])
-	AX_PYTHON_DEVEL(>= '2.6')
+dnl AX_PYTHON_DEVEL uses AC_MSG_ERROR in case it doesn't find things.
+dnl Temporarily make AC_MSG_ERROR a soft error (to be restored by popdef()).
+pushdef([AC_MSG_ERROR])
+define([AC_MSG_ERROR],
+	lg_python_unusable=yes
+	[AC_MSG_NOTICE([$1])])
+
+Python2Found=no # This and the next variables should persist the Python2 check
+PYTHON2= PYTHON2_CPPFLAGS= PYTHON2_LIBS= PYTHON2_LDFLAGS= python2dir=
+AC_VARNAMES_CHECKPOINT # Remember the current variable names
+
+if test "x$enable_python_bindings" = xyes -o "x$enable_python_bindings" = x2; then
+	AM_PATH_PYTHON(PYTHON2_REQUIRED, [Python2Found=yes], [Python2Found=no])
+	AX_PYTHON_DEVEL(>= 'PYTHON2_REQUIRED')
+	test -n "$lg_python_unusable" && Python2Found=no
+	if test x$Python2Found = xyes; then
+		Python2Found=$PYTHON_VERSION
+		PYTHON2=$PYTHON
+		PYTHON2_CPPFLAGS=$PYTHON_CPPFLAGS
+		PYTHON2_LIBS=$PYTHON_LIBS
+		PYTHON2_LDFLAGS=$PYTHON_LDFLAGS
+		python2dir=$pythondir
+		AC_SUBST(PYTHON2_CPPFLAGS)
+		AC_SUBST(PYTHON2_LIBS)
+		AC_SUBST(PYTHON2_LDFLAGS)
+		AC_SUBST(python2dir)
+	fi
 fi
-AM_CONDITIONAL(HAVE_PYTHON, test x${PythonFound} = xyes)
+AC_VARNAMES_RESTORE    # Discard all the added variables
+AM_CONDITIONAL(HAVE_PYTHON2, test x$Python2Found != xno)
 
+PYTHON= # Search for another version.
 Python3Found=no
-if test "x$enable_python_bindings" = "xyes"; then
-	AM_PATH_PYTHON(3.4, [Python3Found=yes], [Python3Found=no])
-	AX_PYTHON_DEVEL(>= '3.4')
+if test "x$enable_python_bindings" = xyes -o "x$enable_python_bindings" = x3; then
+	AM_PATH_PYTHON(PYTHON3_REQUIRED, [Python3Found=yes], [Python3Found=no])
+	AX_PYTHON_DEVEL(>= 'PYTHON3_REQUIRED')
+	test -n "$lg_python_unusable" && Python3Found=no
+	if test x$Python3Found = xyes; then
+		Python3Found=$PYTHON_VERSION
+		#PYTHON3=$PYTHON
+		PYTHON3_CPPFLAGS=$PYTHON_CPPFLAGS
+		PYTHON3_LIBS=$PYTHON_LIBS
+		PYTHON3_LDFLAGS=$PYTHON_LDFLAGS
+		python3dir=$pythondir
+		AC_SUBST(PYTHON3_CPPFLAGS)
+		AC_SUBST(PYTHON3_LIBS)
+		AC_SUBST(PYTHON3_LDFLAGS)
+		AC_SUBST(python3dir)
+	fi
 fi
-AM_CONDITIONAL(HAVE_PYTHON3, test x${Python3Found} = xyes)
+AM_CONDITIONAL(HAVE_PYTHON3, test x$Python3Found != xno)
+
+# Python binary default for "make check" - $PYTHON2 if exists.
+# This is used for the definitions of the pre/post install tests.
+if test -n "$PYTHON2"; then
+	PYTHON=$PYTHON2
+	pythondir=$python2dir
+fi
+AC_SUBST(PYTHON)
+AC_SUBST(pythondir)
+
+# HAVE_PYTHON is redefined if we have both Python2 and Python3. This
+# generates a lot of compiler warnings. But we don't use it - so discard it.
+# Note: The v command allows to differentiate between the two flavors of sed.
+edit_in_place=-i
+sed v </dev/null 2>/dev/null || edit_in_place="-i ''"
+sed $edit_in_place '/HAVE_PYTHON/d' confdefs.h
+
+popdef([AC_MSG_ERROR])
 
 # ====================================================================
 # check compiler flags
@@ -907,7 +960,7 @@ $PACKAGE-$VERSION  build configuration settings
 	Swig interfaces generator:      ${SWIGfound}
 	Perl interfaces:                ${PerlFound}
 	Perl install location:          ${PERL_EXT_LIB}
-	Python2 interfaces:             ${PythonFound}
+	Python2 interfaces:             ${Python2Found}
 	Python3 interfaces:             ${Python3Found}
 	ASpell spell checker:           ${ASpellFound}
 	HunSpell spell checker:         ${HunSpellFound}

--- a/m4/varcheckpoint.m4
+++ b/m4/varcheckpoint.m4
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2016 Amir Plivatsky <amirpli@gmail.com>
+#
+
+# In configure.in, use as:
+#
+#   # AM_ABC sets cache variables that prevent using it again,
+#   # unless they are removed
+#   abc_persistent=  # to be included in the checkpoint below
+#   AM_VARNAMES_CHECKPOINT
+#   AM_ABC
+#   abc_persistent=$am_cv_abc
+#   AM_VARNAMES_RESTORE
+#   if test -n "$abc_persistent"; then
+#       ...
+#   fi
+#   AM_ABC
+
+# SYNOPSIS
+#
+#   AC_VARNAMES_CHECKPOINT
+#
+# DESCRIPTION
+#
+#   Save the current list of shell variables, to be restored later
+#   by AC_VARNAMES_RESTORE.
+#   Note that the filtering is not technically correct for eliminating the
+#   continuation lines of some theoretically possible multi-line variable
+#   values.
+#   For example, x='ab\ncd=\n' (when \n is a real newline) may cause troubles.
+#   For a general use, this has to be fixed. A fix is welcome.
+
+#serial 1
+
+AC_DEFUN([AC_VARNAMES_CHECKPOINT],
+[
+	am_varnames_checkpoint=`set | sed '/^[[a-zA-Z_]][[a-zA-Z0-9_]]*=/!d;s/=.*/\
+/;/'\''/d'`
+]
+)
+
+# SYNOPSIS
+#
+#   AC_VARNAMES_RESTORE
+#
+# DESCRIPTION
+#
+#   Restore the list of shell variable saved by AC_VARNAMES_CHECKPOINT.
+#   Variables that got created after its call get unset.
+#   See the above comment for a problem in the filter pattern.
+
+AC_DEFUN([AC_VARNAMES_RESTORE],
+[
+	if test -z "$am_varnames_checkpoint"; then
+		AC_MSG_ERROR([No prior variable checkpoint (already restored?)])
+
+	fi
+
+	am_varnames_curr=`set | sed '/^[[a-zA-Z_]][[a-zA-Z0-9_]]*=/!d;s/=.*/\
+/;/'\''/d'`
+	# A variable containing only a newline
+	NL='
+'
+	am_varnames_combined="$am_varnames_checkpoint${NL}$am_varnames_curr"
+	am_varnames_tounset=`echo "$am_varnames_combined" | sort | uniq -u`
+	for am_varname_tmp in $am_varnames_tounset
+	do
+		unset $am_varname_tmp
+	done
+	# Unset all the variables created between the calls to AC_VARNAMES_CHECKPOINT
+	# and AC_VARNAMES_RESTORE.
+	# Especially be careful to unset am_varnames_checkpoint in order to detect
+	# unmatched AC_VARNAMES_RESTORE calls.
+	unset am_varnames_checkpoint am_varnames_curr am_varnames_combined
+	unset am_varnames_tounset am_varname_tmp NL
+]
+)


### PR DESCRIPTION
See issue #419.

Main changes:
- Provide Python bindings by default, to both versions 2  & 3 (if instaleld).
- If one of them (or both) are not installed, no error happens.
- If it is desired to provide only bindings to one version, `--enable-python-bindings=N" can be used.

**FIXME**: If both versions cannot be configured, a configuration error should be generated unless `--disable-python-bindings` is given.

In order to configure both versions and one, **unusual** ways are used (maybe for the first time - I couldn't find any prior such implementations), involving these methods:
1. Since AM_PATH_PYTHON/ AX_PYTHON_DEVEL create cached variables and others that prevent using them again, a mechanism is introduced to forget them. This is a general idea for which I couldn't find any macro implementation, so I included it as general autoconf m4 macros in `m4/varcheckpoint.m4`.
2. Since AX_PYTHON_DEVEL hard fails if the Python version it tries to detect doesn't cannot be configured, AC_MSG_ERROR is temporarily converted to a "**soft error**".
3. Since AX_PYTHON_DEVEL defines HAVE_PYTHON, a redefinition problem happens if both versions are configured. The solution is to discard it from `confdefs.h`, since this definition is not used.

**FIXME?** `m4` was in `.gitignore`. But I have created `m4/varcheckpoint.m4` which cannot be ignored. So I ignored instead the other files in `m4`. However, some other files can be added there automagically and not be ignored. Maybe it is better to ignore `m4` and just unignore `m4/varcheckpoint.m4`.
