### PR TITLE
Fix a crash in alt_connection_possible() - replaces #513

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -778,6 +778,23 @@ static void word_queue_delete(Sentence sent)
 	sent->word_queue = NULL;
 }
 
+/**
+ * Delete the gword_set associated with the Wordgraph.
+ * @w First Wordgraph word.
+ */
+static void gword_set_delete(Gword *w)
+{
+	for (w = w->chain_next; NULL != w; w = w->chain_next)
+	{
+		gword_set *n;
+		for (gword_set *f = w->gword_set_head.chain_next; NULL != f; f = n)
+		{
+			n = f->chain_next;
+			free(f);
+		}
+	}
+}
+
 void sentence_delete(Sentence sent)
 {
 	if (!sent) return;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -800,6 +800,7 @@ void sentence_delete(Sentence sent)
 	if (!sent) return;
 	sat_sentence_delete(sent);
 	free_sentence_words(sent);
+	gword_set_delete(sent->wordgraph);
 	wordgraph_delete(sent);
 	word_queue_delete(sent);
 	string_set_delete(sent->string_set);
@@ -1083,11 +1084,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		/* Proceed in all the paths in which the word is found. */
 		for (wpp = wp_old; NULL != wpp->word; wpp++)
 		{
-			const Gword **wlp; /* disjunct word list */
-
-			for (wlp = cdj->word; *wlp; wlp++)
+			for (gword_set *gl = cdj->originating_gword; NULL != gl; gl =  gl->next)
 			{
-				if (*wlp == wpp->word)
+				if (gl->o_gword == wpp->word)
 				{
 					match_found = true;
 					for (next = wpp->word->next; NULL != *next; next++)

--- a/link-grammar/build-disjuncts.c
+++ b/link-grammar/build-disjuncts.c
@@ -302,7 +302,6 @@ build_disjunct(Clause * cl, const char * string, double cost_cutoff)
 			ndis->string = string;
 			ndis->cost = cl->cost;
 			ndis->next = dis;
-			ndis->word = NULL;
 			dis = ndis;
 		}
 	}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -209,6 +209,15 @@ static void disjunct_dup_table_delete(disjunct_dup_table *dt)
 	xfree(dt, sizeof(disjunct_dup_table));
 }
 
+#ifdef DEBUG
+GNUC_UNUSED static int gword_set_len(const gword_set *gl)
+{
+	int len = 0;
+	for (; NULL != gl; gl = gl->next) len++;
+	return len;
+}
+#endif
+
 /**
  * Takes the list of disjuncts pointed to by d, eliminates all
  * duplicates, and returns a pointer to a new list.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -219,6 +219,75 @@ GNUC_UNUSED static int gword_set_len(const gword_set *gl)
 #endif
 
 /**
+ * Return a new gword_set element, initialized from the given element.
+ * @old_e Existing element.
+ */
+static gword_set *gword_set_element_new(gword_set *old_e)
+{
+	gword_set *new_e = malloc(sizeof(gword_set));
+	*new_e = (gword_set){0};
+
+	new_e->o_gword = old_e->o_gword;
+	gword_set *chain_next = old_e->chain_next;
+	old_e->chain_next = new_e;
+	new_e->chain_next = chain_next;
+
+	return new_e;
+}
+
+/**
+ * Add an element to existing gword_set. Uniqueness is assumed.
+ * @return A new set with the element.
+ */
+static gword_set *gword_set_add(gword_set *gset, gword_set *ge)
+{
+	gword_set *n = gword_set_element_new(ge);
+	n->next = gset;
+	gset = n;
+
+	return gset;
+}
+
+/**
+ * Combine the given gword sets.
+ * The gword sets are not modified.
+ * This function is used for adding the gword pointers of an eliminated
+ * disjunct to the ones of the kept disjuncts, with no duplicates.
+ *
+ * @kept gword_set of the kept disjunct.
+ * @eliminated gword_set of the eliminated disjunct.
+ * @return Use copy-on-write semantics - the gword_set of the kept disjunct
+ * just gets returned if there is nothing to add to it. Else - a new gword
+ * set is returned.
+ */
+static gword_set *gword_set_union(gword_set *kept, gword_set *eliminated)
+{
+	/* Preserve the gword pointers of the eliminated disjunct if different. */
+	gword_set *preserved_set = NULL;
+	for (gword_set *e = eliminated; NULL != e; e = e->next)
+	{
+		gword_set *k;
+
+		/* Ensure uniqueness. */
+		for (k = kept; NULL != k; k = k->next)
+			if (e->o_gword == k->o_gword) break;
+		if (NULL != k) continue;
+
+		preserved_set = gword_set_add(preserved_set, e);
+	}
+
+	if (preserved_set)
+	{
+		/* Preserve the originating gword pointers of the remaining disjunct. */
+		for (gword_set *k = kept; NULL != k; k = k->next)
+			preserved_set = gword_set_add(preserved_set, k);
+		kept = preserved_set;
+	}
+
+	return kept;
+}
+
+/**
  * Takes the list of disjuncts pointed to by d, eliminates all
  * duplicates, and returns a pointer to a new list.
  * It frees the disjuncts that are eliminated.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -33,7 +33,6 @@ void free_disjuncts(Disjunct *c)
 		c1 = c->next;
 		free_connectors(c->left);
 		free_connectors(c->right);
-		free(c->word);
 		xfree((char *)c, sizeof(Disjunct));
 	}
 }
@@ -178,9 +177,7 @@ Disjunct *disjuncts_dup(Disjunct *origd)
 		newd->cost = t->cost;
 		newd->left = connectors_dup(t->left);
 		newd->right = connectors_dup(t->right);
-		newd->word = NULL;
-		gwordlist_append_list(&newd->word, t->word);
-
+		newd->originating_gword = t->originating_gword;
 		prevd->next = newd;
 		prevd = newd;
 	}
@@ -319,7 +316,10 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * d)
 		{
 			d->next = NULL;  /* to prevent it from freeing the whole list */
 			if (d->cost < dx->cost) dx->cost = d->cost;
-			gwordlist_append_list(&dx->word, d->word);
+
+			dx->originating_gword =
+				gword_set_union(dx->originating_gword, d->originating_gword);
+
 			free_disjuncts(d);
 			count++;
 		}
@@ -390,9 +390,7 @@ char * print_one_disjunct(Disjunct *dj)
 void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 {
 	for (;d != NULL; d=d->next) {
-		d->word = malloc(sizeof(*d->word)*2);
-		d->word[0] = gw;
-		d->word[1] = NULL;
+		d->originating_gword = (gword_set *)&gw->gword_set_head;
 	}
 }
 /* ========================= END OF FILE ============================== */

--- a/link-grammar/linkage.c
+++ b/link-grammar/linkage.c
@@ -405,8 +405,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 			/* TODO: Suppress "virtual-morphemes", currently the dictcap ones. */
 			char *sm;
 
-			assert(MT_EMPTY != cdj->word[0]->morpheme_type);/* already discarded */
-
 			t = cdj->string;
 			/* Print the subscript, as in "dog.n" as opposed to "dog". */
 

--- a/link-grammar/preparation.c
+++ b/link-grammar/preparation.c
@@ -130,9 +130,9 @@ static void gword_record_in_connector(Sentence sent)
 	for (size_t w = 0; w < sent->length; w++) {
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next) {
 			for (Connector *c = d->right; NULL != c; c = c->next)
-				c->word = d->word;
+				c->originating_gword = d->originating_gword;
 			for (Connector *c = d->left; NULL != c; c = c->next)
-				c->word = d->word;
+				c->originating_gword = d->originating_gword;
 		}
 	}
 }

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -286,6 +286,9 @@ struct Gword_struct
 	Gword **prev;        /* Left-going tree */
 	Gword *chain_next;   /* Next word in the chain of all words */
 
+	/* Disjuncts and connectors point back to their originating Gword(s). */
+	gword_set gword_set_head;
+
 	/* For debug and inspiration. */
 	const char *label;   /* Debug label - code locations of tokenization */
 	size_t node_num;     /* For differentiating words with identical subwords,

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -138,7 +138,7 @@ struct Connector_struct
 	union
 	{
 		Connector * tableNext;
-		const Gword **word;
+		const gword_set *originating_gword;
 	};
 };
 
@@ -166,7 +166,7 @@ struct Disjunct_struct
 #ifdef VERIFY_MATCH_LIST
 	int match_id;              /* verify the match list integrity */
 #endif
-	const Gword **word;        /* NULL terminated list of originating words */
+	gword_set *originating_gword; /* List of originating gwords */
 	const char * string;       /* subscripted dictionary word */
 };
 

--- a/link-grammar/structures.h
+++ b/link-grammar/structures.h
@@ -83,6 +83,33 @@
 #define SHORT_LEN 6
 #define NO_WORD 255
 
+/* An ordered set of gword pointers, used to indicate the source gword
+ * (Wordgraph word) of disjuncts and connectors. Usually it contains only
+ * one element.  However, when a duplicate disjunct is eliminated (see
+ * eliminate_duplicate_disjuncts()) and it originated from a different
+ * gword (a relatively rare event) its gword is added to the gword_set of
+ * the remaining disjunct. A set of 3 elements is extremely rare. The
+ * original order is preserved, in a hope for better caching on
+ * alternatives match checks in fast-match.c.
+ *
+ * Memory management:
+ * A copy-on-write semantics is used when constructing a new gword_set.  It
+ * means that all the gword sets with one element are shared.  These gword
+ * sets are part of the Gword structure. Copied and added element are
+ * alloc'ed and chained. The result is that the chain_next of the gword
+ * sets that are part of each gword contains the list of alloc'ed elements -
+ * to be used in gword_set_delete() called *only* in sentence_delete().
+ * This ensures that the gword_set of connectors doesn't get stale when
+ * their disjuncts are deleted and later restored in one-parse when
+ * min_null_count=0 and max_null count>0 (see classic_parse()).
+ */
+typedef struct gword_set
+{
+	Gword *o_gword;
+	struct gword_set *next;
+	struct gword_set *chain_next;
+} gword_set;
+
 /* On a 64-bit machine, this struct should be exactly 4*8=32 bytes long.
  * Lets try to keep it that way.
  */

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -39,7 +39,7 @@
 
 Gword *gword_new(Sentence sent, const char *s)
 {
-	Gword * const gword = malloc(sizeof(*gword));
+	Gword *gword = malloc(sizeof(*gword));
 
 	memset(gword, 0, sizeof(*gword));
 	assert(NULL != gword, "Null-string subword");
@@ -48,6 +48,9 @@ Gword *gword_new(Sentence sent, const char *s)
 	if (NULL != sent->last_word) sent->last_word->chain_next = gword;
 	sent->last_word = gword;
 	gword->node_num = sent->gword_node_num++;
+
+	gword->gword_set_head = (gword_set){0};
+	gword->gword_set_head.o_gword = gword;
 
 	return gword;
 }

--- a/link-grammar/wordgraph.c
+++ b/link-grammar/wordgraph.c
@@ -241,25 +241,20 @@ GNUC_UNUSED void print_hier_position(const Gword *word)
 }
 
 /* Debug printout of a wordgraph Gword list. */
-GNUC_UNUSED void gwordlist_print(const Gword **wl)
+GNUC_UNUSED void gword_set_print(const gword_set *gs)
 {
 	printf("Gword list: ");
 
-	if (NULL == wl)
+	if (NULL == gs)
 	{
 		printf("(null)\n");
 		return;
 	}
-	if (NULL == *wl)
-	{
-		printf("No elements\n");
-		return;
-	}
 
-	for (; *wl; wl++)
+	for (; NULL != gs; gs = gs->next)
 	{
-		printf("word %p '%s' unsplit '%s'%s", *wl, (*wl)->subword,
-		       (*wl)->unsplit_word->subword, NULL == *(wl+1) ? "" : ", ");
+		printf("word %p '%s' unsplit '%s'%s", gs->o_gword, (gs->o_gword)->subword,
+		       (gs->o_gword)->unsplit_word->subword, NULL==gs->next ? "" : ", ");
 	}
 	printf("\n");
 

--- a/link-grammar/wordgraph.h
+++ b/link-grammar/wordgraph.h
@@ -21,7 +21,7 @@ Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);
 void gwordlist_append(Gword ***, Gword *);
 void gwordlist_append_list(const Gword ***, const Gword **);
-void gwordlist_print(const Gword **);
+void gword_set_print(const gword_set *);
 
 const Gword **wordgraph_hier_position(Gword *);
 void print_hier_position(const Gword *);


### PR DESCRIPTION
This is a better fix than #513, which was just a fast hack to fix the problem.
It includes  a mostly shared "gword_set" instead of the "gword list" in disjuncts (the list of wordgraph words that the disjunct represents - can be more than one word in some cases of duplicate disjunct deletion).
The result of this sharing is a speedup of about 2-3% in en and ru.