### PR TITLE
Fixes for Cygwin

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,9 +30,13 @@ libtoolize --force --copy || {
 
 # Produce aclocal.m4, so autoconf gets the automake macros it needs
 # 
-echo "Creating aclocal.m4: aclocal $ACLOCAL_FLAGS"
+case `uname` in
+    CYGWIN*)
+        include_dir='-I m4' # Needed for Cygwin only.
+esac
+echo "Creating aclocal.m4: aclocal $include_dir $ACLOCAL_FLAGS"
 
-aclocal $ACLOCAL_FLAGS 2>> autogen.err
+aclocal $include_dir $ACLOCAL_FLAGS 2>> autogen.err
 
 # Produce all the `GNUmakefile.in's and create neat missing things
 # like `install-sh', etc.

--- a/configure.ac
+++ b/configure.ac
@@ -177,6 +177,7 @@ fi
 # is used there instead, but _BSD_SOURCE and _SVID_SOURCE can still be
 # specified (no effect). So just add it.
 CFLAGS="${CFLAGS} -D_DEFAULT_SOURCE"
+CXXFLAGS="${CXXFLAGS} -D_DEFAULT_SOURCE"
 
 # ====================================================================
 # Debugging

--- a/mingw/README.Cygwin
+++ b/mingw/README.Cygwin
@@ -31,9 +31,9 @@ Configuring
   POSIX regex for Windows. The library basename must b:e "libregex". The
   -host value is for compiling for 64-bits.
 
-  The SAT solver cannot be enabled for now due to a missing definition in
-the build system. Python bindings fail because it currently tries to use the Cygwin Python
-  system. More development work is needed on these.
+  The SAT solver cannot be enabled for now due to a missing definition in the
+  build system. Python bindings fail because it currently tries to use the
+  Cygwin Python system. More development work is needed on these.
 
   (The Java bindings has not been tested in this version. Most probably the
   way described in README.MSYS can be used.)


### PR DESCRIPTION
Main fixes:
1. Workaround a problem of not using the new m4/varcheckpoint.m4 (a problem unique to Cygwin).
2. The just-introduced Cygwin 2.6.0 implements `locate_t`. However, it needs a compatibility definition in order to expose it properly. It miss causes a problem in the C++ code since it included utilities.h, in which `locale_t` is mentioned. Fix it by adding `-D_DEFAULT_SOURCE` also to the C++ flags.

FIXME: Rework the C/C++ configuration flags.

There are two problems in the test of Cygwin. I will open an issue for that.
