### PR TITLE
configure.ac: Add -D__STDC_FORMAT_MACROS and -D__STDC_LIMIT_MACROS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,11 @@ AC_MSG_RESULT(no)
 	)
 )
 
+dnl CentOS-7 (at least) needs these to expose the C99 format and limit macros
+dnl in C++ source code.  They are needed for minisat.
+AC_DEFINE(__STDC_FORMAT_MACROS)
+AC_DEFINE(__STDC_LIMIT_MACROS)
+
 dnl Check for specific OSs
 # ====================================================================
 


### PR DESCRIPTION
This fixes a failure in sat-solver compilation, due to undefined
macros PRI* and INT32_* in the minisat header file Options.h (both in
the bundled and unbundled minisat versions).

The added __STDC_* definitions are needed for CentOS-7 in order to expose
the C99 format and limit macros also in C++ source code.

Add them always in case there are other distributions that define them.

---
The problem reported by  Stephen John Smoogen in https://groups.google.com/d/msg/link-grammar/9-WpNNy0aJ0/8vkL3SL1BgAJ .

BTW, configure.ac could add these macos only if they are defined (in stdint.h and inttype.h), but
for simplicity I added them unconditionally.