### PR TITLE
Fix token marking bugs that may cause "Invalid morpheme type combination"

### DIFF
--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -208,7 +208,7 @@ typedef enum
 
 /* Word status */
 /* - Tokenization */
-#define WS_UNKNOWN (1<<0) /* Unknown word (FIXME? Unused) */
+#define WS_UNKNOWN (1<<0) /* Unknown word */
 #define WS_REGEX   (1<<1) /* Matches a regex */
 #define WS_SPELL   (1<<2) /* Result of a spell guess */
 #define WS_RUNON   (1<<3) /* Separated from words run-on */

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -506,8 +506,11 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					}
 					break;
 				case SUFFIX: /* set to =word */
-					/* If the suffix starts with an apostrophe, don't mark it */
-					if ((('\0' != (*affix)[0]) &&
+					/* XXX If the suffix starts with an apostrophe, don't mark it.
+					 * Actually - any non-alpha is checked. The random-splitting
+					 * "languages" always need the suffix marking. */
+					if (((NULL == sent->dict->affix_table->anysplit) &&
+					     ('\0' != (*affix)[0]) &&
 					     !is_utf8_alpha(*affix, sent->dict->lctype)) ||
 					    '\0' == infix_mark)
 					{

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2687,7 +2687,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	{
 		we = build_word_expressions(sent, w, UNKNOWN_WORD);
 		assert(we, UNKNOWN_WORD " supposed to be defined in the dictionary!");
-		w->morpheme_type = MT_UNKNOWN;
+		w->status |= WS_UNKNOWN;
 	}
 	else
 	{

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -2686,7 +2686,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	else if (dict->unknown_word_defined && dict->use_unknown_word)
 	{
 		we = build_word_expressions(sent, w, UNKNOWN_WORD);
-		assert(we, UNKNOWN_WORD "must be defined in the dictionary!");
+		assert(we, UNKNOWN_WORD " supposed to be defined in the dictionary!");
 		w->morpheme_type = MT_UNKNOWN;
 	}
 	else

--- a/link-grammar/tokenize.c
+++ b/link-grammar/tokenize.c
@@ -561,6 +561,8 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					word_label(sent, unsplit_word, "+", label);
 					word_label(sent, unsplit_word, NULL, "IU");
 					lgdebug(D_IWA, " (issued_unsplit)\n");
+					/* Note: The original morpheme_type is preserved.
+					 * The morpheme_type value set above is just ignored. */
 					return unsplit_word;
 				}
 


### PR DESCRIPTION
E.g. it may cause:
`Invalid morpheme type combination 'wwptwwtstsptwww'.`

(Of course I don't like some things there. This is fixes so it just works until redone...)