### PR TITLE
Improved error facility

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 5.3.14 (?? 2017)
  * Fix broken randomization in the "any" language.
  * Add UTF-8 support to the random morpheme splitter (amy).
  * Create an "ady" language for two-part morphology splits.
+ * Improved error notification facility (experimental).
 
 Version 5.3.13 (19 Nov 2016)
  * Fix fatal errors w/ zlib-dev and python dependencies.

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -18,7 +18,7 @@ for v in 'PYTHONPATH', 'srcdir', 'LINK_GRAMMAR_DATA':
 
 
 from linkgrammar import (Sentence, Linkage, ParseOptions, Link, Dictionary,
-                         LG_DictionaryError, LG_TimerExhausted,
+                         LG_Error, LG_DictionaryError, LG_TimerExhausted,
                          Clinkgrammar as clg)
 
 
@@ -58,7 +58,8 @@ class AAALinkTestCase(unittest.TestCase):
 
 class AADictionaryTestCase(unittest.TestCase):
     def test_open_nonexistent_dictionary(self):
-        self.assertRaises(LG_DictionaryError, Dictionary, 'No such language')
+        self.assertRaises(LG_DictionaryError, Dictionary, 'No such language test 1')
+        self.assertRaises(LG_Error, Dictionary, 'No such language test 2')
 
 class BParseOptionsTestCase(unittest.TestCase):
     def test_setting_verbosity(self):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -326,7 +326,159 @@ class DBasicParsingTestCase(unittest.TestCase):
                           "This should take more than one second to parse! " * 20,
                           self.po)
 
-class ESATsolverTestCase(unittest.TestCase):
+# The tests here are are numbered since their order is important.
+# They depend on the result and state of the previous ones as follows:
+# - set_handler() returned a value that depend on it previous invocation.
+# - A class variable "handler" to record its previous results.
+class EErrorFacilityTestCase(unittest.TestCase):
+    # Initialize class variables to invalid (for the test) values.
+    handler = {
+        "default":  lambda x, y=None: None,
+        "previous": lambda x, y=None: None
+    }
+
+    def setUp(self): # pylint: disable=attribute-defined-outside-init,no-member
+        self.testit = "testit"
+        self.testleaks = 0  # A repeat count for validating no memory leaks
+
+    @staticmethod
+    def error_handler_test(errinfo, data):
+        # A test error handler.  It assigns the errinfo struct as an attribute
+        # of its data so it can be examined after the call. In addition, the
+        # ability of the error handler to use its data argument is tested by
+        # the "testit" attribute.
+        if data is None:
+            return
+        data.errinfo = errinfo
+        data.gotit = data.testit
+
+    def test_10_set_error_handler(self):
+        # Set the error handler and validate that it
+        # gets the error info and the data.
+        self.__class__.handler["default"] = \
+            LG_Error.set_handler(self.error_handler_test, self)
+        self.assertEqual(self.__class__.handler["default"].__name__,
+                         "_default_handler")
+        self.gotit = None
+        self.assertRaises(LG_Error, Dictionary, "seh_dummy1")
+        self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_Error, "Error"))
+        self.assertEqual(self.gotit, "testit")
+        self.assertRegexpMatches(self.errinfo.text, "Could not open dictionary.*seh_dummy1")
+
+    def test_20_set_error_handler_None(self):
+        # Set the error handler to None and validate that printall()
+        # gets the error info and the data and returns the number of errors.
+        self.__class__.handler["previous"] = LG_Error.set_handler(None)
+        self.assertEqual(self.__class__.handler["previous"].__name__, "error_handler_test")
+        self.assertRaises(LG_Error, Dictionary, "seh_dummy2")
+        self.gotit = None
+        for i in range(0, 2+self.testleaks):
+            self.numerr = LG_Error.printall(self.error_handler_test, self)
+            if 0 == i:
+                self.assertEqual(self.numerr, 1)
+            if 1 == i:
+                self.assertEqual(self.numerr, 0)
+        self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_Error, "Error"))
+        self.assertEqual(self.gotit, "testit")
+        self.assertRegexpMatches(self.errinfo.text, ".*seh_dummy2")
+
+    def test_21_set_error_handler_None(self):
+        # Further test of correct number of errors.
+        self.numerr = 3
+        for _ in range(0, self.numerr):
+            self.assertRaises(LG_Error, Dictionary, "seh_dummy2")
+        self.numerr = LG_Error.printall(self.error_handler_test, None)
+        self.assertEqual(self.numerr, self.numerr)
+
+    def test_22_defaut_handler_param(self):
+        """Test bad data parameter to default error handler"""
+        # (It should be an integer >=0 and <= lg_None.)
+        # Here the error handler is still set to None.
+
+        # This test doesn't work - TypeError is somehow raised inside
+        # linkgrammar.py when _default_handler() is invoked as a callback.
+        #
+        #LG_Error.set_handler(self.__class__.handler["default"], "bad param")
+        #with self.assertRaises(TypeError):
+        #    try:
+        #        Dictionary("a visible dummy dict name (bad param test)")
+        #    except LG_Error:
+        #        pass
+
+        # So test it directly.
+        self.assertRaises(LG_Error, Dictionary, "a visible dummy dict name (bad param test)")
+        LG_Error.printall(self.error_handler_test, self) # grab a valid errinfo
+        self.assertRaisesRegexp(TypeError, "must be an integer",
+                                self.__class__.handler["default"],
+                                self.errinfo, "bad param")
+        self.assertRaisesRegexp(ValueError, "must be an integer",
+                                self.__class__.handler["default"],
+                                self.errinfo, clg.lg_None+1)
+        self.assertRaises(ValueError, self.__class__.handler["default"],
+                          self.errinfo, -1)
+        try:
+            self.param_ok = False
+            self.__class__.handler["default"](self.errinfo, 1)
+            self.param_ok = True
+        except (TypeError, ValueError):
+            self.assertTrue(self.param_ok)
+
+    def test_23_prt_error(self):
+        LG_Error.message("Info: prt_error test\n")
+        LG_Error.printall(self.error_handler_test, self)
+        self.assertRegexpMatches(self.errinfo.text, "prt_error test\n")
+        self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_Info, "Info"))
+
+    def test_24_prt_error_in_parts(self):
+        LG_Error.message("Trace: part one... ")
+        LG_Error.message("part two\n")
+        LG_Error.printall(self.error_handler_test, self)
+        self.assertEqual(self.errinfo.text, "part one... part two\n")
+        self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_Trace, "Trace"))
+
+    def test_25_prt_error_in_parts_with_embedded_newline(self):
+        LG_Error.message("Trace: part one...\n\\")
+        LG_Error.message("part two\n")
+        LG_Error.printall(self.error_handler_test, self)
+        self.assertEqual(self.errinfo.text, "part one...\npart two\n")
+        self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_Trace, "Trace"))
+
+    def test_26_prt_error_plain_message(self):
+        LG_Error.message("This is a regular output line.\n")
+        LG_Error.printall(self.error_handler_test, self)
+        self.assertEqual(self.errinfo.text, "This is a regular output line.\n")
+        self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_None, ""))
+
+    def test_30_formatmsg(self):
+        # Here the error handler is still set to None.
+        for _ in range (0, 1+self.testleaks):
+            self.assertRaises(LG_Error, Dictionary, "formatmsg-test-dummy-dict")
+            LG_Error.printall(self.error_handler_test, self)
+            self.assertRegexpMatches(self.errinfo.formatmsg(), "link-grammar: Error: .*formatmsg-test-dummy-dict")
+
+    def test_40_clearall(self):
+        # Here the error handler is still set to None.
+        # Call LG_Error.clearall() and validate it indeed clears the error.
+        self.assertRaises(LG_Error, Dictionary, "clearall-test-dummy-dict")
+        LG_Error.clearall()
+        self.testit = "clearall"
+        self.numerr = LG_Error.printall(self.error_handler_test, self)
+        self.assertEqual(self.numerr, 0)
+        self.assertFalse(hasattr(self, "gotit"))
+
+    def test_50_set_orig_error_handler(self):
+        # Set the error handler back to the default handler.
+        # The error message is now visible (but we cannot test that).
+        self.__class__.handler["previous"] = LG_Error.set_handler(self.__class__.handler["default"])
+        self.assertIsNone(self.__class__.handler["previous"])
+        for _ in range(0, 1+self.testleaks):
+            self.__class__.handler["previous"] = LG_Error.set_handler(self.__class__.handler["default"])
+        self.assertEqual(self.__class__.handler["previous"].__name__, "_default_handler")
+        self.errinfo = "dummy"
+        self.assertRaises(LG_Error, Dictionary, "a visible dummy dict name (default handler test)")
+        self.assertEqual(self.errinfo, "dummy")
+
+class FSATsolverTestCase(unittest.TestCase):
     def setUp(self):
         self.d, self.po = Dictionary(lang='en'), ParseOptions()
         self.po = ParseOptions(use_sat=True)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -14,7 +14,7 @@ except ImportError:
 
 Clinkgrammar = clg
 __all__ = ['ParseOptions', 'Dictionary', 'Link', 'Linkage', 'Sentence',
-           'LG_DictionaryError', 'LG_TimerExhausted', 'Clinkgrammar']
+           'LG_Error', 'LG_DictionaryError', 'LG_TimerExhausted', 'Clinkgrammar']
 
 # A decorator to ensure keyword-only arguments to __init__ (besides self).
 # In Python3 it can be done by using "*" as the second __init__ argument,
@@ -275,7 +275,10 @@ class ParseOptions(object):
         clg.parse_options_set_all_short_connectors(self._obj, 1 if value else 0)
 
 
-class LG_DictionaryError(Exception):
+class LG_Error(Exception):
+    pass
+
+class LG_DictionaryError(LG_Error):
     pass
 
 class Dictionary(object):
@@ -405,7 +408,7 @@ class Linkage(object):
         return clg.linkage_print_constituent_tree(self._obj, mode)
 
 
-class LG_TimerExhausted(Exception):
+class LG_TimerExhausted(LG_Error):
     pass
 
 class Sentence(object):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -276,7 +276,34 @@ class ParseOptions(object):
 
 
 class LG_Error(Exception):
-    pass
+    @staticmethod
+    def set_handler(ehandler_function, ehandler_data=None):
+        old_handler = clg._py_error_set_handler((ehandler_function, ehandler_data))
+        if isinstance(old_handler, str):
+            return LG_Error._default_handler
+        return old_handler
+
+    # lg_error_formatmsg is implemented as method "formatmsg" on errinfo
+    #@staticmethod
+    #def format(lgerror):
+    #    return clg.lg_error_formatmsg(lgerror)
+
+    @staticmethod
+    def printall(ehandler_func, ehandler_data=None):
+        return clg._py_error_printall((ehandler_func, ehandler_data))
+
+    @staticmethod
+    def clearall():
+        return clg.lg_error_clearall()
+
+    @staticmethod
+    def message(msg):
+        return clg._prt_error(msg)
+
+    @staticmethod
+    def _default_handler(errinfo, data):
+        # Exceptions (on data): TypeError, ValueError
+        clg._py_error_default_handler(errinfo, data)
 
 class LG_DictionaryError(LG_Error):
     pass

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,10 @@ dnl in C++ source code.  They are needed for minisat.
 AC_DEFINE(__STDC_FORMAT_MACROS)
 AC_DEFINE(__STDC_LIMIT_MACROS)
 
+dnl Check for a keyword for Thread Local Storage declaration.
+dnl If found - define TLS to it.
+AX_TLS(,:)
+
 dnl Check for specific OSs
 # ====================================================================
 

--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,23 @@ CFLAGS="${CFLAGS} -D_DEFAULT_SOURCE"
 CXXFLAGS="${CXXFLAGS} -D_DEFAULT_SOURCE"
 
 # ====================================================================
+# TLS support (for per-thread error handling)
+
+error_handler_per_thread=no
+AC_ARG_ENABLE([TLS],
+  [AS_HELP_STRING([--disable-TLS], [Do not use TLS (disable per-thread error handling)])],
+  [],
+  [enable_TLS=yes])
+
+if test "x$enable_TLS" == xyes
+then
+	dnl Check for a keyword for Thread Local Storage declaration.
+	dnl If found - define TLS to it.
+	AX_TLS(,:)
+	test "$ac_cv_tls" != "none" && error_handler_per_thread=yes
+fi
+
+# ====================================================================
 # Debugging
 
 AC_ARG_ENABLE( debug,
@@ -1015,6 +1032,7 @@ $PACKAGE-$VERSION  build configuration settings
 	C compiler:                     ${CC} ${CPPFLAGS} ${CFLAGS}
 	C++ compiler:                   ${CXX} ${CPPFLAGS} ${CXXFLAGS}
 	Posix threads:                  ${enable_pthreads}
+	Error handler per-thread:       ${error_handler_per_thread}
 	Editline command-line history:  ${edlin}
 	UTF8 editline support:          ${wedlin}
 	Java libraries:                 ${JNIfound}

--- a/link-grammar/README
+++ b/link-grammar/README
@@ -13,7 +13,7 @@ The dict-sql directory contains code to read dictionaries from an SQL DB.
    (unfinished, under development!)
 
 
-Version 5.3.15 - Improved error notification facility
+Version 5.3.14 - Improved error notification facility
 -----------------------------------------------------
 
 This code is still "experimental", so its API may get changed.

--- a/link-grammar/README
+++ b/link-grammar/README
@@ -13,6 +13,116 @@ The dict-sql directory contains code to read dictionaries from an SQL DB.
    (unfinished, under development!)
 
 
+Version 5.3.15 - Improved error notification facility
+-----------------------------------------------------
+
+This code is still "experimental", so its API may get changed.
+
+It is intended to be mostly compatible. It supports multi-threading -
+all of its operations are local per-thread.
+A visible change is that the first parameter of prt_error() should now end
+with a newline in order to actually issue a message. However, its previous
+auto-issuing of a newline was not documented.
+
+Features:
+---------
+- Ability to intercept error messages (when required). This allow printing
+them not only to stdout/stderr, but to any other stream (like logging)
+or place (like a GUI window). This also allows to reformat the message.
+
+- Possibility to print a message in part and still have it printed as one
+ complete message. The API for that is natural - messages are gathered
+until a newline (if a message ends with "\n\" this is an embedded
+newline). The severity level of the last part, if exists, is used for the
+whole message.
+
+- New "severity levels":
+  -- Trace (for lgdebug()).
+  -- Debug (for other debug messages).
+  -- None (for plain messages that need to use the error facility).
+
+C API:
+------
+1.  lg_error_handler lg_error_set_handler(lg_error_handler, void *data);
+
+Set an error handler function. Return the previous one.
+On first call it returns the default handler function, that is
+pre-installed on program start.
+If the error handler is set to NULL, the messages are just queued,
+and can be retrieved by lg_error_printall() (see (4) below).
+
+For the default error handler, if data is not NULL, it is an
+(int *) severity_level. Messages with <= this level are printed to stdout.
+The default is to print Debug and lower to stdout.
+For custom error handler it can be of course a more complex user-data.
+
+2.  const void *lg_error_set_handler_data(void * data);
+
+Return the current error handler user data.
+(This function is useful mainly for implementing correct language
+bindings, which may need to free previously-allocated user-data).
+
+3.   char *lg_error_formatmsg(lg_errinfo *lge);
+
+Format the argument message.
+It adds "link-grammar" and severity.
+The lg_errinfo struct is part of the API.
+
+4.   int lg_error_printall(lg_error_handler, void *data);
+
+Print all the queued error messages and clear the queue.
+Return the number of messages.
+
+5.  int lg_error_clearall(void);
+Clear the queue of error messages.
+Return the number of messages.
+
+5.  int prt_error(const char *fmt, ...);
+Previously it was a void function, but now it returns int (always 0) so
+it can be used in complex macros (which make it necessary to use the comma
+operator).
+
+prt_error() still gets the severity label as a message prefix.
+The list of error severities is defined as part of the API, and the
+prefix that is used here is without the "lg_" part of the corresponding
+enums.  The default severity is "None", i.e. a plain message.
+(However, the enum severity code can be specified with the internal API
+err_msg(). When both are specified, the label takes precedence. All of
+these ways have their use in the code.)
+
+Issuing a message in parts is supported. The message is collected until
+its end and issued as one complete message. Issuing an embedded newline is
+supported. In addition to a newline in a middle of string, which doesn't
+terminate the message, and ending "\n\\" is a embedded newline.
+This allows, for example, constructing a single message using a loop or
+conditionals.
+
+See "link-includes.h" for the definition of severity levels and the
+lg_errinfo structure.
+
+Notes:
+------
+1.  lgdebug() (used internally to issue messages on verbosity levels > 0)
+now usually uses the new severity level lg_Trace (but sometimes lg_Debug
+or lg_Info).
+
+2.  Some messages from the library may still use printf(), and the
+intention is to convert them too to use the new error facility.
+
+Language bindings:
+------------------
+A Complete Python binding is provided under class LG_Error:
+LG_Error.set_handler()
+LG_Error.printall()
+LG_Error.clearall()
+LG_Error.message()     # prt_error()
+errinfo.formatmsg()    # errinfo is the first argument of the error handler
+errinfo.severity, errinfo.severity_label, errinfo.text # lg_errinfo fields
+
+LG_Error is also used as a general exception.
+See "tests.py" for usage of all of the above bindings.
+
+
 Version 5.3.0 - Introduction of a word-graph for tokenizing
 -----------------------------------------------------------
 

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -363,13 +363,13 @@ bool anysplit_init(Dictionary afdict)
 	if (0 == regparts->length)
 	{
 		if (debug_level(+D_AS))
-			prt_error("Warning: File %s: Anysplit disabled (%s not defined)",
-			          afdict->name, afdict_classname[AFDICT_REGPARTS]);
+			prt_error("Warning: File %s: Anysplit disabled (%s not defined)\n",
+		             afdict->name, afdict_classname[AFDICT_REGPARTS]);
 		return true;
 	}
 	if (1 != regparts->length)
 	{
-		prt_error("Error: File %s: Must have %s defined with one value",
+		prt_error("Error: File %s: Must have %s defined with one value\n",
 		          afdict->name, afdict_classname[AFDICT_REGPARTS]);
 		return false;
 	}
@@ -390,7 +390,7 @@ bool anysplit_init(Dictionary afdict)
 	if (as->nparts < 0)
 	{
 		free_anysplit(afdict);
-		prt_error("Error: File %s: Value of %s must be a non-negative number",
+		prt_error("Error: File %s: Value of %s must be a non-negative number\n",
 		          afdict->name, afdict_classname[AFDICT_REGPARTS]);
 		return false;
 	}
@@ -405,7 +405,7 @@ bool anysplit_init(Dictionary afdict)
 	if (2 != regalts->length)
 	{
 		free_anysplit(afdict);
-		prt_error("Error: File %s: Must have %s defined with 2 values",
+		prt_error("Error: File %s: Must have %s defined with 2 values\n",
 		          afdict->name, afdict_classname[AFDICT_REGALTS]);
 		return false;
 	}
@@ -414,7 +414,7 @@ bool anysplit_init(Dictionary afdict)
 	if ((atoi(regalts->string[0]) <= 0) || (atoi(regalts->string[1]) <= 0))
 	{
 		free_anysplit(afdict);
-		prt_error("Error: File %s: Value of %s must be 2 positive numbers",
+		prt_error("Error: File %s: Value of %s must be 2 positive numbers\n",
 		          afdict->name, afdict_classname[AFDICT_REGALTS]);
 		return false;
 	}

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -221,8 +221,8 @@ static int split(int word_length, int nparts, split_cache *scl)
 		//printf("nsplits %zu\n", nsplits);
 		if (0 == nsplits)
 		{
-			fprintf(stderr, "Error: nsplits=%zu (word_length=%d, nparts=%d)\n",
-				nsplits, word_length, nparts);
+			prt_error("Error: nsplits=0 (word_length=%d, nparts=%d)\n",
+				word_length, nparts);
 			return 0;
 		}
 		scl->sp = malloc(sizeof(p_start)*nparts * nsplits);

--- a/link-grammar/anysplit.c
+++ b/link-grammar/anysplit.c
@@ -362,7 +362,7 @@ bool anysplit_init(Dictionary afdict)
 
 	if (0 == regparts->length)
 	{
-		if (debug_level(+D_AS))
+		if (verbosity_level(+D_AS))
 			prt_error("Warning: File %s: Anysplit disabled (%s not defined)\n",
 		             afdict->name, afdict_classname[AFDICT_REGPARTS]);
 		return true;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -766,7 +766,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 
 	print_time(opts, "Postprocessed all linkages");
 
-	if (debug_level(6))
+	if (verbosity_level(6))
 	{
 		err_msg(lg_Info, "Info: %zu of %zu linkages with no P.P. violations",
 		        N_valid_linkages, N_linkages_post_processed);
@@ -1208,7 +1208,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 
 		assert(MT_EMPTY != cdj->word[0]->morpheme_type); /* already discarded */
 
-		if (debug_level(D_SLM))
+		if (verbosity_level(D_SLM))
 		{
 			char *djw_tmp = strdupa(cdj->string);
 			char *sm = strrchr(djw_tmp, SUBSCRIPT_MARK);
@@ -1390,7 +1390,7 @@ static void sane_morphism(Sentence sent, Parse_Options opts)
 			N_invalid_morphism ++;
 	}
 
-	if (debug_level(5))
+	if (verbosity_level(5))
 	{
 		prt_error("Info: sane_morphism(): %zu of %zu linkages had "
 		          "invalid morphology construction\n",
@@ -1504,7 +1504,7 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 		hist = do_parse(sent, mchxt, ctxt, sent->null_count, opts);
 		total = hist_total(&hist);
 
-		if (debug_level(5))
+		if (verbosity_level(5))
 		{
 			prt_error("Info: Total count with %zu null links:   %lld\n",
 			          sent->null_count, total);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1452,7 +1452,7 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 	 * if it was previously parsed.  If so we free it up before
 	 * building another.  Huh ?? How could that happen? */
 #ifdef DEBUG
-	if (sent->parse_info) fprintf(stderr, "XXX Freeing parse_info\n");
+	if (sent->parse_info) err_msg(Debug, "XXX Freeing parse_info\n");
 #endif
 	free_parse_info(sent->parse_info);
 	sent->parse_info = parse_info_new(sent->length);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1522,8 +1522,8 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 		sane_morphism(sent, opts);
 		post_process_linkages(sent, opts);
 		if (sent->num_valid_linkages > 0) break;
-		if ((0 == nl) && (0 < max_null_count))
-			lgdebug(1, "No complete linkages found.\n");
+		if ((0 == nl) && (0 < max_null_count) && verbosity > 0)
+			prt_error("No complete linkages found.\n");
 
 		/* If we are here, then no valid linkages were found.
 		 * If there was a parse overflow, give up now. */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -511,10 +511,9 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 
 	if (overflowed && (1 < opts->verbosity))
 	{
-		err_ctxt ec;
-		ec.sent = sent;
-		err_msg(&ec, Warn, "Warning: Count overflow.\n"
-		  "Considering a random subset of %zu of an unknown and large number of linkages\n",
+		err_ctxt ec = { sent };
+		err_msgc(&ec, Warn, "Warning: Count overflow.\n"
+		  "Considering a random subset of %zu of an unknown and large number of linkages",
 			opts->linkage_limit);
 	}
 	N_linkages_found = sent->num_linkages_found;
@@ -533,10 +532,9 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 		N_linkages_alloced = opts->linkage_limit;
 		if (opts->verbosity > 1)
 		{
-			err_ctxt ec;
-			ec.sent = sent;
-			err_msg(&ec, Warn,
-			    "Warning: Considering a random subset of %zu of %zu linkages\n",
+			err_ctxt ec = { sent };
+			err_msgc(&ec, Warn,
+			    "Warning: Considering a random subset of %zu of %zu linkages",
 			    N_linkages_alloced, N_linkages_found);
 		}
 	}
@@ -770,9 +768,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 
 	if (debug_level(6))
 	{
-		err_ctxt ec;
-		ec.sent = sent;
-		err_msg(&ec, Info, "Info: %zu of %zu linkages with no P.P. violations\n",
+		err_msg(Info, "Info: %zu of %zu linkages with no P.P. violations",
 		        N_valid_linkages, N_linkages_post_processed);
 	}
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -1157,7 +1157,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 
 		if (NULL == wp_new)
 		{
-			lgdebug(+D_SLM, "- No more words in the wordgraph\n");
+			lgdebug(D_SLM, "- No more words in the wordgraph\n");
 			match_found = false;
 			break;
 		}
@@ -1208,7 +1208,13 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 
 		assert(MT_EMPTY != cdj->word[0]->morpheme_type); /* already discarded */
 
-		if (debug_level(D_SLM)) print_with_subscript_dot(cdj->string);
+		if (debug_level(D_SLM))
+		{
+			char *djw_tmp = strdupa(cdj->string);
+			char *sm = strrchr(djw_tmp, SUBSCRIPT_MARK);
+			if (NULL != sm) *sm = SUBSCRIPT_DOT;
+			lgdebug(0, "%s", djw_tmp);
+		}
 
 		match_found = false;
 		/* Proceed in all the paths in which the word is found. */
@@ -1337,9 +1343,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			/* Notify to stdout, so it will be shown along with the result.
 			 * XXX We should have a better way to notify. */
 			if (0 < opts->verbosity)
-				printf("Warning: Invalid morpheme type combination '%s'.\n"
-				       "Run with !bad and !verbosity>"STRINGIFY(D_USER_MAX)
-				       " to debug\n", affix_types);
+				prt_error("Warning: Invalid morpheme type combination '%s'.\n"
+				          "Run with !bad and !verbosity>"STRINGIFY(D_USER_MAX)
+				          " to debug\n", affix_types);
 		}
 	}
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -512,7 +512,7 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 	if (overflowed && (1 < opts->verbosity))
 	{
 		err_ctxt ec = { sent };
-		err_msgc(&ec, Warn, "Warning: Count overflow.\n"
+		err_msgc(&ec, lg_Warn, "Warning: Count overflow.\n"
 		  "Considering a random subset of %zu of an unknown and large number of linkages",
 			opts->linkage_limit);
 	}
@@ -533,7 +533,7 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 		if (opts->verbosity > 1)
 		{
 			err_ctxt ec = { sent };
-			err_msgc(&ec, Warn,
+			err_msgc(&ec, lg_Warn,
 			    "Warning: Considering a random subset of %zu of %zu linkages",
 			    N_linkages_alloced, N_linkages_found);
 		}
@@ -768,7 +768,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 
 	if (debug_level(6))
 	{
-		err_msg(Info, "Info: %zu of %zu linkages with no P.P. violations",
+		err_msg(lg_Info, "Info: %zu of %zu linkages with no P.P. violations",
 		        N_valid_linkages, N_linkages_post_processed);
 	}
 
@@ -1452,7 +1452,7 @@ static void chart_parse(Sentence sent, Parse_Options opts)
 	 * if it was previously parsed.  If so we free it up before
 	 * building another.  Huh ?? How could that happen? */
 #ifdef DEBUG
-	if (sent->parse_info) err_msg(Debug, "XXX Freeing parse_info\n");
+	if (sent->parse_info) err_msg(lg_Debug, "XXX Freeing parse_info\n");
 #endif
 	free_parse_info(sent->parse_info);
 	sent->parse_info = parse_info_new(sent->length);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -288,7 +288,7 @@ void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {
 	if (dummy && (verbosity > D_USER_BASIC))
 	{
 		prt_error("Error: Cannot enable the Boolean SAT parser; "
-		          "this library was built without SAT solver support.");
+		          "this library was built without SAT solver support.\n");
 	}
 #endif
 }
@@ -352,7 +352,7 @@ void parse_options_set_spell_guess(Parse_Options opts, int dummy) {
 	if (dummy && (verbosity > D_USER_BASIC))
 	{
 		prt_error("Error: Cannot enable spell guess; "
-		        "this library was built without spell guess support.");
+		        "this library was built without spell guess support.\n");
 	}
 
 #endif /* defined HAVE_HUNSPELL || defined HAVE_ASPELL */
@@ -873,7 +873,7 @@ int sentence_split(Sentence sent, Parse_Options opts)
 	{
 		/* Make sure an error message is always printed.
 		 * So it may be redundant. */
-		prt_error("Error: sentence_split(): Internal error detected");
+		prt_error("Error: sentence_split(): Internal error detected\n");
 		return -3;
 	}
 
@@ -1200,9 +1200,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 
 		if (!match_found)
 		{
-			const char *e = "Internal error: Too many words in the linkage\n";
-			lgdebug(D_SLM, "- %s", e);
-			prt_error("Error: %s.", e);
+			const char *e = "Internal error: Too many words in the linkage";
+			lgdebug(D_SLM, "- %s\n", e);
+			prt_error("Error: %s.\n", e);
 			break;
 		}
 
@@ -1579,7 +1579,7 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 	if ((verbosity > 0) &&
 	   (PARSE_NUM_OVERFLOW < sent->num_linkages_found))
 	{
-		prt_error("WARNING: Combinatorial explosion! nulls=%zu cnt=%d\n"
+		prt_error("Warning: Combinatorial explosion! nulls=%zu cnt=%d\n"
 			"Consider retrying the parse with the max allowed disjunct cost set lower.\n"
 			"At the command line, use !cost-max\n",
 			sent->null_count, sent->num_linkages_found);

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -664,7 +664,7 @@ static const char * cons_of_domain(const Linkage linkage, char domain_type)
 	default:
 		{
 			err_ctxt ec = { linkage->sent };
-			err_msg(&ec, Error, "Error: Illegal domain: %c\n", domain_type);
+			err_msgc(&ec, Error, "Error: Illegal domain: %c", domain_type);
 			return "";
 		}
 	}
@@ -821,12 +821,12 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 		if (ctxt->constituent[c].domain_type == '\0')
 		{
 			err_ctxt ec = { linkage->sent };
-			err_msg(&ec, Error, "Error: no domain type assigned to constituent\n");
+			err_msgc(&ec, Error, "Error: no domain type assigned to constituent");
 		}
 		if (ctxt->constituent[c].start_link == NULL)
 		{
 			err_ctxt ec = { linkage->sent };
-			err_msg(&ec, Error, "Error: no type assigned to constituent\n");
+			err_msgc(&ec, Error, "Error: no type assigned to constituent");
 		}
 	}
 
@@ -932,9 +932,9 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 						if (debug_level(D_CONST))
 						{
 							err_ctxt ec = { linkage->sent };
-							err_msg(&ec, Warn,
+							err_msgc(&ec, Warn,
 							      "Warning: the constituents aren't nested! "
-							      "Adjusting them. (%d, %d)\n", c, c2);
+							      "Adjusting them. (%d, %d)", c, c2);
 					  }
 					  ctxt->constituent[c].left = ctxt->constituent[c2].left;
 					}

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -216,7 +216,7 @@ static int gen_comp(con_context_t *ctxt, Linkage linkage,
 		if (!(strcmp(ctxt->constituent[c1].type, ctype1)==0))
 			continue;
 
-		if (debug_level(D_CONST))
+		if (verbosity_level(D_CONST))
 			err_msg(lg_Debug, "Generating complement constituent for c %d of type %s\n",
 				   c1, ctype1);
 		done = false;
@@ -267,7 +267,7 @@ static int gen_comp(con_context_t *ctxt, Linkage linkage,
 					ctxt->constituent[c].domain_type = 'x';
 					ctxt->constituent[c].start_link =
 						string_set_add("XX", ctxt->phrase_ss);
-					if (debug_level(D_CONST))
+					if (verbosity_level(D_CONST))
 					{
 						err_msg(lg_Debug, "Larger c found: c %d (%s); ", c2, ctype2);
 						err_msg(lg_Debug, "Adding constituent:\n\\");
@@ -279,7 +279,7 @@ static int gen_comp(con_context_t *ctxt, Linkage linkage,
 				}
 			}
 		}
-		if (debug_level(D_CONST))
+		if (verbosity_level(D_CONST))
 		{
 			if (done == false)
 				err_msg(lg_Debug, "No constituent added, because no larger %s" \
@@ -328,7 +328,7 @@ static void adjust_subordinate_clauses(con_context_t *ctxt, Linkage linkage,
 						w = ctxt->constituent[c].left - 1;
 						ctxt->constituent[c2].right = w;
 
-						if (debug_level(D_CONST))
+						if (verbosity_level(D_CONST))
 						{
 							err_msg(lg_Debug, "Adjusting constituent %d:\n\\", c2);
 							print_constituent(ctxt, linkage, c2);
@@ -587,7 +587,7 @@ static int last_minute_fixes(con_context_t *ctxt, Linkage linkage, int numcon_to
 		ctxt->constituent[c].valid = true;
 		ctxt->constituent[c].domain_type = 'x';
 		numcon_total++;
-		if (debug_level(D_CONST))
+		if (verbosity_level(D_CONST))
 		{
 			err_msg(lg_Debug, "Adding global sentence constituent:\n\\");
 			print_constituent(ctxt, linkage, c);
@@ -832,7 +832,7 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 	numcon_subl = c - numcon_total;
 	/* numcon_subl = handle_islands(linkage, numcon_total, numcon_subl);  */
 
-	if (debug_level(D_CONST))
+	if (verbosity_level(D_CONST))
 	{
 		err_msg(lg_Debug, "Constituents added at first stage:\n\\");
 		for (c = numcon_total; c < numcon_total + numcon_subl; c++)
@@ -916,21 +916,21 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 						(strcmp(linkage->word[ctxt->constituent[c2].right],
 								"RIGHT-WALL") == 0))
 					{
-						if (debug_level(D_CONST))
+						if (verbosity_level(D_CONST))
 							err_msg(lg_Debug, "Adjusting %d to fix comma overlap\n", c2);
 						adjust_for_right_comma(ctxt, linkage, c2);
 						adjustment_made = true;
 					}
 					else if (strcmp(linkage->word[ctxt->constituent[c].left], ",") == 0)
 					{
-						if (debug_level(D_CONST))
+						if (verbosity_level(D_CONST))
 							err_msg(lg_Debug, "Adjusting c %d to fix comma overlap\n", c);
 						adjust_for_left_comma(ctxt, linkage, c);
 						adjustment_made = true;
 					}
 					else
 					{
-						if (debug_level(D_CONST))
+						if (verbosity_level(D_CONST))
 						{
 							err_ctxt ec = { linkage->sent };
 							err_msgc(&ec, lg_Warn,

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -107,13 +107,13 @@ static void print_constituent(con_context_t *ctxt, Linkage linkage, int c)
 {
 	size_t w;
 
-	printf("  c %2d %4s [%c] (%2zu-%2zu): ",
+	err_msg(lg_Debug, "  c %2d %4s [%c] (%2zu-%2zu): ",
 		   c, ctxt->constituent[c].type, ctxt->constituent[c].domain_type,
 		   ctxt->constituent[c].left, ctxt->constituent[c].right);
 	for (w = ctxt->constituent[c].left; w <= ctxt->constituent[c].right; w++) {
-		printf("%s ", linkage->word[w]); /**PV**/
+		err_msg(lg_Debug, "%s ", linkage->word[w]); /**PV**/
 	}
-	printf("\n");
+	err_msg(lg_Debug, "\n");
 }
 
 /******************************************************
@@ -217,7 +217,7 @@ static int gen_comp(con_context_t *ctxt, Linkage linkage,
 			continue;
 
 		if (debug_level(D_CONST))
-			printf("Generating complement constituent for c %d of type %s\n",
+			err_msg(lg_Debug, "Generating complement constituent for c %d of type %s\n",
 				   c1, ctype1);
 		done = false;
 		for (w2 = ctxt->constituent[c1].left; (done == false) && (w2 != (size_t)-1); w2--)
@@ -269,9 +269,8 @@ static int gen_comp(con_context_t *ctxt, Linkage linkage,
 						string_set_add("XX", ctxt->phrase_ss);
 					if (debug_level(D_CONST))
 					{
-						printf("Larger c found: c %d (%s); ",
-							   c2, ctype2);
-						printf("Adding constituent:\n");
+						err_msg(lg_Debug, "Larger c found: c %d (%s); ", c2, ctype2);
+						err_msg(lg_Debug, "Adding constituent:\n\\");
 						print_constituent(ctxt, linkage, c);
 					}
 					c++;
@@ -283,7 +282,7 @@ static int gen_comp(con_context_t *ctxt, Linkage linkage,
 		if (debug_level(D_CONST))
 		{
 			if (done == false)
-				printf("No constituent added, because no larger %s " \
+				err_msg(lg_Debug, "No constituent added, because no larger %s" \
 					   " was found\n", ctype2);
 		}
 	}
@@ -331,7 +330,7 @@ static void adjust_subordinate_clauses(con_context_t *ctxt, Linkage linkage,
 
 						if (debug_level(D_CONST))
 						{
-							printf("Adjusting constituent %d:\n", c2);
+							err_msg(lg_Debug, "Adjusting constituent %d:\n\\", c2);
 							print_constituent(ctxt, linkage, c2);
 						}
 					}
@@ -590,7 +589,7 @@ static int last_minute_fixes(con_context_t *ctxt, Linkage linkage, int numcon_to
 		numcon_total++;
 		if (debug_level(D_CONST))
 		{
-			printf("Adding global sentence constituent:\n");
+			err_msg(lg_Debug, "Adding global sentence constituent:\n\\");
 			print_constituent(ctxt, linkage, c);
 		}
 	}
@@ -835,9 +834,11 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 
 	if (debug_level(D_CONST))
 	{
-		printf("Constituents added at first stage:\n");
+		err_msg(lg_Debug, "Constituents added at first stage:\n\\");
 		for (c = numcon_total; c < numcon_total + numcon_subl; c++)
 		{
+			/* FIXME: Here it cannot be printed as one debug message because
+			 * a newline is printed at the end. */
 			print_constituent(ctxt, linkage, c);
 		}
 	}
@@ -916,14 +917,14 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 								"RIGHT-WALL") == 0))
 					{
 						if (debug_level(D_CONST))
-							printf("Adjusting %d to fix comma overlap\n", c2);
+							err_msg(lg_Debug, "Adjusting %d to fix comma overlap\n", c2);
 						adjust_for_right_comma(ctxt, linkage, c2);
 						adjustment_made = true;
 					}
 					else if (strcmp(linkage->word[ctxt->constituent[c].left], ",") == 0)
 					{
 						if (debug_level(D_CONST))
-							printf("Adjusting c %d to fix comma overlap\n", c);
+							err_msg(lg_Debug, "Adjusting c %d to fix comma overlap\n", c);
 						adjust_for_left_comma(ctxt, linkage, c);
 						adjustment_made = true;
 					}
@@ -968,9 +969,6 @@ exprint_constituent_structure(con_context_t *ctxt,
 		leftdone[c] = false;
 		rightdone[c] = false;
 	}
-
-	if (debug_level(D_CONST))
-		printf("\n");
 
 	/* Skip left wall; don't skip right wall, since it may
 	 * have constituent boundaries. */

--- a/link-grammar/constituents.c
+++ b/link-grammar/constituents.c
@@ -664,7 +664,7 @@ static const char * cons_of_domain(const Linkage linkage, char domain_type)
 	default:
 		{
 			err_ctxt ec = { linkage->sent };
-			err_msgc(&ec, Error, "Error: Illegal domain: %c", domain_type);
+			err_msgc(&ec, lg_Error, "Error: Illegal domain: %c", domain_type);
 			return "";
 		}
 	}
@@ -821,12 +821,12 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 		if (ctxt->constituent[c].domain_type == '\0')
 		{
 			err_ctxt ec = { linkage->sent };
-			err_msgc(&ec, Error, "Error: no domain type assigned to constituent");
+			err_msgc(&ec, lg_Error, "Error: no domain type assigned to constituent");
 		}
 		if (ctxt->constituent[c].start_link == NULL)
 		{
 			err_ctxt ec = { linkage->sent };
-			err_msgc(&ec, Error, "Error: no type assigned to constituent");
+			err_msgc(&ec, lg_Error, "Error: no type assigned to constituent");
 		}
 	}
 
@@ -932,7 +932,7 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 						if (debug_level(D_CONST))
 						{
 							err_ctxt ec = { linkage->sent };
-							err_msgc(&ec, Warn,
+							err_msgc(&ec, lg_Warn,
 							      "Warning: the constituents aren't nested! "
 							      "Adjusting them. (%d, %d)", c, c2);
 					  }

--- a/link-grammar/corpus/corpus.c
+++ b/link-grammar/corpus/corpus.c
@@ -83,13 +83,13 @@ Corpus * lg_corpus_new(void)
 		if (SQLITE_CANTOPEN == c->rc)
 		{
 			prt_error("Warning: File not found: %s\n"
-			          "\tWas looking for: " DBNAME,
+			          "\tWas looking for: " DBNAME "\n",
 				c->errmsg);
 		}
 		else
 		{ 
 			prt_error("Warning: Can't open database: %s\n"
-			          "\tWas looking for: " DBNAME,
+			          "\tWas looking for: " DBNAME "\n",
 				c->errmsg);
 		}
 		return c;

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -298,7 +298,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 			bool Rmatch = d->match_right;
 
 #ifdef VERIFY_MATCH_LIST
-			assert(id == d->match_id, "Modified id (%d!=%d)\n", id, d->match_id);
+			assert(id == d->match_id, "Modified id (%d!=%d)", id, d->match_id);
 #endif
 			/* _p1 avoids a gcc warning about unsafe loop opt */
 			unsigned int null_count_p1 = null_count + 1;

--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -344,7 +344,7 @@ void dictionary_delete(Dictionary dict)
 	if (!dict) return;
 
 	if (verbosity > 0) {
-		prt_error("Info: Freeing dictionary %s", dict->name);
+		prt_error("Info: Freeing dictionary %s\n", dict->name);
 	}
 
 #ifdef USE_CORPUS

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -74,7 +74,7 @@ Afdict_class * afdict_find(Dictionary afdict, const char * con, bool notify_err)
 	}
 	if (notify_err) {
 		prt_error("Warning: Unknown class name %s found near line %d of %s.\n"
-		          "\tThis class name will be ignored.",
+		          "\tThis class name will be ignored.\n",
 		          con, afdict->line_number, afdict->name);
 	}
 	return NULL;
@@ -109,7 +109,7 @@ static void load_affix(Dictionary afdict, Dict_node *dn, int l)
 			/* ??? should we support here more than one class? */
 			prt_error("Warning: Word \"%s\" found near line %d of %s.\n"
 			          "\tWord has more than one connector.\n"
-			          "\tThis word will be ignored.",
+			          "\tThis word will be ignored.\n",
 			          dn->string, afdict->line_number, afdict->name);
 			return;
 		}
@@ -451,7 +451,7 @@ dictionary_six_str(const char * lang,
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
 		if (debug_level(D_USER_BASIC) && (NULL == dict->spell_checker))
-			prt_error("Info: %s: Spell checker disabled.", dict->lang);
+			prt_error("Info: %s: Spell checker disabled.\n", dict->lang);
 #endif
 		dict->insert_entry = insert_list;
 
@@ -530,7 +530,7 @@ dictionary_six_str(const char * lang,
 	{
 		dict->locale = setlocale(LC_CTYPE, NULL);
 		prt_error("Warning: Couldn't set dictionary locale! "
-		          "Using current program locale \"%s\"", dict->locale);
+		          "Using current program locale \"%s\"\n", dict->locale);
 	}
 
 	/* setlocale() returns a string owned by the system. Copy it. */
@@ -556,7 +556,7 @@ dictionary_six_str(const char * lang,
 	dict->affix_table = dictionary_six(lang, affix_name, NULL, NULL, NULL, NULL);
 	if (dict->affix_table == NULL)
 	{
-		prt_error("Error: Could not open affix file %s", affix_name);
+		prt_error("Error: Could not open affix file %s\n", affix_name);
 		goto failure;
 	}
 	if (! afdict_init(dict))
@@ -629,7 +629,7 @@ dictionary_six(const char * lang, const char * dict_name,
 	char* input = get_file_contents(dict_name);
 	if (NULL == input)
 	{
-		prt_error("Error: Could not open dictionary %s", dict_name);
+		prt_error("Error: Could not open dictionary %s\n", dict_name);
 		return NULL;
 	}
 
@@ -670,7 +670,7 @@ Dictionary dictionary_create_from_file(const char * lang)
 	}
 	else
 	{
-		prt_error("Error: No language specified!");
+		prt_error("Error: No language specified!\n");
 		dictionary = NULL;
 	}
 

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -302,7 +302,7 @@ static bool afdict_init(Dictionary dict)
 		affix_list_add(afdict, &afdict->afdict_class[AFDICT_INFIXMARK], "");
 	}
 
-	if (debug_level(+D_AI))
+	if (verbosity_level(+D_AI))
 	{
 		size_t l;
 
@@ -450,7 +450,7 @@ dictionary_six_str(const char * lang,
 		dict->spell_checker = spellcheck_create(dict->lang);
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
-		if (debug_level(D_USER_BASIC) && (NULL == dict->spell_checker))
+		if (verbosity_level(D_USER_BASIC) && (NULL == dict->spell_checker))
 			prt_error("Info: %s: Spell checker disabled.\n", dict->lang);
 #endif
 		dict->insert_entry = insert_list;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -629,7 +629,7 @@ dictionary_six(const char * lang, const char * dict_name,
 	char* input = get_file_contents(dict_name);
 	if (NULL == input)
 	{
-		prt_error("Error: Could not open dictionary %s\n", dict_name);
+		prt_error("Error: Could not open dictionary \"%s\"\n", dict_name);
 		return NULL;
 	}
 

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -580,7 +580,7 @@ dictionary_six_str(const char * lang,
 		goto failure;
 	}
 	locale = setlocale(LC_CTYPE, locale);            /* Restore the locale. */
-	assert(NULL != locale, "Cannot restore program locale\n");
+	assert(NULL != locale, "Cannot restore program locale");
 
 #ifdef USE_CORPUS
 	dict->corpus = lg_corpus_new();

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1832,7 +1832,7 @@ static bool read_entry(Dictionary dict)
 			instr = get_file_contents(dict_name + skip_slash);
 			if (NULL == instr)
 			{
-				prt_error("Error: Could not open subdictionary %s\n", dict_name);
+				prt_error("Error: Could not open subdictionary \"%s\"\n", dict_name);
 				goto syntax_error;
 			}
 			dict->input = instr;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -348,19 +348,15 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 
 	if (s2)
 	{
-		err_ctxt ec;
-		ec.sent = NULL;
-		err_msg(&ec, Error, "Error parsing dictionary %s.\n"
-		          "%s %s\n\t line %d, tokens = %s\n",
+		err_msg(Error, "Error parsing dictionary %s.\n"
+		          "%s %s\n\t line %d, tokens = %s",
 		        dict->name,
 		        s, s2, dict->line_number, tokens);
 	}
 	else
 	{
-		err_ctxt ec;
-		ec.sent = NULL;
-		err_msg(&ec, Error, "Error parsing dictionary %s.\n"
-		          "%s\n\t line %d, tokens = %s\n",
+		err_msg(Error, "Error parsing dictionary %s.\n"
+		          "%s\n\t line %d, tokens = %s",
 		        dict->name,
 		        s, dict->line_number, tokens);
 	}
@@ -374,10 +370,8 @@ static void dict_error(Dictionary dict, const char * s)
 
 static void warning(Dictionary dict, const char * s)
 {
-	err_ctxt ec;
-	ec.sent = NULL;
-	err_msg(&ec, Warn, "Warning: %s\n"
-	        "\tline %d, current token = \"%s\"\n",
+	err_msg(Warn, "Warning: %s\n"
+	        "\tline %d, current token = \"%s\"",
 	        s, dict->line_number, dict->token);
 }
 
@@ -1743,9 +1737,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	}
 	else if (is_idiom_word(dn->string))
 	{
-		err_ctxt ec;
-		ec.sent = NULL;
-		err_msg(&ec, Warn, "Warning: Word \"%s\" found near line %d of %s.\n"
+		err_msg(Warn, "Warning: Word \"%s\" found near line %d of %s.\n"
 		        "\tWords ending \".Ix\" (x a number) are reserved for idioms.\n"
 		        "\tThis word will be ignored.",
 		        dn->string, dict->line_number, dict->name);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -58,7 +58,7 @@ static const char * format_locale(Dictionary dict,
 	r = mbstowcs(wlocale, locale, LOCALE_NAME_MAX_LENGTH);
 	if ((size_t)-1 == r)
 	{
-		prt_error("Error: Error converting %s to wide character.", locale);
+		prt_error("Error: Error converting %s to wide character.\n", locale);
 		return NULL;
 	}
 	wlocale[LOCALE_NAME_MAX_LENGTH-1] = L'\0';
@@ -66,20 +66,20 @@ static const char * format_locale(Dictionary dict,
 	if (0 >= GetLocaleInfoEx(wlocale, LOCALE_SENGLISHLANGUAGENAME,
 	                         wtmpbuf, LOCALE_NAME_MAX_LENGTH))
 	{
-		prt_error("Error: GetLocaleInfoEx LOCALE_SENGLISHLANGUAGENAME Locale=%s: "
+		prt_error("Error: GetLocaleInfoEx LOCALE_SENGLISHLANGUAGENAME Locale=%s: \n"
 		          "Error %d", locale, (int)GetLastError());
 		return NULL;
 	}
 	r = wcstombs(tmpbuf, wtmpbuf, LOCALE_NAME_MAX_LENGTH);
 	if ((size_t)-1 == r)
 	{
-		prt_error("Error: Error converting locale language from wide character.");
+		prt_error("Error: Error converting locale language from wide character.\n");
 		return NULL;
 	}
 	tmpbuf[LOCALE_NAME_MAX_LENGTH-1] = '\0';
 	if (0 == strncmp(tmpbuf, "Unknown", 7))
 	{
-		prt_error("Error: Unknown territory code in locale \"%s\"", locale);
+		prt_error("Error: Unknown territory code in locale \"%s\"\n", locale);
 		return NULL;
 	}
 	strcpy(locale_buf, tmpbuf);
@@ -88,20 +88,20 @@ static const char * format_locale(Dictionary dict,
 	if (0 >= GetLocaleInfoEx(wlocale, LOCALE_SENGLISHCOUNTRYNAME,
 	                         wtmpbuf, LOCALE_NAME_MAX_LENGTH))
 	{
-		prt_error("Error: GetLocaleInfoEx LOCALE_SENGLISHCOUNTRYNAME Locale=%s: "
+		prt_error("Error: GetLocaleInfoEx LOCALE_SENGLISHCOUNTRYNAME Locale=%s: \n"
 		          "Error %d", locale, (int)GetLastError());
 		return NULL;
 	}
 	r = wcstombs(tmpbuf, wtmpbuf, LOCALE_NAME_MAX_LENGTH);
 	if ((size_t)-1 == r)
 	{
-		prt_error("Error: Error converting locale territory from wide character.");
+		prt_error("Error: Error converting locale territory from wide character.\n");
 		return NULL;
 	}
 	tmpbuf[LOCALE_NAME_MAX_LENGTH-1] = '\0';
 	if (0 == strncmp(tmpbuf, "Unknown", 7))
 	{
-		prt_error("Error: Unknown territory code in locale \"%s\"", locale);
+		prt_error("Error: Unknown territory code in locale \"%s\"\n", locale);
 		return NULL;
 	}
 	locale = strcat(locale_buf, tmpbuf);
@@ -160,7 +160,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 			prt_error("Error: \"<dictionary-locale>: %s\" "
 			          "should be in the form LL4cc+\n"
 						 "\t(LL: language code; cc: territory code) "
-						 "\tor C+ for transliterated dictionaries.",
+						 "\tor C+ for transliterated dictionaries.\n",
 						 dn->exp->u.string);
 			goto locale_error;
 		}
@@ -169,7 +169,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 
 		if (!try_locale(locale))
 		{
-			prt_error("Debug: Dictionary \"%s\": Locale \"%s\" unknown",
+			prt_error("Debug: Dictionary \"%s\": Locale \"%s\" unknown\n",
 			          dict->name, locale);
 			goto locale_error;
 		}
@@ -189,7 +189,7 @@ locale_error:
 		const char *sslocale = string_set_add(locale, dict->string_set);
 		free((void *)locale);
 		prt_error("Info: Dictionary '%s': No locale definition - "
-		          "\"%s\" will be used.", dict->name, sslocale);
+		          "\"%s\" will be used.\n", dict->name, sslocale);
 		if (!try_locale(sslocale))
 		{
 			lgdebug(D_USER_FILES, "Debug: Unknown locale \"%s\"...\n", sslocale);
@@ -1754,9 +1754,9 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 		          "found near line %d of %s matches the following words:",
 	             dn->string, dict->line_number, dict->name);
 		for (dnx = dn_head; dnx != NULL; dnx = dnx->right) {
-			fprintf(stderr, "\t%s", dnx->string);
+			prt_error("\a\t%s", dnx->string);
 		}
-		fprintf(stderr, "\n\tThis word will be ignored.\n");
+		prt_error("\a\n\tThis word will be ignored.\n");
 		free_lookup(dn_head);
 		free_dict_node(dn);
 	}
@@ -1800,7 +1800,7 @@ static bool read_entry(Dictionary dict)
 			dn = read_word_file(dict, dn, dict->token);
 			if (dn == NULL)
 			{
-				prt_error("Error opening word file %s", dict->token);
+				prt_error("Error opening word file %s\n", dict->token);
 				return false;
 			}
 		}
@@ -1832,7 +1832,7 @@ static bool read_entry(Dictionary dict)
 			instr = get_file_contents(dict_name + skip_slash);
 			if (NULL == instr)
 			{
-				prt_error("Error: Could not open subdictionary %s", dict_name);
+				prt_error("Error: Could not open subdictionary %s\n", dict_name);
 				goto syntax_error;
 			}
 			dict->input = instr;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -348,14 +348,14 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 
 	if (s2)
 	{
-		err_msg(Error, "Error parsing dictionary %s.\n"
+		err_msg(lg_Error, "Error parsing dictionary %s.\n"
 		          "%s %s\n\t line %d, tokens = %s",
 		        dict->name,
 		        s, s2, dict->line_number, tokens);
 	}
 	else
 	{
-		err_msg(Error, "Error parsing dictionary %s.\n"
+		err_msg(lg_Error, "Error parsing dictionary %s.\n"
 		          "%s\n\t line %d, tokens = %s",
 		        dict->name,
 		        s, dict->line_number, tokens);
@@ -370,7 +370,7 @@ static void dict_error(Dictionary dict, const char * s)
 
 static void warning(Dictionary dict, const char * s)
 {
-	err_msg(Warn, "Warning: %s\n"
+	err_msg(lg_Warn, "Warning: %s\n"
 	        "\tline %d, current token = \"%s\"",
 	        s, dict->line_number, dict->token);
 }
@@ -1737,7 +1737,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	}
 	else if (is_idiom_word(dn->string))
 	{
-		err_msg(Warn, "Warning: Word \"%s\" found near line %d of %s.\n"
+		err_msg(lg_Warn, "Warning: Word \"%s\" found near line %d of %s.\n"
 		        "\tWords ending \".Ix\" (x a number) are reserved for idioms.\n"
 		        "\tThis word will be ignored.",
 		        dn->string, dict->line_number, dict->name);

--- a/link-grammar/dict-file/word-file.c
+++ b/link-grammar/dict-file/word-file.c
@@ -42,7 +42,7 @@ static const char * get_a_word(Dictionary dict, FILE * fp)
 
 	if (j >= MAX_WORD) {
 		word[MAX_WORD] = '\0';
-		prt_error("The dictionary contains a word that is too long: %s", word);
+		prt_error("The dictionary contains a word that is too long: %s\n", word);
 		return ""; /* error indication */
 	}
 	word[j] = '\0';

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -327,7 +327,7 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->spell_checker = spellcheck_create(dict->lang);
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
-		if (debug_level(D_USER_BASIC) && (NULL == dict->spell_checker))
+		if (verbosity_level(D_USER_BASIC) && (NULL == dict->spell_checker))
 			prt_error("Info: %s: Spell checker disabled.\n", dict->lang);
 #endif
 	dict->base_knowledge = NULL;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -328,7 +328,7 @@ Dictionary dictionary_create_from_db(const char *lang)
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
 		if (debug_level(D_USER_BASIC) && (NULL == dict->spell_checker))
-			prt_error("Info: %s: Spell checker disabled.", dict->lang);
+			prt_error("Info: %s: Spell checker disabled.\n", dict->lang);
 #endif
 	dict->base_knowledge = NULL;
 	dict->hpsg_knowledge = NULL;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -270,7 +270,7 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * d)
 		}
 	}
 
-	if (debug_level(5) && (count != 0)) printf("killed %u duplicates\n", count);
+	lgdebug(+5+(0==count)*1000, "Killed %u duplicates\n", count);
 
 	disjunct_dup_table_delete(dt);
 	return d;

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -360,13 +360,31 @@ void err_msgc(err_ctxt *ec, lg_error_severity sev, const char *fmt, ...)
 	va_end(args);
 }
 
-void prt_error(const char *fmt, ...)
+/**
+ * Issue the given message.
+ * This is an API function.
+ *
+ * Usage notes:
+ * The severity can be specified as an initial string in the message,
+ * such as "Error: Rest of message".  For known severity names see
+ * \link severity_label_by_level List of severity strings. \endlink.
+ * See \link verr_msg \endlink for how the severity is handled
+ * if it is not specified.
+ *
+ * @fmt printf()-like format.
+ * @... printf()-like arguments.
+ * @retrun Always 0, not to be used. This is needed so prt_error()
+ * can be used in complex macros that have to use the comma operator.
+ */
+int prt_error(const char *fmt, ...)
 {
 	va_list args;
 
 	va_start(args, fmt);
 	verr_msg(NULL, 0, fmt, args);
 	va_end(args);
+
+	return 0;
 }
 
 /**

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -81,7 +81,7 @@ static lg_error_severity message_error_severity(const char *msg)
 		}
 	}
 
-	return None;
+	return lg_None;
 }
 
 static void lg_error_msg_free(lg_error *lge)
@@ -160,7 +160,7 @@ int lg_error_clearall(void)
 /**
  * Format the given raw error message.
  * Create a complete error message, ready to be printed.
- * If the severity is not None, add the library name.
+ * If the severity is not lg_None, add the library name.
  * Also add the severity label.
  * @param lge The raw error message.
  * @return The complete error message. The caller needs to free the memory.
@@ -172,11 +172,11 @@ char *lg_error_formatmsg(lg_error *lge)
 	String *s = string_new();
 
 	/* Prepend libname to messages with higher severity than Debug. */
-	if (lge->severity < Debug)
+	if (lge->severity < lg_Debug)
 		append_string(s, "%s: ", libname);
 
 	/* Prepend severity label to messages which don't already have it. */
-	if (None == message_error_severity(lge->msg))
+	if (lg_None == message_error_severity(lge->msg))
 		append_string(s, "%s", lge->severity_label);
 
 	append_string(s, "%s", lge->msg);
@@ -196,12 +196,12 @@ static void default_error_handler(lg_error *lge, void *data)
 {
 	FILE *outfile = stdout;
 
-	if (((NULL == data) && (lge->severity <= Debug)) ||
+	if (((NULL == data) && (lge->severity <= lg_Debug)) ||
 	    ((NULL != data) && (lge->severity <= *(lg_error_severity *)data) &&
-	     (None !=  lge->severity)))
-	if (((NULL == data) && (lge->severity < Debug)) ||
+	     (lg_None !=  lge->severity)))
+	if (((NULL == data) && (lge->severity < lg_Debug)) ||
 	    ((NULL != data) && (lge->severity < *(lg_error_severity *)data) &&
-	     (None !=  lge->severity)))
+	     (lg_None !=  lge->severity)))
 	{
 		fflush(stdout); /* Make sure that stdout has been written out first. */
 		outfile = stderr;
@@ -222,11 +222,11 @@ static const char *error_severity_label(lg_error_severity sev)
 	char *sevlabel;
 	sevlabel = alloca(MAX_SEVERITY_LABEL_SIZE);
 
-	if (None == sev)
+	if (lg_None == sev)
 	{
 		sevlabel[0] = '\0';
 	}
-	else if ((sev < 1) || (sev > None))
+	else if ((sev < 1) || (sev > lg_None))
 	{
 		snprintf(sevlabel, MAX_SEVERITY_LABEL_SIZE, "Message severity %d: ", sev);
 	}
@@ -335,7 +335,7 @@ static void verr_msg(err_ctxt *ec, lg_error_severity sev, const char *fmt, va_li
 	/* current_error.ec = *ec; */
 	current_error.msg = string_value(outbuf);
 	lg_error_severity msg_sev = message_error_severity(current_error.msg);
-	current_error.severity = ((None == msg_sev) && (0 != sev)) ? sev : msg_sev;
+	current_error.severity = ((lg_None == msg_sev) && (0 != sev)) ? sev : msg_sev;
 	current_error.severity_label = error_severity_label(current_error.severity);
 
 	if (NULL == error_handler)

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -249,7 +249,7 @@ static void verr_msg(err_ctxt *ec, lg_error_severity sev, const char *fmt, va_li
 
 	vappend_string(outbuf, fmt, args);
 
-	if ((Info != sev) && ec->sent != NULL)
+	if ((NULL != ec) && (NULL != ec->sent))
 	{
 		size_t i, j;
 		const char **a, **b;
@@ -326,7 +326,7 @@ static void verr_msg(err_ctxt *ec, lg_error_severity sev, const char *fmt, va_li
 	string_delete(outbuf);
 }
 
-void err_msg(err_ctxt *ec, lg_error_severity sev, const char *fmt, ...)
+void err_msgc(err_ctxt *ec, lg_error_severity sev, const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
@@ -336,12 +336,10 @@ void err_msg(err_ctxt *ec, lg_error_severity sev, const char *fmt, ...)
 
 void prt_error(const char *fmt, ...)
 {
-	err_ctxt ec;
 	va_list args;
 
-	ec.sent = NULL;
 	va_start(args, fmt);
-	verr_msg(&ec, 0, fmt, args);
+	verr_msg(NULL, 0, fmt, args);
 	va_end(args);
 }
 

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -64,19 +64,19 @@ const char *feature_enabled(const char *, ...);
  * Return true if the debug-messages block should be executed, else false.
  *
  * Usage example, for debug messages at verbosity V:
- * if (debug_level(V))
+ * if (verbosity_level(V))
  * {
  *    print_disjunct(d);
  * }
  *
  * The optional printing of the function name is done here by prt_error()
  * and not err_msg(), in order to not specify the message severity.
- * Also not there is no trailing newline  in that case. These things
+ * Also note there is no trailing newline in that case. These things
  * ensured the message severity will be taken from a following message
- * which includes a newline. So debug_level()V) can be used for any
+ * which includes a newline. So verbosity_level()V) can be used for any
  * desired message severity.
  */
-#define debug_level(level) \
+#define verbosity_level(level) \
 (((verbosity>=(level)) && (((level)<=1) || \
 	!(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
 	(('\0' == debug[0]) || \

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -66,15 +66,22 @@ const char *feature_enabled(const char *, ...);
  * Usage example, for debug messages at verbosity V:
  * if (debug_level(V))
  * {
- * 	print_disjunct(d);
+ *    print_disjunct(d);
  * }
+ *
+ * The optional printing of the function name is done here by prt_error()
+ * and not err_msg(), in order to not specify the message severity.
+ * Also not there is no trailing newline  in that case. These things
+ * ensured the message severity will be taken from a following message
+ * which includes a newline. So debug_level()V) can be used for any
+ * desired message severity.
  */
 #define debug_level(level) \
 (((verbosity>=(level)) && (((level)<=1) || \
 	!(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
 	(('\0' == debug[0]) || \
 	feature_enabled(debug, __func__, __FILE__, NULL))) \
-	? ((STRINGIFY(level)[0] == '+' ? printf("%s: ", __func__) : 0), true) \
+	? ((STRINGIFY(level)[0] == '+' ? prt_error("%s: ", __func__) : 0), true) \
 	: false)
 
 /**

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -28,16 +28,7 @@ typedef struct
 	Sentence sent;
 } err_ctxt;
 
-typedef enum
-{
-	Fatal = 1,
-	Error,
-	Warn,
-	Info,
-	Debug
-} severity;
-
-void err_msg(err_ctxt *, severity, const char *fmt, ...) GNUC_PRINTF(3,4);
+void err_msg(err_ctxt *, lg_error_severity, const char *fmt, ...) GNUC_PRINTF(3,4);
 const char *feature_enabled(const char *, ...);
 
 /**

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -48,9 +48,9 @@ const char *feature_enabled(const char *, ...);
 	feature_enabled(debug, __func__, __FILE__, NULL))) ? \
 	( \
 		(STRINGIFY(level)[0] == '+' ? \
-			(void)err_msg(Trace, "%s: ", __func__) : \
+			(void)err_msg(lg_Trace, "%s: ", __func__) : \
 			(void)0), \
-		(void)err_msg(Trace,  __VA_ARGS__) \
+		(void)err_msg(lg_Trace,  __VA_ARGS__) \
 	) : \
 	(void)0)
 

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -45,9 +45,14 @@ const char *feature_enabled(const char *, ...);
 (((verbosity>=(level)) && (((level)<=1) || \
 	!(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
 	(('\0' == debug[0]) || \
-	feature_enabled(debug, __func__, __FILE__, NULL))) \
-	? ((STRINGIFY(level)[0] == '+' ? (void)printf("%s: ", __func__) : (void)0), \
-	(void)printf(__VA_ARGS__)) : (void)0)
+	feature_enabled(debug, __func__, __FILE__, NULL))) ? \
+	( \
+		(STRINGIFY(level)[0] == '+' ? \
+			(void)err_msg(Trace, "%s: ", __func__) : \
+			(void)0), \
+		(void)err_msg(Trace,  __VA_ARGS__) \
+	) : \
+	(void)0)
 
 /**
  * Wrap-up a debug-messages block.

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -28,7 +28,8 @@ typedef struct
 	Sentence sent;
 } err_ctxt;
 
-void err_msg(err_ctxt *, lg_error_severity, const char *fmt, ...) GNUC_PRINTF(3,4);
+void err_msgc(err_ctxt *, lg_error_severity, const char *fmt, ...) GNUC_PRINTF(3,4);
+#define err_msg(...) err_msgc(NULL, __VA_ARGS__)
 const char *feature_enabled(const char *, ...);
 
 /**

--- a/link-grammar/expand.c
+++ b/link-grammar/expand.c
@@ -16,6 +16,7 @@
 
 #include "api-structures.h"
 #include "expand.h"
+#include "externs.h"
 #include "disjunct-utils.h"
 #include "word-utils.h"
 #include "corpus/cluster.h"
@@ -26,7 +27,7 @@ static Disjunct * build_expansion_disjuncts(Cluster *clu, X_node *x)
 {
 	Disjunct *dj;
 	dj = lg_cluster_get_disjuncts(clu, x->string);
-	if (dj) printf("Expanded %s \n", x->string);
+	if (dj && (verbosity > 0)) prt_error("Expanded %s \n", x->string);
 	return dj;
 }
 

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -381,7 +381,7 @@ static void print_match_list(fast_matcher_t *ctxt, int id, size_t mlb, int w,
                              Connector *lc, int lw,
                              Connector *rc, int rw)
 {
-	if (!debug_level(9)) return;
+	if (!verbosity_level(9)) return;
 	Disjunct **m = &ctxt->match_list[mlb];
 
 	for (; NULL != *m; m++)

--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -262,7 +262,7 @@ static void put_into_match_table(unsigned int size, Match_node ** t,
 	m->d = d;
 
 	xl = get_match_table_entry(size, t, c, dir);
-	assert(NULL != xl, "get_match_table_entry: Overflow\n");
+	assert(NULL != xl, "get_match_table_entry: Overflow");
 	if (dir == 1) {
 		*xl = add_to_right_table_list(m, *xl);
 	}

--- a/link-grammar/idiom.c
+++ b/link-grammar/idiom.c
@@ -195,7 +195,7 @@ static void increment_current_name(void)
 		if (current_name[i] <= 'Z') return;
 		current_name[i] = 'A';
 	} while (i-- > 0);
-	assert(0, "increment_current_name: Overflow\n");
+	assert(0, "increment_current_name: Overflow");
 }
 
 /**

--- a/link-grammar/lg_assert.h
+++ b/link-grammar/lg_assert.h
@@ -21,8 +21,8 @@
 
 #define assert(ex, ...) {                                                   \
 	if (!(ex)) {                                                             \
-		prt_error("\nAssertion (" #ex ") failed at " FILELINE ": " __VA_ARGS__);  \
-		fprintf(stderr, "\n");                                                \
+		prt_error("Fatal error: \nAssertion (" #ex ") failed at " FILELINE ": " __VA_ARGS__);  \
+		prt_error("\n");                                                \
 		DEBUG_TRAP;  /* leave stack trace in debugger */                      \
 	}                                                                        \
 }

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -123,3 +123,8 @@ print_one_disjunct
 build_disjuncts_for_exp
 left_print_string
 regex_tokenizer_test
+lg_error_set_handler
+lg_error_set_handler_data
+lg_error_formatmsg
+lg_error_printall
+lg_error_clearall

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -66,22 +66,23 @@ typedef enum
 } lg_error_severity;
 
 /* Raw error message. */
-typedef struct lg_error {
+typedef struct
+{
 	/* err_ctxt ec; */
 	lg_error_severity severity;
 	const char *severity_label;
-	const char *msg;
-} lg_error;
+	const char *text;
+} lg_errinfo;
 
 /* Error handler callback function. */
-typedef void (*lg_error_handler)(lg_error *, void *);
+typedef void (*lg_error_handler)(lg_errinfo *, void *);
 
 link_public_api(lg_error_handler)
      lg_error_set_handler(lg_error_handler, void *data);
 link_public_api(const void *)
      lg_error_set_handler_data(void * data);
 link_public_api(char *)
-     lg_error_formatmsg(lg_error *lge);
+     lg_error_formatmsg(lg_errinfo *lge);
 link_public_api(int)
      lg_error_printall(lg_error_handler, void *data);
 link_public_api(int)

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -56,13 +56,13 @@ link_public_api(const char *)
  ***********************************************************************/
 typedef enum
 {
-	Fatal = 1,
-	Error,
-	Warn,
-	Info,
-	Debug,
-	Trace,
-	None
+	lg_Fatal = 1,
+	lg_Error,
+	lg_Warn,
+	lg_Info,
+	lg_Debug,
+	lg_Trace,
+	lg_None
 } lg_error_severity;
 
 /* Raw error message. */

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -396,7 +396,7 @@ link_public_api(void)
 #define GNUC_PRINTF( format_idx, arg_idx )
 #endif
 
-link_public_api(void)
+link_public_api(int)
      prt_error(const char *fmt, ...) GNUC_PRINTF(1,2);
 
 /*******************************************************

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -51,6 +51,44 @@ link_public_api(const char *)
 
 /**********************************************************************
  *
+ * Functions and definitions for the error handler.
+ *
+ ***********************************************************************/
+typedef enum
+{
+	Fatal = 1,
+	Error,
+	Warn,
+	Info,
+	Debug,
+	Trace,
+	None
+} lg_error_severity;
+
+/* Raw error message. */
+typedef struct lg_error {
+	/* err_ctxt ec; */
+	lg_error_severity severity;
+	const char *severity_label;
+	const char *msg;
+} lg_error;
+
+/* Error handler callback function. */
+typedef void (*lg_error_handler)(lg_error *, void *);
+
+link_public_api(lg_error_handler)
+     lg_error_set_handler(lg_error_handler, void *data);
+link_public_api(const void *)
+     lg_error_set_handler_data(void * data);
+link_public_api(char *)
+     lg_error_formatmsg(lg_error *lge);
+link_public_api(int)
+     lg_error_printall(lg_error_handler, void *data);
+link_public_api(int)
+     lg_error_clearall(void);
+
+/**********************************************************************
+ *
  * Functions to manipulate Dictionaries
  *
  ***********************************************************************/

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -224,7 +224,7 @@ void remove_empty_words(Linkage lkg)
 	Disjunct **cdj = lkg->chosen_disjuncts;
 	int *remap = alloca(lkg->num_words * sizeof(*remap));
 
-	if (debug_level(+D_REE))
+	if (verbosity_level(+D_REE))
 	{
 		err_msg(lg_Debug, "chosen_disjuncts before:\n\\");
 		print_chosen_disjuncts_words(lkg);
@@ -246,7 +246,7 @@ void remove_empty_words(Linkage lkg)
 	lkg->num_words = j;
 	/* Unused memory not freed - all of it will be freed in free_linkages(). */
 
-	if (debug_level(+D_REE))
+	if (verbosity_level(+D_REE))
 	{
 		err_msg(lg_Debug, "chosen_disjuncts after:\n\\");
 		print_chosen_disjuncts_words(lkg);

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -226,7 +226,7 @@ void remove_empty_words(Linkage lkg)
 
 	if (debug_level(+D_REE))
 	{
-		printf("Info: chosen_disjuncts before:\n");
+		err_msg(lg_Debug, "chosen_disjuncts before:\n\\");
 		print_chosen_disjuncts_words(lkg);
 	}
 
@@ -248,7 +248,7 @@ void remove_empty_words(Linkage lkg)
 
 	if (debug_level(+D_REE))
 	{
-		printf("Info: chosen_disjuncts after:\n");
+		err_msg(lg_Debug, "chosen_disjuncts after:\n\\");
 		print_chosen_disjuncts_words(lkg);
 	}
 

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -928,7 +928,7 @@ static void build_domains(Postprocessor *pp, Linkage sublinkage)
 	{
 		i = find_domain_name(pp, pp_data->domain_array[d].string);
 		if (i == SIZE_MAX)
-			prt_error("Error: post_process(): Need an entry for %s in LINK_TYPE_TABLE",
+			prt_error("Error: post_process(): Need an entry for %s in LINK_TYPE_TABLE\n",
 			          pp_data->domain_array[d].string);
 		pp_data->domain_array[d].type = i;
 	}
@@ -1010,7 +1010,7 @@ internal_process(Postprocessor *pp, Linkage sublinkage, const char **msg)
 	/* These messages were deemed to not be useful, so
 	 * this code is commented out. See comment above. */
 	if (!check_domain_nesting(pp, sublinkage->num_links))
-		printf("WARNING: The domains are not nested.\n");
+		printf("Warning: The domains are not nested.\n");
 #endif
 
 	/* The order below should be optimal for most cases */

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -1068,7 +1068,7 @@ static void prune_irrelevant_rules(Postprocessor *pp)
 	}
 	pp->relevant_contains_none_rules[rcnIDX] = -1;
 
-	if (debug_level(5))
+	if (verbosity_level(5))
 	{
 		err_msg(lg_Debug, "PP: Saw %zd unique link names in all linkages.\n\\",
 		       pp_linkset_population(pp->set_of_links_of_sentence));
@@ -1207,7 +1207,7 @@ static void report_pp_stats(Postprocessor *pp)
 	size_t rule_cnt = 0;
 	size_t unused_cnt = 0;
 	pp_knowledge * kno;
-	if (!debug_level(9)) return;
+	if (!verbosity_level(9)) return;
 
 	err_msg(lg_Debug, "PP stats: local_rules_firing=%d\n", pp->n_local_rules_firing);
 	kno = pp->knowledge;

--- a/link-grammar/post-process.c
+++ b/link-grammar/post-process.c
@@ -1010,7 +1010,7 @@ internal_process(Postprocessor *pp, Linkage sublinkage, const char **msg)
 	/* These messages were deemed to not be useful, so
 	 * this code is commented out. See comment above. */
 	if (!check_domain_nesting(pp, sublinkage->num_links))
-		printf("Warning: The domains are not nested.\n");
+		prt_error("Warning: The domains are not nested.\n");
 #endif
 
 	/* The order below should be optimal for most cases */
@@ -1070,9 +1070,10 @@ static void prune_irrelevant_rules(Postprocessor *pp)
 
 	if (debug_level(5))
 	{
-		printf("PP: Saw %zd unique link names in all linkages.\n",
+		err_msg(lg_Debug, "PP: Saw %zd unique link names in all linkages.\n\\",
 		       pp_linkset_population(pp->set_of_links_of_sentence));
-		printf("PP: Using %i 'contains one' rules and %i 'contains none' rules\n",
+		err_msg(lg_Debug, "PP: Using %i 'contains one' rules "
+		                  "and %i 'contains none' rules\n",
 		       rcoIDX, rcnIDX);
 	}
 }
@@ -1180,7 +1181,7 @@ static size_t report_rule_use(pp_rule *set)
 	size_t i;
 	for (i=0; set[i].msg != NULL; i++)
 	{
-		printf("usage: %d rule: %s\n", set[i].use_count, set[i].msg);
+		err_msg(lg_Debug, "Used: %d rule: %s\n", set[i].use_count, set[i].msg);
 		cnt++;
 	}
 	return cnt;
@@ -1194,7 +1195,7 @@ static size_t report_unused_rule(pp_rule *set)
 	{
 		if (0 == set[i].use_count)
 		{
-			printf("Unused rule: %s\n", set[i].msg);
+			err_msg(lg_Debug, "Unused rule: %s\n", set[i].msg);
 			cnt++;
 		}
 	}
@@ -1208,28 +1209,28 @@ static void report_pp_stats(Postprocessor *pp)
 	pp_knowledge * kno;
 	if (!debug_level(9)) return;
 
-	printf("PP stats: local_rules_firing=%d\n", pp->n_local_rules_firing);
+	err_msg(lg_Debug, "PP stats: local_rules_firing=%d\n", pp->n_local_rules_firing);
 	kno = pp->knowledge;
 
-	printf("\nPP stats: form_a_cycle_rules\n");
+	err_msg(lg_Debug, "\nPP stats: form_a_cycle_rules\n");
 	rule_cnt += report_rule_use(kno->form_a_cycle_rules);
 
-	printf("\nPP stats: contains_one_rules\n");
+	err_msg(lg_Debug, "\nPP stats: contains_one_rules\n");
 	rule_cnt += report_rule_use(kno->contains_one_rules);
 
-	printf("\nPP stats: contains_none_rules\n");
+	err_msg(lg_Debug, "\nPP stats: contains_none_rules\n");
 	rule_cnt += report_rule_use(kno->contains_none_rules);
 
-	printf("\nPP stats: bounded_rules\n");
+	err_msg(lg_Debug, "\nPP stats: bounded_rules\n");
 	rule_cnt += report_rule_use(kno->bounded_rules);
 
-	printf("\nPP stats: Rules that were not used:\n");
+	err_msg(lg_Debug, "\nPP stats: Rules that were not used:\n");
 	unused_cnt += report_unused_rule(kno->form_a_cycle_rules);
 	unused_cnt += report_unused_rule(kno->contains_one_rules);
 	unused_cnt += report_unused_rule(kno->contains_none_rules);
 	unused_cnt += report_unused_rule(kno->bounded_rules);
 
-	printf("\nPP stats: %zd of %zd rules unused\n", unused_cnt, rule_cnt);
+	err_msg(lg_Debug, "\nPP stats: %zd of %zd rules unused\n", unused_cnt, rule_cnt);
 }
 
 /**

--- a/link-grammar/pp_knowledge.c
+++ b/link-grammar/pp_knowledge.c
@@ -115,7 +115,7 @@ static pp_linkset *read_link_set(pp_knowledge *k,
   pp_linkset *ls;
   if (!pp_lexer_set_label(k->lt, label))
   {
-    if (debug_level(+D_PPK))
+    if (verbosity_level(+D_PPK))
       prt_error("Warning: File %s: Link set %s not defined: assuming empty\n",
              k->path, label);
     n_strings = 0;
@@ -183,7 +183,7 @@ static bool read_form_a_cycle_rules(pp_knowledge *k, const char *label)
   const char **tokens;
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_form_a_cycle_rules = 0;
-      if (debug_level(+D_PPK))
+      if (verbosity_level(+D_PPK))
           prt_error("Warning: File %s: Not using any 'form a cycle' rules\n",
                     k->path);
   }
@@ -233,7 +233,7 @@ static bool read_bounded_rules(pp_knowledge *k, const char *label)
   size_t r;
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_bounded_rules = 0;
-      if (debug_level(+D_PPK))
+      if (verbosity_level(+D_PPK))
         prt_error("Warning: File %s: Not using any 'bounded' rules\n", k->path);
   }
   else {
@@ -283,7 +283,7 @@ static bool read_contains_rules(pp_knowledge *k, const char *label,
   const char **tokens;
   if (!pp_lexer_set_label(k->lt, label)) {
       *nRules = 0;
-      if (debug_level(+D_PPK))
+      if (verbosity_level(+D_PPK))
         prt_error("Warning: File %s: Not using any %s rules\n", k->path, label);
   }
   else {

--- a/link-grammar/pp_knowledge.c
+++ b/link-grammar/pp_knowledge.c
@@ -33,7 +33,7 @@ static bool check_domain_is_legal(pp_knowledge *k, const char *p)
 {
   if (0x0 != p[1])
   {
-    prt_error("Error: File %s: Domain (%s) must be a single character",
+    prt_error("Error: File %s: Domain (%s) must be a single character\n",
               k->path, p);
     return false;
   }
@@ -69,7 +69,7 @@ static bool read_starting_link_table(pp_knowledge *k)
 
   if (!pp_lexer_set_label(k->lt, label))
   {
-    prt_error("Error: File %s: Couldn't find starting link table %s",
+    prt_error("Error: File %s: Couldn't find starting link table %s\n",
               k->path, label);
     return false;
   }
@@ -79,7 +79,7 @@ static bool read_starting_link_table(pp_knowledge *k)
   even = n_tokens % 2;
   if(0 != even)
   {
-    prt_error("Error: Link table must have format [<link> <domain name>]+");
+    prt_error("Error: Link table must have format [<link> <domain name>]+\n");
     return false;
   }
 
@@ -116,7 +116,7 @@ static pp_linkset *read_link_set(pp_knowledge *k,
   if (!pp_lexer_set_label(k->lt, label))
   {
     if (debug_level(+D_PPK))
-      prt_error("Warning: File %s: Link set %s not defined: assuming empty",
+      prt_error("Warning: File %s: Link set %s not defined: assuming empty\n",
              k->path, label);
     n_strings = 0;
   }
@@ -184,7 +184,7 @@ static bool read_form_a_cycle_rules(pp_knowledge *k, const char *label)
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_form_a_cycle_rules = 0;
       if (debug_level(+D_PPK))
-          prt_error("Warning: File %s: Not using any 'form a cycle' rules",
+          prt_error("Warning: File %s: Not using any 'form a cycle' rules\n",
                     k->path);
   }
   else {
@@ -199,7 +199,7 @@ static bool read_form_a_cycle_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens <= 0)
       {
-        prt_error("Error: File %s: Syntax error", k->path);
+        prt_error("Error: File %s: Syntax error\n", k->path);
         return false;
       }
       lsHandle = pp_linkset_open(n_tokens);
@@ -211,7 +211,7 @@ static bool read_form_a_cycle_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens > 1)
       {
-         prt_error("Error: File %s: Invalid syntax (rule %zu of %s)",
+         prt_error("Error: File %s: Invalid syntax (rule %zu of %s)\n",
                    k->path, r+1,label);
          return false;
       }
@@ -234,7 +234,7 @@ static bool read_bounded_rules(pp_knowledge *k, const char *label)
   if (!pp_lexer_set_label(k->lt, label)) {
       k->n_bounded_rules = 0;
       if (debug_level(+D_PPK))
-        prt_error("Warning: File %s: Not using any 'bounded' rules", k->path);
+        prt_error("Warning: File %s: Not using any 'bounded' rules\n", k->path);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -247,7 +247,7 @@ static bool read_bounded_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens!=1)
       {
-        prt_error("Error: File %s: Invalid syntax: rule %zu of %s",
+        prt_error("Error: File %s: Invalid syntax: rule %zu of %s\n",
                   k->path, r+1,label);
         return false;
       }
@@ -257,7 +257,7 @@ static bool read_bounded_rules(pp_knowledge *k, const char *label)
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens!=1)
       {
-        prt_error("Error: File %s: Invalid syntax: rule %zu of %s",
+        prt_error("Error: File %s: Invalid syntax: rule %zu of %s\n",
                   k->path, r+1,label);
         return false;
       }
@@ -284,7 +284,7 @@ static bool read_contains_rules(pp_knowledge *k, const char *label,
   if (!pp_lexer_set_label(k->lt, label)) {
       *nRules = 0;
       if (debug_level(+D_PPK))
-        prt_error("Warning: File %s: Not using any %s rules", k->path, label);
+        prt_error("Warning: File %s: Not using any %s rules\n", k->path, label);
   }
   else {
     n_commas = pp_lexer_count_commas_of_label(k->lt);
@@ -298,7 +298,7 @@ static bool read_contains_rules(pp_knowledge *k, const char *label,
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens > 1)
       {
-        prt_error("Error: File %s: Invalid syntax in %s (rule %zu)",
+        prt_error("Error: File %s: Invalid syntax in %s (rule %zu)\n",
                   k->path, label, r+1);
         return false;
       }
@@ -322,7 +322,7 @@ static bool read_contains_rules(pp_knowledge *k, const char *label,
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);
       if (n_tokens > 1)
       {
-        prt_error("Error: File %s: Invalid syntax in %s (rule %zu)",
+        prt_error("Error: File %s: Invalid syntax in %s (rule %zu)\n",
                   k->path, label, r+1);
         return false;
       }
@@ -389,7 +389,7 @@ pp_knowledge *pp_knowledge_open(const char *path)
   FILE *f = dictopen(path, "r");
   if (NULL == f)
   {
-    prt_error("Error: Couldn't find post-process knowledge file %s", path);
+    prt_error("Error: Couldn't find post-process knowledge file %s\n", path);
     return NULL;
   }
   pp_knowledge *k = (pp_knowledge *) xalloc (sizeof(pp_knowledge));
@@ -407,7 +407,7 @@ pp_knowledge *pp_knowledge_open(const char *path)
   return k;
 
 failure:
-  prt_error("Error: Unable to open knowledge file %s.", path);
+  prt_error("Error: Unable to open knowledge file %s.\n", path);
   pp_knowledge_close(k);
   return NULL;
 }

--- a/link-grammar/pp_lexer.c
+++ b/link-grammar/pp_lexer.c
@@ -430,12 +430,12 @@ static PPLexTable *clt=NULL; /* ptr to lex table we're currently filling in */
 		if ( c == '\n' ) \
 			buf[n++] = '\n'; \
 		if ( c == EOF && ferror( yyin ) ) \
-			{prt_error("Input in flex scanner failed"); reterror();} \
+			{prt_error("Fatal error: Input in flex scanner failed\n"); reterror();} \
 		result = n; \
 		} \
 	else if ( ((result = fread( buf, 1, max_size, yyin )) == 0) \
 		  && ferror( yyin ) ) \
-		{prt_error("Input in flex scanner failed"); reterror();}
+		{prt_error("Fatal error: Input in flex scanner failed\n"); reterror();}
 #endif
 
 /* No semi-colon after return; correct usage is to write "yyterminate();" -
@@ -620,7 +620,7 @@ YY_RULE_SETUP
 case 7:
 YY_RULE_SETUP
 	/* #line 66 "pp_lexer.fl" --DS */
-{ prt_error("Error: pp_lexer: unable to parse file (line %i).", yylineno); reterror(); }
+{ prt_error("Error: pp_lexer: unable to parse file (line %i).\n", yylineno); reterror(); }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
@@ -757,7 +757,7 @@ ECHO;
 		}
 
 	default:
-		prt_error("Fatal flex scanner internal error--no action found");
+		prt_error("Fatal error: flex scanner internal error--no action found\n");
 		reterror();
 	} /* end of action switch */
 		} /* end of scanning one token */
@@ -781,7 +781,7 @@ static int yy_get_next_buffer(void)
 
 	if ( yy_c_buf_p > &yy_current_buffer->yy_ch_buf[yy_n_chars + 1] )
 	{
-		prt_error("fatal flex scanner internal error--end of buffer missed");
+		prt_error("Fatal error: flex scanner internal error--end of buffer missed\n");
 		reterror();
 	}
 
@@ -826,8 +826,8 @@ static int yy_get_next_buffer(void)
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 #ifdef YY_USES_REJECT
-			prt_error(
-"Input buffer overflow, can't enlarge buffer because scanner uses REJECT");
+			prt_error("Fatal error: "
+"Input buffer overflow, can't enlarge buffer because scanner uses REJECT\n");
 			reterror();
 #else
 
@@ -857,7 +857,7 @@ static int yy_get_next_buffer(void)
 
 			if ( ! b->yy_ch_buf )
 			{
-				prt_error("fatal error - scanner input buffer overflow");
+				prt_error("Fatal error: scanner input buffer overflow\n");
 				reterror();
 			}
 
@@ -1195,7 +1195,7 @@ int pp_lexer_count_tokens_of_label(PPLexTable *lt)
   pp_label_node *p;
   if (lt->idx_of_active_label==-1)
   {
-    prt_error("Error: pp_lexer: current label is invalid");
+    prt_error("Error: pp_lexer: current label is invalid\n");
     return -1;
   }
   for (n=0, p=lt->nodes_of_label[lt->idx_of_active_label]; p;p=p->next, n++){}
@@ -1219,7 +1219,7 @@ int pp_lexer_count_commas_of_label(PPLexTable *lt)
   pp_label_node *p;
   if (lt->idx_of_active_label==-1)
   {
-    prt_error("Error: pp_lexer: current label is invalid");
+    prt_error("Error: pp_lexer: current label is invalid\n");
     return -1;
   }
   for (n=0,p=lt->nodes_of_label[lt->idx_of_active_label];p!=NULL;p=p->next)
@@ -1286,7 +1286,7 @@ static bool set_label(PPLexTable *lt, const char *label)
   c=&(label_sans_colon[strlen(label_sans_colon)-1]);
   if (*c != ':')
   {
-    prt_error("Error: Label %s must end with :", label);
+    prt_error("Error: Label %s must end with :\n", label);
     return false;
   }
   *c = 0;
@@ -1295,14 +1295,14 @@ static bool set_label(PPLexTable *lt, const char *label)
   for (i=0;lt->labels[i]!=NULL && strcmp(lt->labels[i],label_sans_colon);i++) {}
   if (lt->labels[i]!=NULL)
   {
-    prt_error("Error: pp_lexer: label %s multiply defined!", label_sans_colon);
+    prt_error("Error: pp_lexer: label %s multiply defined!\n", label_sans_colon);
     return false;
   }
 
   /* new label. Store it */
   if (i == PP_LEXER_MAX_LABELS-1)
   {
-    prt_error("Error: pp_lexer: too many labels. Raise PP_LEXER_MAX_LABELS");
+    prt_error("Error: pp_lexer: too many labels. Raise PP_LEXER_MAX_LABELS\n");
     return false;
   }
   lt->labels[i] = string_set_add(label_sans_colon, lt->string_set);
@@ -1321,7 +1321,7 @@ static bool add_string_to_label(PPLexTable *lt, const char *str)
 
   if (lt->idx_of_active_label == -1)
   {
-    prt_error("Error: pp_lexer: invalid syntax (line %i)", yylineno);
+    prt_error("Error: pp_lexer: invalid syntax (line %i)\n", yylineno);
     return false;
   }
 
@@ -1358,12 +1358,12 @@ static bool add_set_of_strings_to_label(PPLexTable *lt,const char *label_of_set)
   int idx_of_label_of_set;
   if (lt->idx_of_active_label==-1)
   {
-    prt_error("Error: pp_lexer: invalid syntax (line %i)", yylineno);
+    prt_error("Error: pp_lexer: invalid syntax (line %i)\n", yylineno);
     return false;
   }
   if ((idx_of_label_of_set = get_index_of_label(lt, label_of_set))==-1)
   {
-    prt_error("Error: pp_lexer: label %s must be defined before it's referred to (line %i)",
+    prt_error("Error: pp_lexer: label %s must be defined before it's referred to (line %i)\n",
               label_of_set, yylineno);
     return false;
   }
@@ -1385,7 +1385,7 @@ static bool check_string(const char *str)
 {
   if (strlen(str)>1 && strchr(str, ',')!=NULL)
   {
-    prt_error("Error: pp_lexer: string %s contains a comma, which is a no-no.", str);
+    prt_error("Error: pp_lexer: string %s contains a comma, which is a no-no.\n", str);
     return false;
   }
   return true;

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -130,7 +130,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	size_t i;
 
 	build_sentence_disjuncts(sent, opts->disjunct_cost);
-	if (debug_level(5)) {
+	if (verbosity_level(5)) {
 		printf("After expanding expressions into disjuncts:");
 		print_disjunct_counts(sent);
 	}
@@ -145,7 +145,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 	print_time(opts, "Eliminated duplicate disjuncts");
 
-	if (debug_level(5)) {
+	if (verbosity_level(5)) {
 		printf("\nAfter expression pruning and duplicate elimination:\n");
 		print_disjunct_counts(sent);
 	}

--- a/link-grammar/print-util.h
+++ b/link-grammar/print-util.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <stdlib.h>
+#include <stdarg.h>
 
 typedef struct String_s String;
 
@@ -28,6 +29,8 @@ void string_delete(String *);
 const char * string_value(String *);
 char * string_copy(String *);
 void append_string(String * string, const char *fmt, ...) GNUC_PRINTF(2,3);
+void vappend_string(String * string, const char *fmt, va_list args)
+	GNUC_PRINTF(2,0);
 size_t append_utf8_char(String * string, const char * mbs);
 
 #endif

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1223,7 +1223,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		return;
 	}
 
-	if (debugprint) lgdebug(+0, "\n");
+	if (debugprint) lgdebug(+0, "\n\\");
 	else if (NULL != tokenpos)
 		; /* Do nothing */
 	else
@@ -1295,7 +1295,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		if (debugprint) lgdebug(0, "  word%d %c%c: %s\n   ",
 		 wi, w.firstupper ? 'C' : ' ', sent->post_quote[wi] ? 'Q' : ' ',
 #endif
-		if (debugprint) lgdebug(0, "  word%zu: %s\n   ", wi, w.unsplit_word);
+		if (debugprint) lgdebug(0, "  word%zu: %s\n\\", wi, w.unsplit_word);
 
 		/* There should always be at least one alternative */
 		assert((NULL != w.alternatives) && (NULL != w.alternatives[0]) &&
@@ -1396,7 +1396,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 			//if (word_split && (NULL == display)) printf("\n");
 		}
 		wi--;
-		if (debugprint) lgdebug(0, "\n");
+		if (debugprint) lgdebug(0, "\n\\");
 	}
 	if (debugprint) lgdebug(0, "\n");
 	else if (word_split) printf("\n\n");

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1301,7 +1301,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		assert((NULL != w.alternatives) && (NULL != w.alternatives[0]) &&
 		 ('\0' != w.alternatives[0][0]), "Missing alt for word %zu", wi);
 
-		//printf("DEBUG: word%zu '%s' nalts %zu\n",
+		//err_msg(lg_Debug, "word%zu '%s' nalts %zu\n",
 		//	 wi, sent->word[wi].unsplit_word, altlen(sent->word[wi].alternatives));
 
 		for (wi = w_start; (wi == w_start) ||
@@ -1420,10 +1420,7 @@ void print_with_subscript_dot(const char *s)
 void print_lwg_path(Gword **w)
 {
 	lgdebug(+0, " ");
-	for (; *w; w++)
-	{
-		print_with_subscript_dot((*w)->subword);
-	}
+	for (; *w; w++) lgdebug(0, "%s ", (*w)->subword);
 	lgdebug(0, "\n");
 }
 
@@ -1454,8 +1451,9 @@ void print_wordgraph_pathpos(const Wordgraph_pathpos *wp)
 void print_chosen_disjuncts_words(const Linkage lkg)
 {
 	size_t i;
+	String *djwbuf = string_new();
 
-	lgdebug(+0, "Linkage %p (%zu words): ", lkg, lkg->num_words);
+	err_msg(lg_Debug, "Linkage %p (%zu words): ", lkg, lkg->num_words);
 	for (i = 0; i < lkg->num_words; i++)
 	{
 		Disjunct *cdj = lkg->chosen_disjuncts[i];
@@ -1470,7 +1468,12 @@ void print_chosen_disjuncts_words(const Linkage lkg)
 		else
 			djw = cdj->string;
 
-		print_with_subscript_dot(djw);
+		char *djw_tmp = strdupa(djw);
+		char *sm = strrchr(djw_tmp, SUBSCRIPT_MARK);
+		if (NULL != sm) *sm = SUBSCRIPT_DOT;
+
+		append_string(djwbuf, "%s ", djw_tmp);
 	}
-	lgdebug(0, "\n");
+	err_msg(lg_Debug, "%s\n", string_value(djwbuf));
+	string_delete(djwbuf);
 }

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1253,7 +1253,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 
 				/* There should always be at least one alternative */
 				assert((NULL != w.alternatives) && (NULL != w.alternatives[0]) &&
-				 ('\0' != w.alternatives[0][0]), "Missing alt for word %zu\n", wi);
+				 ('\0' != w.alternatives[0][0]), "Missing alt for word %zu", wi);
 
 				if (NULL != w.alternatives[1])
 				{
@@ -1299,7 +1299,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 
 		/* There should always be at least one alternative */
 		assert((NULL != w.alternatives) && (NULL != w.alternatives[0]) &&
-		 ('\0' != w.alternatives[0][0]), "Missing alt for word %zu\n", wi);
+		 ('\0' != w.alternatives[0][0]), "Missing alt for word %zu", wi);
 
 		//printf("DEBUG: word%zu '%s' nalts %zu\n",
 		//	 wi, sent->word[wi].unsplit_word, altlen(sent->word[wi].alternatives));

--- a/link-grammar/prune.c
+++ b/link-grammar/prune.c
@@ -676,7 +676,7 @@ DBG(printf("after purging: "); print_expression(x->exp); printf("\n"););
 			}
 		}
 
-		if (debug_level(D_PRUNE))
+		if (verbosity_level(D_PRUNE))
 		{
 			printf("l->r pass removed %d\n", N_deleted);
 			print_expression_sizes(sent);
@@ -712,7 +712,7 @@ DBG(printf("after purging: "); print_expression(x->exp); printf("\n"););
 			}
 		}
 
-		if (debug_level(D_PRUNE))
+		if (verbosity_level(D_PRUNE))
 		{
 			printf("r->l pass removed %d\n", N_deleted);
 			print_expression_sizes(sent);
@@ -1181,7 +1181,7 @@ int power_prune(Sentence sent, Parse_Options opts)
 			}
 			sent->word[w].d = nd;
 		}
-		if (debug_level(D_PRUNE))
+		if (verbosity_level(D_PRUNE))
 		{
 			printf("l->r pass changed %d and deleted %zu\n", pc->N_changed, N_deleted);
 		}
@@ -1216,7 +1216,7 @@ int power_prune(Sentence sent, Parse_Options opts)
 			sent->word[w].d = nd;
 		}
 
-		if (debug_level(D_PRUNE))
+		if (verbosity_level(D_PRUNE))
 		{
 			printf("r->l pass changed %d and deleted %zu\n",
 				pc->N_changed, N_deleted);
@@ -1230,10 +1230,11 @@ int power_prune(Sentence sent, Parse_Options opts)
 	pt = NULL;
 	pc->pt = NULL;
 
-	if (debug_level(D_PRUNE)) printf("power prune cost: %d\n", pc->power_cost);
+	if (verbosity_level(D_PRUNE))
+		printf("power prune cost: %d\n", pc->power_cost);
 
 	print_time(opts, "power pruned");
-	if (debug_level(D_PRUNE))
+	if (verbosity_level(D_PRUNE))
 	{
 		printf("\nAfter power_pruning:\n");
 		print_disjunct_counts(sent);
@@ -1576,12 +1577,13 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			}
 		}
 
-		if (debug_level(D_PRUNE)) printf("pp_prune pass deleted %d\n", N_deleted);
+		if (verbosity_level(D_PRUNE))
+			printf("pp_prune pass deleted %d\n", N_deleted);
 	}
 	delete_unmarked_disjuncts(sent);
 	cms_table_delete(cmt);
 
-	if (debug_level(D_PRUNE))
+	if (verbosity_level(D_PRUNE))
 	{
 		printf("\nAfter pp_pruning:\n");
 		print_disjunct_counts(sent);

--- a/link-grammar/regex-morph.c
+++ b/link-grammar/regex-morph.c
@@ -41,7 +41,7 @@ static void prt_regerror(const char *msg, const Regex_node *re, int rc)
 					re->pattern, re->name, erroroffset, error);
 	*/
 	regerror(rc, re->re, errbuf, errbuf_size);
-	prt_error("Error: %s: \"%s\" (%s): %s", msg, re->pattern, re->name, errbuf);
+	prt_error("Error: %s: \"%s\" (%s): %s\n", msg, re->pattern, re->name, errbuf);
 	free(errbuf);
 }
 

--- a/link-grammar/regex-tokenizer.c
+++ b/link-grammar/regex-tokenizer.c
@@ -356,7 +356,7 @@ static int callout(pcre_callout_block *cb)
 
 			lgdebug(2, "Current capture %d: s=%d, e=%d\n",
 			        cb->capture_last, cb_ov->s, cb_ov->e);
-			assert(cb_ov->s>=0 && cb_ov->e>=0, "Bad start/end in capture group %d: s=%d e=%d\n",
+			assert(cb_ov->s>=0 && cb_ov->e>=0, "Bad start/end in capture group %d: s=%d e=%d",
 			       cb->capture_last, cb_ov->s, cb_ov->e);
 
 			if (verbosity >= 6)
@@ -442,7 +442,7 @@ static int callout(pcre_callout_block *cb)
 				int numchar = cb_ov->e - cb_ov->s;
 
 				/* Debug: Sanity check. */
-				assert(numchar>=0, "numchar=%d\n", numchar);
+				assert(numchar>=0, "numchar=%d", numchar);
 				endname = NULL;
 				for (openp = &cd->pattern[cb->pattern_position-5]; *openp; openp--)
 				{

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -12,6 +12,8 @@
 
 #include <time.h>
 
+#include "externs.h"
+
 #if !defined(_WIN32)
 	#include <sys/time.h>
 	#include <sys/resource.h>
@@ -133,10 +135,9 @@ static void resources_print_time(int verbosity, Resources r, const char * s)
 {
 	double now;
 	now = current_usage_time();
-	if (verbosity > 1) {
-		printf("++++");
-		left_print_string(stdout, s, RES_COL_WIDTH);
-		printf("%7.2f seconds\n", now - r->when_last_called);
+	if (verbosity >= D_USER_TIMES)
+	{
+		prt_error("++++ %-36s %7.2f seconds\n", s, now - r->when_last_called);
 	}
 	r->when_last_called = now;
 }
@@ -147,22 +148,20 @@ static void resources_print_total_time(int verbosity, Resources r)
 	double now;
 	now = current_usage_time();
 	r->cumulative_time += (now - r->time_when_parse_started) ;
-	if (verbosity > 0) {
-		printf("++++");
-		left_print_string(stdout, "Time", RES_COL_WIDTH);
-		printf("%7.2f seconds (%.2f total)\n",
-			   now - r->time_when_parse_started, r->cumulative_time);
+	if (verbosity >= D_USER_BASIC)
+	{
+		prt_error("++++ %-36s %7.2f seconds (%.2f total)\n", "Time",
+		          now - r->time_when_parse_started, r->cumulative_time);
 	}
 	r->time_when_parse_started = now;
 }
 
 static void resources_print_total_space(int verbosity, Resources r)
 {
-	if (verbosity > 1) {
-		printf("++++");
-		left_print_string(stdout, "Total space", RES_COL_WIDTH);
-		printf("%zu bytes (%zu max)\n",
-			get_space_in_use(), get_max_space_used());
+	if (verbosity >= D_USER_TIMES)
+	{
+		prt_error("++++ %-36s %zu bytes (%zu max)\n", "Total space",
+		          get_space_in_use(), get_max_space_used());
 	}
 }
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1673,7 +1673,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     add_anded_exp(exp_word[var->left_word], lcexp);
     add_anded_exp(exp_word[var->right_word], rcexp);
 
-    if (debug_level(D_SAT)) {
+    if (verbosity_level(D_SAT)) {
       //cout<< "Lexp[" <<left_xnode->word->subword <<"]: ";  print_expression(var->left_exp);
       cout<< "LCexp[" <<left_xnode->word->subword <<"]: ";  print_expression(lcexp);
       //cout<< "Rexp[" <<right_xnode->word->subword <<"]: "; print_expression(var->right_exp);

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1746,7 +1746,8 @@ extern "C" int sat_parse(Sentence sent, Parse_Options  opts)
     // For now, just avoid the delay of a useless re-parsing.
     if (opts->verbosity >= 1)
       prt_error("Info: use-sat: Cannot parse with null links (yet).\n"
-                "              Set the \"null\" option to 0 to turn off parsing with null links.");
+                "              Set the \"null\" option to 0 to turn off "
+                "parsing with null links.\n");
     sent->num_valid_linkages = 0;
     sent->num_linkages_post_processed = 0;
     return 0;
@@ -1793,8 +1794,9 @@ extern "C" int sat_parse(Sentence sent, Parse_Options  opts)
     if (opts->max_null_count > 0) {
       // The sat solver doesn't support (yet) parsing with nulls.
       if (opts->verbosity >= 1)
-        prt_error("Info: use-sat: Cannot parse with null links (yet).\n"
-                  "              Set the \"null\" option to 0 to turn off parsing with null links.");
+      prt_error("Info: use-sat: Cannot parse with null links (yet).\n"
+                "              Set the \"null\" option to 0 to turn off "
+                "parsing with null links.\n");
     }
   } else {
     /* We found a valid linkage.
@@ -1827,7 +1829,7 @@ extern "C" Linkage sat_create_linkage(LinkageIdx k, Sentence sent, Parse_Options
   if(k > encoder->_next_linkage_index)           // skips unproduced linkages
   {
     prt_error("Error: Linkage index %zu is greater than the "
-              "maximum expected one %zu", k, encoder->_next_linkage_index);
+              "maximum expected one %zu\n", k, encoder->_next_linkage_index);
     return NULL;
   }
   if (k < encoder->_next_linkage_index)          // already produced

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -21,7 +21,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
   double cost = parent_cost + exp->cost;
 
 #ifdef DEBUG
-  if (0 && debug_level(+D_IC)) { // Extreme debug
+  if (0 && verbosity_level(+D_IC)) { // Extreme debug
     printf("Expression type %d for Word%d, var %s:\n", exp->type, _word, var);
     printf("parent_exp: "); print_expression(parent_exp);
     printf("exp: "); print_expression(exp);
@@ -117,7 +117,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       }
 
 #ifdef DEBUG
-      if (0 && debug_level(+D_IC)) { // Extreme debug
+      if (0 && verbosity_level(+D_IC)) { // Extreme debug
         printf("Word%d, var %s OR_type:\n", _word, var);
         printf("exp mem: "); prt_exp_mem(exp, 0);
       }

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -3043,7 +3043,7 @@ bool sentence_in_dictionary(Sentence sent)
 	if (!ok_so_far)
 	{
 		err_ctxt ec = { sent };
-		err_msgc(&ec, Error, "Error: Sentence not in dictionary\n%s", temp);
+		err_msgc(&ec, lg_Error, "Error: Sentence not in dictionary\n%s", temp);
 	}
 	return ok_so_far;
 }

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -325,13 +325,14 @@ static bool word_start_another_alternative(Dictionary dict,
 {
 	Gword **n;
 
+	lgdebug(+D_WSAA, "\n"); /* Terminate a previous partial trace message. */
 	lgdebug(+D_WSAA, "Checking %s in alternatives of %zu:%s (prev %zu:%s)\n",
 	        altword0, unsplit_word->node_num, unsplit_word->subword,
 	        unsplit_word->prev[0]->node_num, unsplit_word->prev[0]->subword);
 
 	for (n = unsplit_word->prev[0]->next; NULL != *n; n++)
 	{
-		lgdebug(D_WSAA, "Comparing alt %s\n", (*n)->subword);
+		lgdebug(D_WSAA, "Comparing alt %s\n\\", (*n)->subword);
 		if ((0 == strcmp((*n)->subword, altword0) ||
 		    ((0 == strncmp((*n)->subword, altword0, strlen((*n)->subword))) &&
 			 !find_word_in_dict(dict, altword0))))

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1525,11 +1525,18 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 	n = spellcheck_suggest(dict->spell_checker, &alternates, word);
 	if (debug_level(+D_SW))
 	{
-		printf("Info: guess_misspelled_word() spellcheck_suggest for %s:%s\n",
-		       word, (0 == n) ? " (nothing)" : "");
+		lgdebug(0, "spellcheck_suggest for %s:\\", word);
+		if (0 == n)
+			lgdebug(0, " (nothing)\n");
+		else
+			lgdebug(0, "\n\\");
+
 		for (j=0; j<n; j++)
 		{
-			printf("- %s\n", alternates[j]);
+			if (n-1 != j)
+				lgdebug(0, "- %s\n\\", alternates[j]);
+			else
+				lgdebug(0, "- %s\n", alternates[j]);
 		}
 	}
 	/* Word split for run-on and guessed words.

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2011,9 +2011,11 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 * http://en.wiktionary.org/wiki/Category:English_double_contractions*/
 			if (!word_is_known)
 			{
-				/* This is not really a debug message, so it is in verbosity 1.
-				 * XXX Maybe prt_error()? */
-				lgdebug(+1, "Contracted word part %s is not in the dict\n", word);
+				/* Note: If we are here it means dict->affix_table is not NULL. */
+				prt_error("Warning: Contracted word part %s is in '%s/%s' "
+				          "but not in '%s/%s'\n", word,
+				          dict->lang, dict->affix_table->name,
+				          dict->lang, dict->name);
 			}
 			return;
 		}

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -955,7 +955,7 @@ static bool synthetic_split(Sentence sent, Gword *unsplit_word)
 				{
 					if (c == s)
 					{
-						printf(SYNTHSPLIT_ERROR("(empty subword)."), w);
+						prt_error(SYNTHSPLIT_ERROR("(empty subword)."), w);
 						goto error;
 					}
 					strncpy(alt, s, c-s);
@@ -988,13 +988,13 @@ static bool synthetic_split(Sentence sent, Gword *unsplit_word)
 				      ((*c >= '0') && (*c <= '9')) ||
 				      ('_' == *c)))
 				{
-					printf(SYNTHSPLIT_ERROR("('%c' not alphanumeric)."), w, *c);
+					prt_error(SYNTHSPLIT_ERROR("('%c' not alphanumeric)."), w, *c);
 					goto error;
 				}
 		}
 		if (0 > plevel)
 		{
-			printf(SYNTHSPLIT_ERROR("extra ')'"), w);
+			prt_error(SYNTHSPLIT_ERROR("extra ')'"), w);
 			goto error;
 		}
 
@@ -1002,7 +1002,7 @@ static bool synthetic_split(Sentence sent, Gword *unsplit_word)
 
 	if (0 < plevel)
 	{
-		printf(SYNTHSPLIT_ERROR("missing '('."), w);
+		prt_error(SYNTHSPLIT_ERROR("missing '('."), w);
 		goto error;
 	}
 
@@ -1589,7 +1589,7 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 				set_alt_word_status(sent->dict, altp, WS_SPELL);
 				num_guesses++;
 			}
-			//else printf("Spell guess '%s' ignored\n", alternates[j]);
+			//else prt_error("Debug: Spell guess '%s' ignored\n", alternates[j]);
 		}
 
 		if (num_guesses >= opts->use_spell_guess) break;
@@ -2724,12 +2724,12 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	if (debug_level(D_X_NODE))
 	{
 		/* Print the X_node details for the word. */
-		printf("Tokenize word/alt=%zu/%zu '%s' re=%s\n",
+		prt_error("Debug: Tokenize word/alt=%zu/%zu '%s' re=%s\n\\",
 				 wordpos, altlen(sent->word[wordpos].alternatives), s,
 				 w->regex_name ? w->regex_name : "");
 		while (we)
 		{
-			printf(" xstring='%s' expr=", we->string);
+			prt_error(" xstring='%s' expr=", we->string);
 			print_expression(we->exp);
 			we = we->next;
 		}

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1524,7 +1524,7 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 	/* Else, ask the spell-checker for alternate spellings
 	 * and see if these are in the dict. */
 	n = spellcheck_suggest(dict->spell_checker, &alternates, word);
-	if (debug_level(+D_SW))
+	if (verbosity_level(+D_SW))
 	{
 		lgdebug(0, "spellcheck_suggest for %s:\\", word);
 		if (0 == n)
@@ -2722,7 +2722,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	/* At last .. concatenate the word expressions we build for
 	 * this alternative. */
 	sent->word[wordpos].x = catenate_X_nodes(sent->word[wordpos].x, we);
-	if (debug_level(D_X_NODE))
+	if (verbosity_level(D_X_NODE))
 	{
 		/* Print the X_node details for the word. */
 		prt_error("Debug: Tokenize word/alt=%zu/%zu '%s' re=%s\n\\",
@@ -3005,7 +3005,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 
 	free(wp_new);
 	lgdebug(+D_FW, "sent->length %zu\n", sent->length);
-	if (debug_level(D_SW))
+	if (verbosity_level(D_SW))
 		print_sentence_word_alternatives(sent, true, NULL, NULL);
 
 	return !error_encountered;

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -3042,9 +3042,8 @@ bool sentence_in_dictionary(Sentence sent)
 	}
 	if (!ok_so_far)
 	{
-		err_ctxt ec;
-		ec.sent = sent;
-		err_msg(&ec, Error, "Error: Sentence not in dictionary\n%s\n", temp);
+		err_ctxt ec = { sent };
+		err_msgc(&ec, Error, "Error: Sentence not in dictionary\n%s", temp);
 	}
 	return ok_so_far;
 }

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -680,7 +680,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 							}
 							assert(NULL != *n, "Adding subword '%s': "
 							       "No corresponding next link for a prev link: "
-							       "prevword='%s' word='%s'\n",
+							       "prevword='%s' word='%s'",
 							       subword->subword, (*p)->subword, unsplit_word->subword);
 						}
 					}
@@ -727,7 +727,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 							assert(NULL!=*p,
 								"Adding subword '%s': "
 								"No corresponding prev link for a next link"
-								"nextword='%s' word='%s'\n",
+								"nextword='%s' word='%s'",
 								subword->subword, (*n)->subword, unsplit_word->subword);
 						}
 
@@ -758,7 +758,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					sole_alternative_of_itself : alternative_id;
 				Gword **alts;
 
-				assert(curr_alt, "'%s': No alt mark\n", unsplit_word->subword);
+				assert(curr_alt, "'%s': No alt mark", unsplit_word->subword);
 				assert(prev, "'%s': No prev", unsplit_word->subword);
 				assert(prev[0], "'%s': No prev[0]", unsplit_word->subword);
 				assert(prev[0]->next, "%s': No next",prev[0]->subword);
@@ -2690,7 +2690,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	if (NULL == we)
 	{
 		/* FIXME Change it to assert() when the Wordgraph version is mature. */
-		prt_error("Error: Word '%s': Internal error: NULL X_node\n", w->subword);
+		prt_error("Error: Word '%s': Internal error: NULL X_node", w->subword);
 		return false;
 	}
 #endif
@@ -2859,7 +2859,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 			else
 			{
 				/* Words are not supposed to get issued more than once. */
-				assert(!wpp_old->used, "Word %zu:%s has been used\n",
+				assert(!wpp_old->used, "Word %zu:%s has been used",
 				       wg_word->node_num, wpp_old->word->subword);
 
 				/* This is a new wordgraph word.

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -683,8 +683,8 @@ void * object_open(const char *filename,
 		{
 			char cwd[MAX_PATH_NAME];
 			char *cwdp = getcwd(cwd, sizeof(cwd));
-			printf("Debug: Current directory: %s\n", NULL == cwdp ? "NULL": cwdp);
-			printf("Debug: Last-resort data directory: %s\n",
+			prt_error("Debug: Current directory: %s\n", NULL == cwdp ? "NULL": cwdp);
+			prt_error("Debug: Last-resort data directory: %s\n",
 					  data_dir ? data_dir : "NULL");
 		}
 	}

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -260,7 +260,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t local
 	nbh = mbrtowc (&c, from, MB_CUR_MAX, &mbs);
 	if (nbh < 0)
 	{
-		prt_error("Error: Invalid UTF-8 string!");
+		prt_error("Error: Invalid UTF-8 string!\n");
 		return;
 	}
 	c = towlower_l(c, locale_t);
@@ -270,7 +270,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t local
 	if ((nbh < nbl) && (to == from))
 	{
 		/* I'm to lazy to fix this */
-		prt_error("Error: can't downcase UTF-8 string!");
+		prt_error("Error: can't downcase UTF-8 string!\n");
 		return;
 	}
 
@@ -302,7 +302,7 @@ void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale_
 	nbh = mbrtowc (&c, from, MB_CUR_MAX, &mbs);
 	if (nbh < 0)
 	{
-		prt_error("Error: Invalid UTF-8 string!");
+		prt_error("Error: Invalid UTF-8 string!\n");
 		return;
 	}
 	c = towupper_l(c, locale_t);
@@ -312,7 +312,7 @@ void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale_
 	if ((nbh < nbl) && (to == from))
 	{
 		/* I'm to lazy to fix this */
-		prt_error("Error: can't upcase UTF-8 string!");
+		prt_error("Error: can't upcase UTF-8 string!\n");
 		return;
 	}
 
@@ -464,7 +464,7 @@ void * xalloc(size_t size)
 #endif /* TRACK_SPACE_USAGE */
 	if ((p == NULL) && (size != 0))
 	{
-		prt_error("Fatal Error: Ran out of space. (int)");
+		prt_error("Fatal Error: Ran out of space. (int)\n");
 		abort();
 		exit(1);
 	}
@@ -497,7 +497,7 @@ void * exalloc(size_t size)
 
 	if ((p == NULL) && (size != 0))
 	{
-		prt_error("Fatal Error: Ran out of space. (ext)");
+		prt_error("Fatal Error: Ran out of space. (ext)\n");
 		abort();
 		exit(1);
 	}
@@ -600,20 +600,20 @@ char * dictionary_get_data_dir(void)
 
 	if (!GetModuleFileNameA(NULL, prog_path, sizeof(prog_path)))
 	{
-		prt_error("Warning: GetModuleFileName error %d", (int)GetLastError());
+		prt_error("Warning: GetModuleFileName error %d\n", (int)GetLastError());
 	}
 	else
 	{
 		if (NULL == prog_path)
 		{
 			/* Can it happen? */
-			prt_error("Warning: GetModuleFileName returned a NULL program path!");
+			prt_error("Warning: GetModuleFileName returned a NULL program path!\n");
 		}
 		else
 		{
 			if (!PathRemoveFileSpecA(prog_path))
 			{
-				prt_error("Warning: Cannot get directory from program path '%s'!",
+				prt_error("Warning: Cannot get directory from program path '%s'!\n",
 				          prog_path);
 			}
 			else
@@ -746,7 +746,7 @@ void * object_open(const char *filename,
 
 		path_found = strdup((NULL != completename) ? completename : filename);
 		if (0 < verbosity)
-			prt_error("Info: Dictionary found at %s", path_found);
+			prt_error("Info: Dictionary found at %s\n", path_found);
 		for (i = 0; i < 2; i++)
 		{
 			char *root = strrchr(path_found, DIR_SEPARATOR[0]);
@@ -841,7 +841,7 @@ char *get_file_contents(const char * dict_name)
 
 	if (left < 0)
 	{
-		prt_error("Error: File size is insane!");
+		prt_error("Error: File size is insane!\n");
 		free(contents);
 		return NULL;
 	}
@@ -918,18 +918,18 @@ void set_utf8_program_locale(void)
 		if ((0 != strcmp(locale, "C")) && (0 != strcmp(locale, "POSIX")))
 		{
 			prt_error("Warning: Program locale \"%s\" (codeset %s) was not UTF-8; "
-						 "force-setting to en_US.UTF-8", locale, codeset);
+						 "force-setting to en_US.UTF-8\n", locale, codeset);
 		}
 		locale = setlocale(LC_CTYPE, "en_US.UTF-8");
 		if (NULL == locale)
 		{
 			prt_error("Warning: Program locale en_US.UTF-8 could not be set; "
-			          "force-setting to C.UTF-8");
+			          "force-setting to C.UTF-8\n");
 			locale = setlocale(LC_CTYPE, "C.UTF-8");
 			if (NULL == locale)
 			{
 				prt_error("Warning: Could not set a UTF-8 program locale; "
-				          "program may malfunction");
+				          "program may malfunction\n");
 			}
 		}
 	}
@@ -948,7 +948,7 @@ win32_getlocale (void)
 	if (0 >= GetLocaleInfoA(lcid, LOCALE_SISO639LANGNAME, lbuf, sizeof(lbuf)))
 	{
 		prt_error("Error: GetLocaleInfoA LOCALE_SENGLISHLANGUAGENAME LCID=%d: "
-		          "Error %d", (int)lcid, (int)GetLastError());
+		          "Error %d\n", (int)lcid, (int)GetLastError());
 		return NULL;
 	}
 	strcpy(locale, lbuf);
@@ -957,7 +957,7 @@ win32_getlocale (void)
 	if (0 >= GetLocaleInfoA(lcid, LOCALE_SISO3166CTRYNAME, lbuf, sizeof(lbuf)))
 	{
 		prt_error("Error: GetLocaleInfoA LOCALE_SISO3166CTRYNAME LCID=%d: "
-		          "Error %d", (int)lcid, (int)GetLastError());
+		          "Error %d\n", (int)lcid, (int)GetLastError());
 		return NULL;
 	}
 	strcat(locale, lbuf);

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -679,7 +679,7 @@ void * object_open(const char *filename,
 	if (NULL == path_found)
 	{
 		data_dir = dictionary_get_data_dir();
-		if (debug_level(D_USER_FILES))
+		if (verbosity_level(D_USER_FILES))
 		{
 			char cwd[MAX_PATH_NAME];
 			char *cwdp = getcwd(cwd, sizeof(cwd));

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -66,6 +66,16 @@ void *alloca (size_t);
 #define strdupa(s) strcpy(alloca(strlen(s)+1), s)
 #endif
 
+/* Windows, POSIX and GNU have different ideas about thread-safe strerror(). */
+#ifdef _WIN32
+#define strerror_r(errno, buf, len) strerror_s(buf, len, errno)
+#else
+#ifdef _GNU_SOURCE
+/* Emulate the POSIX version; assuming len>0 and a successful call. */
+#define strerror_r(errno, buf, len) abs((strcpy(buf, strerror_r (errno, buf, len)), 0))
+#endif /* _GNU_SOURCE */
+#endif /* _WIN32 */
+
 #ifdef _MSC_VER
 /* These definitions are incorrect, as these functions are different(!)
  * (non-standard functionality).

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -53,6 +53,14 @@ extern "C"
 void *alloca (size_t);
 #endif
 
+#ifndef TLS
+#ifdef _MSC_VER
+#define TLS __declspec(thread)
+#else
+#define TLS
+#endif /* _MSC_VER */
+#endif /* !TLS */
+
 #ifndef strdupa
 /* In the following, the argument should not have side effects. */
 #define strdupa(s) strcpy(alloca(strlen(s)+1), s)

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -95,13 +95,12 @@ void *alloca (size_t);
 #include <windows.h>
 #include <mbctype.h>
 
+/* Compatibility definitions. */
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif
-
-/* MS changed the name of rand_r to rand_s */
+/* Note that "#define _CRT_RAND_S" is needed before "#include <stdlib.h>" */
 #define rand_r(seedp) rand_s(seedp)
-/* And strtok_r is strtok_s */
 #define strtok_r strtok_s
 
 /* Native windows has locale_t, and hence HAVE_LOCALE_T is defined here.

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -197,18 +197,18 @@ GNUC_UNUSED void print_hier_position(const Gword *word)
 {
 	const Gword **p;
 
-	err_msg(Debug, "[Word %zu:%s hier_position(hier_depth=%zu): ",
+	err_msg(lg_Debug, "[Word %zu:%s hier_position(hier_depth=%zu): ",
 	        word->node_num, word->subword, word->hier_depth);
 	assert(2*word->hier_depth==gwordlist_len(word->hier_position), "word '%s'",
 	       word->subword);
 
 	for (p = word->hier_position; NULL != *p; p += 2)
 	{
-		err_msg(Debug, "(%zu:%s/%zu:%s)",
+		err_msg(lg_Debug, "(%zu:%s/%zu:%s)",
 		        p[0]->node_num, debug_show_subword(p[0]),
 		        p[1]->node_num, debug_show_subword(p[1]));
 	}
-	err_msg(Debug, "]\n");
+	err_msg(lg_Debug, "]\n");
 }
 #endif
 

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -197,19 +197,18 @@ GNUC_UNUSED void print_hier_position(const Gword *word)
 {
 	const Gword **p;
 
-	fflush(stdout);
-	fprintf(stderr, "[Word %zu:%s hier_position(hier_depth=%zu): ",
+	err_msg(Debug, "[Word %zu:%s hier_position(hier_depth=%zu): ",
 	        word->node_num, word->subword, word->hier_depth);
 	assert(2*word->hier_depth==gwordlist_len(word->hier_position), "word '%s'",
 	       word->subword);
 
 	for (p = word->hier_position; NULL != *p; p += 2)
 	{
-		fprintf(stderr, "(%zu:%s/%zu:%s)",
+		err_msg(Debug, "(%zu:%s/%zu:%s)",
 		        p[0]->node_num, debug_show_subword(p[0]),
 		        p[1]->node_num, debug_show_subword(p[1]));
 	}
-	fprintf(stderr, "]\n");
+	err_msg(Debug, "]\n");
 }
 #endif
 

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -793,14 +793,14 @@ static void x_popen(const char *cmd, const char *wgds)
 
 	if (NULL == cmdf)
 	{
-		prt_error("Error: popen of '%s' failed: %s", cmd, strerror(errno));
+		prt_error("Error: popen of '%s' failed: %s\n", cmd, strerror(errno));
 	}
 	else
 	{
 		if (fprintf(cmdf, "%s", wgds) == -1)
-			prt_error("Error: print to display command: %s", strerror(errno));
+			prt_error("Error: print to display command: %s\n", strerror(errno));
 		if (pclose(cmdf) == -1)
-			prt_error("Error: pclose of display command: %s", strerror(errno));
+			prt_error("Error: pclose of display command: %s\n", strerror(errno));
 	}
 }
 #else
@@ -816,7 +816,7 @@ static void x_forkexec(const char *const argv[], pid_t *pid)
 		if (0 == rpid) return; /* viewer still active */
 		if (-1 == rpid)
 		{
-			prt_error("Error: waitpid(%d): %s", *pid, strerror(errno));
+			prt_error("Error: waitpid(%d): %s\n", *pid, strerror(errno));
 			*pid = 0;
 			return;
 		}
@@ -835,7 +835,7 @@ static void x_forkexec(const char *const argv[], pid_t *pid)
 #endif
 			/* Not closing fd 0/1/2, to allow interaction with the program */
 			execvp(argv[0], (char **)argv);
-			prt_error("Error: execlp of %s: %s", argv[0], strerror(errno));
+			prt_error("Error: execlp of %s: %s\n", argv[0], strerror(errno));
 			_exit(1);
 		default:
 #ifndef HAVE_PRCTL
@@ -923,7 +923,7 @@ void wordgraph_show(Sentence sent, const char *modestr)
 		gvf = fopen(gvf_name, "w");
 		if (NULL == gvf)
 		{
-			prt_error("Error: wordgraph_show: open %s failed: %s",
+			prt_error("Error: wordgraph_show: open %s failed: %s\n",
 						 gvf_name, strerror(errno));
 		}
 		else
@@ -931,13 +931,13 @@ void wordgraph_show(Sentence sent, const char *modestr)
 			if (fprintf(gvf, "%s", wgds) == -1)
 			{
 				gvf_error = true;
-				prt_error("Error: wordgraph_show: print to %s failed: %s",
+				prt_error("Error: wordgraph_show: print to %s failed: %s\n",
 							 gvf_name, strerror(errno));
 			}
 			if (fclose(gvf) == EOF)
 			{
 				gvf_error = true;
-				prt_error("Error: wordgraph_show: close %s failed: %s",
+				prt_error("Error: wordgraph_show: close %s failed: %s\n",
 							  gvf_name, strerror(errno));
 			}
 		}
@@ -979,6 +979,6 @@ void wordgraph_show(Sentence sent, const char *modestr)
 #else
 void wordgraph_show(Sentence sent, const char *modestr)
 {
-		prt_error("Error: Not configured with --enable-wordgraph-display");
+		prt_error("Error: Not configured with --enable-wordgraph-display\n");
 }
 #endif /* USE_WORDGRAPH_DISPLAY */

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -144,7 +144,7 @@ bool wordgraph_pathpos_add(Wordgraph_pathpos **wp, Gword *p, bool used,
 	assert(NULL != p);
 
 #ifdef DEBUG
-	if (debug_level(+9)) print_hier_position(p);
+	if (verbosity_level(+9)) print_hier_position(p);
 #endif
 
 	if (NULL != *wp)

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -144,7 +144,7 @@ bool wordgraph_pathpos_add(Wordgraph_pathpos **wp, Gword *p, bool used,
 	assert(NULL != p);
 
 #ifdef DEBUG
-	if (debug_level(9)) { printf("\n"); print_hier_position(p); }
+	if (debug_level(+9)) print_hier_position(p);
 #endif
 
 	if (NULL != *wp)
@@ -961,7 +961,7 @@ void wordgraph_show(Sentence sent, const char *modestr)
 #endif
 
 #ifdef EXITKEY
-	printf("Press "EXITKEY" in the graphical display window to continue\n");
+	prt_error("Press "EXITKEY" in the graphical display window to continue\n");
 #endif
 
 #if !defined HAVE_FORK || defined POPEN_DOT

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -381,7 +381,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		}
 		else
 		{
-			printf("Internal error: Unknown variable type %d\n", as[j].param_type);
+			prt_error("Error: Internal error: Unknown variable type %d\n",
+			          as[j].param_type);
 			return -1;
 		}
 	}

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -622,7 +622,7 @@ int main(int argc, char * argv[])
 	opts = copts->popts;
 	if (copts == NULL || opts == NULL || copts->panic_opts == NULL)
 	{
-		fprintf(stderr, "%s: Fatal error: unable to create parse options\n", argv[0]);
+		prt_error("Fatal error: unable to create parse options\n");
 		exit(-1);
 	}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -656,7 +656,7 @@ int main(int argc, char * argv[])
 		dict = dictionary_create_lang(language);
 		if (dict == NULL)
 		{
-			prt_error("Fatal error: Unable to open dictionary.");
+			prt_error("Fatal error: Unable to open dictionary.\n");
 			exit(-1);
 		}
 	}
@@ -665,7 +665,7 @@ int main(int argc, char * argv[])
 		dict = dictionary_create_default_lang();
 		if (dict == NULL)
 		{
-			prt_error("Fatal error: Unable to open default dictionary.");
+			prt_error("Fatal error: Unable to open default dictionary.\n");
 			exit(-1);
 		}
 	}
@@ -682,10 +682,10 @@ int main(int argc, char * argv[])
 
 	check_winsize(copts);
 
-	prt_error("Info: Dictionary version %s, locale %s",
+	prt_error("Info: Dictionary version %s, locale %s\n",
 		linkgrammar_get_dict_version(dict),
 		linkgrammar_get_dict_locale(dict));
-	prt_error("Info: Library version %s. Enter \"!help\" for help.",
+	prt_error("Info: Library version %s. Enter \"!help\" for help.\n",
 		linkgrammar_get_version());
 
 	/* Main input loop */

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -42,7 +42,7 @@ char *get_console_line(void)
 		                             NULL, OPEN_EXISTING, 0, NULL);
 		if (!console_handle || (INVALID_HANDLE_VALUE == console_handle))
 		{
-			prt_error("CreateFileA CONIN$: Error %d.", (int)GetLastError());
+			prt_error("Error: CreateFileA CONIN$: Error %d.\n", (int)GetLastError());
 			return NULL;
 		}
 	}
@@ -50,7 +50,7 @@ char *get_console_line(void)
 	DWORD nchar;
 	if (!ReadConsoleW(console_handle, &winbuf, MAX_INPUT-sizeof(wchar_t), &nchar, NULL))
 	{
-		printf("ReadConsoleW: Error %d\n", (int)GetLastError());
+		prt_error("Error: ReadConsoleW: Error %d\n", (int)GetLastError());
 		return NULL;
 	}
 	winbuf[nchar] = L'\0';
@@ -59,7 +59,7 @@ char *get_console_line(void)
 	                            sizeof(utf8inbuf), NULL, NULL);
 	if (0 == nchar)
 	{
-		prt_error("Error: WideCharToMultiByte CP_UTF8 failed: Error %d.",
+		prt_error("Error: WideCharToMultiByte CP_UTF8 failed: Error %d.\n",
 		          (int)GetLastError());
 		return NULL;
 	}
@@ -67,7 +67,7 @@ char *get_console_line(void)
 	/* Make sure we don't have conversion problems, by searching for '�'. */
 	const char *invlid_char  = strstr(utf8inbuf, "\xEF\xBF\xBD");
 	if (NULL != invlid_char)
-		prt_error("Warning: Invalid input character encountered.");
+		prt_error("Warning: Invalid input character encountered.\n");
 
 	/* ^Z is read as a character. Convert it to an EOF indication. */
 	if ('\x1A' == utf8inbuf[0]) /* Only handle it at line start. */
@@ -103,7 +103,7 @@ void win32_set_utf8_output(void)
 {
 	if (-1 == _setmode(fileno(stdout), _O_BINARY))
 	{
-		prt_error("Warning: _setmode(fileno(stdout), _O_BINARY): %s.",
+		prt_error("Warning: _setmode(fileno(stdout), _O_BINARY): %s.\n",
 			strerror(errno));
 	}
 
@@ -112,20 +112,20 @@ void win32_set_utf8_output(void)
 	atexit(restore_console_cp);
 	if (!SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandler, TRUE))
 	{
-		prt_error("Warning: Cannot not set code page restore handler.");
+		prt_error("Warning: Cannot not set code page restore handler.\n");
 	}
 	/* For file output. It is too late for output pipes.
 	 * If output pipe is desired, one can set CP_UTF8 by the
 	 * command "chcp 65001" before invoking link-parser. */
 	if (!SetConsoleCP(CP_UTF8))
 	{
-		prt_error("Warning: Cannot set input codepage %d (error %d).",
+		prt_error("Warning: Cannot set input codepage %d (error %d).\n",
 			CP_UTF8, (int)GetLastError());
 	}
 	/* For Console output. */
 	if (!SetConsoleOutputCP(CP_UTF8))
 	{
-		prt_error("Warning: Cannot set output codepage %d (error %d).",
+		prt_error("Warning: Cannot set output codepage %d (error %d).\n",
 			CP_UTF8, (int)GetLastError());
 	}
 }


### PR DESCRIPTION
Per issue #414.

**N.B.**
The branches for eliminating the empty word from the regular and SAT parsers are also ready,
and I'm waiting for merging this PR in order that I will be able to rebase on the result (may be tedious because of common touched areas). After sending them I will prepare the ZZZ elimination PR.

I propose to issue a new version after this PR (5.3.14). I already included this version number in `link-grammar/README` (please change if needed). Before that, I can fix any problem you find in your code review.
