### PR TITLE
tests.py: Fix testing linkages from file with Python3

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -857,7 +857,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             diagram = ""
             constituents = ""
             linkage = next(linkages, None)
-            self.assertTrue(linkage, "{}:{}: Sentence has too few linkages".format(testfile, lineno))
+            self.assertTrue(linkage, "at {}:{}: Sentence has too few linkages".format(testfile, lineno))
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -834,6 +834,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
     Reads sentences and their corresponding
     linkage diagrams / constituent printings.
     """
+    self.__class__.longMessage = True
     if '' != desc:
         desc = desc + '-'
     testfile = clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(lgdict._obj) + ".txt"

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -844,6 +844,8 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
     lineno = 0
     for line in parses:
         lineno += 1
+        if sys.version_info > (3, 0):
+            line = line.decode('utf-8')
         # Lines starting with I are the input sentences
         if 'I' == line[0]:
             sent = line[1:]

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -842,12 +842,14 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
     diagram = None
     sent = None
     lineno = 0
+    opcode_detected = 0 # function sanity check
     for line in parses:
         lineno += 1
         if sys.version_info > (3, 0):
             line = line.decode('utf-8')
         # Lines starting with I are the input sentences
         if 'I' == line[0]:
+            opcode_detected += 1
             sent = line[1:]
             diagram = ""
             constituents = ""
@@ -857,6 +859,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
 
         # Generate the next linkage of the last input sentence
         if 'N' == line[0]:
+            opcode_detected += 1
             diagram = ""
             constituents = ""
             linkage = next(linkages, None)
@@ -865,6 +868,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         # Lines starting with O are the parse diagram
         # It ends with an empty line
         if 'O' == line[0]:
+            opcode_detected += 1
             diagram += line[1:]
             if '\n' == line[1] and 1 < len(diagram):
                 self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
@@ -872,10 +876,13 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         # Lines starting with C are the constituent output (type 1)
         # It ends with an empty line
         if 'C' == line[0]:
+            opcode_detected += 1
             if '\n' == line[1] and 1 < len(constituents):
                 self.assertEqual(linkage.constituent_tree(), constituents, "at {}:{}".format(testfile, lineno))
             constituents += line[1:]
     parses.close()
+
+    self.assertGreaterEqual(opcode_detected, 2, "Nothing has been done for " + testfile)
 
 def warning(*msg):
     progname = os.path.basename(sys.argv[0])

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -864,13 +864,13 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         if 'O' == line[0]:
             diagram += line[1:]
             if '\n' == line[1] and 1 < len(diagram):
-                self.assertEqual(linkage.diagram(), diagram)
+                self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
 
         # Lines starting with C are the constituent output (type 1)
         # It ends with an empty line
         if 'C' == line[0]:
             if '\n' == line[1] and 1 < len(constituents):
-                self.assertEqual(linkage.constituent_tree(), constituents)
+                self.assertEqual(linkage.constituent_tree(), constituents, "at {}:{}".format(testfile, lineno))
             constituents += line[1:]
     parses.close()
 

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -852,7 +852,8 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             diagram = ""
             constituents = ""
             linkages = Sentence(sent, lgdict, popt).parse()
-            linkage = linkages.next()
+            linkage = next(linkages, None)
+            self.assertTrue(linkage, "at {}:{}: Sentence has no linkages".format(testfile, lineno))
 
         # Generate the next linkage of the last input sentence
         if 'N' == line[0]:


### PR DESCRIPTION
In Python3 it just doesn't do anything, so its tests never fail...

Also in this PR:
- Validate that testing linkages from file actually does something.
- Include the original unitest failure message when indicating file:line failure position.
- Add file:line failure position for linkage and constituent tests too.
- Preven aborting if there is no linkage for a test sentence