### PR TITLE
SAT parser memleak

### DIFF
--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -185,7 +185,17 @@ static void remap_linkages(Linkage lkg, const int *remap)
 
 			new_lnk->link_name = old_lnk->link_name;
 
+			/* Remap the pp_info, too. */
+			if (lkg->pp_info)
+				lkg->pp_info[j] = lkg->pp_info[i];
+
 			j++;
+		}
+		else
+		{
+			/* Whack this slot of pp_info. */
+			if (lkg->pp_info)
+				exfree_domain_names(&lkg->pp_info[i]);
 		}
 	}
 

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -229,7 +229,9 @@ void remove_empty_words(Linkage lkg)
 		}
 		else
 		{
+			Disjunct *cdtmp = cdj[j];
 			cdj[j] = cdj[i];
+			cdj[i] = cdtmp; /* The SAT parser frees chosen_disjuncts elements. */
 			remap[i] = j;
 			j++;
 		}
@@ -676,7 +678,9 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		if (chosen_words[i] &&
 		    (chosen_words[i][0] || (!HIDE_MORPHO || show_word[i])))
 		{
+			const char *cwtmp = linkage->word[j];
 			linkage->word[j] = chosen_words[i];
+			chosen_words[i] = cwtmp;
 			remap[i] = j;
 			j++;
 		}

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -16,7 +16,7 @@ void free_linkage_connectors_and_disjuncts(Linkage lkg)
     free(lkg->link_array[i].lc);
   }
   // Free the disjuncts
-  for (size_t i = 0; i < lkg->num_words; i++) {
+  for (size_t i = 0; i < lkg->cdsz; i++) {
     free_disjuncts(lkg->chosen_disjuncts[i]);
   }
 }


### PR DESCRIPTION
The SAT parser creates the disjuncts for the chosen_disjuncts array,
and has to free them on sentence deletion.

The sat-no-empty-word version changed the memory management to free the
chosen_disjuncts elements. This caused a memleak on !morphology=0 (the
HIDE_MORPHO feature) because elements may then be deleted from the
chosen_disjuncts array.

Fix it by moving the deleted elements to the end of the chosen_disjuncts
array and change free_linkage_connectors_and_disjuncts() to free the
whole original array.