### PR TITLE
Add alternatives check in the fast-matcher

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -97,15 +97,15 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 }
 
 /* FIXME? Can the same word get appended again? If so - prevent it. */
-static void disjuct_gwordlist_append(Disjunct * dx, const Gword **word)
+void gwordlist_append_list(const Gword ***to_word, const Gword **from_word)
 {
-	size_t to_word_arr_len = gwordlist_len(dx->word);
-	size_t from_word_arr_len = gwordlist_len(word);
+	size_t to_word_arr_len = gwordlist_len(*to_word);
+	size_t from_word_arr_len = gwordlist_len(from_word);
 
-	dx->word = realloc(dx->word,
-	   sizeof(*(dx->word)) * (to_word_arr_len + from_word_arr_len + 1));
-	memcpy(&dx->word[to_word_arr_len], word,
-	       sizeof(*dx->word) * (from_word_arr_len + 1));
+	*to_word = realloc(*to_word,
+	   sizeof(**to_word) * (to_word_arr_len + from_word_arr_len + 1));
+	memcpy(&(*to_word)[to_word_arr_len], from_word,
+	       sizeof(**to_word) * (from_word_arr_len + 1));
 }
 
 /**
@@ -191,7 +191,7 @@ Disjunct *disjuncts_dup(Disjunct *origd)
 		newd->left = connectors_dup(t->left);
 		newd->right = connectors_dup(t->right);
 		newd->word = NULL;
-		disjuct_gwordlist_append(newd, t->word);
+		gwordlist_append_list(&newd->word, t->word);
 
 		prevd->next = newd;
 		prevd = newd;
@@ -253,7 +253,7 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * d)
 		{
 			d->next = NULL;  /* to prevent it from freeing the whole list */
 			if (d->cost < dx->cost) dx->cost = d->cost;
-			disjuct_gwordlist_append(dx, d->word);
+			gwordlist_append_list(&dx->word, d->word);
 			free_disjuncts(d);
 			count++;
 		}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -96,16 +96,24 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	return (i & (dt->dup_table_size-1));
 }
 
-/* FIXME? Can the same word get appended again? If so - prevent it. */
+/**
+ * Append a Gword list to a given Gword list (w/o duplicates).
+ */
 void gwordlist_append_list(const Gword ***to_word, const Gword **from_word)
 {
 	size_t to_word_arr_len = gwordlist_len(*to_word);
-	size_t from_word_arr_len = gwordlist_len(from_word);
 
-	*to_word = realloc(*to_word,
-	   sizeof(**to_word) * (to_word_arr_len + from_word_arr_len + 1));
-	memcpy(&(*to_word)[to_word_arr_len], from_word,
-	       sizeof(**to_word) * (from_word_arr_len + 1));
+	for (const Gword **f = from_word; NULL != *f; f++)
+	{
+		size_t l;
+
+		/* Note: Must use indexing because to_word may get realloc'ed. */
+		for (l = 0; l < to_word_arr_len; l++)
+			if (*f == (*to_word)[l]) break; /* Filter duplicates. */
+
+		if (l == to_word_arr_len)
+			gwordlist_append((Gword ***)to_word, (Gword *)*f);
+	}
 }
 
 /**

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -97,26 +97,6 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 }
 
 /**
- * Append a Gword list to a given Gword list (w/o duplicates).
- */
-void gwordlist_append_list(const Gword ***to_word, const Gword **from_word)
-{
-	size_t to_word_arr_len = gwordlist_len(*to_word);
-
-	for (const Gword **f = from_word; NULL != *f; f++)
-	{
-		size_t l;
-
-		/* Note: Must use indexing because to_word may get realloc'ed. */
-		for (l = 0; l < to_word_arr_len; l++)
-			if (*f == (*to_word)[l]) break; /* Filter duplicates. */
-
-		if (l == to_word_arr_len)
-			gwordlist_append((Gword ***)to_word, (Gword *)*f);
-	}
-}
-
-/**
  * The connectors must be exactly equal.  A similar function
  * is connectors_equal_AND(), but that ignores priorities,
  * this does not.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -329,35 +329,4 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 		d->word[1] = NULL;
 	}
 }
-
-/* Debug printout of a disjunct word list */
-void disjunct_word_print(Disjunct * d)
-{
-	const Gword *const *wl = d->word;
-	const char *c;
-
-	printf("Disjunct word: ");
-	for (c = d->string; '\0' != *c; c++)
-		printf("%c", *c == SUBSCRIPT_MARK ? '.' : *c);
-	printf("; Wordgraph: ");
-
-	if (NULL == wl)
-	{
-		printf("BUG: NULL list!\n");
-		return;
-	}
-	if (NULL == *wl)
-	{
-		printf("BUG: None\n");
-		return;
-	}
-
-	for (; *wl; wl++)
-	{
-		printf("word '%s' unsplit '%s'%s", (*wl)->subword,
-		       (*wl)->unsplit_word->subword, NULL == *(wl+1) ? "" : ",");
-	}
-	printf("\n");
-}
-
 /* ========================= END OF FILE ============================== */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -354,8 +354,8 @@ void disjunct_word_print(Disjunct * d)
 
 	for (; *wl; wl++)
 	{
-		printf("word '%s' unsplit '%s'%s", NULL == *(wl+1) ? "" : ",",
-		       (*wl)->subword, (*wl)->unsplit_word->subword);
+		printf("word '%s' unsplit '%s'%s", (*wl)->subword,
+		       (*wl)->unsplit_word->subword, NULL == *(wl+1) ? "" : ",");
 	}
 	printf("\n");
 }

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -24,6 +24,5 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * );
 char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);
-void gwordlist_append_list(const Gword ***, const Gword **);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -23,7 +23,6 @@ Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct * );
 char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
-void disjunct_word_print(Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);
 void gwordlist_append_list(const Gword ***, const Gword **);
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -25,5 +25,6 @@ char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
 void disjunct_word_print(Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);
+void gwordlist_append_list(const Gword ***, const Gword **);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -122,6 +122,22 @@ static void setup_connectors(Sentence sent)
 }
 
 /**
+ * Record the wordgraph word in each of its connectors.
+ * It is used for checking alternatives consistency.
+ */
+static void gword_record_in_connector(Sentence sent)
+{
+	for (size_t w = 0; w < sent->length; w++) {
+		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next) {
+			for (Connector *c = d->right; NULL != c; c = c->next)
+				c->word = d->word;
+			for (Connector *c = d->left; NULL != c; c = c->next)
+				c->word = d->word;
+		}
+	}
+}
+
+/**
  * Assumes that the sentence expression lists have been generated.
  */
 void prepare_to_parse(Sentence sent, Parse_Options opts)
@@ -149,6 +165,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 		print_disjunct_counts(sent);
 	}
 
+	gword_record_in_connector(sent);
 	set_connector_length_limits(sent, opts);
 	setup_connectors(sent);
 }

--- a/link-grammar/prune.c
+++ b/link-grammar/prune.c
@@ -979,6 +979,7 @@ static bool possible_connection(prune_context *pc,
                                 int lword, int rword)
 {
 	int dist;
+	bool same_alternative = false;
 	if ((!lshallow) && (!rshallow)) return false;
 
 	/* Two deep connectors can't work */
@@ -1010,6 +1011,24 @@ static bool possible_connection(prune_context *pc,
 	    (!lc->multi) && (!rc->multi) &&
 	    !optional_gap_collapse(pc->sent, lword, rword))
 	{
+		return false;
+	}
+
+	for (Gword **lg = (Gword **)lc->word; NULL != (*lg); lg++) {
+		for (Gword **rg = (Gword **)rc->word; NULL != (*rg); rg++) {
+			if (in_same_alternative(*lg, *rg)) {
+				same_alternative = true;
+			}
+		}
+	}
+
+	//if (!easy_match(lc->string, rc->string)) return false;
+
+	if (!same_alternative) {
+		lgdebug(8, "w%d=%s and w%d=%s NSA\n",
+		       lword, lc->word[0]->subword,
+		       rword, rc->word[0]->subword);
+
 		return false;
 	}
 

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -108,7 +108,11 @@ struct Connector_struct
 	const char * string; /* The connector name w/o the direction mark, e.g. AB */
 
 	/* Hash table next pointer, used only during pruning. */
-	Connector * tableNext;
+	union
+	{
+		Connector * tableNext;
+		const Gword **word;
+	};
 };
 
 static inline void connector_set_string(Connector *c, const char *s)

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -212,6 +212,31 @@ GNUC_UNUSED void print_hier_position(const Gword *word)
 	}
 	err_msg(lg_Debug, "]\n");
 }
+
+/* Debug printout of a wordgraph Gword list. */
+GNUC_UNUSED void gwordlist_print(const Gword **wl)
+{
+	printf("Gword list: ");
+
+	if (NULL == wl)
+	{
+		printf("(null)\n");
+		return;
+	}
+	if (NULL == *wl)
+	{
+		printf("No elements\n");
+		return;
+	}
+
+	for (; *wl; wl++)
+	{
+		printf("word %p '%s' unsplit '%s'%s", *wl, (*wl)->subword,
+		       (*wl)->unsplit_word->subword, NULL == *(wl+1) ? "" : ", ");
+	}
+	printf("\n");
+
+}
 #endif
 
 /**

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -90,6 +90,26 @@ void gwordlist_append(Gword ***arrp, Gword *p)
 	(*arrp)[n] = p;
 }
 
+/**
+ * Append a Gword list to a given Gword list (w/o duplicates).
+ */
+void gwordlist_append_list(const Gword ***to_word, const Gword **from_word)
+{
+	size_t to_word_arr_len = gwordlist_len(*to_word);
+
+	for (const Gword **f = from_word; NULL != *f; f++)
+	{
+		size_t l;
+
+		/* Note: Must use indexing because to_word may get realloc'ed. */
+		for (l = 0; l < to_word_arr_len; l++)
+			if (*f == (*to_word)[l]) break; /* Filter duplicates. */
+
+		if (l == to_word_arr_len)
+			gwordlist_append((Gword ***)to_word, (Gword *)*f);
+	}
+}
+
 #if 0
 /**
  * Replace "count" words from the position "start" by word "wnew".

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -20,6 +20,7 @@ Gword *gword_new(Sentence, const char *);
 Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);
 void gwordlist_append(Gword ***, Gword *);
+void gwordlist_append_list(const Gword ***, const Gword **);
 void gwordlist_print(const Gword **);
 
 const Gword **wordgraph_hier_position(Gword *);

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -20,6 +20,7 @@ Gword *gword_new(Sentence, const char *);
 Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);
 void gwordlist_append(Gword ***, Gword *);
+void gwordlist_print(const Gword **);
 
 const Gword **wordgraph_hier_position(Gword *);
 void print_hier_position(const Gword *);


### PR DESCRIPTION
This PR also contains (ifdef'ed out) the power-prune alt-pruning code.

BTW, here is a convenient way to produce a list of linkages:
`link-parser amy -m -test=auto-next-linkage < file`
when file contains one or more sentences. Note that you need to add **-batch** in case the file
sets batch mode (to negate it).
OR
`echo 'This is a sentence' | link-parser amy -m -test=auto-next-linkage`

As far as I have checked, this PR removes all the duplicates.

(A similar check can be added in the SAT-parser.)
