### PR TITLE
remap_linkages(): Restore pp_info handling

### DIFF
--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -185,7 +185,17 @@ static void remap_linkages(Linkage lkg, const int *remap)
 
 			new_lnk->link_name = old_lnk->link_name;
 
+			/* Remap the pp_info, too. */
+			if (lkg->pp_info)
+				lkg->pp_info[j] = lkg->pp_info[i];
+
 			j++;
+		}
+		else
+		{
+			/* Whack this slot of pp_info. */
+			if (lkg->pp_info)
+				exfree_domain_names(&lkg->pp_info[i]);
 		}
 	}
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -236,16 +236,18 @@ void remove_empty_words(Linkage lkg)
 			j++;
 		}
 	}
-	lkg->num_words = j;
-	/* Unused memory not freed - all of it will be freed in free_linkages(). */
+	if (lkg->num_words != j)
+	{
+		/* Unused memory not freed - all of it will be freed in free_linkages(). */
+		lkg->num_words = j;
+		remap_linkages(lkg, remap); /* Update lkg->link_array and lkg->num_links. */
+	}
 
 	if (verbosity_level(+D_REE))
 	{
 		err_msg(lg_Debug, "chosen_disjuncts after:\n\\");
 		print_chosen_disjuncts_words(lkg);
 	}
-
-	remap_linkages(lkg, remap); /* Update lkg->link_array and lkg->num_links. */
 }
 #undef D_REE
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -229,7 +229,9 @@ void remove_empty_words(Linkage lkg)
 		}
 		else
 		{
+			Disjunct *cdtmp = cdj[j];
 			cdj[j] = cdj[i];
+			cdj[i] = cdtmp; /* The SAT parser frees chosen_disjuncts elements. */
 			remap[i] = j;
 			j++;
 		}
@@ -676,7 +678,9 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		if (chosen_words[i] &&
 		    (chosen_words[i][0] || (!HIDE_MORPHO || show_word[i])))
 		{
+			const char *cwtmp = linkage->word[j];
 			linkage->word[j] = chosen_words[i];
+			chosen_words[i] = cwtmp;
 			remap[i] = j;
 			j++;
 		}

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -16,7 +16,7 @@ void free_linkage_connectors_and_disjuncts(Linkage lkg)
     free(lkg->link_array[i].lc);
   }
   // Free the disjuncts
-  for (size_t i = 0; i < lkg->num_words; i++) {
+  for (size_t i = 0; i < lkg->cdsz; i++) {
     free_disjuncts(lkg->chosen_disjuncts[i]);
   }
 }


### PR DESCRIPTION
Fix issue #509.

Commit 0cf8c60f removed remapping/freeng of pp_info.
This causes a memleak in case of HIDE_MORPHO, because then the pp_info
related to the removed links is not freed at linkage_free_pp_info().

Restore the relevant part of the removed code.

The part that zeros out the rest of the domain name array is not restored
because it seems it is not needed, as anything beyond pp_info[j] is not
going to be accessed any more.