### PR TITLE
configure minisat: Fix C++ function check problem on Gentoo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -344,7 +344,7 @@ if test "x$enable_sat_solver" = xyes; then
 		dnl Adapt to slight variations in minisat2.2 code.
 
 		# The function for making a literal can be Lit() or mkLit()
-		AC_CHECK_DECL([mkLit], [AC_DEFINE(HAVE_MKLIT, 1, [Define if exists])], [],
+		AC_CHECK_DECL([mkLit(Var, bool)], [AC_DEFINE(HAVE_MKLIT, 1, [Define if exists])], [],
 			[#include <minisat/core/Solver.h>]
 			[using namespace Minisat;]
 			[Solver x;])

--- a/link-grammar/minisat/Makefile.am
+++ b/link-grammar/minisat/Makefile.am
@@ -1,10 +1,6 @@
-VERSION=2.2.0
-MINISAT_VERSION_INFO=2:2:0
-
-libminisat_la_LDFLAGS = -version-info $(MINISAT_VERSION_INFO) -no-undefined
 libminisat_la_CPPFLAGS = $(ZLIB_CPPFLAGS)
 
-lib_LTLIBRARIES = libminisat.la
+noinst_LTLIBRARIES = libminisat.la
 
 libminisat_la_SOURCES = \
 	minisat/core/Dimacs.h \

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -26,14 +26,6 @@ if HAVE_SQLITE
 link_parser_LDADD += $(SQLITE3_LIBS)
 endif
 
-if WITH_SAT_SOLVER
-if LIBMINISAT_BUNDLED
-link_parser_LDADD  += $(top_builddir)/link-grammar/minisat/libminisat.la
-else !LIBMINISAT_BUNDLED
-link_parser_LDADD  += ${MINISAT_LIBS}
-endif !LIBMINISAT_BUNDLED
-endif WITH_SAT_SOLVER
-
 if WITH_VITERBI
 link_parser_LDADD += $(top_builddir)/viterbi/libvitacog.la
 link_parser_LDADD += $(LIBGC_LIBS)


### PR DESCRIPTION
(Solving issue #442.)

"AC_CHECK_DECL([mkLit], ..." uses the C++ code line "(void) mkLit;"
which causes the errro:
conftest.cpp:44:10: error: conversion to void cannot resolve address of overloaded function
   (void) mkLit;
(gcc version 4.9.3 (Gentoo 4.9.3 p1.5, pie-0.6.4))

Solve this by specifying its arguments.
(This function has only one definition. On higher gcc versions I didn't
encounter this problem.)
