### PR TITLE
Add a missing library linkage dependency: link-grammar.def

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -36,6 +36,8 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) $(WARN_CFLAGS) \
 
 lib_LTLIBRARIES = liblink-grammar.la
 
+EXTRA_liblink_grammar_la_DEPENDENCIES = $(srcdir)/link-grammar.def
+
 liblink_grammar_la_LDFLAGS = -version-info @VERSION_INFO@ \
 	-export-dynamic -no-undefined \
 	-export-symbols $(srcdir)/link-grammar.def \


### PR DESCRIPTION
I added functions to link-grammar.def and noted that issuing `make` afterwards just did nothing.

This patch adds `link-grammar.def` as a library linkage dependency.

Check by:
```
make
touch link-grammar/link-grammar.def
make
```