### PR TITLE
configure Python: "python" can be Python3

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -6,8 +6,8 @@
 
 # Run tests.py if the user says 'make check'
 TESTS = tests.py
-AM_TESTS_ENVIRONMENT = python=$(PYTHON) \
-   PYTHONPATH=$(srcdir)/../python:../$${python\#\#*/}:../$${python\#\#*/}/.libs \
+AM_TESTS_ENVIRONMENT = \
+   PYTHONPATH=$(srcdir)/../python:../$(LG_PYDIR):../$(LG_PYDIR)/.libs \
    LINK_GRAMMAR_DATA=$(srcdir)/../../data; \
    export PYTHONPATH LINK_GRAMMAR_DATA;
 

--- a/configure.ac
+++ b/configure.ac
@@ -773,6 +773,12 @@ PYTHON2= PYTHON2_CPPFLAGS= PYTHON2_LIBS= PYTHON2_LDFLAGS= python2dir=
 AC_VARNAMES_CHECKPOINT # Remember the current variable names
 
 if test "x$enable_python_bindings" = xyes -o "x$enable_python_bindings" = x2; then
+	# Check whether "python" is actually Python3 (as on Gentoo and Arch). If so,
+	# if Python2 exists it is most probably "python2" (but surely not "python").
+	AC_MSG_CHECKING([whether "python" is Python3])
+	AM_PYTHON_CHECK_VERSION([python], [3],
+	   [AC_MSG_RESULT(yes); PYTHON=python2], [AC_MSG_RESULT(no)])
+
 	AM_PATH_PYTHON(PYTHON2_REQUIRED, [Python2Found=yes], [Python2Found=no])
 	AX_PYTHON_DEVEL(>= 'PYTHON2_REQUIRED')
 	test -n "$lg_python_unusable" && Python2Found=no
@@ -815,10 +821,15 @@ AM_CONDITIONAL(HAVE_PYTHON3, test x$Python3Found != xno)
 
 # Python binary default for "make check" - $PYTHON2 if exists.
 # This is used for the definitions of the pre/post install tests.
+# $LG_PYDIR is used to construct $PYTHONPATH.
 if test -n "$PYTHON2"; then
 	PYTHON=$PYTHON2
 	pythondir=$python2dir
+	LG_PYDIR=python
+else
+	LG_PYDIR=python3
 fi
+AC_SUBST(LG_PYDIR)
 AC_SUBST(PYTHON)
 AC_SUBST(PYTHON3)
 AC_SUBST(pythondir)


### PR DESCRIPTION
On Gentoo "python" is Python3, and as a result the Python2 bindings
doesn't work. Take that into account so the Python2 binary (if exists)
will be found.
