### PR TITLE
Cleanup

### DIFF
--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -20,7 +20,6 @@
 #include "spellcheck.h"
 #include "string-set.h"
 #include "structures.h"
-#include "utilities.h"
 #include "word-utils.h"
 #include "dict-sql/read-sql.h"
 #include "dict-file/read-dict.h"

--- a/link-grammar/disjuncts.c
+++ b/link-grammar/disjuncts.c
@@ -20,7 +20,6 @@
 #include "api-structures.h"
 #include "disjuncts.h"
 #include "structures.h"
-#include "utilities.h"
 
 /**
  * Print connector list to string.

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -20,11 +20,6 @@
 #include "structures.h"
 #include "api-structures.h"
 
-#if defined(_MSC_VER) && !defined(LINK_GRAMMAR_STATIC)
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT
-#endif
 
 /* ============================================================ */
 

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -20,9 +20,6 @@
 #include "structures.h"
 #include "api-structures.h"
 
-
-/* ============================================================ */
-
 static void verr_msg(err_ctxt *ec, severity sev, const char *fmt, va_list args)
 	GNUC_PRINTF(3,0);
 
@@ -164,5 +161,3 @@ const char *feature_enabled(const char * list, ...)
 
 	return NULL;
 }
-
-/* ============================================================ */

--- a/link-grammar/idiom.c
+++ b/link-grammar/idiom.c
@@ -18,7 +18,6 @@
 #include "idiom.h"
 #include "string-set.h"
 #include "structures.h"
-#include "utilities.h"
 
 /**
  * Find if a string signifies an idiom.

--- a/link-grammar/pp_knowledge.c
+++ b/link-grammar/pp_knowledge.c
@@ -18,13 +18,11 @@
  pp_lexer.h
 ***********************************************************************/
 
-#include "error.h"
 #include "externs.h"
 #include "pp_knowledge.h"
 #include "pp_lexer.h"
 #include "pp_linkset.h"
 #include "string-set.h"
-#include "utilities.h"
 
 #define D_PPK 10                       /* verbosity level for this file */
 #define PP_MAX_UNIQUE_LINK_NAMES 1024  /* just needs to be approximate */

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -22,7 +22,6 @@
 #include "string-set.h"
 #include "structures.h"
 #include "print.h"      /* needs structure.h */
-#include "utilities.h"
 #include "word-utils.h"
 
 #define LEFT_WALL_SUPPRESS ("Wd") /* If this connector is used on the wall, */

--- a/link-grammar/spellcheck-aspell.c
+++ b/link-grammar/spellcheck-aspell.c
@@ -19,7 +19,6 @@
 
 #include "link-includes.h"
 #include "spellcheck.h"
-#include "utilities.h"  /* For Win32 compatibility */
 
 #define ASPELL_LANG_KEY  "lang"
 /* FIXME: Move to a definition file (affix file?). */

--- a/link-grammar/spellcheck-hun.c
+++ b/link-grammar/spellcheck-hun.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include "link-includes.h"
 #include "spellcheck.h"
-#include "utilities.h"  /* For Win32 compatibility */
 
 #ifdef HAVE_HUNSPELL
 

--- a/link-grammar/spellcheck.h
+++ b/link-grammar/spellcheck.h
@@ -22,15 +22,11 @@ int spellcheck_suggest(void * chk, char ***sug, const char * word);
 void spellcheck_free_suggest(void * chk, char **sug, int size);
 
 #else
-
-#include "utilities.h"  /* For MSVC inline portability */
-
 static inline void * spellcheck_create(const char * lang) { return NULL; }
 static inline void spellcheck_destroy(void * chk) {}
 static inline bool spellcheck_test(void * chk, const char * word) { return false; }
 static inline int spellcheck_suggest(void * chk, char ***sug, const char * word) { return 0; }
 static inline void spellcheck_free_suggest(void * chk, char **sug, int size) {}
-
 #endif 
 
 #endif /* _SPELLCHECK_H */

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -34,7 +34,7 @@
 
    String_set * string_set_create(void);
      Create a new empty String_set.
- 
+
    string_set_delete(String_set *ss);
      Free all the space associated with this string set.
 
@@ -108,7 +108,7 @@ static void grow_table(String_set *ss)
 	String_set old;
 	size_t i;
 	unsigned int p;
-	
+
 	old = *ss;
 	ss->size = next_prime_up(2 * old.size);  /* at least double the size */
 	ss->table = (char **) xalloc(ss->size * sizeof(char *));
@@ -133,12 +133,12 @@ const char * string_set_add(const char * source_string, String_set * ss)
 	char * str;
 	size_t len;
 	unsigned int p;
-	
+
 	assert(source_string != NULL, "STRING_SET: Can't insert a null string");
 
 	p = find_place(source_string, ss);
 	if (ss->table[p] != NULL) return ss->table[p];
-	
+
 	len = strlen(source_string);
 #ifdef DEBUG
 	/* Store the String_set structure address for debug verifications */
@@ -151,19 +151,19 @@ const char * string_set_add(const char * source_string, String_set * ss)
 	strcpy(str, source_string);
 	ss->table[p] = str;
 	ss->count++;
-	
+
 	/* We just added it to the table.
 	   If the table got too big, we grow it.
 	   Too big is defined as being more than 3/4 full */
 	if ((4 * ss->count) > (3 * ss->size)) grow_table(ss);
-	
+
 	return str;
 }
 
 const char * string_set_lookup(const char * source_string, String_set * ss)
 {
 	unsigned int p;
-	
+
 	p = find_place(source_string, ss);
 	return ss->table[p];
 }
@@ -171,7 +171,7 @@ const char * string_set_lookup(const char * source_string, String_set * ss)
 void string_set_delete(String_set *ss)
 {
 	size_t i;
-	
+
 	if (ss == NULL) return;
 	for (i=0; i<ss->size; i++)
 	{

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -12,9 +12,11 @@
 #ifndef _STRING_SET_H_
 #define _STRING_SET_H_
 
+#include <string.h>
 #include <stddef.h>
+
 #include "api-types.h"
-#include "utilities.h"
+#include "lg_assert.h"
 
 struct String_set_s
 {

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -4,7 +4,7 @@
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */
-/* license set forth in the LICENSE file included with this software.    */ 
+/* license set forth in the LICENSE file included with this software.    */
 /* This license allows free redistribution and use in source and binary  */
 /* forms, with or without modification, subject to certain conditions.   */
 /*                                                                       */


### PR DESCRIPTION
- Remove leftover Windows defines.
- Clean whitespace / remove old /\* ==== */ separators.
- Remove `#define "utilities.h"` from 9 files and `"error.h"` from 1 file (checked on Windows).
