### PR TITLE
Add library debug information

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -622,7 +622,7 @@ static void post_process_lkgs(Sentence sent, Parse_Options opts)
 
 	if (verbosity_level(6))
 	{
-		err_msg(lg_Info, "Info: %zu of %zu linkages with no P.P. violations",
+		err_msg(lg_Info, "%zu of %zu linkages with no P.P. violations\n",
 		        N_valid_linkages, N_linkages_post_processed);
 	}
 


### PR DESCRIPTION
Add information on using the **verbosity**, **debug** and **test** options, including useful examples.
Also add other useful debug related information.

The new `README.md` file is in in a new directory `debug`.
The idea is to eventually add there some link-grammar debug and development scripts (I have many),
Valgrind and ASAN definition files, link-grammar specific `gdb` scripts etc.

Also included here a message fix (a missing newline that I noted in one of the debug usage examples).