### PR TITLE
Changelog: Update recent changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ Version 5.3.12: (??? 2016?)
  * Fix bug in 'any' language (opencog/relex/issues/248).
  * Preliminary support for common typos in English.
  * Enable both python2 & python3 bindings by default.
+ * Fix locale_t use for the newly introduced Cygwin 2.6.0.
+ * Include in the distribution the missing make-check.py (for Windows).
+ * Minisat configuration improvements + fix a problem on Gentoo.
+ * When using the bundled minisat, link it statically and don't install it.
 
 Version 5.3.11: (26 Sept 2016)
  * Re-enable postscript header printing!


### PR DESCRIPTION
I propose to release 5.3.12 now.
The next changes that I would like to send are the improved error facility, that I propose to include in a yet new release (5.3.13).

---
* Fix locale_t use for the newly introduced Cygwin 2.6.0.
* Include in the distribution the missing make-check.py (for Windows).
* Minisat configuration improvements + fix a problem on Gentoo.
* When using the bundled minisat, link it statically and don't install it.
