### PR TITLE
Account for optional words when islands_ok=true

### DIFF
--- a/link-grammar/count.c
+++ b/link-grammar/count.c
@@ -254,7 +254,14 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 			/* There is no solution without nulls in this case. There is
 			 * a slight efficiency hack to separate this null_count==0
 			 * case out, but not necessary for correctness */
-			t->count = zero;
+			if ((rw-lw-1) == num_optional_words(ctxt, lw, rw))
+			{
+				t->count = hist_one();
+			}
+			else
+			{
+				t->count = zero;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
This is a bug fix.
In b10861b78e0d57ff017babea955be1599fbfe43f I neglected to support the case of `ilands_ok=1`.
This PR supports it too.
The original comments above the code changes in these both PR's are now not accurate and need changing.

---

BTW, I encountered  a problem in this idea of eliminating the empty word (may happen in certain cases when parsing with null_count>0), for which I will open an issue soon so we will be able to discuss it.

