### PR TITLE
Add utf8 support to the random morpheme splitter.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 Version 5.3.14 (?? 2017)
  * Fix printing widths for Chinese ideographs.
  * Fix broken randomization in the "any" language.
+ * Add UTF-8 support to the random morpheme splitter (amy).
+ * Create an "ady" language for two-part morphology splits.
 
 Version 5.3.13 (19 Nov 2016)
  * Fix fatal errors w/ zlib-dev and python dependencies.

--- a/configure.ac
+++ b/configure.ac
@@ -979,6 +979,7 @@ morphology/Makefile
 link-parser/Makefile
 tests/Makefile
 data/Makefile
+data/ady/Makefile
 data/amy/Makefile
 data/any/Makefile
 data/ar/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS=amy any ar de en fa he id kz lt ru tr vn demo-sql
+SUBDIRS=ady amy any ar de en fa he id kz lt ru tr vn demo-sql
 
 # Include the README in the tarball, but do not install it.
 EXTRA_DIST= README

--- a/data/README
+++ b/data/README
@@ -35,9 +35,19 @@ any -- Will parse "any" language, exploring all combinatoric possibilities.
        This is useful for certain machine-learning tasks, when one might
        want to iterate over all possible parse trees in every way.
 
+ady -- Will parse "any" language, exploring all possible morphological
+       decompositions of the words in a sentence, as well as using
+       random linkages between words and morphemes. The assumed
+       morphology splits a word into at most two parts: a stem,
+       having no syntactic structure, and a suffix, which carries
+       the inflection -- that is, the stem carries all the syntactic
+       structure.
+
 amy -- Will parse "any" language, exploring all possible morphological
        decompositions of the words in a sentence, as well as using
-       random linkages between words and morphemes.
+       random linkages between words and morphemes. Configured to
+       explore morphology of 3 or more parts: syntactically inactive
+       prefixes and stems, and a single syntactically active suffix.
 
 demo-sql -- An almost empty demonstration dictionary, showing what an
        SQLite-backed dictionary might look like.

--- a/data/ady/4.0.affix
+++ b/data/ady/4.0.affix
@@ -1,0 +1,42 @@
+
+% Mark the first morpheme by appending STEMSUBSCR.
+.=: STEMSUBSCR+;
+
+% Mark the rest of morphemes by prepending INFIXMARK
+=: INFIXMARK+;
+
+% Program and dictionary sanity check: Allow only these combinations.
+% (w: word, t:stem, s: suffix)
+
+% Split words into 1 or 2 parts (and no more than two parts)
+% Accroding to the 4.0.dict, the first part will act as a stem,
+% and the second part as a suffix carrying syntactic inflection.
+2: REGPARTS+;
+
+% Allowed structure for REGPARTS == 2
+"w|ts": SANEMORPHISM+;
+
+% Anysplit parameters
+
+% Number of alternatives to issue for a word. Two values: minimum and maximum.
+% If the word has more possibilities to split than the minimum, but less
+% than the maximum, then issue them without sampling. Else use pseudo-random
+% sampling until the minimum number is reached or all possibilities exhausted.
+2 10: REGALTS+;
+
+% When all word parts match these regexes,
+% the word is issued as an alternative.
+% Multiple regexes per class are permitted.
+%
+% The word parts currently contain at least one character
+% (null morphems are not supported).
+%
+% If needed, add the same regex in more than one definition.
+
+% Regex to match the prefix (including the whole word)
+".*" : REGPRE+;
+
+% Regex to match the suffix (not including the whole word)
+".*": REGSUF+;
+
+% End of Anysplit parameters

--- a/data/ady/4.0.constituent-knowledge
+++ b/data/ady/4.0.constituent-knowledge
@@ -1,0 +1,5 @@
+
+STARTING_LINK_TYPE_TABLE: 
+ANY*  v
+
+

--- a/data/ady/4.0.dict
+++ b/data/ady/4.0.dict
@@ -1,0 +1,27 @@
+
+ %***************************************************************************%
+ %                                                                           %
+ %       Copyright (C) 2013, 2014, 2017 Linas Vepstas                        %
+ %                                                                           %
+ %  See file "README" for information about commercial use of this system    %
+ %                                                                           %
+ %***************************************************************************%
+
+% Dictionary version number is 5.3.14 (formatted as V5v3v14+)
+<dictionary-version-number>: V5v3v14+;
+
+EMPTY-WORD.zzz: ZZZ-;
+
+LEFT-WALL: ANY+;
+ANY-WORD: {@ANY-} & {@ANY+};
+UNKNOWN-WORD: {@ANY-} & {@ANY+};
+ANY-PUNCT: {@ANY-} & {@ANY+};
+
+JUNK: {@ANY-} & {@ANY+};
+
+
+% A simple two-part morphology:  Some stem, which carries only
+% semantics but no syntax, and a single suffix, which carries
+% all of the syntactic information.
+SIMPLE-STEM: LL+;
+SIMPLE-SUFF: LL- & {@ANY-} & {@ANY+};

--- a/data/ady/4.0.knowledge
+++ b/data/ady/4.0.knowledge
@@ -1,0 +1,28 @@
+; Post-processing knowledge file
+
+; ----------------------------------------------------------------------------
+; This file contains the knowledge related to post-processing, in the 
+; form of lists and rules. This file is read by post-process.c at run-time. 
+; Syntax of file:
+;           line starting with ";" is a comment
+;           commas are field delimiters 
+;           any token beginning with the character @ is expanded to the set
+;               of symbols it defined. e.g. one could write
+; FOO: blah1 blah2 blah3
+; thus defining a set FOO containing three strings. Then one could later write
+; BAR: blah5 @FOO blah8
+; which defines a set BAR containing 5 strings. 
+; 
+; Capitalized tokens are *required*, though if you feel like providing an
+; empty list afterwards, that's your right.
+; ----------------------------------------------------------------------------
+
+; ----------------------------------------------------------------------
+; ---------------------- LINK TYPE TABLE-------------------------------
+; ----------------------------------------------------------------------
+; The following table associates a domain type with each possible
+; starting link. It contains pairs: the first of each pair is a link
+; type, and the second is the domain to which that link type belongs.
+
+STARTING_LINK_TYPE_TABLE: 
+ ANY    e  

--- a/data/ady/Makefile.am
+++ b/data/ady/Makefile.am
@@ -1,0 +1,12 @@
+
+DICTS=                           \
+      4.0.affix                  \
+      4.0.constituent-knowledge  \
+      4.0.dict                   \
+      4.0.knowledge              \
+      4.0.regex
+
+dictdir=$(pkgdatadir)/ady
+dict_DATA = $(DICTS)
+
+EXTRA_DIST = $(DICTS)

--- a/data/amy/4.0.affix
+++ b/data/amy/4.0.affix
@@ -9,7 +9,9 @@
 % (w: word, t:stem, s: suffix)
 
 % For REGPARTS > 2
-"w|ts+": SANEMORPHISM+;
+% See the file api.c circa line 1100 for details
+% (or grep for AFFIXTYPE in the code).
+"w|ts|pts|pms": SANEMORPHISM+;
 
 
 % Anysplit parameters

--- a/data/amy/4.0.affix
+++ b/data/amy/4.0.affix
@@ -6,9 +6,8 @@
 =: INFIXMARK+;
 
 % Program and dictionary sanity check: Allow only these combinations.
-% (w: word, t:stem, s: suffix)
-
-% For REGPARTS > 2
+% (w: word, p:prefix, m:middle, t:stem, s: suffix)
+%
 % See the file api.c circa line 1100 for details
 % (or grep for AFFIXTYPE in the code).
 "w|ts|pts|pms": SANEMORPHISM+;

--- a/data/amy/4.0.affix
+++ b/data/amy/4.0.affix
@@ -8,25 +8,22 @@
 % Program and dictionary sanity check: Allow only these combinations.
 % (w: word, t:stem, s: suffix)
 
-% For REGPARTS == 2
-"w|ts": SANEMORPHISM+;
-
 % For REGPARTS > 2
-%"w|ts+": SANEMORPHISM+;
+"w|ts+": SANEMORPHISM+;
 
 
 % Anysplit parameters
 
-% Maximum number of word partitions - 0 disables Anysplit
+% Maximum number of word partitions
 % 6: REGPARTS+;
-2: REGPARTS+;
+3: REGPARTS+;
 
 % Number of alternatives to issue for a word. Two values: minimum and maximum.
 % If the word has more possibilities to split than the minimum, but less
 % than the maximum, then issue them without sampling. Else use pseudo-random
 % sampling until the minimum number is reached or all possibilities exhausted.
 % 10 20: REGALTS+;
-2 10: REGALTS+;
+2 16: REGALTS+;
 
 % When all word parts match these regexes,
 % the word is issued as an alternative.

--- a/data/amy/4.0.dict
+++ b/data/amy/4.0.dict
@@ -7,8 +7,8 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.3.12 (formatted as V5v3v12+)
-<dictionary-version-number>: V5v3v12+;
+% Dictionary version number is 5.3.14 (formatted as V5v3v14+)
+<dictionary-version-number>: V5v3v14+;
 
 EMPTY-WORD.zzz: ZZZ-;
 
@@ -19,6 +19,6 @@ ANY-PUNCT: {@ANY-} & {@ANY+};
 
 JUNK: {@ANY-} & {@ANY+};
 
-
+MOR-PREF: PF+;
+MOR-STEM: {@PF-} & LL+;
 MOR-SUFF: LL- & {@ANY-} & {@ANY+};
-MOR-STEM: LL+;

--- a/data/amy/4.0.regex
+++ b/data/amy/4.0.regex
@@ -7,14 +7,15 @@
 
 % Want to match apostrophes, for abreviations (I'm I've, etc.) since these
 % cannot be auto-split with the current splitter.  Also want to accept
-% hyphenated words, and word with underbars in them.
+% hyphenated words, and words with underbars in them.
 ANY-WORD:  /^[[:alnum:]_'-]+$/
 ANY-PUNCT:  /^[[:punct:]]+$/
 
-% Random morphology: match any string of one or more letters as stem, or suffix.
-% We are currently using .= to denote the end of a stem.
+% Multi-part random morphology: match any string as prefix, stem, or
+% suffix.
+MOR-PREF: /^[[:alnum:]_'-]+.=/
+MOR-STEM: /=[[:alnum:]_'-]+.=/
 MOR-SUFF: /[[:alnum:]_'-]+$/
-MOR-STEM: /^[[:alnum:]_'-]+.=/
 
 % Match anything that doesn't match the above.
 % Match anything that isn't white-space.

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -215,6 +215,8 @@ static int split(int word_length, int nparts, split_cache *scl)
 
 	if (NULL == scl->sp)
 	{
+		// XXX FIXME -- there are more efficient ways of counting
+		// the number of splits. But this is OK for now.
 		nsplits = split_and_cache(word_length, nparts, NULL);
 		//printf("nsplits %zu\n", nsplits);
 		if (0 == nsplits)
@@ -492,7 +494,7 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 	        "as->altsmin=%zu, as->altsmax=%zu\n", use_sampling ? "" : " no",
 	        word, nsplits, as->nparts, as->altsmin, as->altsmax);
 
-	while (rndtried < nsplits && (!use_sampling || (rndissued < as->altsmin)))
+	while (rndtried < nsplits && (!use_sampling || (rndissued < as->altsmax)))
 	{
 		if (use_sampling)
 		{

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -433,6 +433,7 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 	size_t stemsubscr_len;
 
 	size_t l = strlen(word);
+	size_t lutf = utf8_strlen(word);
 	p_list pl;
 	size_t pos;
 	int p;
@@ -463,8 +464,8 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 		strlen(stemsubscr->string[0]);
 
 	/* Don't split morphemes again. If INFIXMARK and/or SUBSCRMARK are
-	 * not defined in the affix file, then morphemes may get split again unless
-	 * restricted by REGPRE/REGMID/REGSUF. */
+	 * not defined in the affix file, then morphemes may get split again,
+	 * unless restricted by REGPRE/REGMID/REGSUF. */
 	if (word[0] == infix_mark) return true;
 	if ((l > stemsubscr_len) &&
 	    (0 == strcmp(word+l-stemsubscr_len, stemsubscr->string[0])))
@@ -476,7 +477,7 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 	gw = word;
 #endif
 
-	nsplits = split(l, as->nparts, &as->scl[l]);
+	nsplits = split(lutf, as->nparts, &as->scl[l]);
 	if (0 == nsplits)
 	{
 		prt_error("Warning: anysplit(): split() failed (shouldn't happen)\n");

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -358,7 +358,7 @@ bool anysplit_init(Dictionary afdict)
 	{
 		if (debug_level(+D_AS))
 			prt_error("Warning: File %s: Anysplit disabled (%s not defined)",
-		             afdict->name, afdict_classname[AFDICT_REGPARTS]);
+			          afdict->name, afdict_classname[AFDICT_REGPARTS]);
 		return true;
 	}
 	if (1 != regparts->length)
@@ -443,7 +443,7 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 	size_t i;
 	unsigned int seed = sent->rand_state;
 	char *prefix_string = alloca(l+2+1); /* word + ".=" + NUL */
-	char *suffix_string = alloca(l+1);   /* word + NUL */
+	char *suffix_string = alloca(l+1+1); /* "=" + word + NUL */
 	bool use_sampling = true;
 	const char infix_mark = INFIX_MARK(afdict);
 
@@ -570,9 +570,14 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 			if (pos == l) break;
 		}
 
+		// XXX FIXME -- this is wrong, it calls the stem the "prefix",
+		// it doesn't actually handle true prfixes, and assumes a
+		// variable number of suffixes
 		/* Here a leading INFIX_MARK is added to the suffixes if needed. */
 		issue_word_alternative(sent, unsplit_word, "AS",
-		   0,NULL,  1,(const char **)&prefix_string, num_suffixes,suffixes);
+		        0, NULL,  /* Zero prefixes */
+		        1, (const char **)&prefix_string,
+		        num_suffixes,suffixes);
 		free(suffixes);
 	}
 

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -550,7 +550,7 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 				prefix_string[pl[p]-pos] = '\0';
 			}
 			else
-			if (0 == pos)   /* The first but not the only morpheme */
+			if (0 == pos)   /* The first, but not the only morpheme */
 			{
 				strncpy(prefix_string, &word[pos], pl[p]-pos);
 				prefix_string[pl[p]-pos] = '\0';
@@ -558,7 +558,7 @@ bool anysplit(Sentence sent, Gword *unsplit_word)
 				if (0 != stemsubscr->length)
 				    strcat(prefix_string, stemsubscr->string[0]);
 			}
-			else           /* 2nd and on morphemes */
+			else           /* 2nd and subsequent morphemes */
 			{
 				strncpy(suffix_string, &word[pos], pl[p]-pos);
 				suffix_string[pl[p]-pos] = '\0';

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -269,15 +269,15 @@ static bool morpheme_match(Sentence sent, const char *word, int l, p_list pl)
 		prefix_string[pl[p]-pos] = '\0';
 
 		/* For flexibility, REGRPE is matched only to the prefix part,
-		 * REGMID only to the middle suffixes, and REGSUF only to the suffix part -
-		 * which cannot be the prefix. */
+		 * REGMID only to the middle suffixes, and REGSUF only to the
+		 * suffix part - which cannot be the prefix. */
 		if (0 == p) re = as->regpre;
 		else if (pl[p] == l) re = as->regsuf;
 		else re = as->regmid;
 		lgdebug(2, "re=%s part%d=%s: ", re->name, p, prefix_string);
 
 		/* A NULL regex always matches */
-		if ((NULL != re) && (NULL == match_regex(re ,prefix_string)))
+		if ((NULL != re) && (NULL == match_regex(re, prefix_string)))
 		{
 			lgdebug(2, "No match\n");
 			return false;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1092,13 +1092,14 @@ static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
 /* ============================================================== */
 /* A kind of morphism post-processing */
 
-/* These letters create a string that should be matched by a SANEMORPHISM regex,
- * given in the affix file. The empty word doesn't have a letter. E.g. for the
- * Russian dictionary: "w|ts". It is converted here to: "^((w|ts)b)+$".
+/* These letters create a string that should be matched by a
+ * SANEMORPHISM regex, given in the affix file. The empty word
+ * doesn't have a letter. E.g. for the Russian dictionary: "w|ts".
+ * It is converted here to: "^((w|ts)b)+$".
  * It matches "wbtsbwbtsbwb" but not "wbtsbwsbtsb".
  * FIXME? In this version of the function, 'b' is not yet supported,
- * so "w|ts" is converted to "^(w|ts)+$" for now. */
-
+ * so "w|ts" is converted to "^(w|ts)+$" for now.
+ */
 #define AFFIXTYPE_PREFIX   'p'   /* prefix */
 #define AFFIXTYPE_STEM     't'   /* stem */
 #define AFFIXTYPE_SUFFIX   's'   /* suffix */

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1316,9 +1316,13 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		for (ai=0; ai < max_nalt;  ai++)
 		{
 			if (debugprint)
+			{
+				if (0 < ai) lgdebug(0, "\n   ");
 				lgdebug(0, "   alt%zu:", ai);
+			}
+
 			for (wi = w_start; (wi == w_start) ||
-			 ((wi < sentlen) && (! sent->word[wi].unsplit_word)); wi++)
+			    ((wi < sentlen) && (! sent->word[wi].unsplit_word)); wi++)
 			{
 				size_t nalts = altlen(sent->word[wi].alternatives);
 				const char *wt;

--- a/link-grammar/regex-morph.c
+++ b/link-grammar/regex-morph.c
@@ -102,21 +102,19 @@ const char *match_regex(const Regex_node *re, const char *s)
 
 	while (re != NULL)
 	{
-		if (re->re == NULL)
-		{
-			/* Re not compiled; if this happens, it's likely an
-			 *  internal error, but nevermind for now.  */
-			continue;
-		}
-		/* Try to match with no extra data (NULL), whole str (0 to strlen(s)),
-		 * and default options (second 0). */
-		/* int rc = pcre_exec(re->re, NULL, s, strlen(s), 0,
-		 *                    0, ovector, PCRE_OVEC_SIZE); */
+		/* Make sure the regex has been compiled. */
+		assert(re->re);
+
+#if 0
+		/* Try to match with no extra data (NULL), whole str
+		 * (0 to strlen(s)), and default options (second 0). */
+		int rc = pcre_exec(re->re, NULL, s, strlen(s), 0,
+		                   0, ovector, PCRE_OVEC_SIZE);
+#endif
 
 		rc = regexec((regex_t*) re->re, s, 0, NULL, 0);
 		if (0 == rc)
 		{
-			
 			lgdebug(+D_MRE, "%s%s %s\n", &"!"[!re->neg], re->name, s);
 			if (!re->neg)
 				return re->name; /* Match found - return--no multiple matches. */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -240,7 +240,8 @@ size_t utf8_strwidth(const char *);
 
 /**
  * Return the length, in codepoints/glyphs, of the utf8-encoded
- * string.  This is needed when splitting words into morphemes.
+ * string.  The string is assumed to be null-terminated.
+ * This is needed when splitting words into morphemes.
  */
 static inline size_t utf8_strlen(const char *s)
 {
@@ -252,7 +253,6 @@ static inline size_t utf8_strlen(const char *s)
 	return mbsrtowcs(NULL, &s, 0, &mbss);
 #endif
 }
-
 
 /**
  * Return the distance, in bytes, to the next character, in the
@@ -283,6 +283,19 @@ static inline size_t utf8_next(const char *s)
 	return len;
 #endif /* _WIN32 */
 }
+
+/**
+ * Return the length, in codepoints/glyphs, of the utf8-encoded
+ * string.  The string is assumed to be at least `len` code-points
+ * long. This is needed when splitting words into morphemes.
+ */
+static inline size_t utf8_strnlen(const char *s, size_t len)
+{
+	size_t by = 0;
+	while (0 < len) { by += utf8_next(&s[by]); }
+	return by;
+}
+
 
 /**
  * Copy `n` utf8 characters from `src` to `dest`.

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -239,6 +239,22 @@ typedef int locale_t;
 size_t utf8_strwidth(const char *);
 
 /**
+ * Return the length, in codepoints/glyphs, of the utf8-encoded
+ * string.  This is needed when splitting words into morphemes.
+ */
+static inline size_t utf8_strlen(const char *s)
+{
+	mbstate_t mbss;
+	memset(&mbss, 0, sizeof(mbss));
+#if defined(_MSC_VER) || defined(__MINGW32__)
+	return MultiByteToWideChar(CP_UTF8, 0, s, -1, NULL, 0)-1;
+#else
+	return mbsrtowcs(NULL, &s, 0, &mbss);
+#endif
+}
+
+
+/**
  * Return the distance, in bytes, to the next character, in the
  * input utf8-encoded string.
  */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -284,6 +284,26 @@ static inline size_t utf8_next(const char *s)
 #endif /* _WIN32 */
 }
 
+/**
+ * Copy `n` utf8 characters from `src` to `dest`.
+ * Return the number of bytes actually copied.
+ * The `dest` must have enough room to hold the copy.
+ */
+static inline size_t utf8_strncpy(char *dest, const char *src, size_t n)
+{
+	size_t b = 0;
+	while (0 < n)
+	{
+		size_t k = utf8_next(src);
+		b += k;
+		while (0 < k) { *dest = *src; dest++; src++; k--; }
+		n--;
+		if (0x0 == *src) break;
+	}
+
+	return b;
+}
+
 static inline int is_utf8_upper(const char *s, locale_t dict_locale)
 {
 	mbstate_t mbs;


### PR DESCRIPTION
Add utf8 support to the random morpheme splitter. 
Also, create a second language, "ady", which only splits into two morphemes: stem+suffix.
The "amy" language will be reserved for splits into 3 or more morphemes. (which is 
currently broken, anyway).