### PR TITLE
configure sat-solver fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,9 +326,11 @@ if test "x$enable_sat_solver" = xyes; then
 			[ use_minisat_bundled_library=yes ]
 			[AC_MSG_NOTICE([No system minisat2 library found - using the bundled library])])
 
-		AC_CHECK_HEADER([minisat/core/Solver.h], [MINISAT_INCLUDES="$minisat_headers"],
-			[ use_minisat_bundled_library=yes ]
-			[AC_MSG_NOTICE([System minisat2 headers not found in $CPPFLAGS - using the bundled library])])
+		if test -z "$use_minisat_bundled_library"; then
+			AC_CHECK_HEADER([minisat/core/Solver.h], [MINISAT_INCLUDES="$minisat_headers"],
+				[ use_minisat_bundled_library=yes ]
+				[AC_MSG_NOTICE([System minisat2 headers not found in $CPPFLAGS - using the bundled library])])
+		fi
 	fi
 
 	dnl Note that the above checks may find the need to use the bundled library

--- a/configure.ac
+++ b/configure.ac
@@ -360,9 +360,8 @@ if test "x$enable_sat_solver" = xyes; then
 		AC_SUBST(ZLIB_CPPFLAGS)
 	fi
 
-	CPPFLAGS_SAVE=$CPPFLAGS
 	AC_LANG([C])
-	CPPFLAGS="$CPPFLAGS -DUSE_SAT_SOLVER=1"
+	CPPFLAGS="$CPPFLAGS_SAVE -DUSE_SAT_SOLVER=1"
 fi
 
 AM_CONDITIONAL(LIBMINISAT_BUNDLED, test -n "$use_minisat_bundled_library")

--- a/configure.ac
+++ b/configure.ac
@@ -357,11 +357,11 @@ if test "x$enable_sat_solver" = xyes; then
 
 		AC_SUBST(MINISAT_LIBS)
 		AC_SUBST(MINISAT_INCLUDES)
-		AC_SUBST(ZLIB_CPPFLAGS)
 	fi
 
 	AC_LANG([C])
 	CPPFLAGS="$CPPFLAGS_SAVE -DUSE_SAT_SOLVER=1"
+	AC_SUBST(ZLIB_CPPFLAGS)
 fi
 
 AM_CONDITIONAL(LIBMINISAT_BUNDLED, test -n "$use_minisat_bundled_library")


### PR DESCRIPTION
1. Bug fix: The minisat system header standard location is added  to CPPFLAGS for its existence check, but the original CPPFLAGS is not used afterwards. This leaves the headers in it even if the bundled library is finally used. I don't know if this is related to issue #442.
2.  Minor ZLIB_CPPFLAGS fix.
3. Cosmetic fix: Don't check for minisat headers if the minisat lib is not found.