### PR TITLE
Java-JNI -- manage allocation of the dictionary better.

### DIFF
--- a/bindings/java-jni/jni-client.c
+++ b/bindings/java-jni/jni-client.c
@@ -83,6 +83,11 @@ static void throwException(JNIEnv *env, const char* message)
 // setting it up. It is up to the user to make sure that this thread
 // (more generally, that all threads that call init) return before
 // any of the threads call the parse functions.
+//
+// The only purpose of using the atomic_flag is to prevent two
+// different threads from accidentally trying to initialize the
+// dict at exactly the same time. (Which does seem like a reasonable
+// guarantee to offer).
 static void global_init(JNIEnv *env)
 {
 	if (atomic_flag_test_and_set(&dict_is_init)) return;

--- a/bindings/java-jni/jni-client.c
+++ b/bindings/java-jni/jni-client.c
@@ -351,6 +351,8 @@ Java_org_linkgrammar_LinkGrammar_getMaxLinkages(JNIEnv *env, jclass cls)
 JNIEXPORT void JNICALL
 Java_org_linkgrammar_LinkGrammar_init(JNIEnv *env, jclass cls)
 {
+	// Force global init, always.
+	global_init(env);
 	get_ptd(env, cls);
 }
 
@@ -393,6 +395,9 @@ Java_org_linkgrammar_LinkGrammar_close(JNIEnv *env, jclass cls)
 JNIEXPORT void JNICALL
 Java_org_linkgrammar_LinkGrammar_doFinalize(JNIEnv *env, jclass cls)
 {
+	if (local_ptd) finish(local_ptd);
+	local_ptd = NULL;
+
 	if (dict) dictionary_delete(dict);
 	dict = NULL;
 }


### PR DESCRIPTION
Some confusion in the init and finalize methods; fix these up.