### PR TITLE
Fix a crash in alt_connection_possible()

### DIFF
--- a/link-grammar/fast-match.c
+++ b/link-grammar/fast-match.c
@@ -503,7 +503,6 @@ typedef struct
  * (The first wordgraph word is used for cache validity indication,
  * but there is only one most of the times anyway.)
  */
-#define ALT_CONNECTION_POSSIBLE
 #define OPTIMIZE_EN
 static bool alt_connection_possible(Connector *c1, Connector *c2,
                                     gword_cache *c_con)

--- a/link-grammar/fast-match.h
+++ b/link-grammar/fast-match.h
@@ -16,6 +16,8 @@
 #include "link-includes.h"
 #include "structures.h"
 
+#define ALT_CONNECTION_POSSIBLE /* validate alt connectivity */
+
 struct fast_matcher_s
 {
 	size_t size;

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -122,22 +122,6 @@ static void setup_connectors(Sentence sent)
 }
 
 /**
- * Record the wordgraph word in each of its connectors.
- * It is used for checking alternatives consistency.
- */
-static void gword_record_in_connector(Sentence sent)
-{
-	for (size_t w = 0; w < sent->length; w++) {
-		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next) {
-			for (Connector *c = d->right; NULL != c; c = c->next)
-				c->word = d->word;
-			for (Connector *c = d->left; NULL != c; c = c->next)
-				c->word = d->word;
-		}
-	}
-}
-
-/**
  * Assumes that the sentence expression lists have been generated.
  */
 void prepare_to_parse(Sentence sent, Parse_Options opts)
@@ -165,7 +149,6 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 		print_disjunct_counts(sent);
 	}
 
-	gword_record_in_connector(sent);
 	set_connector_length_limits(sent, opts);
 	setup_connectors(sent);
 }


### PR DESCRIPTION
The crash can be repeated by:
tests.py ZENLangTestCase

Problem explanation:
gword_record_in_connector() is called once, in prepare_to_parse().
It puts a reference in each connector to the gword array of its
disjunct.

In case a parse with possible nulls is done in one step (i.e. using
min_null_count=0 and max_null_count>0), some disjuncts may get freed
by power_prune() along with their gword array, leading to a stale
reference in the connectors in case a parse with null_count>0 is needed
(such as in the test that crashes).

The solution that is implemented here is to use the disjuncts_copy that
is done in that case, since it is valid until the end of the parse.

This doesn't look nice. Hence the FIXME.
It can be done better by using a gword linked-list in the disjuncts that
is not getting freed along with the disjuncts but separately in
sentence_delete(). This is also lighter in CPU and memory.