### PR TITLE
Empty word elimination

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -56,7 +56,7 @@
 % FIXME: A better comment maybe.
 % See also EMPTY-WORD.x for the highly-unusual situation that EMPTY-WORD
 % appears in the input text.
-EMPTY-WORD.zzz: ZZZ-;
+%EMPTY-WORD.zzz: ZZZ-;
 
 % Capitalization handling (null effect for now- behave as empty words).
 1stCAP.zzz: ZZZ-;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -65,7 +65,7 @@ changecom(`%')
 % FIXME: A better comment maybe.
 % See also EMPTY-WORD.x for the highly-unusual situation that EMPTY-WORD
 % appears in the input text.
-EMPTY-WORD.zzz: ZZZ-;
+%EMPTY-WORD.zzz: ZZZ-;
 
 % Capitalization handling (null effect for now- behave as empty words).
 1stCAP.zzz: ZZZ-;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -588,7 +588,7 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 }
 
 /* Partial, but not full initialization of the linakge struct ... */
-void partial_init_linkage(Linkage lkg, unsigned int N_words)
+void partial_init_linkage(Sentence sent, Linkage lkg, unsigned int N_words)
 {
 	lkg->num_links = 0;
 	lkg->lasz = 2 * N_words;
@@ -606,6 +606,7 @@ void partial_init_linkage(Linkage lkg, unsigned int N_words)
 #endif
 
 	lkg->pp_info = NULL;
+	lkg->sent = sent;
 }
 
 void check_link_size(Linkage lkg)
@@ -631,7 +632,7 @@ static void compute_chosen_disjuncts(Sentence sent)
 
 		if (lifo->discarded || lifo->N_violations) continue;
 
-		partial_init_linkage(lkg, pi->N_words);
+		partial_init_linkage(sent, lkg, pi->N_words);
 		extract_links(lkg, pi);
 		compute_link_names(lkg, sent->string_set);
 		/* Because the empty words are used only in the parsing stage, they are

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -181,6 +181,19 @@ static bool pseudocount(count_context_t * ctxt,
 	return true;
 }
 
+/**
+ * Return the number of optional words strictly between w1 and w2.
+ */
+static int num_optional_words(count_context_t *ctxt, int w1, int w2)
+{
+	int n = 0;
+
+	for (int w = w1+1; w < w2; w++)
+		if (ctxt->local_sent[w].optional) n++;
+
+	return n;
+}
+
 static Count_bin do_count(fast_matcher_t *mchxt,
                           count_context_t *ctxt,
                           int lw, int rw,
@@ -226,7 +239,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 			/* If we don't allow islands (a set of words linked together
 			 * but separate from the rest of the sentence) then the
 			 * null_count of skipping n words is just n. */
-			if (null_count == (rw-lw-1))
+			if (null_count == (rw-lw-1) - num_optional_words(ctxt, lw, rw))
 			{
 				t->count = hist_one();
 			}

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -727,7 +727,6 @@ Linkage linkage_create(LinkageIdx k, Sentence sent, Parse_Options opts)
 	/* Perform remaining initialization we haven't done yet...*/
 	compute_chosen_words(sent, linkage, opts);
 
-	linkage->sent = sent;
 	linkage->is_sent_long = (linkage->num_words >= opts->twopass_length);
 
 	return linkage;

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -232,7 +232,7 @@ void remove_empty_words(Linkage lkg)
 
 	for (i = 0, j = 0; i < lkg->num_words; i++)
 	{
-		if ((NULL != cdj[i]) && (MT_EMPTY == cdj[i]->word[0]->morpheme_type))
+		if ((NULL == cdj[i]) && lkg->sent->word[i].optional)
 		{
 			remap[i] = -1;
 		}

--- a/link-grammar/linkage.h
+++ b/link-grammar/linkage.h
@@ -3,7 +3,7 @@
 void remap_linkages(Linkage, const int *remap);
 void compute_chosen_words(Sentence, Linkage, Parse_Options);
 
-void partial_init_linkage(Linkage, unsigned int N_words);
+void partial_init_linkage(Sentence, Linkage, unsigned int N_words);
 void check_link_size(Linkage);
 void remove_empty_words(Linkage);
 void free_linkage(Linkage);

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1363,7 +1363,17 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 					wt = wprint;
 				}
 
-				if (debugprint) lgdebug(0, " %s", '\0' == wt[0] ? "[missing]" : wt);
+				if (debugprint)
+				{
+					const char *opt_start = "", *opt_end = "";
+					if (sent->word[wi].optional)
+					{
+						opt_start = "{";
+						opt_end = "}";
+					}
+					lgdebug(0, " %s%s%s",
+					        opt_start, '\0' == wt[0] ? "[missing]" : wt, opt_end);
+				}
 
 				/* Don't try to give info on the empty word. */
 				if (('\0' != wt[0]) && (0 != strcmp(wt, EMPTY_WORD_DISPLAY)))

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -336,7 +336,9 @@ void SATEncoder::generate_satisfaction_conditions()
     name[0] = 'w';
     fast_sprintf(name+1, w);
 
-    determine_satisfaction(w, name);
+    if (!_sent->word[w].optional)
+      determine_satisfaction(w, name);
+
     int dfs_position = 0;
     generate_satisfaction_for_expression(w, dfs_position, exp, name, 0);
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1277,7 +1277,7 @@ Linkage SATEncoder::create_linkage()
   Linkage linkage = (Linkage) exalloc(sizeof(struct Linkage_s));
   memset(linkage, 0, sizeof(struct Linkage_s));
 
-  partial_init_linkage(linkage, _sent->length);
+  partial_init_linkage(_sent, linkage, _sent->length);
   sat_extract_links(linkage);
   compute_link_names(linkage, _sent->string_set);
   /* Because the empty words are used only in the parsing stage, they are

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -176,6 +176,7 @@ struct Word_struct
 
 	X_node * x;          /* Sentence starts out with these, */
 	Disjunct * d;        /* eventually these get generated. */
+	bool optional;       /* Linkage is optional. */
 
 	const char **alternatives;
 };

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2848,12 +2848,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 				 */
 				if (!empty_word_encountered)
 				{
-					/* ??? Should we check it earlier? */
-					if (!sent->dict->empty_word_defined)
-						prt_error("Error: %s must be defined!\n", EMPTY_WORD_DOT);
-
-					if (!determine_word_expressions(sent, empty_word(), &ZZZ_added))
-						error_encountered = true;
+					sent->word[sent->length - 1].optional = true;
 					empty_word_encountered = true;
 				}
 			}

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2622,6 +2622,7 @@ static Word *word_new(Sentence sent)
 		sent->word[len].x= NULL;
 		sent->word[len].unsplit_word = NULL;
 		sent->word[len].alternatives = NULL;
+		sent->word[len].optional = false;
 		sent->length++;
 
 		return &sent->word[len];


### PR DESCRIPTION
See issue #468.

**This is only for a demo**, as the SAT-parser malfunctions now for sentences that used to have an empty-word in them.

Notes:
1) It seems to fix the current bogus null count that happens when empty words are counted as null-words.
2) An original bug with LL link is now more apparent, as there are no empty-words "guards" to prevent malformed linkages between a root and a suffix of another word, in case the suffix of that root happens to not have a linkage.
E.g. (real example):
```
>     +--------------------------------------Xp-------------------------------------+
>     +-----------------------Wd----------------------+                             |
>     |                            +-------MVIag------+         +------Jd------+    |
>     |       +--------LLFHW-------+        +--LLFYZ--+----Ew---+      +-LLAAQ-+    |
>     |       |                    |        |         |         |      |       |    |
> LEFT-WALL али.= [са] [стрел] =ой.nlfsg взле.= =тела.vsndpfs по.jd трап.= =у.ndmsd . 
```
Possible solution:  Set LL links to length limit 1.
3) A current bug with empty-word handling is automatically corrected (because empty words are not used).
It may happens only for sentences which don't have a full linkage.
Here is how:
ZZZ link are set with length limit 1.
If a word is a null word, the empty word after it cannot be attached to it.
So it cannot be attached at all.
Even without setting length limit 1 it cannot be attached to the previous word (if there exists so not null word) due to an optimization of attaching ZZZ+ to the previous word on demand, so the word before the said null word doesn't have the needed ZZZ+. But even without this optimization there may be a bug in that case when the word before the said null word is also an empty-word, since it doesn't have ZZZ+.
Test sentence:
`In Xanadu did Kubla Kahn a stately pleasure dome decree.`
(There is currently an empty word in it due to did -> "d id", because of unit separation, that we also need to discuss.)