### PR TITLE
Fix a bogus enum Clang warning

### DIFF
--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -353,7 +353,7 @@ void prt_exp_mem(Exp *e, int i)
 
 	if (e == NULL) return;
 
-	if (e->type > 0 && e->type < 4)
+	if (e->type > 0 && e->type <= 3)
 	{
 		type = ((const char *[]) {"OR_type", "AND_type", "CONNECTOR_type"}) [e->type-1];
 	}


### PR DESCRIPTION
Also for 5.3.12.
build-disjuncts.c:356:29: warning: comparison of constant 4 with expression of
  type 'Exp_type' is always true [-Wtautological-constant-out-of-range-compare]