### PR TITLE
Intensive README fixing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ EXTRA_DIST =            \
 	msvc14/Python2.vcxproj                 \
 	msvc14/Python2.vcxproj.filters         \
 	msvc14/Python3.vcxproj.filters         \
-	msvc14/README                          \
+	msvc14/README.md                       \
 	msvc14/make-check.py                   \
 	mingw/README.Cygwin                    \
 	mingw/README.MSYS                      \

--- a/README.md
+++ b/README.md
@@ -164,27 +164,32 @@ then the java bindings will not be built.
 
 Python2 and Python3 Bindings
 ----------------------------
-The python bindings are NOT built by default. To enable this, run
-configure as one of the following:
+The Python2 and Python3 bindings are built by default, providing that
+the corresponding Python developement packages are installed.
 
-```
-./configure --enable-python-bindings
-./configure --enable-python3-bindings
-```
+These packages are:
+- Linux:
+ * Systems using 'rpm' packages: Python2: python-devel; Python3: python3-devel
+ * Systems using 'deb' packages: Python2: python-dev; Python3: python3-dev
+- Windows:
+ * Install Python2 and Python3 from https://www.python.org/downloads/windows/ .
+   You also have to install SWIG from http://www.swig.org/download .
+- MacOS:
+ * Install the python and python3 packages using [HomeBrew](http://brew.sh/).
 
 The use of the Python bindings is *OPTIONAL*; you do not need these if
-you do not plan to use link-grammar with python.  If you do enable the
-python bindings, be sure that the python-devel package was previously
-installed.
+you do not plan to use link-grammar with python.  If you like
+to disable these bindings, use one of:
+
+```
+./configure --diable-python-bindings
+./configure --disable-python2-bindings
+./configure --disable-python3-bindings
+```
 
 The linkgrammar.py module provides a high-level interface in Python.
-The example.py script provides a demo. and tests.py runs unit tests.
-
-The first option builds bindings compatible with python2.7; the
-second specifies python3.4.  Both options cannot be specified at the
-same time; however, after building and installing the one, the other
-can be built and installed ... but only if you really, really need
-both.
+The example.py and sentence-check.py scripts provide a demo,
+and tests.py runs unit tests.
 
 Install location
 ----------------

--- a/README.md
+++ b/README.md
@@ -625,10 +625,10 @@ grammar.
 
 The dependency arrows have the following properties:
 
- * anti-reflexive (a word cannot depend on itself; it cannot point
+ * Anti-reflexive (a word cannot depend on itself; it cannot point
    at itself.)
 
- * anti-symmetric (if Word1 depends on Word2, then Word2 cannot
+ * Anti-symmetric (if Word1 depends on Word2, then Word2 cannot
    depend on Word1) (so, e.g. determiners depend on nouns, but
    never vice-versa)
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ for more information.  This version is a continuation of the original
 parser posted at http://www.link.cs.cmu.edu/link
 
 
-CONTENTS of this directory:
----------------------------
+CONTENTS of this directory
+--------------------------
 
 | Content       | Description |
 | ------------- |-------------|
@@ -71,8 +71,8 @@ CONTENTS of this directory:
 | msvc14/ | Microsoft Visual-C project files |
 | mingw/ | Information on using MinGW under MSYS or Cygwin |
 
-UNPACKING and signature verification:
--------------------------------------
+UNPACKING and signature verification
+------------------------------------
 The system is distributed using the normal tar.gz format; it can be
 extracted using the "tar -zxf link-grammar.tar.gz" command at the
 command line.
@@ -95,8 +95,8 @@ cryptographic security, but they can detect simple corruption. To
 verify the check-sums, issue "md5sum -c MD5SUM" at the command line.
 
 
-CREATING the system:
---------------------
+CREATING the system
+-------------------
 To compile the link-grammar shared library and demonstration program,
 at the command line, type:
 ```
@@ -215,8 +215,8 @@ systems, under various different Windows development environments.
 Specific OS-dependent notes follow.
 
 
-BUILDING on MacOS:
-------------------
+BUILDING on MacOS
+-----------------
 Plain-vanilla Link Grammar should compile and run on Apple MacOSX
 just fine, as described above.  At this time, there are no reported
 issues.
@@ -232,7 +232,7 @@ http://trac.macports.org/browser/trunk/dports/textproc/link-grammar/Portfile
 It does not currently specify any additional steps to perform.
 
 If you do NOT need the java bindings, you should almost surely
-configure with
+configure with:
 ```
 ./configure --disable-java-bindings
 ```
@@ -276,7 +276,7 @@ BUILDING on Windows (Cygwin)
 The easiest way to have link-grammar working on MS Windows is to
 use Cygwin, a Linux-like environment for Windows making it possible
 to port software running on POSIX systems to Windows.  Download and
-install Cygwin from http://www.cygwin.com/
+install Cygwin from http://www.cygwin.com/ .
 
 Unfortunately, the Cygwin system is not compatible with Java, so if
 you need the Java bindings, you must use MSVC or MinGW, below.
@@ -297,8 +297,8 @@ BUILDING and RUNNING on Windows (MSVC)
 Microsoft Visual C/C++ project files can be found in the msvc14 directory.
 For directions see the README.md file there.
 
-RUNNING the program:
---------------------
+RUNNING the program
+-------------------
 To run the program issue the command (supposing it is in your PATH):
 ```
 link-parser [arguments]
@@ -331,7 +331,7 @@ link-parser ../path/to-my/modified/data/en
 ```
 
 When accessing dictionaries in non-standard locations, the standard
-file-names are still assumed (i.e. 4.0.dict, 4.0.affix, etc.)
+file-names are still assumed (i.e. 4.0.dict, 4.0.affix, etc.).
 
 The Russian dictionaries are in data/ru. Thus, the Russian parser
 can be started as:
@@ -359,8 +359,8 @@ combinations or variants of these, depending on your operating
 system.
 
 
-TESTING the program:
---------------------
+TESTING the program
+-------------------
 There are several ways to test the resulting build.  If the Python
 bindings are built, then a test program can be found in the file
 ./bindings/python-examples/tests.py -- When run, it should pass.
@@ -371,7 +371,7 @@ There are also multiple batches of test/example sentences in the
 language data directories, generally having the names corpus-*.batch
 The parser program can be run in batch mode, for testing the system
 on a large number of sentences.  The following command runs the
-parser on a file called corpus-basic.batch
+parser on a file called corpus-basic.batch;
 ```
 link-parser < corpus-basic.batch
 ```
@@ -403,21 +403,21 @@ bindings. It also performs several basic checks that stress the
 link-grammar libraries.
 
 
-USING the parser in your own applications:
-------------------------------------------
+USING the parser in your own applications
+-----------------------------------------
 There is an API (application program interface) to the parser.  This
 makes it easy to incorporate it into your own applications.  The API
 is documented on the web site.
 
 
-USING CMake:
-------------
+USING CMake
+-----------
 The FindLinkGrammar.cmake file can be used to test for and set up
 compilation in CMake-based build environments.
 
 
-USING pkg-config:
------------------
+USING pkg-config
+----------------
 To make compiling and linking easier, the current release uses
 the pkg-config system. To determine the location of the link-grammar
 header files, say `pkg-config --cflags link-grammar`  To obtain
@@ -431,8 +431,8 @@ $(EXE): $(OBJS)
    cc -g -o $@ $^ `pkg-config --libs link-grammar`
 ```
 
-JAVA bindings:
---------------
+JAVA bindings
+-------------
 This release includes Java bindings.  Their use is optional.
 
 The bindings will be built automatically if jni.h can be found.
@@ -507,8 +507,8 @@ transmitted. This can be obtained by sending messages of the form:
 storeDiagramString:true, text: this is a test.
 ```
 
-Spell Guessing:
----------------
+Spell Guessing
+--------------
 The parser will run a spell-checker at an early stage, if it
 encounters a word that it does not know, and cannot guess, based on
 morphology.  The configure script looks for the aspell or hunspell
@@ -519,8 +519,8 @@ Spell guessing may be disabled at runtime, in the link-parser client
 with the !spell=0 flag.  Enter !help for more details.
 
 
-MULTI-THREADED USE:
--------------------
+MULTI-THREADED USE
+------------------
 It is safe to use link-grammar for parsing in multiple threads, once
 the dictionaries have been loaded.  The dictionary loading itself is
 not thread-safe; it is not protected in any way.  Thus, link-grammar
@@ -558,8 +558,8 @@ The following exceptions and special notes apply:
 > to be thread safe.
 
 
-SAT solver:
------------
+SAT solver
+----------
 The current parser uses an algorithm that runs in O(N^3) time, for
 a sentence containing N words.
 
@@ -590,7 +590,7 @@ The following forces using the bundled minisat library:
 ./configure --enable-sat-solver=bundled
 ```
 
-The SAT solver can be disabled by specifying
+The SAT solver can be disabled by specifying:
 ```
 ./configure --disable-sat-solver
 ```
@@ -848,7 +848,7 @@ also work by Bob Coeke on category theory and grammar.  Coecke's
 diagramatic approach is essentially identical to the diagrams given in
 the foundational LG papers; it becomes abundantly clear that the
 category theoretic approach is equivalent to Link Grammar. See, for
-example, this introductory sketch:
+example, this introductory sketch
 http://www.cs.ox.ac.uk/people/bob.coecke/NewScientist.pdf
 and observe how the diagrams are essentially identical to the LG
 jigsaw-puzzle piece diagrams of the foundational LG publications.
@@ -889,8 +889,8 @@ AUTHORS file.  The original authors of the Link Grammar parser are:
 ```
 
 
-TODO -- Working Notes:
-----------------------
+TODO -- Working Notes
+---------------------
 Some working notes.
 
 Easy to fix: provide a more uniform API to the constituent tree.
@@ -1075,7 +1075,7 @@ Other benefits of a Viterbi decoder:
 
 One may argue that Viterbi is a more natural, biological way of
 working with sequences.  Some experimental, psychological support
-for this can be found here:
+for this can be found at
 http://www.sciencedaily.com/releases/2012/09/120925143555.htm
 per Morten Christiansen, Cornell professor of psychology.
 
@@ -1421,8 +1421,8 @@ Version 6.0 TODO list:
 Version 6.0 will change `Sentence` to `Sentence*,` `Linkage` to `Linkage*` in the API.  Perhaps this is a bad idea...
 
 
-A performance diary:
---------------------
+A performance diary
+-------------------
 Time to parse some long sentences:
 The original results below were for version 5.0.8 (April 2014)
 The June 2014 results are for version 5.1.0

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ CONTENTS of this directory
 UNPACKING and signature verification
 ------------------------------------
 The system is distributed using the normal tar.gz format; it can be
-extracted using the "tar -zxf link-grammar.tar.gz" command at the
+extracted using the `tar -zxf link-grammar.tar.gz` command at the
 command line.
 
 The files have been digitally signed to make sure that there was no
@@ -92,7 +92,7 @@ gpg:                 aka "Linas Vepstas (LKML) <linasvepstas@gmail.com>"
 ```
 Alternately, the md5 check-sums can be verified. These do not provide
 cryptographic security, but they can detect simple corruption. To
-verify the check-sums, issue "md5sum -c MD5SUM" at the command line.
+verify the check-sums, issue `md5sum -c MD5SUM` at the command line.
 
 
 CREATING the system
@@ -241,7 +241,7 @@ By default, java requires a 64-bit binary, and not all MacOS systems
 have a 64-bit devel environment installed.
 
 If you do want Java bindings, be sure to set the JDK_HOME environment
-variable to wherever <Headers/jni.h> is.   Set the JAVA_HOME variable
+variable to wherever `<Headers/jni.h>` is.   Set the JAVA_HOME variable
 to the location of the java compiler.  Make sure you have ant
 installed.
 
@@ -305,12 +305,12 @@ link-parser [arguments]
 ```
 
 This starts the program.  The program has many user-settable variables
-and options. These can be displayed by entering !var at the link-parser
-prompt.  Entering !help will display some additional commands.
+and options. These can be displayed by entering `!var` at the link-parser
+prompt.  Entering `!help` will display some additional commands.
 
 The dictionaries are arranged in directories whose name is the 2-letter
 language code. The link-parser program searches for such a language
-directory in that order, directly or under a directory names "data":
+directory in that order, directly or under a directory names `data`:
 
 1. Under your current directory.
 2. Unless compiled with MSVC or run under the Windows console:
@@ -363,8 +363,8 @@ TESTING the program
 -------------------
 There are several ways to test the resulting build.  If the Python
 bindings are built, then a test program can be found in the file
-./bindings/python-examples/tests.py -- When run, it should pass.
-For more details see README.md in the bindings/python-examples
+`./bindings/python-examples/tests.py` -- When run, it should pass.
+For more details see `README.md` in the `bindings/python-examples`
 directory.
 
 There are also multiple batches of test/example sentences in the
@@ -435,13 +435,13 @@ JAVA bindings
 -------------
 This release includes Java bindings.  Their use is optional.
 
-The bindings will be built automatically if jni.h can be found.
+The bindings will be built automatically if `jni.h` can be found.
 Some common java JVM distributions (most notably, the ones from Sun)
 place this file in unusual locations, where it cannot be
 automatically found.  To remedy this, make sure that JAVA_HOME is
-set. The configure script looks for jni.h in $JAVA_HOME/Headers
-and in $JAVA_HOME/include; it also examines corresponding locations
-for $JDK_HOME.  If jni.h still cannot be found, specify the location
+set. The configure script looks for jni.h in `$JAVA_HOME/Headers`
+and in `$JAVA_HOME/include`; it also examines corresponding locations
+for $JDK_HOME.  If `jni.h `still cannot be found, specify the location
 with the CPPFLAGS variable: so, for example,
 ```
 export CPPFLAGS="-I/opt/jdk1.5/include/:/opt/jdk1.5/include/linux"
@@ -477,7 +477,7 @@ class, and in particular, the parse() method.  This class is a network
 client that connects to the JSON server, and converts the response
 back to results accessible via the ParseResult API.
 
-The above-described code will be built if Apache 'ant' is installed.
+The above-described code will be built if Apache `ant` is installed.
 
 
 Using the Network Server
@@ -516,7 +516,7 @@ spell-checkers; if the aspell devel environment is found, then
 aspell is used, else hunspell is used.
 
 Spell guessing may be disabled at runtime, in the link-parser client
-with the !spell=0 flag.  Enter !help for more details.
+with the `!spell=0` flag.  Enter `!help` for more details.
 
 
 MULTI-THREADED USE
@@ -575,7 +575,7 @@ Still not handled (or handled incorrectly):
   still cannot rank sentences by cost, which is the most basic parse
   ranking that we've got... In order not to show incorrect costs, the
   DIS= field in the status message is always 0.
-- Connector order shown by the !disjunct link-parser command.
+- Connector order shown by the `!disjunct` link-parser command.
   Currently it is just a "random" order.
 - Parsing with null count.
 - No panic timeout.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ You can also build with MinGW under Cygwin. See mingw/README.Cygwin .
 BUILDING and RUNNING on Windows (MSVC)
 --------------------------------------
 Microsoft Visual C/C++ project files can be found in the msvc14 directory.
-For directions see the README file there.
+For directions see the README.md file there.
 
 RUNNING the program:
 --------------------

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ CONTENTS of this directory:
 | data/en/words/ | A directory full of word lists. |
 | data/en/corpus*.batch | These files contain sentences (both grammatical and ungrammatical ones) that are used for testing the link-parser These can be run through the parser with the command `./link-parser < corpus.*.batch` |
 |  |  |
-| data/ru/* | A full-fledged Russian dictionary |
-| data/ar/* | A fairly complete Arabic dictionary |
-| data/fa/* | A Persian (Farsi) dictionary |
-| data/de/* | A small prototype German dictionary |
-| data/lt/* | A small prototype Lithuanian dictionary |
-| data/id/* | A small prototype Indonesian dictionary |
-| data/vn/* | A small prototype Vietnamese dictionary |
-| data/he/* | An experimental Hebrew dictionary |
-| data/kz/* | An experimental Kazakh dictionary |
-| data/tr/* | An experimental Turkish dictionary |
+| data/ru/ | A full-fledged Russian dictionary |
+| data/ar/ | A fairly complete Arabic dictionary |
+| data/fa/ | A Persian (Farsi) dictionary |
+| data/de/ | A small prototype German dictionary |
+| data/lt/ | A small prototype Lithuanian dictionary |
+| data/id/ | A small prototype Indonesian dictionary |
+| data/vn/ | A small prototype Vietnamese dictionary |
+| data/he/ | An experimental Hebrew dictionary |
+| data/kz/ | An experimental Kazakh dictionary |
+| data/tr/ | An experimental Turkish dictionary |
 |  |  |
 | morphology/ar/ | An Arabic morphology analyzer |
 | morphology/fa/ | An Persian morphology analyzer |

--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ words. This needs to be fixed. In addition, for now these words are
 shown uncapitalized in the result linkages. This can be fixed.
 
 Maybe capitalization could be handled in the same way that a/an
-could be handled!  After all, its essentially a nearest-neighbor
+could be handled!  After all, it's essentially a nearest-neighbor
 phenomenon!
 
 Capitalization-mark tokens:
@@ -1144,7 +1144,7 @@ Hand-refining verb patterns:
    parsing for sentences containing such quotes. (Note that these are
    in 4.0.affix).
    A mechanism is needed to disentangle the quoting from the quoted
-   text, so that each can be parsed appropriately.  Its somewhat
+   text, so that each can be parsed appropriately.  It's somewhat
    unclear how to handle this within link-grammar. This is somewhat
    related to the problem of morphology (parsing words as if they
    were "mini-sentences",) idioms (phrases that are treated as if

--- a/README.md
+++ b/README.md
@@ -859,6 +859,10 @@ ADDRESSES
 If you have any questions, please feel free to send a note to the
 [mailing list](http://groups.google.com/group/link-grammar).
 
+The source code of link-parser and the link-grammar library is located at
+[GitHub](https://github.com/opencog/link-grammar).<br>
+For bug reports, please open an **issue** there.
+
 Although all messages should go to the mailing list, the current
 maintainers can be contacted at:
 ```text
@@ -951,7 +955,7 @@ Other examples, with the phantom word in parenthesis, include:
  * (You) go home!
  * (Are) you all right?
 
-See github https://github.com/opencog/link-grammar/issues/224
+See [this issue on GitHub](https://github.com/opencog/link-grammar/issues/224).
 
 One possible solution is to perform a one-point compactification.
 The dictionary contains the phantom words, and thier connectors.

--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ Type Theory
 -----------
 Link Grammar can be understood in the context of type theory.
 A simple introduction to type theory can be found in chapter 1
-of the HoTT book: https://homotopytypetheory.org/book/
+of the HoTT book: https://homotopytypetheory.org/book/ .<br>
 This book is freely available online and strongly recommended if
 you are interested in types.
 

--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ Bad grammar: When a sentence fails to parse, look for:
 
 Poor agreement might be handled by giving a cost to mismatched
 lower-case connector letters.
-Hand-refining verb patterns
+
 Poor linkage choices:
 Compare "she will be happier than before" to "she will be more happy
 than before." Current parser makes "happy" the head word, and "more"
@@ -1187,10 +1187,12 @@ Hand-refining verb patterns:<br>
   Sinclair, (ed) (2004) How to use corpora in language teaching,
   Amsterdam: John Benjamins
 
-  See also: Pattern Grammar: A CorpuHand-refining verb patternss-Driven Approach to the Lexical
-  Grammar of English Susan Hunston and Gill Francis (University of
-  Birmingham) Amsterdam: John Benjamins (Studies in corpus linguistics,
-  edited by Elena Tognini-Bonelli, volume 4), 2000
+  See also: Pattern Grammar: A Corpus-Driven Approach to the Lexical
+  Grammar of English<br>
+  Susan Hunston and Gill Francis (University of Birmingham)<br>
+  Amsterdam: John Benjamins (Studies in corpus linguistics,
+  edited by Elena Tognini-Bonelli, volume 4), 2000<br>
+  [Book review](http://www.aclweb.org/anthology/J01-2013).
 
   "holes" in collocations (aka "set phrases" of "phrasemes"):
   The link-grammar provides several mechanisms to support

--- a/README.md
+++ b/README.md
@@ -1387,7 +1387,7 @@ http://www.phon.ucl.ac.uk/home/dick/enc2010/articles/relative-clause.htm
 
    This still needs to be documented.
 
- - Incremental sentence parsing.
+- Incremental sentence parsing.
    There are multiple reasons to support incremental parsing:
    * Real-time dialog
    * Parsing of multiple streams, e.g. from play/movie scripts

--- a/README.md
+++ b/README.md
@@ -1419,7 +1419,7 @@ http://www.phon.ucl.ac.uk/home/dick/enc2010/articles/relative-clause.htm
    * finish sqlite3 work
 
 Version 6.0 TODO list:
-Version 6.0 will change Sentence to Sentence*, Linkage to Linkage* in the API.  Perhaps this is a bad idea...
+Version 6.0 will change `Sentence` to `Sentence*,` `Linkage` to `Linkage*` in the API.  Perhaps this is a bad idea...
 
 
 A performance diary:

--- a/README.md
+++ b/README.md
@@ -685,8 +685,8 @@ exceptions.  It would appear that the concept of "landmark transitivity"
 as defined by Richard Hudson in his theory of "Word Grammar", and then
 advocated by Ben Goertzel, just might be such a mechanism.
 
-ftp://ftp.phon.ucl.ac.uk/pub/Word-Grammar/ell2-wg.pdf
-http://www.phon.ucl.ac.uk/home/dick/enc/syntax.htm
+ftp://ftp.phon.ucl.ac.uk/pub/Word-Grammar/ell2-wg.pdf<br>
+http://www.phon.ucl.ac.uk/home/dick/enc/syntax.htm<br>
 http://goertzel.org/ProwlGrammar.pdf
 
 This mechanism works as follows:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ corruption of the dataset during download, and to help ensure that
 no malicious changes were made to the code internals by third
 parties. The signatures can be checked with the gpg command:
 
-gpg --verify link-grammar-5.3.14.tar.gz.asc
+`gpg --verify link-grammar-5.3.14.tar.gz.asc`
 
 which should generate output identical to (except for the date):
 ```

--- a/README.md
+++ b/README.md
@@ -1262,8 +1262,8 @@ is the "non-referential it", e.g.
 The above is supported by means of special disjuncts for 'it' and
 'that', which must occur in the same post-processing domain.
 
-See also:
-http://www.phon.ucl.ac.uk/home/dick/enc2010/articles/extraposition.htm
+See also:<br>
+http://www.phon.ucl.ac.uk/home/dick/enc2010/articles/extraposition.htm<br>
 http://www.phon.ucl.ac.uk/home/dick/enc2010/articles/relative-clause.htm
 
  "...from X and from Y"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ CONTENTS of this directory:
 | ChangeLog | A compendium of recent changes. |
 | configure | The GNU configuration script |
 | autogen.sh | Developer's configure maintenance tool |
+| debug/ | Information for debugging the library |
 | msvc14/ | Microsoft Visual-C project files |
 | mingw/ | Information on using MinGW under MSYS or Cygwin |
 

--- a/README.md
+++ b/README.md
@@ -263,11 +263,11 @@ http://gnuwin32.sourceforge.net/packages/tre.htm
 
 Another popular choice is PCRE, 'Perl-Compatible Regular Expressions',
 available at:
-http://www.pcre.org/
+http://www.pcre.org/<br>
 Recent 32 and 64-bit binaries can be found at:
-http://www.airesoft.co.uk/pcre
+http://www.airesoft.co.uk/pcre<br>
 Older 32-bit binaries are at:
-http://gnuwin32.sourceforge.net/packages/regex.htm
+http://gnuwin32.sourceforge.net/packages/regex.htm<br>
 See also:
 http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/regex.README
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Windows systems from Vista on.
 Link-grammar requires a working version of POSIX-standard regex
 libraries.  Since these are not provided by Microsoft, a copy must
 be obtained elsewhere.  One popular choice is TRE, available at:
-http://laurikari.net/tre/
+http://gnuwin32.sourceforge.net/packages/tre.htm
 
 Another popular choice is PCRE, 'Perl-Compatible Regular Expressions',
 available at:

--- a/README.md
+++ b/README.md
@@ -856,11 +856,8 @@ jigsaw-puzzle piece diagrams of the foundational LG publications.
 
 ADDRESSES
 ---------
-If you have any questions, or find any bugs, please feel free
-to send a note to the mailing list:
-```text
-link-grammar@googlegroups.com
-```
+If you have any questions, please feel free to send a note to the
+[mailing list](http://groups.google.com/group/link-grammar).
 
 Although all messages should go to the mailing list, the current
 maintainers can be contacted at:

--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ Bad grammar: When a sentence fails to parse, look for:
 
 Poor agreement might be handled by giving a cost to mismatched
 lower-case connector letters.
-
+Hand-refining verb patterns
 Poor linkage choices:
 Compare "she will be happier than before" to "she will be more happy
 than before." Current parser makes "happy" the head word, and "more"
@@ -1126,12 +1126,12 @@ Imperatives:
 ```
 The zero/phantom-word solution, described above, should help with this.
 
-Hand-refining verb patterns:
-   A good reference for refining verb usage patterns is:
-   COBUILD GRAMMAR PATTERNS 1: VERBS
-   from THE COBUILD SERIES /from/ THE BANK OF ENGLISH
-   HARPER COLLINS
-   online at https://arts-ccr-002.bham.ac.uk/ccr/patgram/
+Hand-refining verb patterns:<br>
+   A good reference for refining verb usage patterns is:<br>
+   COBUILD GRAMMAR PATTERNS 1: VERBS<br>
+   from THE COBUILD SERIES /from/ THE BANK OF ENGLISH<br>
+   HARPER COLLINS<br>
+   online at https://arts-ccr-002.bham.ac.uk/ccr/patgram/<br>
    http://www.corpus.bham.ac.uk/publications/index.shtml
 
 
@@ -1187,7 +1187,7 @@ Hand-refining verb patterns:
   Sinclair, (ed) (2004) How to use corpora in language teaching,
   Amsterdam: John Benjamins
 
-  See also: Pattern Grammar: A Corpus-Driven Approach to the Lexical
+  See also: Pattern Grammar: A CorpuHand-refining verb patternss-Driven Approach to the Lexical
   Grammar of English Susan Hunston and Gill Francis (University of
   Birmingham) Amsterdam: John Benjamins (Studies in corpus linguistics,
   edited by Elena Tognini-Bonelli, volume 4), 2000

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See http://www.macports.org/ to find these.
 
 You almost surely do not need a Mac portfile; but you can still
 find one here:
-http://trac.macports.org/browser/trunk/dports/textproc/link-grammar/Portfile
+http://trac.macports.org/browser/trunk/dports/textproc/link-grammar/Portfile .<br>
 It does not currently specify any additional steps to perform.
 
 If you do NOT need the java bindings, you should almost surely

--- a/README.md
+++ b/README.md
@@ -271,12 +271,6 @@ http://gnuwin32.sourceforge.net/packages/regex.htm
 See also:
 http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/regex.README
 
-The different build methods below are NOT regularly tested, and
-some link-grammar versions may have build issues.  If you are an
-experienced Windows developer who knows how to make things work
-in the Microsoft environment, your help would be appreciated!
-
-
 BUILDING on Windows (Cygwin)
 ----------------------------
 The easiest way to have link-grammar working on MS Windows is to

--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ Hand-refining verb patterns:<br>
   in the middle, that require "lacing" to tie them together.
 
   For a general theory, see:
-  http://en.wikipedia.org/wiki/Catena_(linguistics)
+  [](http://en.wikipedia.org/wiki/Catena_(linguistics))
 
   For example, the adposition:
 ```text

--- a/debug/README.md
+++ b/debug/README.md
@@ -14,8 +14,8 @@ For info on common options, see the "Special ! options" of the `link-grammar`
 manual. For a general help message use `link-parser -help`.
 
 
-Debugging options
------------------
+Debug options
+-------------
 
 ### 1) -verbosity=N (-v=N)
 Sets the verbosity level of the library to N (a small non-negative integer).
@@ -86,14 +86,14 @@ Useful examples
 
 `lg -v=7 -debug=api.c`
 
-(`sane_linkage_morphism()` happens to be in api. so this includes its
+(`sane_linkage_morphism()` happens to be in `api.c` so this includes its
 messages too).
 
 4) Debug the tokenizer:
 
 `lg -v=7 -debug=tokenizer.c`
 
-or, in order to display the word array:
+Or, in order to display the word array:
 
 `lg -v=7 -debug=tokenize.c,print_sentence_word_alternatives`
 
@@ -112,7 +112,7 @@ or, in order to display the word array:
 `lg -test=auto-next-linkage`
 Try to type some sentences at the **linkparser>** prompt to see its action.
 
-2) To print more that 1024 linkages in `link-parser` (this is the maximum
+2) Print more that 1024 linkages in `link-parser` (this is the maximum
 `link-parser` would print by default), e.g. 20000:
 
 `lg -test=auto-next-linkage:20000`
@@ -127,15 +127,15 @@ with a backslash.)
 This, along with "diff", "grep" etc., can be used in order to validate
 that a change didn't cause undesired effects. Special care should be taken
 if sentences with more than 1024 linkages are to be verified too (use a
-larger `-limit=N` and a use -test=auto-next-linkage:M`, when N>>M).
+larger `-limit=N` and -test=auto-next-linkage:M`, when N>>M).
 
 Note that this technique is not very effective if the order to the
 linkages got changed (or if SAT-parser linkages need to be compared to the
-classic-parser linkages). In that case the detailed linkages results needs
+classic-parser linkages). In that case the detailed linkages results need
 to be filtered through a script which sorts them according to some
 "canonical order".
 
-4) Display a the word-graph:
+4) Display the wordgraph:
 Currently, to use this feature, the library needs to be compiled with
 `--enable-wordgraph-display`.
 
@@ -150,8 +150,9 @@ For more examples of how to use the wordgraph display, see
 
 Debugging and STDIO streams
 ---------------------------
-Currently, messages at severity Warning and higher (i.e. also Error and
-Fatal) are printed to `stderr`. The others (at Info and below, i.e also
+Messages at severity Warning and higher (i.e. also Error and
+Fatal) are printed to `stderr`. The other severities
+(at Info and below, i.e also
 Debug, Trace and None) are printed to `stdout`. The rational is that
 debugging messages, in order to be useful, need to appear along with the
 regular output of the program, while errors are exceptional and need to
@@ -183,7 +184,7 @@ The wordgraph display function can be invoked from `gdb` using:
 
 `call wordgraph_show(sent, "")`
 
-supposing that "sent" is available (the stacked can be rolled down for
+supposing that "sent" is available (the stack can be rolled down for
 that using the "down" or "frame" `gdb` commands).
 
-(The second argument can include wordgraph display options.)
+The second argument can include wordgraph display options.

--- a/msvc14/README
+++ b/msvc14/README
@@ -44,6 +44,15 @@ sheet "Local", as follows:
    generated from the DLL if it is not included in the distribution (see
    http://stackoverflow.com/questions/9946322).
 
+   A tested library can be downloaded from [Tre for Windows]
+   (http://gnuwin32.sourceforge.net/packages/tre.htm). If your system is
+   64-bits, use the provided 64-bits library. 
+
+   The corresponding lib file is missing there. If you have Cygwin
+   installed, you can generate it as follows (console command):
+
+   `dlltool -l regex.lib -d libtre/win32/tre.def -D regex.dll libtre/win32/bin/x64_release/libtre_dll.dll`
+
 -- LG_DLLPATH should include the directory of the regex DLL, which is
    normally under GNUREGEX_DIR (or it can be a central DLL directory etc.).
    The default is "$(GNUREGEX_DIR)\lib".
@@ -189,6 +198,7 @@ using a 2-letter language code and a 2-letter country code:
 console-prompt>set LANG=ll-CC
 For example:
 console-prompt>set LANG=en-US
+
 
 If you open a dictionary which doesn't have a locale definition, from a
 program (C program or a language with LG bindings) you have to set the

--- a/msvc14/README.md
+++ b/msvc14/README.md
@@ -1,6 +1,6 @@
 Building and Running on Windows
 ===============================
-Note: See also "BUILDING on Windows" in "../README".
+Note: See also "BUILDING on Windows" in `../README.md`.
 
 This directory contains project files for building Link Grammar with the
 Microsoft Visual Studio 2015 IDE (MSVC14). They were created and tested with
@@ -17,8 +17,9 @@ functions which are used are not supported in earlier versions.)
 
 The system compatibility definitions:
 In each project file - Target Platform version: 8.1
-In the MSVC-common property sheet - C/C++->Preprocessor:
-NTDDI_VERSION=NTDDI_VISTA;_WIN32_WINNT=_WIN32_WINNT_VISTA;
+In the MSVC-common property sheet - **C/C++->Preprocessor**:
+
+`NTDDI_VERSION=NTDDI_VISTA;_WIN32_WINNT=_WIN32_WINNT_VISTA;`
 
 Dependencies
 ------------
@@ -26,8 +27,8 @@ The regex package, which includes libraries and header files, must be
 separately downloaded. Also see GNUREGEX_DIR below.
 
 For Python bindings, install the desired Python distributions from
-https://www.python.org/downloads/windows/ .
-You also have to install SWIG from http://www.swig.org/download
+[Python Releases for Windows](https://www.python.org/downloads/windows/).
+You also have to install SWIG from http://www.swig.org/download .
 
 The bindings were testes using swigwin-3.0.10 with Python 2.7.12 and 3.4.4.
 
@@ -36,9 +37,9 @@ Setup
 The build files make use of User Macros, defined in the property
 sheet "Local", as follows:
 
--- GNUREGEX_DIR must be pointing to an unzipped POSIX regex distribution
-   (which has the subdirectories "include" and "lib"). Its default is
-   "%HOMEDRIVE%%HOMEPATH%\Libraries\gnuregex".
+- GNUREGEX_DIR must be pointing to an unzipped POSIX regex distribution
+   (which has the subdirectories `include` and `lib`). Its default is
+   `%HOMEDRIVE%%HOMEPATH%\Libraries\gnuregex`.
    If the environment variable GNUREGEX exists, its value is used instead.
    The library file name is assumed to be "regex.lib" and needs to be
    generated from the DLL if it is not included in the distribution (see
@@ -51,30 +52,34 @@ sheet "Local", as follows:
    The corresponding lib file is missing there. If you have Cygwin
    installed, you can generate it as follows (console command):
 
-   `dlltool -l regex.lib -d libtre/win32/tre.def -D regex.dll libtre/win32/bin/x64_release/libtre_dll.dll`
+```
+dlltool -l regex.lib -d libtre/win32/tre.def -D regex.dll libtre/win32/bin/x64_release/libtre_dll.dll
+```
 
--- LG_DLLPATH should include the directory of the regex DLL, which is
+- LG_DLLPATH should include the directory of the regex DLL, which is
    normally under GNUREGEX_DIR (or it can be a central DLL directory etc.).
-   The default is "$(GNUREGEX_DIR)\lib".
+   The default is `$(GNUREGEX_DIR)\lib`.
 
--- JAVA_HOME, if used, must be pointing to a locally installed SDK/JDK,
-   which has the subdirectories "include" and "include/win32" (defined in
-   the LinkGrammarJava project under Common properties->C/C++->General->
-   Additional Include Directories.
+- JAVA_HOME, if used, must be pointing to a locally installed SDK/JDK,
+   which has the subdirectories "include" and `include/win32` (defined in
+   the LinkGrammarJava project under **Common properties->C/C++->General->
+   Additional Include Directories**.
    If your JAVA SDK/JDK installation has defined the JAVA_HOME environment
    variable (check it) then there is no need to define this User Macro.
 
 ### Definitions for Python bindings
 
---- PYTHON2         - The default is: C:\Python27
---- PYTHON2_INCLUDE - The default is: $(PYTHON2)\include
---- PYTHON2_LIB     - The default is: $(PYTHON2)\lib
---- PYTHON2_EXE     - The default is: $(PYTHON2)\python.exe
-
---- PYTHON3         - The default is: C:\Python34
---- PYTHON3_INCLUDE - The default is: $(PYTHON3)\include
---- PYTHON3_LIB     - The default is: $(PYTHON3)\lib
---- PYTHON3_EXE     - The default is: $(PYTHON3)\python.exe
+   |   |
+---|---|
+PYTHON2         | The default is: C:\Python27 |
+PYTHON2_INCLUDE | The default is: $(PYTHON2)\include |
+PYTHON2_LIB     | The default is: $(PYTHON2)\lib |
+PYTHON2_EXE     | The default is: $(PYTHON2)\python.exe |
+               |  |
+PYTHON3         | The default is: C:\Python34 |
+PYTHON3_INCLUDE | The default is: $(PYTHON3)\include |
+PYTHON3_LIB     | The default is: $(PYTHON3)\lib |
+PYTHON3_EXE     | The default is: $(PYTHON3)\python.exe |
 
 If you want to build any of the bindings, make sure it is marked for build
 in the configuration manager, or select "build" for the desired bindings in
@@ -90,11 +95,11 @@ Compiling
 
 - The solution configuration is configured to create a debug version by
   default.  It's probably a good idea to switch a "Release" configuration.
-  You can do this at Build Menu->Configuration Manager.
+  You can do this at **Build Menu->Configuration Manager**.
 
 - The wordgraph-display feature is enabled when compiled with
   USE_WORDGRAPH_DISPLAY (already defined in the LGfeatures property sheet
-  Common properties->C/C++->Preprocessor/Preprocessor Definitions).
+  **Common properties->C/C++->Preprocessor/Preprocessor Definitions**).
 
 - By default, the library is configured to create a DLL. If you want
   to instead build a static library, the macro LINK_GRAMMAR_STATIC must
@@ -105,35 +110,35 @@ Compiling
 
 Running
 -------
-The last step of the "LinkGrammarExe" project creates "link-parser.bat".  Copy
+The last step of the "LinkGrammarExe" project creates `link-parser.bat`.  Copy
 it to somewhere in your PATH and then customize it if needed (don't customize
 it in-place, since rebuilding would overwrite it). Note that it prepends PATH
 with the User Macro LG_DLLPATH (see Setup above).  If you would like to display
-the wordgraph (see below) set also the PATH for "dot.exe" if it is not already
+the wordgraph (see below) set also the PATH for `dot.exe` if it is not already
 in your PATH.
 
 If USE_WORDGRAPH_DISPLAY has been used when compiling (the default), then
-typing !test=wg at the "link-parser" prompt can be used in order to display the
-wordgraph of the next sentences to be parsed. See "../linkgrammar/README" for
-how to use optional display flags.  By default, "PhotoViewer.dll" is invoked to
-display the graph.  If X11 is available and your "dot.exe" command has the
-"xlib" driver, it can be used to display the wordgraph when the x flag is set
-(i.e.  !test=wg:x), for example when running under Cygwin/X. In any case it
-uses the "dot" command of Graphviz. Graphviz can be installed as part of Cygwin
-(in which case it included the "xlib" driver"), or separately
-(http://www.graphviz.org/Download_windows.php).  Both "PhotoViewer.dll" (if
-used) and "dot" must be in your PATH (if needed, you can customized that in a
-copy of "link-parser.bat", as described above).
+typing `!test=w`g at the `linkparser>` prompt can be used in order to display
+the wordgraph of the next sentences to be parsed. See `../linkgrammar/README`
+for how to use optional display flags.  By default, `PhotoViewer.dll` is
+invoked to display the graph.  If X11 is available and your `dot.exe` command
+has the "xlib" driver, it can be used to display the wordgraph when the x flag
+is set (i.e. `!test=wg:x`), for example when running under Cygwin/X. In any
+case it uses the `dot` command of Graphviz. Graphviz can be installed as part
+of Cygwin (in which case it included the "xlib" driver"), or separately from
+[Graphviz] (http://www.graphviz.org/Download_windows.php).
+Both `PhotoViewer.dll` (if used) and `dot` must be in your PATH (if needed,
+you can customized that in a copy of `link-parser.bat`, as described above).
 
 BTW, when running and MSVC-compiled binary under Cygwin, don't exit
-link-parser by using ^Z - the shell may get stuck because the program
-somehow may continue to run in the background.  Instead, exit using !exit .
+link-parser by using `^Z` - the shell may get stuck because the program
+somehow may continue to run in the background.  Instead, exit using `!exit` .
 
 NOTE: The created DLLs need the MSVC14 runtime environment to run. This is
 normally already installed in your machine with the installation of the IDE.
-But to be able to run Link Grammar on other computer you need to install the
-Visual C++ Redistributable for Visual Studio 2015 from:
-https://www.microsoft.com/en-us/download/details.aspx?id=48145
+But to be able to run Link Grammar on other computer you need to install
+[Visual C++ Redistributable for Visual Studio 2015]
+(https://www.microsoft.com/en-us/download/details.aspx?id=48145).
 This redistributable does not contain debug version of the MSVC runtime, so
 only "Release" Link Grammar will work with it.
 
@@ -153,36 +158,39 @@ configuration directory.  However, it can run from any directory
 using a full or a relative path to invoke it.
 
 Usage:
+```
 console-prompt>make-check [PYTHON_FLAG] PYTHON_OUTDIR [script.py] [ARGUMENTS]
+```
 
-- PYTHON_FLAG: Optional flag for the Python program, e.g. -vv to debug
+- PYTHON_FLAG: Optional flag for the Python program, e.g. `-vv` to debug
 imports.
 - PYTHON_OUTDIR: The directory to which the Python bindings got written.
-For example, x64\Release\Python3 .
+For example, `x64\Release\Python3`.
 - script.py: Path leading to the script. If only a filename is specified
 (i.e. no "\" in the path) the specified script file is taken from the
-"bindings\python-examples\" directory.  In order to run tests.py in
+`bindings\python-examples\` directory.  In order to run tests.py in
 its default location you can leave it empty.
-- ARGUMENTS: Optional script arguments, for example -v for tests.py.
+- ARGUMENTS: Optional script arguments, for example `-v` for `tests.py`.
 
-So in order to run tests.py with Python2 for a Debug compilation on x64
+So in order to run `tests.py` with Python2 for a Debug compilation on x64
 platform, enter:
-
+```
 console-prompt>make-check x64\Debug\Python2
-
+```
 To debug a Python3 script "mylgtest.py" that resides in
-"bindings\python-examples":
-
+`bindings\python-examples`:
+```
 console-prompt>make-check -mpdb x64\Debug\Python3 mylgtest.py
-
+```
 To run a script in your home directory:
+```
 console-prompt>make-check x64\Debug\Python3 \Users\username\mylgtest.py
-
+```
 The following starts an interactive Python with the correct PYTHONPATH
 and PATH:
-
+```
 console-prompt>make-check.py x64\Debug\Python2 ""
-
+```
 Locale and code page settings
 -----------------------------
 In this version, the language dictionaries under the data directory define
@@ -194,11 +202,13 @@ If you use a dictionary which doesn't have this definition, or would like
 to set the default language when link-parser is invoked without a language
 argument, you can set the locale using the environment variable LANG,
 using a 2-letter language code and a 2-letter country code:
-
+```
 console-prompt>set LANG=ll-CC
+```
 For example:
+```
 console-prompt>set LANG=en-US
-
+```
 
 If you open a dictionary which doesn't have a locale definition, from a
 program (C program or a language with LG bindings) you have to set the
@@ -210,10 +220,10 @@ The code page of the console should not be changed, unless it is desired
 to pipe the output to another program. In that case, this other program
 may read garbage due to a limitation in the way cmd.exe implements pipes.
 This can be solved as following ("more" is the example program)
-
+```
 link-parser | (chcp 65001 & more)
-
-In that case "more" will be able to read UTF-8 input. However, the
+```
+In that case `more` will be able to read UTF-8 input. However, the
 display may still not be perfect due to additional cmd.exe limitations.
 The code page can changed manually to 65001, see below in the "Note for
 Python bindings".
@@ -222,10 +232,12 @@ Python bindings".
 In order to produce UTF-8 output to the console, it needs use the CP_UTF8
 code page (65001):
 
+```
 console-prompt>chcp
 Active code page NNNN
 console-prompt>chcp 65001
 Active code page: 65001
+```
 
 Other programs may malfunction with this code page, so it can be restored
 when needed (or this console window can be used only for working with
@@ -241,26 +253,29 @@ through the registry (Google it).
 Permanent installation
 ----------------------
 For using the library independently of the build directory:
-1. If Python bindings were generated, copy the following modules to a
-   directory "linkgrammar" in a fixed location: linkgrammar.py,
-   clinkgrammar.py, __init__.py, _clinkgrammar.pyd .
+
+1) If Python bindings were generated, copy the following modules to a
+   directory `linkgrammar` in a fixed location: `linkgrammar.py`,
+   `clinkgrammar.py`, `__init__.py`, `_clinkgrammar.pyd`.
    Set the PYTHONPATH environment variable to point to the said
    "linkgrammar" directory.
-2. Copy the link-grammar DLL to a fixed location.
+
+2) Copy the link-grammar DLL to a fixed location.
    Add the DLL location permanently to PATH.
-3. Copy the "data" directory to the location of the DLL so it will get found.
+
+3) Copy the `data` directory to the location of the DLL so it will get found.
 
 
 Implementation notes:
 ---------------------
 
-- The file "link-grammar/link-features.h.in" has a Custom Build Tool definition
-  which invokes "mk-link-features-h" to generate
-  "link-grammar/link-features.h", with LINK_*_VERSION variable replacement as
-  defined in "configure.ac".
+- The file `link-grammar/link-features.h.in` has a Custom Build Tool definition
+  which invokes `mk-link-features-h` to generate
+  `link-grammar/link-features.h`, with LINK_*_VERSION variable replacement as
+  defined in `configure.ac`.
 
-- The project file "LinkGrammarExe" has a Post-Build-Event definition for
-  generating "link-parser.bat".
+- The project file `LinkGrammarExe` has a Post-Build-Event definition for
+  generating `link-parser.bat`.
 
 
 Using a remote network share
@@ -275,9 +290,9 @@ if this makes a security or another problem in your case.
 
 Here is what worked for me:
 Suppose you use host:/usr/local/src remotely as share "src":
-
+```
 mklink /J src-j \\host\src
 mklink /D src src-link
-
+```
 The second one needs administrator privileges.
 Then use the repository through "src".


### PR DESCRIPTION
Ending dot consistency (see the second column of the table). A dot should always be present, or always absent (but in any case, always present for multi-sentences). Please indicate which solution is preferred, and I will send a PR.

Further things to (maybe) fix (please indicate for which to send PR):

1) +| link-grammar/minisat/ | Optional SAT Solver. (Written in C++) |
-| link-grammar/sat-solver | Optional SAT Solver. (Written in C++) |
For the second one I propose: Optional SAT parser. (Written in C++)
(The original naming is confusing.)

2) Many sentence examples don't need quotes around them any more, because they can be understood as examples by using md markup instead.
