### PR TITLE
Remove unneeded include files

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,9 +30,13 @@ libtoolize --force --copy || {
 
 # Produce aclocal.m4, so autoconf gets the automake macros it needs
 # 
-echo "Creating aclocal.m4: aclocal $ACLOCAL_FLAGS"
+case `uname` in
+    CYGWIN*)
+        include_dir='-I m4' # Needed for Cygwin only.
+esac
+echo "Creating aclocal.m4: aclocal $include_dir $ACLOCAL_FLAGS"
 
-aclocal $ACLOCAL_FLAGS 2>> autogen.err
+aclocal $include_dir $ACLOCAL_FLAGS 2>> autogen.err
 
 # Produce all the `GNUmakefile.in's and create neat missing things
 # like `install-sh', etc.

--- a/configure.ac
+++ b/configure.ac
@@ -178,6 +178,7 @@ fi
 # is used there instead, but _BSD_SOURCE and _SVID_SOURCE can still be
 # specified (no effect). So just add it.
 CFLAGS="${CFLAGS} -D_DEFAULT_SOURCE"
+CXXFLAGS="${CXXFLAGS} -D_DEFAULT_SOURCE"
 
 # ====================================================================
 # Debugging

--- a/link-grammar/build-disjuncts.h
+++ b/link-grammar/build-disjuncts.h
@@ -11,6 +11,9 @@
 /*                                                                       */
 /*************************************************************************/
 
+#ifndef _LINKGRAMMAR_BUILD_DISJUNCTS_H
+#define _LINKGRAMMAR_BUILD_DISJUNCTS_H
+
 #include "api-types.h"
 #include "structures.h"
 
@@ -23,4 +26,6 @@ unsigned int count_disjunct_for_dict_node(Dict_node *dn);
 #ifdef DEBUG
 void prt_exp(Exp *, int);
 void prt_exp_mem(Exp *, int);
-#endif
+#endif /* DEBUG */
+
+#endif /* _LINKGRAMMAR_BUILD_DISJUNCTS_H */

--- a/link-grammar/corpus/corpus.h
+++ b/link-grammar/corpus/corpus.h
@@ -11,11 +11,12 @@
 #ifndef _LINKGRAMMAR_CORPUS_H
 #define _LINKGRAMMAR_CORPUS_H
 
-#include "../api-types.h"
 #include "../link-includes.h"
-#include "../utilities.h"
 
 #ifdef USE_CORPUS
+
+#include "../api-types.h"
+#include "../utilities.h"
 
 Corpus * lg_corpus_new(void);
 void lg_corpus_delete(Corpus *);
@@ -37,10 +38,10 @@ void lg_sense_delete(Linkage);
 
 static inline void lg_corpus_score(Linkage l) {}
 static inline void lg_corpus_linkage_senses(Linkage l) {}
-static inline Sense * lg_get_word_sense(Linkage lkg, WordIdx word) { return NULL; }
-static inline Sense * lg_sense_next(Sense *s ) {return NULL; }
-static inline const char * lg_sense_get_sense(Sense *s) { return NULL; }
-static inline double lg_sense_get_score(Sense *s) { return 0.0; }
+static inline void * lg_get_word_sense(Linkage lkg, WordIdx word) { return NULL; }
+static inline void * lg_sense_next(void *s) {return NULL; }
+static inline const char * lg_sense_get_sense(void *s) { return NULL; }
+static inline double lg_sense_get_score(void *s) { return 0.0; }
 static inline double lg_corpus_disjunct_score(Linkage linkage, WordIdx w) { return 998.0; }
 #endif /* USE_CORPUS */
 

--- a/link-grammar/corpus/corpus.h
+++ b/link-grammar/corpus/corpus.h
@@ -3,7 +3,7 @@
  *
  * Data for corpus statistics, used to provide a parse ranking
  * to drive the SAT solver, as well as parse ranking with the
- * ordinary solver. 
+ * ordinary solver.
  *
  * Copyright (c) 2008, 2009 Linas Vepstas <linasvepstas@gmail.com>
  */

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -1,8 +1,7 @@
 #include "util.hpp"
 
 extern "C" {
-#include "api-structures.h"
-#include "structures.h"
+#include "utilities.h"
 #include "linkage.h"
 };
 

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -3,8 +3,6 @@
 
 extern "C" {
 #include "link-includes.h"
-#include "api-structures.h"
-#include "structures.h"
 #include "disjunct-utils.h"
 }
 

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -20,8 +20,6 @@
 #include "api-structures.h"
 #include "dict-structures.h"  /* For Exp, Exp_list */
 #include "histogram.h"  /* Count_bin */
-#include "utilities.h"  /* Needed for inline defn in Windows */
-
 
 #define NEGATIVECOST -1000000
 /* This is a hack that allows one to discard disjuncts containing

--- a/mingw/README.Cygwin
+++ b/mingw/README.Cygwin
@@ -31,9 +31,9 @@ Configuring
   POSIX regex for Windows. The library basename must b:e "libregex". The
   -host value is for compiling for 64-bits.
 
-  The SAT solver cannot be enabled for now due to a missing definition in
-the build system. Python bindings fail because it currently tries to use the Cygwin Python
-  system. More development work is needed on these.
+  The SAT solver cannot be enabled for now due to a missing definition in the
+  build system. Python bindings fail because it currently tries to use the
+  Cygwin Python system. More development work is needed on these.
 
   (The Java bindings has not been tested in this version. Most probably the
   way described in README.MSYS can be used.)


### PR DESCRIPTION
A change in utilities.h currently causes recompilation of 39 files out of 51 C/C++ files.
This change reduces it to 37 files. But only 25 C/C++ files include utilities.h directly.
It means utilities.h is still indirectly included in 8 files.
I will try to further reduce it and some other includes.