### PR TITLE
OS X: Remove an incompatible installcheck printout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,7 @@ case "$host" in
     ;;
 esac
 AC_MSG_RESULT([$apple_osx])
+AM_CONDITIONAL(OS_X, test "x$apple_osx" = "xyes")
 
 # ====================================================================
 

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -43,7 +43,9 @@ endif
 # Note the "cd .libs" - it ensures that it will not find "../data".
 # To run these checks, issue "make installcheck" from a regular user.
 installcheck-local:
+if !OS_X
 	$(AM_V_at)echo; echo -n 'Location of '; cd .libs; whereis -b link-parser; echo
+endif !OS_X
 	$(AM_V_at)cd .libs; [ "`which link-parser`" == $(bindir)/link-parser ] || \
 		{ echo "Incorrect location for link-parser: `which link-parser`"; exit 1; }
 	$(AM_V_at)cd .libs; for d in . .. ../data ./data; do \


### PR DESCRIPTION
Apple mangled "whereis" to the point that it is not actually functional
and cannot be used here in any form. BTW, shell "echo" there doesn't
support -n, but /bin/echo could be used instead if this was the only
problem here.