### PR TITLE
Validate Python ParseOptions() option names

### DIFF
--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -33,11 +33,11 @@ def nsuffix(q):
 #-----------------------------------------------------------------------------#
 
 DISPLAY_GUESSES = True   # Display regex and POS guesses
+DEBUG_POSITION = True    # Debug word position
 
-po = ParseOptions(verbosity=1)
+po = ParseOptions(verbosity=0) # 1=more verbose; 2=trace; >5=debug
 lgdict = Dictionary('en')
 
-po.verbosity = 0         # 1=more verbose; 2=trace; >5=debug
 po.max_null_count = 999  # > allowed maximum number of words
 po.max_parse_time = 10   # actual parse timeout may be about twice bigger
 po.spell_guess = 0       # spell guesses are not handled in this demo

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -40,7 +40,7 @@ lgdict = Dictionary('en')
 po.verbosity = 0         # 1=more verbose; 2=trace; >5=debug
 po.max_null_count = 999  # > allowed maximum number of words
 po.max_parse_time = 10   # actual parse timeout may be about twice bigger
-po.spell = 0             # spell guesses are not handled in this demo
+po.spell_guess = 0       # spell guesses are not handled in this demo
 
 # iter(): avoid python2 input buffering
 for sentence_text in iter(sys.stdin.readline, ''):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -215,6 +215,18 @@ class CParseOptionsTestCase(unittest.TestCase):
         linkages = s.parse()
         del s
 
+    def test_that_invalid_options_are_disallowed(self):
+        self.assertRaisesRegexp(TypeError, "unexpected keyword argument",
+                                ParseOptions, invalid_option=1)
+
+    def test_that_invalid_option_properties_cannot_be_used(self):
+        po = ParseOptions()
+        self.assertRaisesRegexp(TypeError, "Unknown parse option",
+                                setattr, po, "invalid_option", 1)
+
+    def test_that_ParseOptions_cannot_get_positional_arguments(self):
+        self.assertRaisesRegexp(TypeError, "Positional arguments are not allowed",
+                                ParseOptions, 1)
 
 class DBasicParsingTestCase(unittest.TestCase):
     def setUp(self):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -45,6 +45,13 @@ class ParseOptions(object):
         self.max_parse_time = max_parse_time
         self.disjunct_cost = disjunct_cost
 
+    # Allow only the attribute names listed below.
+    def __setattr__(self, name, value):
+        if not hasattr(self, name) and name != "_obj":
+            # TypeError for consistency. It maybe should have been NameError.
+            raise TypeError('Unknown parse option "{}".'.format(name))
+        super(self.__class__, self).__setattr__(name, value)
+
     def __del__(self):
         if hasattr(self, '_obj'):
             clg.parse_options_delete(self._obj)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -16,8 +16,19 @@ Clinkgrammar = clg
 __all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence',
            'LG_DictionaryError', 'LG_TimerExhausted', 'Clinkgrammar']
 
+# A decorator to ensure keyword-only arguments to __init__ (besides self).
+# In Python3 it can be done by using "*" as the second __init__ argument,
+# but here it is done with a decorator so it will work also in Python2.
+def kwargs_only(init):
+    def new_init(self_, *args, **kwargs):
+        if args:
+            raise TypeError("{}: Positional arguments are "
+                            "not allowed".format(self_.__class__.__name__))
+        return init(self_, **kwargs)
+    return new_init
 
 class ParseOptions(object):
+    @kwargs_only
     def __init__(self, verbosity=0,
                  linkage_limit=100,
                  min_null_count=0,


### PR DESCRIPTION
The sentence-check.py example script has an error that was not cought by the Python bindings:
`po.spell = 0`

This patch validates the option names, and raises TypeError (not NameError) on invakid names.
The reason for TypeError is because this is what Python already raises on an unexpected keyword argument, as explained in the commit for "Allow only valid option names".

So after this patch, the following, that are currently undetected, are detected:
1)
```python
po = ParseOptions()
po.invalid_option = 1
```
2) 
```python
ParseOptions(invalid_option=1)
```
3)
```python
po = ParseOptions(1)
```

I also added test cases for these 3 cases.