### PR TITLE
libeditline: Restore tty setting on returning to shell

### DIFF
--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -68,6 +68,8 @@ char *lg_readline(const char *mb_prompt)
 		el_source(el, NULL);       /* Source the user's defaults file. */
 		history_w(hist, &ev, H_LOAD, HFILE);
 
+		el_set(el, EL_SIGNAL, 1); /* Restore tty setting on returning to shell */
+
 		/* By default, it comes up in vi mode, with the editor not in
 		 * insert mode; and even when in insert mode, it drops back to
 		 * command mode at the drop of a hat. Totally confusing/lame. */


### PR DESCRIPTION
Fix issue #522.

Problem description:

When using libeditline, the tty setting is mangled when returning to
the shell due to a signal (SIGTERM, SIGHUP, ..., including ^C and ^Z).
This is normally hidden in Linux, in which the common shells take care
to restore the settings.

However, it still can be seen with (^C after *linkparser>* is the keyboard ^C):

```
$ stty -a>/tmp/a; sh -c 'trap : INT;link-parser'; stty -a>/tmp/b; dwdiff /tmp/a /tmp/b
link-grammar: Info: Dictionary found at ../en/4.0.dict
link-grammar: Info: Dictionary version 5.3.15, locale en_US.UTF-8
link-grammar: Info: Library version link-grammar-5.3.15. Enter "!help" for help.
linkparser> ^C speed 38400 baud; rows 70; columns 187; line = 0;
intr = ^C; quit = ^\; erase = ^?; kill = ^U; eof = [-^D;-] {+<undef>;+} eol = <undef>;
eol2 = <undef>; swtch = <undef>; start = ^Q; stop = ^S; susp = ^Z;
rprnt = [-^R;-] {+<undef>;+} werase = [-^W;-] {+<undef>;+} lnext = [-^V;-] {+<undef>;+} discard = ^O;
min = 1; time = 0;
-parenb -parodd -cmspar cs8 -hupcl -cstopb cread -clocal -crtscts
-ignbrk -brkint -ignpar -parmrk -inpck -istrip [--inlcr-] {+inlcr+} -igncr icrnl ixon -ixoff
-iuclc -ixany -imaxbel iutf8
opost -olcuc -ocrnl onlcr -onocr -onlret -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
isig [-icanon iexten echo-] {+-icanon -iexten -echo+} echoe [-echok-] {+-echok+} -echonl -noflsh -xcase -tostop -echoprt
echoctl echoke -flusho -extproc
```
Note the output of `dwdiff`:
The tty setup before appears in [...], and after in {...}.

(EDIT: Modified invocation of link-parser.)