### PR TITLE
SAT optional word

### DIFF
--- a/data/amy/4.0.dict
+++ b/data/amy/4.0.dict
@@ -10,8 +10,6 @@
 % Dictionary version number is 5.3.14 (formatted as V5v3v14+)
 <dictionary-version-number>: V5v3v14+;
 
-EMPTY-WORD.zzz: ZZZ-;
-
 LEFT-WALL: ANY+;
 ANY-WORD: {@ANY-} & {@ANY+};
 UNKNOWN-WORD: {@ANY-} & {@ANY+};

--- a/data/any/4.0.dict
+++ b/data/any/4.0.dict
@@ -16,6 +16,3 @@ ANY-PUNCT: {@ANY-} & {@ANY+};
 UNKNOWN-WORD: {@ANY-} & {@ANY+};
 
 JUNK: {@ANY-} & {@ANY+};
-
-% Needed to get single-quotes to parse: e.g. "'relex' is the best"
-EMPTY-WORD.zzz: ZZZ-;

--- a/data/de/4.0.dict
+++ b/data/de/4.0.dict
@@ -11,10 +11,6 @@
 <dictionary-version-number>: V5v0v2+;
 <dictionary-locale>: DE4de+;
 
-% Word-count balancing for suffixes
-EMPTY-WORD.zzz: ZZZ-;
-
-
 % NOUNS, PRONOUNS
 
 % Masculine singular

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -49,15 +49,6 @@
  % This is mostly fixed, except that some uses of <noun-main-m>
  % remain, below.
 
-% The empty word is a used in the 2D array used by the parser,
-% in "word slots" in which "no word" is a possibility to consider.
-% When the Wordgraph is converted ("flattened") to this 2D array,
-% empty words are issued whenever needed.
-% FIXME: A better comment maybe.
-% See also EMPTY-WORD.x for the highly-unusual situation that EMPTY-WORD
-% appears in the input text.
-EMPTY-WORD.zzz: ZZZ-;
-
 % Capitalization handling (null effect for now- behave as empty words).
 1stCAP.zzz: ZZZ-;
 nonCAP.zzz: ZZZ-;
@@ -334,9 +325,6 @@ INITIALS <entity-singular>:
 % should have a cost that is even higher (so that we take the
 % capitalized version before we take any other matches.)
 CAPITALIZED-WORDS: [<entity-singular>]0.05;
-
-% Hack, see EMPTY-WORD, up top.
-EMPTY-WORD.x: CAPITALIZED-WORDS;
 
 % Capitalized words that seem to be plural (by ending with an s, etc)
 % -- But not all words that end with an 's' are plural:

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -58,15 +58,6 @@ changecom(`%')
  % This is mostly fixed, except that some uses of <noun-main-m>
  % remain, below.
 
-% The empty word is a used in the 2D array used by the parser,
-% in "word slots" in which "no word" is a possibility to consider.
-% When the Wordgraph is converted ("flattened") to this 2D array,
-% empty words are issued whenever needed.
-% FIXME: A better comment maybe.
-% See also EMPTY-WORD.x for the highly-unusual situation that EMPTY-WORD
-% appears in the input text.
-EMPTY-WORD.zzz: ZZZ-;
-
 % Capitalization handling (null effect for now- behave as empty words).
 1stCAP.zzz: ZZZ-;
 nonCAP.zzz: ZZZ-;
@@ -343,9 +334,6 @@ INITIALS <entity-singular>:
 % should have a cost that is even higher (so that we take the
 % capitalized version before we take any other matches.)
 CAPITALIZED-WORDS: [<entity-singular>]0.05;
-
-% Hack, see EMPTY-WORD, up top.
-EMPTY-WORD.x: CAPITALIZED-WORDS;
 
 % Capitalized words that seem to be plural (by ending with an s, etc)
 % -- But not all words that end with an 's' are plural:

--- a/data/he/4.0.dict
+++ b/data/he/4.0.dict
@@ -44,9 +44,6 @@
 <dictionary-version-number>: V5v3v0+;
 <dictionary-locale>: HE4il+;
 
-% The empty word.
-EMPTY-WORD.zzz: ZZZ-;
-
 % For now.
 LEFT-WALL: {Wa+} or {Wd+} or ();
 

--- a/data/he/4.0.dict.m4
+++ b/data/he/4.0.dict.m4
@@ -49,9 +49,6 @@ changecom(`%')dnl
 <dictionary-version-number>: V5v3v0+;
 <dictionary-locale>: HE4il+;
 
-% The empty word.
-EMPTY-WORD.zzz: ZZZ-;
-
 % For now.
 LEFT-WALL: {Wa+} or {Wd+} or ();
 

--- a/data/kz/4.0.dict
+++ b/data/kz/4.0.dict
@@ -6,9 +6,6 @@
 <dictionary-version-number>: V5v3v5+;
 <dictionary-locale>: KK4kz+;
 
-% The empty word.
-EMPTY-WORD.zzz: ZZZ-;
-
 мен.pron: {W-} & S1s+;
 сен.pron: {W-} & S2s+;
 сіз.pron: {W-} & Sr2s+;

--- a/data/lt/4.0.dict
+++ b/data/lt/4.0.dict
@@ -15,10 +15,6 @@
 <dictionary-version-number>: V5v1v0+;
 <dictionary-locale>: LT4lt+;
 
-% Empty word; required for basic morphology analysis.
-EMPTY-WORD.zzz: ZZZ-;
-%
-%
 % Ženklai:
 % Ą Č Ę Ė Į Š Ų Ū Ž
 % ą č ė ę į š ū ų ž

--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -11,9 +11,6 @@
 <dictionary-version-number>: V5v1v0+;
 <dictionary-locale>: RU4ru+;
 
-% The empty word.
-EMPTY-WORD.zzz: ZZZ-;
-
 <costly-null>: [[[[]]]];
 
 <наречие-куда>: ({Xc-} & Ed-) or ({XIc+} & EId+) or ({Xt- & S-});

--- a/data/tr/4.0.dict
+++ b/data/tr/4.0.dict
@@ -5,10 +5,6 @@
 <dictionary-version-number>: V5v3v4+;
 <dictionary-locale>: TR4tr+;
 
-% The empty word.
-EMPTY-WORD.zzz: ZZZ-;
-
-
 % adjectives
 kırmızı şişman hasta kızgın güzel genç yasli iyi kötü hos üzücü mutlu aç siyah beyaz mavi yeşil mor pembe sarı: {AO+};
 

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -138,7 +138,6 @@ struct Dictionary_s
 	bool         unknown_word_defined;
 	bool         left_wall_defined;
 	bool         right_wall_defined;
-	bool         empty_word_defined;
 	bool         shuffle_linkages;
 
 	/* Affixes are used during the tokenization stage. */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -622,7 +622,7 @@ static void select_linkages(Sentence sent, fast_matcher_t* mchxt,
 }
 
 /* Partial, but not full initialization of the linakge struct ... */
-void partial_init_linkage(Linkage lkg, unsigned int N_words)
+void partial_init_linkage(Sentence sent, Linkage lkg, unsigned int N_words)
 {
 	lkg->num_links = 0;
 	lkg->lasz = 2 * N_words;
@@ -640,6 +640,7 @@ void partial_init_linkage(Linkage lkg, unsigned int N_words)
 #endif
 
 	lkg->pp_info = NULL;
+	lkg->sent = sent;
 }
 
 void check_link_size(Linkage lkg)
@@ -665,7 +666,7 @@ static void compute_chosen_disjuncts(Sentence sent)
 
 		if (lifo->discarded || lifo->N_violations) continue;
 
-		partial_init_linkage(lkg, pi->N_words);
+		partial_init_linkage(sent, lkg, pi->N_words);
 		extract_links(lkg, pi);
 		compute_link_names(lkg, sent->string_set);
 		/* Because the empty words are used only in the parsing stage, they are

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -669,10 +669,7 @@ static void compute_chosen_disjuncts(Sentence sent)
 		partial_init_linkage(sent, lkg, pi->N_words);
 		extract_links(lkg, pi);
 		compute_link_names(lkg, sent->string_set);
-		/* Because the empty words are used only in the parsing stage, they are
-		 * removed here along with their links, so from now on we will not need to
-		 * consider them. */
-		remove_empty_words(lkg);
+		remove_empty_words(lkg); /* Discard optional words. */
 	}
 }
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -744,9 +744,7 @@ static void post_process_linkages(Sentence sent, Parse_Options opts)
 
 	/* If the timer expired, then we never finished post-processing.
 	 * Mark the remaining sentences as bad, as otherwise strange
-	 * results get reported.  At any rate, need to compute the link
-	 * names, as otherwise linkage_create() will crash and burn
-	 * trying to touch them. */
+	 * results get reported. */
 	for (; in < N_linkages_alloced; in++)
 	{
 		Linkage lkg = &sent->lnkages[in];

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -857,8 +857,8 @@ int sentence_split(Sentence sent, Parse_Options opts)
 
 	/* Flatten the word graph created by separate_sentence() to a 2D-word-array
 	 * which is compatible to the current parsers.
-	 * This may fail if the EMPTY_WORD_DOT or UNKNOWN_WORD words are needed but
-	 * are not defined in the dictionary, or an internal error happens. */
+	 * This may fail if UNKNOWN_WORD is needed but
+	 * is not defined in the dictionary, or an internal error happens. */
 	fw_failed = !flatten_wordgraph(sent, opts);
 
 	/* If unknown_word is not defined, then no special processing
@@ -1207,15 +1207,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			break;
 		}
 
-		assert(MT_EMPTY != cdj->word[0]->morpheme_type); /* already discarded */
-
-		if (verbosity_level(D_SLM))
-		{
-			char *djw_tmp = strdupa(cdj->string);
-			char *sm = strrchr(djw_tmp, SUBSCRIPT_MARK);
-			if (NULL != sm) *sm = SUBSCRIPT_DOT;
-			lgdebug(0, "%s", djw_tmp);
-		}
+		if (verbosity_level(D_SLM)) print_with_subscript_dot(cdj->string);
 
 		match_found = false;
 		/* Proceed in all the paths in which the word is found. */
@@ -1285,7 +1277,6 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		for (w = wpp->path; *w; w++)
 		{
 			i++;
-			if (MT_EMPTY == (*w)->morpheme_type) continue; /* really a null word */
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wswitch-enum"

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -664,7 +664,7 @@ static void compute_chosen_disjuncts(Sentence sent)
 		Linkage lkg = &sent->lnkages[in];
 		Linkage_info *lifo = &lkg->lifo;
 
-		if (lifo->discarded || lifo->N_violations) continue;
+		if (lifo->discarded) continue;
 
 		partial_init_linkage(sent, lkg, pi->N_words);
 		extract_links(lkg, pi);

--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -349,7 +349,8 @@ void prt_exp(Exp *e, int i)
 
 void prt_exp_mem(Exp *e, int i)
 {
-	const char *type;
+	char unknown_type[32] = "";
+	const char *type = unknown_type;
 
 	if (e == NULL) return;
 
@@ -359,31 +360,33 @@ void prt_exp_mem(Exp *e, int i)
 	}
 	else
 	{
-		type = "unknown";
+		snprintf(unknown_type, sizeof(type)-1, "unknown-%d", e->type);
+		type = unknown_type;
 	}
 
 	for(int j =0; j<i; j++) printf(" ");
-	printf ("e=%p: type=%d (%s) dir=%c multi=%d cost=%f\n", e, e->type, type,
-	        e->type==CONNECTOR_type?e->dir:' ',
-	        e->type==CONNECTOR_type?e->multi:0, e->cost);
+	printf ("e=%p: %s cost=%f\n", e, type, e->cost);
 	if (e->type != CONNECTOR_type)
 	{
 		E_list *l;
-		int c = 0;
-		for (l = e->u.l; NULL != l; l = l->next) c++;
 		for(int j =0; j<i+2; j++) printf(" ");
-		l = e->u.l;
-		printf("E_list=%p count %d\n", l, c);
-		while(l)
+		printf("E_list=%p (", e->u.l);
+		for (l = e->u.l; NULL != l; l = l->next)
+		{
+			printf("%p", l->e);
+			if (NULL != l->next) printf(" ");
+		}
+		printf(")\n");
+
+		for (l = e->u.l; NULL != l; l = l->next)
 		{
 			prt_exp_mem(l->e, i+2);
-			l = l->next;
 		}
 	}
 	else
 	{
 		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s\n", e->u.string);
+		printf("con=%s dir=%c multi=%d\n", e->u.string, e->dir, e->multi);
 	}
 }
 #endif

--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -181,6 +181,19 @@ static bool pseudocount(count_context_t * ctxt,
 	return true;
 }
 
+/**
+ * Return the number of optional words strictly between w1 and w2.
+ */
+static int num_optional_words(count_context_t *ctxt, int w1, int w2)
+{
+	int n = 0;
+
+	for (int w = w1+1; w < w2; w++)
+		if (ctxt->local_sent[w].optional) n++;
+
+	return n;
+}
+
 static Count_bin do_count(fast_matcher_t *mchxt,
                           count_context_t *ctxt,
                           int lw, int rw,
@@ -226,7 +239,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 			/* If we don't allow islands (a set of words linked together
 			 * but separate from the rest of the sentence) then the
 			 * null_count of skipping n words is just n. */
-			if (null_count == (rw-lw-1))
+			if (null_count == (rw-lw-1) - num_optional_words(ctxt, lw, rw))
 			{
 				t->count = hist_one();
 			}

--- a/link-grammar/dict-common.c
+++ b/link-grammar/dict-common.c
@@ -515,7 +515,16 @@ static void print_expression_parens(const Exp * n, int need_parens)
 			print_expression_parens(el->e, true);
 		}
 		if (el->next != NULL)
-			printf ("\nERROR! Unexpected list!\n");
+		{
+			// printf ("\nERROR! Unexpected list!\n");
+			/* The SAT parser just naively joins all X_node expressions
+			 * using "or", and this check used to give an error due to that,
+			 * preventing a convenient debugging.
+			 * Just accept it (but mark it with '!'). */
+			if (n->type == AND_type) printf(" &! ");
+			if (n->type == OR_type) printf(" or! ");
+			print_expression_parens(el->next->e, true);
+		}
 	}
 
 	for (i=0; i<icost; i++) printf("]");

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -183,8 +183,7 @@ static void get_dict_affixes(Dictionary dict, Dict_node * dn,
 		strncpy(w_last, w, w_len);
 		w_last[w_len] = '\0';
 
-		if ((infix_mark == w_last[0]) &&
-			 (0 != strcmp(w_last, EMPTY_WORD_MARK)))
+		if (infix_mark == w_last[0])
 		{
 			affix_list_add(afdict, &afdict->afdict_class[AFDICT_SUF], w_last+1);
 		}
@@ -588,8 +587,6 @@ dictionary_six_str(const char * lang,
 
 	dict->left_wall_defined  = boolean_dictionary_lookup(dict, LEFT_WALL_WORD);
 	dict->right_wall_defined = boolean_dictionary_lookup(dict, RIGHT_WALL_WORD);
-
-	dict->empty_word_defined = boolean_dictionary_lookup(dict, EMPTY_WORD_MARK);
 
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	if (NULL == dict->base_knowledge) goto failure;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -154,8 +154,6 @@ static int revcmplen(const void *a, const void *b)
  * and prefixes - every time we see a new suffix/prefix (the previous one is
  * remembered by w_last), we save it in the corresponding affix-class list.
  * The saved affixes don't include the infix mark.
- *
- * The empty word is not an affix so it is ignored.
  */
 static void get_dict_affixes(Dictionary dict, Dict_node * dn,
                              char infix_mark, char * w_last)

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1159,36 +1159,10 @@ static Exp * make_connector(Dictionary dict)
 /* ======================================================================== */
 /* Empty-word handling. */
 
-/** Insert empty-word connectors.
- *
- * The "empty word" is a concept used in order to make the current parser able
- * to parse "alternatives" within a sentence. The "empty word" can link to any
- * word as a pseudo-suffix and hence it is issued when a word is optional, a
- * thing that happens when there are word alternatives with a different number
- * of tokens in each of them.
- *
- * Such alternatives can be created when splitting words into morphemes, such
- * as stem and suffix, in multiple ways, when correcting spell errors, when
- * splitting contractions, or when splitting punctuation off words or into
- * smaller parts.
- *
- * For example, in the Russian dictionary, это.msi appears as a single word,
- * but can also be split into эт.= =о.mnsi. The problem arises because это.msi
- * is a single word, while эт.= =о.mnsi counts as two words, and there is no
- * pretty way to handle both during parsing. Thus a work-around is introduced:
- * add the empty word EMPTY-WORD.zzz: ZZZ+; to the dictionary.  This becomes
- * a pseudo-suffix that can attach to the previous word. It can attach to
- * the previous word only because the routine below, add_empty_word(), adds
- * the corresponding connector ZZZ- to the word.  This is done "on the
- * fly", because we don't want to pollute the dictionary with this stuff.
- * Besides, the Russian dictionary has more then 23K words that qualify for
- * this treatment (It has 22.5K words that appear both as plain words, and
- * as stems, and can thus attach to null suffixes. For non-null suffix
- * splits, there are clearly many more.)
- *
- * The empty words are removed from the linkages after the parsing step.
- * FIXME However, the ZZZ connectors are still found in the chosen disjuncts
- * and can be visible in the API.
+/** Insert ZZZ+ connectors.
+ *  This function was mainly used to support using empty-words, a concept
+ *  that has been eliminated. However, it is still used to support linking of
+ *  quotes that don't get the QUc/QUd links.
  */
 void add_empty_word(Dictionary const dict, X_node *x)
 {
@@ -1203,18 +1177,7 @@ void add_empty_word(Dictionary const dict, X_node *x)
 	for(; NULL != x; x = x->next)
 	{
 		/* Ignore stems for now, decreases a little the overhead for
-		 * stem-suffix languages.
-		 * This line should be removed if these 2 conditions happen together:
-		 * 1. Multi-stem splits are to be supported.
-		 * 2. Affix splits are done by wordgraph splits.
-		 *
-		 * FIXME: A more general solution instead of this line is to add
-		 * empty-word connectors only to the x-nodes that need them, instead
-		 * of adding them, like now, to all the x-nodes of the word that come
-		 * before the empty-word. This will support wordgraph affix splits (if
-		 * will ever be done) and will slightly increase the efficiency of
-		 * handling sentences with multi-suffix splits (less empty-word
-		 * connectors in the sentence). */
+		 * stem-suffix languages. */
 		if (is_stem(x->string)) continue; /* Avoid an unneeded overhead. */
 		//lgdebug(+0, "Processing '%s'\n", x->string);
 

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -349,8 +349,6 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->left_wall_defined  = boolean_dictionary_lookup(dict, LEFT_WALL_WORD);
 	dict->right_wall_defined = boolean_dictionary_lookup(dict, RIGHT_WALL_WORD);
 
-	dict->empty_word_defined = boolean_dictionary_lookup(dict, EMPTY_WORD_MARK);
-
 	dict->unknown_word_defined = boolean_dictionary_lookup(dict, UNKNOWN_WORD);
 	dict->use_unknown_word = true;
 

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -274,7 +274,6 @@ static void print_sentence_context(String *outbuf, const err_ctxt *ec)
 		{
 			bool next_word = false;
 
-			if (0 == strcmp(*a, EMPTY_WORD_MARK)) continue;
 			for (j=0; j<ec->sent->length; j++)
 			{
 				for (b = ec->sent->word[j].alternatives; NULL != *b; b++)

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -727,7 +727,6 @@ Linkage linkage_create(LinkageIdx k, Sentence sent, Parse_Options opts)
 	/* Perform remaining initialization we haven't done yet...*/
 	compute_chosen_words(sent, linkage, opts);
 
-	linkage->sent = sent;
 	linkage->is_sent_long = (linkage->num_words >= opts->twopass_length);
 
 	return linkage;

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -232,7 +232,7 @@ void remove_empty_words(Linkage lkg)
 
 	for (i = 0, j = 0; i < lkg->num_words; i++)
 	{
-		if ((NULL != cdj[i]) && (MT_EMPTY == cdj[i]->word[0]->morpheme_type))
+		if ((NULL == cdj[i]) && lkg->sent->word[i].optional)
 		{
 			remap[i] = -1;
 		}

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -159,19 +159,28 @@ void remap_linkages(Linkage lkg, const int *remap)
 
 	for (i = 0, j = 0; i < lkg->num_links; i++)
 	{
-		const Link *old_lnk = &lkg->link_array[i];
+		Link *old_lnk = &lkg->link_array[i];
 
 		if (NULL != old_lnk->link_name &&  /* discarded link */
 		   (-1 != remap[old_lnk->rw]) && (-1 != remap[old_lnk->lw]))
 		{
 			Link *new_lnk = &lkg->link_array[j];
+			Connector *ctmp;
 
 			/* Copy the entire link contents, thunking the word numbers.
 			 * Note that j is always <= i so this is always safe. */
+
 			new_lnk->lw = remap[old_lnk->lw];
 			new_lnk->rw = remap[old_lnk->rw];
+
+			ctmp = new_lnk->lc;
 			new_lnk->lc = old_lnk->lc;
+			old_lnk->lc = ctmp;
+
+			ctmp = new_lnk->rc;
 			new_lnk->rc = old_lnk->rc;
+			old_lnk->rc = ctmp;
+
 			new_lnk->link_name = old_lnk->link_name;
 
 			/* Remap the pp_info, too. */

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -129,21 +129,6 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
  * for working with linkages.
  */
 
-/*
- * The "empty word" is a concept used in order to make the current parser able
- * to parse "alternatives" within a sentence. The "empty word" can link to any
- * word, hence it is issued when a word is optional, a thing that happens when
- * there are alternatives with different number of tokens in each of them.
- *
- * However, the empty words are not needed after the linkage step, and so,
- * below, we remove them from the linkage, as well as the links that
- * connect to them.
- *
- * When the word-graph is converted ("flattened") to the 2D array used by
- * the parser, empty words are issued whenever needed.  This essentially
- * means that the empty word (EMPTY-WORD.zzz) must be defined in the
- * dictionary of every language.
- */
 #define SUBSCRIPT_SEP SUBSCRIPT_DOT /* multiple-subscript separator */
 
 #define SUFFIX_SUPPRESS ("LL") /* suffix links start with this */
@@ -213,7 +198,7 @@ void remap_linkages(Linkage lkg, const int *remap)
 }
 
 /**
- * Remove the empty words from a linkage.
+ * Remove unlinked optional words from a linkage.
  * XXX Should we remove here also the dict-cap tokens? In any case, for now they
  * are left for debug.
  */

--- a/link-grammar/linkage.h
+++ b/link-grammar/linkage.h
@@ -3,7 +3,7 @@
 void remap_linkages(Linkage, const int *remap);
 void compute_chosen_words(Sentence, Linkage, Parse_Options);
 
-void partial_init_linkage(Linkage, unsigned int N_words);
+void partial_init_linkage(Sentence, Linkage, unsigned int N_words);
 void check_link_size(Linkage);
 void remove_empty_words(Linkage);
 void free_linkage(Linkage);

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -57,8 +57,7 @@ set_connector_length_limits(Sentence sent, Parse_Options opts)
 	{
 		/* Not setting the length_limit saves observable time. However, if we
 		 * would like to set the ZZZ connector length_limit to 1 for all
-		 * sentences, we cannot do the following.
-		 * FIXME(?): Use a flag that the sentence contains an empty word. */
+		 * sentences, we cannot do the following. */
 		if (len >= sent->length) return; /* No point to enforce short_length. */
 	}
 

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1461,7 +1461,7 @@ void print_chosen_disjuncts_words(const Linkage lkg)
 		const char *djw; /* disjunct word - the chosen word */
 
 		if (NULL == cdj)
-			djw = "[]"; /* null word */
+			djw = lkg->sent->word[i].optional ? "{}" : "[]";
 		else if ('\0' == cdj->string[0])
 			djw = "\\0"; /* null string - something is wrong */
 		else

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1272,10 +1272,10 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		 *   ה=  כלב  לב  ב=
 		 *   ה=  כ=  ל=
 		 *   ה=  כ=
-		 * For "'50s," (∅ means empty word):
+		 * For "'50s,"
 		 *   ' s s ,
-		 *   '50 50 , ∅
-		 *   '50s ∅
+		 *   '50 50 ,
+		 *   '50s
 		 * Clearly, this is not informative any more. Instead, one line with a
 		 * list of tokens (without repetitions) is printed
 		 * ה= כלב לב ב= כ= ל=

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1372,7 +1372,17 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 					wt = wprint;
 				}
 
-				if (debugprint) lgdebug(0, " %s", '\0' == wt[0] ? "[missing]" : wt);
+				if (debugprint)
+				{
+					const char *opt_start = "", *opt_end = "";
+					if (sent->word[wi].optional)
+					{
+						opt_start = "{";
+						opt_end = "}";
+					}
+					lgdebug(0, " %s%s%s",
+					        opt_start, '\0' == wt[0] ? "[missing]" : wt, opt_end);
+				}
 
 				/* Don't try to give info on the empty word. */
 				if (('\0' != wt[0]) && (0 != strcmp(wt, EMPTY_WORD_DISPLAY)))

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1329,13 +1329,8 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 				const char *st = NULL;
 				char *wprint = NULL;
 
-				/* In the Wordgraph version alternative slots are not balanced
-				 * with empty words. To see these places for debug, later
-				 * here "[missing]" is printed if wt is "". */
-				if (ai >= nalts)
-					wt = ""; /* missing */
-				else
-					wt = sent->word[wi].alternatives[ai];
+				if (ai >= nalts) continue;
+				wt = sent->word[wi].alternatives[ai];
 
 				/* Don't display information again for the same word */
 				if ((NULL != tokenpos) && (0 == strcmp(tokenpos->token, wt)))
@@ -1380,8 +1375,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 						opt_start = "{";
 						opt_end = "}";
 					}
-					lgdebug(0, " %s%s%s",
-					        opt_start, '\0' == wt[0] ? "[missing]" : wt, opt_end);
+					lgdebug(0, " %s%s%s", opt_start, wt, opt_end);
 				}
 
 				/* Don't try to give info on the empty word. */

--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1354,9 +1354,6 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 					}
 				}
 
-				if (0 == strcmp(wt, EMPTY_WORD_MARK))
-					wt = EMPTY_WORD_DISPLAY;
-
 				/* Restore SUBSCRIPT_DOT for printing */
 				st = strrchr(wt, SUBSCRIPT_MARK);
 				if (st)
@@ -1379,7 +1376,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 				}
 
 				/* Don't try to give info on the empty word. */
-				if (('\0' != wt[0]) && (0 != strcmp(wt, EMPTY_WORD_DISPLAY)))
+				if ('\0' != wt[0])
 				{
 					/* For now each word component is called "Token".
 					 * TODO: Its type can be decoded and a more precise
@@ -1465,8 +1462,6 @@ void print_chosen_disjuncts_words(const Linkage lkg)
 
 		if (NULL == cdj)
 			djw = "[]"; /* null word */
-		else if (MT_EMPTY == cdj->word[0]->morpheme_type)
-			djw = EMPTY_WORD_DISPLAY;
 		else if ('\0' == cdj->string[0])
 			djw = "\\0"; /* null string - something is wrong */
 		else

--- a/link-grammar/prune.c
+++ b/link-grammar/prune.c
@@ -954,11 +954,26 @@ static void clean_table(unsigned int size, C_list ** t)
 }
 
 /**
+ * Find if words w1 and w2 may become adjacent due to optional words.
+ * This may happen if they only contain optional words between them.
+ *
+ * Return true iff they may become adjacent (i.e. all the words
+ * between them are optional).
+ */
+static bool optional_gap_collapse(Sentence sent, int w1, int w2)
+{
+	for (int w = w1+1; w < w2; w++)
+		if (!sent->word[w].optional) return false;
+
+	return true;
+}
+
+/**
  * This takes two connectors (and whether these are shallow or not)
  * (and the two words that these came from) and returns TRUE if it is
  * possible for these two to match based on local considerations.
  */
-static bool possible_connection(bool no_null_links,
+static bool possible_connection(Sentence sent, bool no_null_links,
                                 Connector *lc, Connector *rc,
                                 bool lshallow, bool rshallow,
                                 int lword, int rword)
@@ -992,7 +1007,8 @@ static bool possible_connection(bool no_null_links,
 	if (no_null_links &&
 	    (lc->next == NULL) &&
 	    (rc->next == NULL) &&
-	    (!lc->multi) && (!rc->multi))
+	    (!lc->multi) && (!rc->multi) &&
+	    !optional_gap_collapse(sent, lword, rword))
 	{
 		return false;
 	}
@@ -1005,7 +1021,7 @@ static bool possible_connection(bool no_null_links,
  * a connector that can match to c.  shallow tells if c is shallow.
  */
 static bool
-right_table_search(bool nonul, power_table *pt, int w, Connector *c,
+right_table_search(Sentence sent, bool nonul, power_table *pt, int w, Connector *c,
                    bool shallow, int word_c)
 {
 	unsigned int size, h;
@@ -1015,7 +1031,7 @@ right_table_search(bool nonul, power_table *pt, int w, Connector *c,
 	h = connector_hash(c) & (size-1);
 	for (cl = pt->r_table[w][h]; cl != NULL; cl = cl->next)
 	{
-		if (possible_connection(nonul, cl->c, c, cl->shallow, shallow, w, word_c))
+		if (possible_connection(sent, nonul, cl->c, c, cl->shallow, shallow, w, word_c))
 			return true;
 	}
 	return false;
@@ -1026,7 +1042,7 @@ right_table_search(bool nonul, power_table *pt, int w, Connector *c,
  * a connector that can match to c.  shallows tells if c is shallow
  */
 static bool
-left_table_search(bool nonul, power_table *pt, int w, Connector *c,
+left_table_search(Sentence sent, bool nonul, power_table *pt, int w, Connector *c,
                   bool shallow, int word_c)
 {
 	unsigned int size, h;
@@ -1036,7 +1052,7 @@ left_table_search(bool nonul, power_table *pt, int w, Connector *c,
 	h = connector_hash(c) & (size-1);
 	for (cl = pt->l_table[w][h]; cl != NULL; cl = cl->next)
 	{
-		if (possible_connection(nonul, c, cl->c, shallow, cl->shallow, word_c, w))
+		if (possible_connection(sent, nonul, c, cl->c, shallow, cl->shallow, word_c, w))
 			return true;
 	}
 	return false;
@@ -1051,14 +1067,14 @@ left_table_search(bool nonul, power_table *pt, int w, Connector *c,
  * correctly.
  */
 static int
-left_connector_list_update(prune_context *pc, Connector *c,
+left_connector_list_update(prune_context *pc, Sentence sent, Connector *c,
                            int w, bool shallow)
 {
 	int n, lb;
 	bool foundmatch, no_null_links;
 
 	if (c == NULL) return w;
-	n = left_connector_list_update(pc, c->next, w, false) - 1;
+	n = left_connector_list_update(pc, sent, c->next, w, false) - 1;
 	if (((int) c->nearest_word) < n) n = c->nearest_word;
 
 	/* lb is now the leftmost word we need to check */
@@ -1071,7 +1087,7 @@ left_connector_list_update(prune_context *pc, Connector *c,
 	for (; n >= lb ; n--)
 	{
 		pc->power_cost++;
-		if (right_table_search(no_null_links, pc->pt, n, c, shallow, w))
+		if (right_table_search(sent, no_null_links, pc->pt, n, c, shallow, w))
 		{
 			foundmatch = true;
 			break;
@@ -1114,7 +1130,7 @@ right_connector_list_update(prune_context *pc, Sentence sent, Connector *c,
 	for (; n <= ub ; n++)
 	{
 		pc->power_cost++;
-		if (left_table_search(no_null_links, pc->pt, n, c, shallow, w))
+		if (left_table_search(sent, no_null_links, pc->pt, n, c, shallow, w))
 		{
 			foundmatch = true;
 			break;
@@ -1159,7 +1175,7 @@ int power_prune(Sentence sent, Parse_Options opts)
 		for (w = 0; w < sent->length; w++) {
 			for (d = sent->word[w].d; d != NULL; d = d->next) {
 				if (d->left == NULL) continue;
-				if (left_connector_list_update(pc, d->left, w, true) < 0) {
+				if (left_connector_list_update(pc, sent, d->left, w, true) < 0) {
 					for (c=d->left;  c != NULL; c = c->next) c->nearest_word = BAD_WORD;
 					for (c=d->right; c != NULL; c = c->next) c->nearest_word = BAD_WORD;
 					N_deleted++;

--- a/link-grammar/sat-solver/guiding.hpp
+++ b/link-grammar/sat-solver/guiding.hpp
@@ -86,8 +86,10 @@ public:
     setParameters(var, isDecision, 0.0, 0.0);
   }
 
+#if 0
   /* thin_link variables */
   virtual void setThinLinkParameters (int var, int wi, int wj) = 0;
+#endif
 
   /* Pass SAT search parameters to the MiniSAT solver */
   void passParametersToSolver(Solver* solver) {
@@ -169,6 +171,7 @@ public:
     setParameters(var, isDecision, priority, polarity);
   }
 
+#if 0
   void setThinLinkParameters(int var, int i, int j)
   {
     bool isDecision = true;
@@ -191,6 +194,7 @@ public:
 
     setParameters(var, isDecision, priority, polarity);
   }
+#endif
 };
 
 
@@ -232,9 +236,11 @@ public:
     setParameters(var, isDecision, priority, polarity);
   }
 
+#if 0
   void setThinLinkParameters(int var, int i, int j) {
     bool isDecision = false;
     setParameters(var, isDecision, 0.0, 0.0);
   }
+#endif
 };
 #endif

--- a/link-grammar/sat-solver/guiding.hpp
+++ b/link-grammar/sat-solver/guiding.hpp
@@ -1,6 +1,7 @@
 #ifndef __GUIDING_HPP__
 #define __GUIDING_HPP__
 
+#include <vector>
 #include <core/Solver.h>
 #undef assert
 #include "util.hpp"

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -3,10 +3,8 @@
  */
 #include <cstdlib>
 #include <cstdio>
-#include <cstring>
 #include <iostream>
 #include <vector>
-#include <map>
 #include <algorithm>
 #include <iterator>
 using std::cout;
@@ -38,7 +36,6 @@ extern "C" {
 #include "linkage.h"
 #include "post-process.h"
 #include "score.h"               // for linkage_score()
-//#include "utilities.h"         // XXX do we need it?
 }
 
 // Macro DEBUG_print is used to dump to stdout information while debugging

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -27,7 +27,6 @@ extern "C" {
 #include "clock.hpp"
 #include "fast-sprintf.hpp"
 
-
 extern "C" {
 #include "analyze-linkage.h"      // for compute_link_names()
 #include "build-disjuncts.h"      // for build_disjuncts_for_exp()
@@ -39,10 +38,6 @@ extern "C" {
 //#include "utilities.h"         // XXX do we need it?
 #include "wordgraph.h"           // for empty_word()
 }
-
-#ifdef HAVE_MKLIT
-#define Lit(...) mkLit(__VA_ARGS__)
-#endif
 
 // Macro DEBUG_print is used to dump to stdout information while debugging
 #ifdef SAT_DEBUG

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -240,18 +240,15 @@ void SATEncoder::build_word_tags()
     _word_tags.push_back(WordTag(w, name, _variables, _sent, _opts));
     int dfs_position = 0;
 
-    if (_sent->word[w].x == NULL) {
-      // Most probably everything got pruned. There will be no linkage.
-      lgdebug(+D_SAT, "Word%zu %s: NULL X_node\n", w, N(_sent->word[w].unsplit_word));
-      continue;
-    }
+    if (_sent->word[w].x == NULL) continue;
 
     bool join = _sent->word[w].x->next != NULL;
     Exp* exp = join ? join_alternatives(w) : _sent->word[w].x->exp;
 
 #ifdef SAT_DEBUG
     cout << "Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << endl;
-    //print_expression(exp);
+    print_expression(exp);
+    //prt_exp_mem(exp, 0);
     cout << endl;
 #endif
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -14,6 +14,10 @@ using std::cerr;
 using std::endl;
 using std::vector;
 
+/* Most of the power pruning is ifdef'ed out intentionally, because The
+ * encoding totally malfunctions when this code is defined. */
+//#define POWER_PRUNE_CONNECTORS
+
 extern "C" {
 #include "sat-encoder.h"
 }
@@ -1087,6 +1091,7 @@ void SATEncoder::power_prune()
 {
   generate_epsilon_definitions();
 
+#ifdef POWER_PRUNE_CONNECTORS
   // on two non-adjacent words, a pair of connectors can be used only
   // if not [both of them are the deepest].
 
@@ -1123,6 +1128,7 @@ void SATEncoder::power_prune()
       }
     }
   }
+#endif
 
   /*
   // on two adjacent words, a pair of connectors can be used only if

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1592,8 +1592,6 @@ static Connector * empty_word_connector()
 
 bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 {
-  lgdebug(+D_SAT, "Index %d\n", lkg->lifo.index);
-
   Disjunct *d;
   int current_link = 0;
   Disjunct *empty_words_tofree = NULL;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -33,7 +33,6 @@ extern "C" {
 #include "dict-api.h"             // for print_expression()
 #include "linkage.h"
 #include "post-process.h"
-#include "preparation.h"
 #include "score.h"               // for linkage_score()
 //#include "utilities.h"         // XXX do we need it?
 #include "wordgraph.h"           // for empty_word()

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1666,13 +1666,13 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 
     if (xnode_word[var->left_word] && xnode_word[var->left_word] != left_xnode) {
       lgdebug(+0, "Warning: Inconsistent X_node for word %d (%s and %s)\n",
-               var->left_word, xnode_word[var->left_word]->word->subword,
-              left_xnode->word->subword);
+              var->left_word, xnode_word[var->left_word]->string,
+              left_xnode->string);
     }
     if (xnode_word[var->right_word] && xnode_word[var->right_word] != right_xnode) {
       lgdebug(+0, "Warning: Inconsistent X_node for word %d (%s and %s)\n",
-              var->right_word, xnode_word[var->right_word]->word->subword,
-              right_xnode->word->subword);
+              var->right_word, xnode_word[var->right_word]->string,
+              right_xnode->string);
     }
 
     xnode_word[var->left_word] = left_xnode;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1332,7 +1332,7 @@ Linkage SATEncoder::get_next_linkage()
       if (display_linkage_disconnected) {
         cout << "Linkage DISCONNECTED" << endl;
       } else {
-        lgdebug(+2, "Linkage DISCONNECTED (skipped)\n");
+        lgdebug(+D_SAT, "Linkage DISCONNECTED (skipped)\n");
       }
     }
   } while (!sane || !(connected || display_linkage_disconnected));

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1280,10 +1280,7 @@ Linkage SATEncoder::create_linkage()
   partial_init_linkage(_sent, linkage, _sent->length);
   sat_extract_links(linkage);
   compute_link_names(linkage, _sent->string_set);
-  /* Because the empty words are used only in the parsing stage, they are
-   * removed here along with their links, so from now on we will not need to
-   * consider them. */
-  remove_empty_words(linkage);
+  remove_empty_words(linkage);  /* Discard optional words. */
   return linkage;
 }
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -914,7 +914,7 @@ bool SATEncoder::connectivity_components(std::vector<int>& components) {
   // (For now these can be only be words marked as "optional").
   std::vector<bool> is_linked_word(_sent->length, false);
   for (size_t node = 0; node < _sent->length; node++) {
-    is_linked_word[node] = _solver->model[_word_tags[node].var] == l_True;
+    is_linked_word[node] = _solver->model[node] == l_True;
   }
 
   // build the connectivity graph
@@ -1037,8 +1037,8 @@ void SATEncoder::generate_disconnectivity_prohibiting(std::vector<int> component
             Lit lhs = Lit(conditional_link_var);
             vec<Lit> rhs;
             rhs.push(Lit(var));
-            if (optlw_exists) rhs.push(~Lit(_word_tags[lv->left_word].var));
-            if (optrw_exists) rhs.push(~Lit(_word_tags[lv->right_word].var));
+            if (optlw_exists) rhs.push(~Lit(lv->left_word));
+            if (optrw_exists) rhs.push(~Lit(lv->right_word));
             generate_or_definition(lhs, rhs);
           }
 
@@ -1051,8 +1051,8 @@ void SATEncoder::generate_disconnectivity_prohibiting(std::vector<int> component
     if (missing_word) {
       // The connectivity may be restored differently if a word reappears
       for (WordIdx w = 0; w < _sent->length; w++) {
-        if (_solver->model[_word_tags[w].var] == l_False)
-          clause.push(Lit(_word_tags[w].var));
+        if (_solver->model[w] == l_False)
+          clause.push(Lit(w));
       }
     }
     CONNECTIVITY_DEBUG(printf("\n"));
@@ -1655,7 +1655,7 @@ void SATEncoderConjunctionFreeSentences::generate_linked_definitions()
       /* The word should be connected to at least another word in order to be
        * in the linkage. */
       DEBUG_print("------------S not linked -> no word (w" << w1 << ")");
-      generate_or_definition(Lit(_word_tags[w1].var), linked_to_word[w1]);
+      generate_or_definition(Lit(w1), linked_to_word[w1]);
       DEBUG_print("------------E not linked -> no word");
     }
   }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1657,9 +1657,9 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 
     if (verbosity_level(D_SAT)) {
       //cout<< "Lexp[" <<left_xnode->word->subword <<"]: ";  print_expression(var->left_exp);
-      cout<< "LCexp[" <<left_xnode->word->subword <<"]: ";  print_expression(lcexp);
+      cout<< "w"<<var->left_word<<" LCexp[" <<left_xnode->word->subword <<"]: ";  print_expression(lcexp);
       //cout<< "Rexp[" <<right_xnode->word->subword <<"]: "; print_expression(var->right_exp);
-      cout<< "RCexp[" <<right_xnode->word->subword <<"]: "; print_expression(rcexp);
+      cout<< "w"<<var->right_word<<" RCexp[" <<right_xnode->word->subword <<"]: "; print_expression(rcexp);
       cout<< "L+L: "; print_expression(exp_word[var->left_word]);
       cout<< "R+R: "; print_expression(exp_word[var->right_word]);
     }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -135,6 +135,7 @@ void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition
   }
 }
 
+#if 0
 void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition1, Lit condition2, Lit lhs, vec<Lit>& rhs) {
   {
     vec<Lit> clause(2);
@@ -156,6 +157,7 @@ void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition
     add_clause(clause);
   }
 }
+#endif
 
 void SATEncoder::generate_xor_conditions(vec<Lit>& vect) {
   vec<Lit> clause(2);
@@ -272,6 +274,7 @@ void SATEncoder::build_word_tags()
   }
 }
 
+#if 0
 void SATEncoder::find_all_matches_between_words(size_t w1, size_t w2,
                                                 std::vector<std::pair<const PositionConnector*, const PositionConnector*> >& matches) {
   const std::vector<PositionConnector>& w1_right = _word_tags[w1].get_right_connectors();
@@ -294,6 +297,7 @@ bool SATEncoder::matches_in_interval(int wi, int pi, int l, int r) {
   }
   return false;
 }
+#endif
 
 /*-------------------------------------------------------------------------*
  *                     S A T I S F A C T I O N                             *
@@ -564,6 +568,7 @@ int SATEncoder::empty_connectors(Exp* e, char dir)
     throw std::string("Unknown connector type");
 }
 
+#if 0
 int SATEncoder::non_empty_connectors(Exp* e, char dir)
 {
   if (e->type == CONNECTOR_type) {
@@ -583,6 +588,7 @@ int SATEncoder::non_empty_connectors(Exp* e, char dir)
   } else
     throw std::string("Unknown connector type");
 }
+#endif
 
 bool SATEncoder::trailing_connectors_and_aux(int w, E_list* l, char dir, int& dfs_position,
                                              std::vector<PositionConnector*>& connectors)
@@ -616,6 +622,7 @@ void SATEncoder::trailing_connectors(int w, Exp* exp, char dir, int& dfs_positio
   }
 }
 
+#if 0
 void SATEncoder::certainly_non_trailing(int w, Exp* exp, char dir, int& dfs_position,
                                        std::vector<PositionConnector*>& connectors, bool has_right) {
   if (exp->type == CONNECTOR_type) {
@@ -646,6 +653,7 @@ void SATEncoder::certainly_non_trailing(int w, Exp* exp, char dir, int& dfs_posi
     }
   }
 }
+#endif
 
 void SATEncoder::leading_connectors(int w, Exp* exp, char dir, int& dfs_position, vector<PositionConnector*>& connectors) {
   if (exp->type == CONNECTOR_type) {
@@ -1485,6 +1493,7 @@ void SATEncoderConjunctionFreeSentences::generate_linked_definitions()
   DEBUG_print("------- end linked definitions");
 }
 
+#if 0
 void SATEncoder::generate_linked_min_max_planarity()
 {
   DEBUG_print("---- linked_max");
@@ -1564,6 +1573,7 @@ void SATEncoder::generate_linked_min_max_planarity()
     }
   }
 }
+#endif
 
 Exp* SATEncoderConjunctionFreeSentences::PositionConnector2exp(const PositionConnector* pc)
 {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -888,6 +888,28 @@ bool SATEncoder::connectivity_components(std::vector<int>& components) {
   return connected;
 }
 
+#ifdef SAT_DEBUG
+#define MVALUE(s, v) (s->model[v] == l_True?'T':(s->model[v] == l_False?'f':'u'))
+static void pmodel(Solver *solver, int var) {
+  printf("%c\n", MVALUE(solver, var));
+}
+
+static void pmodel(Solver *solver, vec<Lit> &clause) {
+  vector<int> t;
+  for (int i = 0; i < clause.size(); i++) {
+    int v = var(clause[i]);
+    printf("%d:%c ", v, MVALUE(solver, v));
+    if (solver->model[v] == l_True) t.push_back(v);
+  }
+  printf("\n");
+  if (t.size()) {
+    printf("l_True:");
+    for (auto i: t) printf(" %d", i);
+    printf("\n");
+  }
+}
+#endif
+
 void SATEncoder::generate_disconnectivity_prohibiting(std::vector<int> components) {
   // vector of unique components
   std::vector<int> different_components = components;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1003,8 +1003,11 @@ void SATEncoder::generate_disconnectivity_prohibiting(std::vector<int> component
   debug_generate_disconnectivity_prohibiting(components, different_components);
   // Each connected component must contain a branch going out of it
   std::vector<int>::const_iterator c;
-  if (*different_components.begin() == -1)
+  bool missing_word = false;
+  if (*different_components.begin() == -1) {
     different_components.erase(different_components.begin());
+    missing_word = true;
+  }
   for (c = different_components.begin(); c != different_components.end(); c++) {
     vec<Lit> clause;
     const std::vector<int>& linked_variables = _variables->linked_variables();
@@ -1042,6 +1045,14 @@ void SATEncoder::generate_disconnectivity_prohibiting(std::vector<int> component
           var = conditional_link_var; // Replace it by its conditional link var
         }
         clause.push(Lit(var)); // Implied link var is used if needed
+      }
+    }
+
+    if (missing_word) {
+      // The connectivity may be restored differently if a word reappears
+      for (WordIdx w = 0; w < _sent->length; w++) {
+        if (_solver->model[_word_tags[w].var] == l_False)
+          clause.push(Lit(_word_tags[w].var));
       }
     }
     CONNECTIVITY_DEBUG(printf("\n"));

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -30,7 +30,7 @@ extern "C" {
 extern "C" {
 #include "analyze-linkage.h"      // for compute_link_names()
 #include "build-disjuncts.h"      // for build_disjuncts_for_exp()
-#include <dict-api.h>             // for print_expression()
+#include "dict-api.h"             // for print_expression()
 #include "linkage.h"
 #include "post-process.h"
 #include "preparation.h"

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -231,8 +231,13 @@ void SATEncoder::encode() {
  *-------------------------------------------------------------------------*/
 void SATEncoder::build_word_tags()
 {
+  char name[MAX_VARIABLE_NAME];
+  name[0] = 'w';
+
   for (size_t w = 0; w < _sent->length; w++) {
-    _word_tags.push_back(WordTag(w, _variables, _sent, _opts));
+    // sprintf(name, "w%zu", w);
+    fast_sprintf(name+1, w);
+    _word_tags.push_back(WordTag(w, name, _variables, _sent, _opts));
     int dfs_position = 0;
 
     if (_sent->word[w].x == NULL) {
@@ -249,11 +254,6 @@ void SATEncoder::build_word_tags()
     //print_expression(exp);
     cout << endl;
 #endif
-
-    char name[MAX_VARIABLE_NAME];
-    // sprintf(name, "w%zu", w);
-    name[0] = 'w';
-    fast_sprintf(name+1, w);
 
     bool leading_right = true;
     bool leading_left = true;
@@ -492,14 +492,7 @@ void SATEncoder::generate_link_cw_ordinary_definition(size_t wi, int pi,
   char dir = e->dir;
   double cost = e->cost;
   Lit lhs = Lit(_variables->link_cw(wj, wi, pi, Ci));
-
-  char name[MAX_VARIABLE_NAME];
-  // sprintf(name, "w%zu", wj);
-  name[0] = 'w';
-  fast_sprintf(name+1, wj);
-
-  Lit condition = Lit(_variables->string(name));
-
+  Lit condition = Lit(_word_tags[wj].var);
   vec<Lit> rhs;
 
   // Collect matches (wi, pi) with word wj

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -66,16 +66,14 @@ void SATEncoder::generate_literal(Lit l) {
 }
 
 void SATEncoder::generate_and_definition(Lit lhs, vec<Lit>& rhs) {
-  vec<Lit> clause;
+  vec<Lit> clause(2);
   for (int i = 0; i < rhs.size(); i++) {
-    clause.growTo(2);
     clause[0] = ~lhs;
     clause[1] = rhs[i];
     add_clause(clause);
   }
 
   for (int i = 0; i < rhs.size(); i++) {
-    clause.growTo(2);
     clause[0] = ~rhs[i];
     clause[1] = lhs;
     add_clause(clause);
@@ -83,10 +81,8 @@ void SATEncoder::generate_and_definition(Lit lhs, vec<Lit>& rhs) {
 }
 void SATEncoder::generate_classical_and_definition(Lit lhs, vec<Lit>& rhs) {
   {
-    vec<Lit> clause;
+    vec<Lit> clause(2);
     for (int i = 0; i < rhs.size(); i++) {
-      clause.growTo(2);
-
       clause[0] = ~lhs;
       clause[1] = rhs[i];
       add_clause(clause);
@@ -105,9 +101,8 @@ void SATEncoder::generate_classical_and_definition(Lit lhs, vec<Lit>& rhs) {
 
 void SATEncoder::generate_or_definition(Lit lhs, vec<Lit>& rhs) {
   {
-    vec<Lit> clause;
+    vec<Lit> clause(2);
     for (int i = 0; i < rhs.size(); i++) {
-      clause.growTo(2);
       clause[0] = lhs;
       clause[1] = ~rhs[i];
       add_clause(clause);
@@ -126,9 +121,8 @@ void SATEncoder::generate_or_definition(Lit lhs, vec<Lit>& rhs) {
 
 void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition, Lit lhs, vec<Lit>& rhs) {
   {
-    vec<Lit> clause;
+    vec<Lit> clause(2);
     for (int i = 0; i < rhs.size(); i++) {
-      clause.growTo(2);
       clause[0] = lhs;
       clause[1] = ~rhs[i];
       add_clause(clause);
@@ -148,9 +142,8 @@ void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition
 
 void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition1, Lit condition2, Lit lhs, vec<Lit>& rhs) {
   {
-    vec<Lit> clause;
+    vec<Lit> clause(2);
     for (int i = 0; i < rhs.size(); i++) {
-      clause.growTo(2);
       clause[0] = lhs;
       clause[1] = ~rhs[i];
       add_clause(clause);
@@ -170,12 +163,11 @@ void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition
 }
 
 void SATEncoder::generate_xor_conditions(vec<Lit>& vect) {
-  vec<Lit> clause;
+  vec<Lit> clause(2);
   for (int i = 0; i < vect.size(); i++) {
     for (int j = i + 1; j < vect.size(); j++) {
       if (vect[i] == vect[j])
         continue;
-      clause.growTo(2);
       clause[0] = ~vect[i];
       clause[1] = ~vect[j];
       add_clause(clause);
@@ -195,14 +187,13 @@ void SATEncoder::generate_or(vec<Lit>& vect) {
 }
 
 void SATEncoder::generate_equivalence_definition(Lit l1, Lit l2) {
+  vec<Lit> clause(2);
   {
-    vec<Lit> clause(2);
     clause[0] = ~l1;
     clause[1] = l2;
     add_clause(clause);
   }
   {
-    vec<Lit> clause(2);
     clause[0] = l1;
     clause[1] = ~l2;
     add_clause(clause);
@@ -695,7 +686,7 @@ void SATEncoder::generate_conjunct_order_constraints(int w, Exp *e1, Exp* e2, in
   int dfs_position_e2 = dfs_position_e1;
   leading_connectors(w, e2, '+', dfs_position_e2, first_right_in_e2);
 
-  vec<Lit> clause;
+  vec<Lit> clause(2);
 
   if (!last_right_in_e1.empty() && !first_right_in_e2.empty()) {
     std::vector<PositionConnector*>::iterator i, j;
@@ -722,7 +713,6 @@ void SATEncoder::generate_conjunct_order_constraints(int w, Exp *e1, Exp* e2, in
         for (mw1i = mw1.begin(); mw1i != mw1.end(); mw1i++) {
           for (mw2i = mw2.begin(); mw2i != mw2.end(); mw2i++) {
             if (*mw1i >= *mw2i) {
-              clause.growTo(2);
               clause[0] = ~Lit(_variables->link_cw(*mw1i, w, (*i)->position, (*i)->connector.string));
               clause[1] = ~Lit(_variables->link_cw(*mw2i, w, (*j)->position, (*j)->connector.string));
               add_clause(clause);
@@ -768,7 +758,6 @@ void SATEncoder::generate_conjunct_order_constraints(int w, Exp *e1, Exp* e2, in
         for (mw1i = mw1.begin(); mw1i != mw1.end(); mw1i++) {
           for (mw2i = mw2.begin(); mw2i != mw2.end(); mw2i++) {
             if (*mw1i <= *mw2i) {
-              clause.growTo(2);
               clause[0] = ~Lit(_variables->link_cw(*mw1i, w, (*i)->position, (*i)->connector.string));
               clause[1] = ~Lit(_variables->link_cw(*mw2i, w, (*j)->position, (*j)->connector.string));
               add_clause(clause);
@@ -928,7 +917,7 @@ void SATEncoder::generate_disconnectivity_prohibiting(std::vector<int> component
  *--------------------------------------------------------------------------*/
 void SATEncoder::generate_planarity_conditions()
 {
-  vec<Lit> clause;
+  vec<Lit> clause(2);
   for (size_t wi1 = 0; wi1 < _sent->length; wi1++) {
     for (size_t wj1 = wi1+1; wj1 < _sent->length; wj1++) {
       for (size_t wi2 = wj1+1; wi2 < _sent->length; wi2++) {
@@ -937,7 +926,6 @@ void SATEncoder::generate_planarity_conditions()
         for (size_t wj2 = wi2+1; wj2 < _sent->length; wj2++) {
           if (!_linked_possible(wj1, wj2))
             continue;
-          clause.growTo(2);
           clause[0] = ~Lit(_variables->linked(wi1, wi2));
           clause[1] = ~Lit(_variables->linked(wj1, wj2));
           add_clause(clause);

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1384,6 +1384,7 @@ Linkage SATEncoder::get_next_linkage()
   if (NULL != ppn->violation) {
     lkg->lifo.N_violations++;
     lkg->lifo.pp_violation_msg = ppn->violation;
+    lgdebug(+D_SAT, "Postprocessing error: %s\n", lkg->lifo.pp_violation_msg);
   } else {
     // XXX We cannot maintain num_valid_linkages, because it starts from
     // a high number. If we start it from 0, then on value 1 link-parser

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -112,6 +112,7 @@ void SATEncoder::generate_or_definition(Lit lhs, vec<Lit>& rhs) {
   }
 }
 
+#if 0
 void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition, Lit lhs, vec<Lit>& rhs) {
   {
     vec<Lit> clause(2);
@@ -132,6 +133,7 @@ void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition
     add_clause(clause);
   }
 }
+#endif
 
 #if 0
 void SATEncoder::generate_conditional_lr_implication_or_definition(Lit condition1, Lit condition2, Lit lhs, vec<Lit>& rhs) {
@@ -497,7 +499,6 @@ void SATEncoder::generate_link_cw_ordinary_definition(size_t wi, int pi,
   char dir = e->dir;
   double cost = e->cost;
   Lit lhs = Lit(_variables->link_cw(wj, wi, pi, Ci));
-  Lit condition = Lit(_word_tags[wj].var);
   vec<Lit> rhs;
 
   // Collect matches (wi, pi) with word wj
@@ -524,7 +525,7 @@ void SATEncoder::generate_link_cw_ordinary_definition(size_t wi, int pi,
 
   // Generate clauses
   DEBUG_print("--------- link_cw as ordinary down");
-  generate_conditional_lr_implication_or_definition(condition, lhs, rhs);
+  generate_or_definition(lhs, rhs);
   generate_xor_conditions(rhs);
   DEBUG_print("--------- end link_cw as ordinary down");
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1277,7 +1277,7 @@ Linkage SATEncoder::create_linkage()
   Linkage linkage = (Linkage) exalloc(sizeof(struct Linkage_s));
   memset(linkage, 0, sizeof(struct Linkage_s));
 
-  partial_init_linkage(linkage, _sent->length);
+  partial_init_linkage(_sent, linkage, _sent->length);
   sat_extract_links(linkage);
   compute_link_names(linkage, _sent->string_set);
   /* Because the empty words are used only in the parsing stage, they are

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -251,12 +251,14 @@ protected:
   void build_word_tags();
 
 
+#if 0
   // Find all matching connectors between two words
   void find_all_matches_between_words(size_t w1, size_t w2,
                                       std::vector<std::pair<const PositionConnector*, const PositionConnector*> >& matches);
 
   // Check if the connector (wi, pi) can match any word in [l, r)
   bool matches_in_interval(int wi, int pi, int l, int r);
+#endif
 
 
   // Join several expressions corresponding to different dictionary

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -4,6 +4,10 @@
 
 using namespace Minisat;
 
+#ifdef HAVE_MKLIT
+#define Lit(...) mkLit(__VA_ARGS__)
+#endif
+
 /**
  *    Base class for all SAT encodings
  */

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -308,6 +308,19 @@ class SATEncoderConjunctionFreeSentences : public SATEncoder
 public:
   SATEncoderConjunctionFreeSentences(Sentence sent, Parse_Options  opts)
     : SATEncoder(sent, opts) {
+#if 0
+    fprintf(stderr, "random_var_freq=%e\ngarbage_frac=%e\nclause_decay=%e\n"
+           "restart_first=%d\nvar_decay=%e\n",
+           _solver->random_var_freq, _solver->garbage_frac, _solver->clause_decay,
+           _solver->restart_first, _solver->var_decay);
+
+    _solver->random_var_freq = 0;
+    _solver->garbage_frac = 0.2;
+    _solver->clause_decay = 0.999;
+    _solver->restart_first = 100;
+    _solver->var_decay = 0.99;
+#endif
+
     verbosity = opts->verbosity;
     debug = opts->debug;
     test = opts->test;

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -283,7 +283,6 @@ protected:
   // Generate clause that prohibits the current model
   void generate_linkage_prohibiting();
 
-
   // Object that contains all information about the variable
   // encoding.
   Variables* _variables;

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -71,9 +71,11 @@ void add_anded_exp(Exp*& orig, Exp* addit)
     }
 }
 
+#if 0
 bool isEndingInterpunction(const char* str)
 {
   return strcmp(str, ".") == 0 ||
     strcmp(str, "?") == 0 ||
     strcmp(str, "!") == 0;
 }
+#endif

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -77,9 +77,3 @@ bool isEndingInterpunction(const char* str)
     strcmp(str, "?") == 0 ||
     strcmp(str, "!") == 0;
 }
-
-const char* word(Sentence sent, int w)
-{
-  // XXX FIXME this is fundamentally wrong, should explore all alternatives!
-  return sent->word[w].alternatives[0];
-}

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -11,7 +11,7 @@ extern "C" {
 void free_linkage_connectors_and_disjuncts(Linkage lkg)
 {
   // Free the connectors
-  for(size_t i = 0; i < lkg->num_links; i++) {
+  for(size_t i = 0; i < lkg->lasz; i++) {
     free(lkg->link_array[i].rc);
     free(lkg->link_array[i].lc);
   }

--- a/link-grammar/sat-solver/variables.cpp
+++ b/link-grammar/sat-solver/variables.cpp
@@ -1,5 +1,5 @@
 #include "variables.hpp"
 
 #ifdef _VARS
-std::ostream& var_defs_stream = cerr;
+std::ostream& var_defs_stream = cout;
 #endif

--- a/link-grammar/sat-solver/variables.cpp
+++ b/link-grammar/sat-solver/variables.cpp
@@ -1,5 +1,5 @@
 #include "variables.hpp"
 
 #ifdef _VARS
-ostream& var_defs_stream = cerr;
+std::ostream& var_defs_stream = cerr;
 #endif

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -91,6 +91,16 @@ public:
    * General purpose variables specified by their names
    */
 
+  bool var_exists(const char* name) {
+    try {
+      int num = _variable_trie.lookup(name);
+      return num != Trie<int>::NOT_FOUND;
+      } catch (const std::string& s) {
+          cout << s << endl;
+          exit(EXIT_FAILURE);
+        }
+  }
+
   // If guiding params are unknown, they are set do default
   int string(const char* name)
   {

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -173,6 +173,7 @@ public:
     return var;
   }
 
+#if 0
   // If guiding params are unknown, they are set do default
   int linked_min(int wi, int wj) {
     int var;
@@ -185,8 +186,7 @@ public:
     assert(var != -1, "Var == -1");
     return var;
   }
-
-
+#endif
 
   /*
    *                  link(wi, pi, wj, pj)
@@ -417,10 +417,12 @@ public:
     const char* connector;
   };
 
+#if 0
   // Returns additional info about the given link_top_cw variable
   const LinkTopCWVar* link_top_cw_variable(int var) const {
     return _link_top_cw_variables[var];
   }
+#endif
 
   /* Pass SAT search parameters to the MiniSAT solver */
   void setVariableParameters(Solver* solver) {
@@ -675,9 +677,11 @@ private:
     return get_3int_variable(i, j, pj, var, _link_cw_variable_map);
   }
 
+#if 0
   bool get_link_top_cw_variable(int i, int j, int pj, int& var) {
     return get_3int_variable(i, j, pj, var, _link_top_cw_variable_map);
   }
+#endif
 
 
 #ifdef _CONNECTIVITY_

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -27,7 +27,7 @@ using std::endl;
 
 
 #ifdef _VARS
-extern ostream& var_defs_stream;
+extern std::ostream& var_defs_stream;
 #endif
 
 static char* construct_link_label(const char* connector1, const char* connector2) {

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -226,6 +226,7 @@ public:
     return var;
   }
 
+#if 0
   /*
    *             thin_link(wi, wj)
    * Variables that specify that two words are linked by a thin link
@@ -244,6 +245,7 @@ public:
     assert(var != -1, "Var == -1");
     return var;
   }
+#endif
 
   /*
    *                   link_cw(wi, wj, pj)

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -89,12 +89,14 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
           insert_connectors(l->e, dfs_position, leading_right, leading_left,
                 eps_right, eps_left, new_var, false, cost, parent_exp, word_xnode);
 
+#ifdef POWER_PRUNE_CONNECTORS
           if (leading_right && var != NULL) {
             eps_right.push_back(_variables->epsilon(new_var, '+'));
           }
           if (leading_left && var != NULL) {
             eps_left.push_back(_variables->epsilon(new_var, '-'));
           }
+#endif
         }
       }
   } else if (exp->type == OR_type) {

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -107,14 +107,17 @@ private:
 
 public:
   WordTag(int word, const char* name, Variables* variables, Sentence sent, Parse_Options opts)
-    : _word(word), _variables(variables), _sent(sent), _opts(opts), var(_variables->string(name)) {
+    : _word(word), _variables(variables), _sent(sent), _opts(opts) {
     _match_possible.resize(_sent->length);
+
+    // The SAT word variables are set to be equal to the word numbers.
+    Var var = _variables->string(name);
+    assert(word == var);
+
     verbosity = opts->verbosity;
     debug = opts->debug;
     test = opts->test;
   }
-
-  int var; // The corresponding SAT variable.
 
   // Added only to suppress the warning:
   // warning: inlining failed in call to ‘WordTag::~WordTag() noexcept’: call is unlikely and code size would grow [-Winline]

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -6,13 +6,10 @@
 #include <set>
 
 extern "C" {
-#include "count.h"
-#include "prune.h"
 #include "word-utils.h"
 };
 
 #include "variables.hpp"
-
 
 struct PositionConnector
 {

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -106,13 +106,15 @@ private:
   }
 
 public:
-  WordTag(int word, Variables* variables, Sentence sent, Parse_Options opts)
-    : _word(word), _variables(variables), _sent(sent), _opts(opts) {
+  WordTag(int word, const char* name, Variables* variables, Sentence sent, Parse_Options opts)
+    : _word(word), _variables(variables), _sent(sent), _opts(opts), var(_variables->string(name)) {
     _match_possible.resize(_sent->length);
     verbosity = opts->verbosity;
     debug = opts->debug;
     test = opts->test;
   }
+
+  int var; // The corresponding SAT variable.
 
   // Added only to suppress the warning:
   // warning: inlining failed in call to ‘WordTag::~WordTag() noexcept’: call is unlikely and code size would grow [-Winline]

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -176,6 +176,7 @@ struct Word_struct
 
 	X_node * x;          /* Sentence starts out with these, */
 	Disjunct * d;        /* eventually these get generated. */
+	bool optional;       /* Linkage is optional. */
 
 	const char **alternatives;
 };

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -42,9 +42,6 @@
  */
 #define SUBSCRIPT_MARK '\3'
 #define SUBSCRIPT_DOT '.'
-#define EMPTY_WORD_DOT   "EMPTY-WORD.zzz"  /* Has SUBSCRIPT_DOT in it! */
-#define EMPTY_WORD_MARK  "EMPTY-WORD\3zzz" /* Has SUBSCRIPT_MARK in it! */
-#define EMPTY_WORD_DISPLAY "∅"   /* Empty word representation for debug */
 #define EMPTY_CONNECTOR "ZZZ"
 
 /* Dictionary capitalization handling */
@@ -188,7 +185,7 @@ typedef enum
 	MT_FEATURE,            /* Pseudo morpheme, currently capitalization marks */
 	MT_INFRASTRUCTURE,     /* Start and end Wordgraph pseudo-words */
 	MT_WALL,               /* The LEFT-WALL and RIGHT-WALL pseudo-words */
-	MT_EMPTY,              /* Empty word */
+	MT_EMPTY,              /* Empty word FIXME: Remove it. */
 	MT_UNKNOWN,            /* Unknown word (FIXME? Unused) */
 	/* Experimental for Semitic languages (yet unused) */
 	MT_TEMPLATE,

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2632,6 +2632,7 @@ static Word *word_new(Sentence sent)
 		sent->word[len].x= NULL;
 		sent->word[len].unsplit_word = NULL;
 		sent->word[len].alternatives = NULL;
+		sent->word[len].optional = false;
 		sent->length++;
 
 		return &sent->word[len];

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -1419,7 +1419,6 @@ static bool mprefix_split(Sentence sent, Gword *unsplit_word, const char *word)
  */
 static bool is_capitalizable(const Dictionary dict, const Gword *word)
 {
-	if (MT_EMPTY == word->morpheme_type) return false; /* no prev pointer */
 	/* Words at the start of sentences are capitalizable */
 	if (MT_WALL == word->prev[0]->morpheme_type) return true;
 	if (MT_INFRASTRUCTURE == word->prev[0]->morpheme_type) return true;

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2810,7 +2810,6 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 	{
 		Word *wa_word; /* A word-array word (for the parsing stage) */
 		const Gword *unsplit_word;
-		bool empty_word_encountered;
 
 		assert(NULL != wp_new, "pathpos word queue is empty");
 		wp_old = wp_new;
@@ -2843,7 +2842,6 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 			}
 		}
 
-		empty_word_encountered = false;
 		/* Generate the X-nodes. */
 		for (wpp_old = wp_old; NULL != wpp_old->word; wpp_old++)
 		{
@@ -2852,20 +2850,13 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 
 			if (wpp_old->same_word)
 			{
-				/* We haven't advanced to the next wordgraph word, so its X-node has
-				 * already been generated in a previous word of the word array.
-				 * Generate an empty word if one has not already been generated.
-				 */
-				if (!empty_word_encountered)
-				{
-					/* ??? Should we check it earlier? */
-					if (!sent->dict->empty_word_defined)
-						prt_error("Error: %s must be defined!\n", EMPTY_WORD_DOT);
-
-					if (!determine_word_expressions(sent, empty_word(), &ZZZ_added))
-						error_encountered = true;
-					empty_word_encountered = true;
-				}
+				/* We haven't advanced to the next wordgraph word, so its X-node
+				 * has already been generated in a previous word of the word
+				 * array.  This means we are in a longer alternative which has
+				 * "extra" words that may not have links, and this is one of
+				 * them.  Mark it as "optional", so we consider that while
+				 * parsing, and then remove it in case it doesn't have links. */
+				sent->word[sent->length - 1].optional = true;
 			}
 			else
 			{

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -52,8 +52,10 @@ Gword *gword_new(Sentence sent, const char *s)
 	return gword;
 }
 
+/* FIXME: Remove it. */
 Gword *empty_word(void)
 {
+	/*
 	static Gword e = {
 		.subword = EMPTY_WORD_MARK,
 		.unsplit_word = &e,
@@ -61,8 +63,8 @@ Gword *empty_word(void)
 		.alternative_id = &e,
 		.status = WS_INDICT,
 	};
-
-	return &e;
+	*/
+	return NULL;
 }
 
 static Gword **gwordlist_resize(Gword **arr, size_t len)

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -17,8 +17,7 @@
 void wordgraph_show(Sentence, const char *);
 
 Gword *gword_new(Sentence, const char *);
-Gword *empty_word(void);
-
+Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);
 void gwordlist_append(Gword ***, Gword *);
 


### PR DESCRIPTION
This is a continuation to PR #477 (that replaces #469).

The batch run times for English are now somewhat slower (~8%), most probably due to added constraints, but maybe also due to more overhead in generate_disconnectivity_prohibited() for handling optional words.

These optional words are a an artifact of extra unit splitting that I think is not really needed, and it introduces significant overhead from the time it has been added (at the start of version 5). For example,
the word "As" gets split to "A s", "mall" to "ma l l", "sin" to "s in", etc. (However, this adds interesting tests cases for the parsers...).  BTW, the current English dict cannot handle such unit splits anyway (it never cold) so introducing them was an incomplete work.

The runtime of Russian is not affected.

I ran detailed comparisons on on the languages (in English also the fixes batch), of producing up to 50K linkages.  The large number of linkages is needed for long sentences, because the SAT parser tends (old problem) to produce more duplicate linkages, especially on very long sentences.

The disconnectivity prohibition is subtle, and I don't have a proof that it is completely right (however, I don't have counter examples).

Most of the power-pruning code is disabled in this PR. It seems to do nothing, besides of adding overhead (checked on the current code - before this PR). Now it even malfunctions (most probably because it doesn't account for optional words).

There are still vast speedup opportunities in the SAT parser code (future work, some of it has already been done).