### PR TITLE
SWIG improvments

### DIFF
--- a/bindings/perl/Makefile.am
+++ b/bindings/perl/Makefile.am
@@ -5,6 +5,7 @@
 #
 
 SWIG_SOURCES = ../swig/link_grammar.i
+SWIG_INCLUDES = ../../link-grammar/link-includes.h
 # BUILT_SOURCES = $(top_builddir)/bindings/perl/lg_perl_wrap.cc
 BUILT_SOURCES = ../../bindings/perl/lg_perl_wrap.cc
 
@@ -15,6 +16,7 @@ dist_pkgperl_SCRIPTS = \
    $(top_builddir)/bindings/perl/clinkgrammar.pm
 
 if HAVE_SWIG
+$(BUILT_SOURCES) $(dist_pkgperl_SCRIPTS): $(SWIG_INCLUDES)
 $(BUILT_SOURCES) $(dist_pkgperl_SCRIPTS): $(SWIG_SOURCES)
 	$(SWIG) -perl5 -module clinkgrammar -I$(top_srcdir)/link-grammar -I$(top_builddir) -o $@ $<
 else

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -5,6 +5,7 @@
 #
 
 SWIG_SOURCES = ../swig/link_grammar.i
+SWIG_INCLUDES = ../../link-grammar/link-includes.h
 # BUILT_C_SOURCES = $(top_builddir)/bindings/python/lg_python_wrap.cc
 BUILT_C_SOURCES = ../../bindings/python/lg_python_wrap.cc
 BUILT_PY_SOURCES = $(top_builddir)/bindings/python/clinkgrammar.py
@@ -34,6 +35,7 @@ DISTCLEANFILES =                                   \
 
 if HAVE_SWIG
 # Swig builds these ....
+$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_INCLUDES)
 $(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_SOURCES)
 	$(SWIG) -python -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 else

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -7,6 +7,7 @@
 PYTHON = $(PYTHON3) # For py-compile.
 
 SWIG_SOURCES = ../swig/link_grammar.i
+SWIG_INCLUDES = ../../link-grammar/link-includes.h
 # BUILT_C_SOURCES = $(top_builddir)/bindings/python3/lg_python_wrap.cc
 BUILT_C_SOURCES = ../../bindings/python3/lg_python_wrap.cc
 BUILT_PY_SOURCES = $(top_builddir)/bindings/python3/clinkgrammar.py
@@ -42,6 +43,7 @@ DISTCLEANFILES =                                   \
 
 if HAVE_SWIG
 # Swig builds these ....
+$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_INCLUDES)
 $(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_SOURCES)
 	$(SWIG) -python -py3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 else

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -11,26 +11,16 @@
 
 %}
 
-typedef struct Dictionary_s * Dictionary;
-typedef struct Parse_Options_s * Parse_Options;
-typedef struct Sentence_s * Sentence;
-typedef struct Linkage_s * Linkage;
-typedef struct Postprocessor_s PostProcessor;
-
-typedef enum
-{
-   NO_DISPLAY = 0,        /** Display is disabled */
-   MULTILINE = 1,         /** multi-line, indented display */
-   BRACKET_TREE = 2,      /** single-line, bracketed tree */
-   SINGLE_LINE = 3,       /** single line, round parenthesis */
-   MAX_STYLES = 3         /* this must always be last, largest */
-} ConstituentDisplayStyle;
-
-typedef enum
-{
-   VDAL=1, /* Sort by Violations, Disjunct cost, Link cost */
-   CORPUS, /* Sort by Corpus cost */
-} Cost_Model_type;
+/* Grab non-function definitions so we do not need to repeat them here. */
+%rename("$ignore", %$isfunction) "";
+#define link_public_api(x) x
+#ifndef bool                         /* Prevent syntax errors if no bool. */
+#define bool int
+#endif /* bool */
+%immutable;                          /* Future-proof for const definitions. */
+%include ../link-grammar/link-includes.h
+%mutable;
+%rename("%s") "";                    /* Grab everything for the rest of file. */
 
 
 const char * linkgrammar_get_version(void);

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -13,6 +13,7 @@
 #ifndef _LINKINCLUDESH_
 #define _LINKINCLUDESH_
 
+#ifndef SWIG
 #include <stdbool.h> /* Needed for bool typedef */
 #include <stdio.h>   /* Needed for FILE* below */
 #include <link-grammar/link-features.h>
@@ -29,6 +30,7 @@ LINK_BEGIN_DECLS
 	#define false                           0
 	#define __bool_true_false_are_defined   1
 #endif
+#endif /* !SWIG */
 
 /**********************************************************************
  *
@@ -383,6 +385,7 @@ link_public_api(void)
  *
  ***********************************************************************/
 
+#ifndef SWIG
 /** Do not use in new code! */
 typedef struct Postprocessor_s PostProcessor;
 
@@ -394,5 +397,6 @@ MS_DEPRECATED link_public_api(void)
      linkage_post_process(Linkage, PostProcessor *) GNUC_DEPRECATED;
 
 LINK_END_DECLS
+#endif /* !SWIG */
 
 #endif


### PR DESCRIPTION
1) Add a link-includes.h dependency.
Strange unreproducible problems were observed while development new
Python bindings, maybe due to changes in link-includes.h that didn't
cause an interface generation.

2)  Automatically include all non-function definitions.
Currently typedef and enum API definitions from link-include.h are
repeated in link_grammar.i.
Instead, grab these definitions automatically.

Notes:
- It also automatically grabs the new error facility non-function definitions (PR to be sent soon).
- Not implemented yet: Most of the functions can be automatically garbd too. The "newobject" ones still need to be mentioned manually.