### PR TITLE
Fix sane_linkage_morphism word trace printing

### DIFF
--- a/link-grammar/print.c
+++ b/link-grammar/print.c
@@ -1414,7 +1414,7 @@ void print_with_subscript_dot(const char *s)
 	const char *mark = strchr(s, SUBSCRIPT_MARK);
 	size_t len = NULL != mark ? (size_t)(mark - s) : strlen(s);
 
-	printf("%.*s%s%s ", (int)len,
+	prt_error("%.*s%s%s ", (int)len,
 			  s, NULL != mark ? "." : "", NULL != mark ? mark+1 : "");
 }
 


### PR DESCRIPTION
Somehow this fix didn't get into the lasterror PR.
It fixes an annoying printing mangling.

See the resulted drastic improvement of sane_linkage_morphism() trace doing before and after  this PR
```
link-parser -v=7 -debug=sane_linkage_morphism,print_with_subscript_dot
linkparser> this is a test
```
