### PR TITLE
Add tarball and GitHub installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Link Grammar Parser
---------------
+===================
 ***Version 5.3.15***
 
 The Link Grammar Parser implements the Sleator/Temperley/Lafferty

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ The system is distributed using the normal tar.gz format; it can be
 extracted using the `tar -zxf link-grammar.tar.gz` command at the
 command line.
 
+A tarball of the latest version can be downloaded from:<br>
+http://www.abisource.com/downloads/link-grammar
+
 The files have been digitally signed to make sure that there was no
 corruption of the dataset during download, and to help ensure that
 no malicious changes were made to the code internals by third
@@ -315,6 +318,60 @@ systems, FreeBSD, MacOSX, as well as on many Microsoft Windows
 systems, under various different Windows development environments.
 Specific OS-dependent notes follow.
 
+BUILDING from the [GitHub repository](https://github.com/opencog/link-grammar)
+------------------------------------------------------------------------------
+
+End users should download the tarball (see
+[UNPACKING and signature verification](#unpacking-and-signature-verification)).
+
+The current GitHub version is intended for developers (including anyone who
+is willing to provide a fix, a new feauture or an improvment). The tip of
+the master branch is often unstable, and can sometimes have bad code in it
+as it is under developementi. It also needs installing of development tools
+that are not installed by default. Due to these reason the use of the GitHub
+version is discouraged for regular end users.
+
+### Installing from GitHub
+Clone it:
+`git clone https://github.com/opencog/link-grammar.git`<br>
+Or download it as a ZIP:<br>
+`https://github.com/opencog/link-grammar/archive/master.zip`
+
+Tools that may need installation before you can compile the system:
+
+make<br>
+gcc<br>
+gcc-c++ (for the SAT solver)<br>
+autoconf<br>
+autoconf-archive<br>
+swig (for language bindings)<br>
+graphpviz (if you like to ue the word-graph display feature)
+
+The GitHub version doesn't include a `configure` script.
+To generate it, use:
+```
+autogen.sh
+```
+
+If you get errors, make sure you have installed the above-listed
+development packages, and that your system installation is up to date.
+
+For more info about how to proceed, continue at the section
+[CREATING the system](#creating-the-system) and the relevant sections after it.
+
+### Additional notes for developers
+
+To configure **debug** mode, use:
+```
+configure --enable-debug
+```
+It adds some verification debug code and functions that can
+pretty-print several data structures.
+
+A feature that may be useful for debugging is the word-graph
+display.  Use the `configure` option `--enable-wordgraph-display` to enable
+it. For more details on this feature, see
+[Word-graph display](link-grammar/README.md#word-graph-display).
 
 BUILDING on MacOS
 -----------------

--- a/link-grammar/README.md
+++ b/link-grammar/README.md
@@ -103,9 +103,10 @@ severity levels and the `lg_errinfo` structure.
 
 Notes:
 ------
-1.  `lgdebug()` (used internally to issue messages on verbosity levels > 0)
-now usually uses the new severity level `lg_Trace` (but sometimes `lg_Debug`
-or `lg_Info)`.
+1.  `lgdebug()` (used internally to issue debug or informational messages at
+a given verbosity level) now usually uses by default the new severity level
+`lg_Trace` but can instead use other levels (currently it sometimes uses
+`lg_Debug` or `lg_Info)`.
 
 2.  Some messages from the library may still use `printf()`, and the
 intention is to convert them too to use the new error facility.

--- a/link-grammar/README.md
+++ b/link-grammar/README.md
@@ -154,7 +154,7 @@ The tokenizing code is still based much on the old code and further
 work is needed to clean it up (or to replace it, e.g. by a
 regex-tokenizer). It still doesn't use the full power of the word-graph,
 and there are constructs that need to be tokenized but they are not (they
-are also not in the sentence test batches). E.g. -- between words without
+are also not in the sentence test batches). E.g. `--` between words without
 whitespace.
 
 There is still no API to get information from the word-graph. In particular,

--- a/link-grammar/README.md
+++ b/link-grammar/README.md
@@ -196,6 +196,8 @@ the first path which is encountered is used. It means that a word in the
 word-graph path corresponding to a null-word, may be only one of the potential
 possibilities.
 
+Word-graph display
+------------------
 Another feature that has been implemented, mainly for debug (but it can
 also be useful for inspiration and fun), is displaying a graphical
 representation of the word graph. The graphs can be displayed in several
@@ -215,12 +217,16 @@ this feature.
 On Windows this feature is enabled when compiled with `USE_WORDGRAPH_DISPLAY`.
 See "../msvcNN/RDADME" (NN is the MSVC version) for further details.
 
+Quote handling
+--------------
 Quotes now are not discarded, but are considered to be regular dict tokens.
 In this version they have no significant linkage and always attach to the word
 before them (or to the LEFT-WALL). In order to compare detailed batch runs with
 previous versions of the library, a `!test=removeZZZ` can be used to remove the
 quote display.
 
+Handling capitalized words
+--------------------------
 Not as in previous releases, capital letters which got downcased are not
 restored for display if the affected words have a linkage.
 

--- a/link-grammar/README.md
+++ b/link-grammar/README.md
@@ -9,8 +9,9 @@ The corpus directory contains code to read word-sense disambiguation
 data from an SQL file.
 
 The dict-file directory contains code to read dictionaries from files.
-The dict-sql directory contains code to read dictionaries from an SQL DB.
-   (unfinished, under development!)
+
+The dict-sql directory contains code to read dictionaries from an SQL DB
+   (unfinished, under development!).
 
 
 Version 5.3.14 - Improved error notification facility
@@ -26,13 +27,13 @@ auto-issuing of a newline was not documented.
 
 Features:
 ---------
-- Ability to intercept error messages (when required). This allow printing
+- Ability to intercept error messages (when required). This allows printing
 them not only to stdout/stderr, but to any other stream (like logging)
 or place (like a GUI window). This also allows to reformat the message.
 
-- Possibility to print a message in part and still have it printed as one
+- Possibility to print a message in parts and still have it printed as one
  complete message. The API for that is natural - messages are gathered
-until a newline (if a message ends with `\n\` this is an embedded
+until a newline (if a message ends with `\n\\` this is an embedded
 newline). The severity level of the last part, if exists, is used for the
 whole message.
 
@@ -102,9 +103,9 @@ severity levels and the `lg_errinfo` structure.
 
 Notes:
 ------
-1.  `lgdebug(`) (used internally to issue messages on verbosity levels > 0)
+1.  `lgdebug()` (used internally to issue messages on verbosity levels > 0)
 now usually uses the new severity level `lg_Trace` (but sometimes `lg_Debug`
-or `lg_Info`).
+or `lg_Info)`.
 
 2.  Some messages from the library may still use `printf()`, and the
 intention is to convert them too to use the new error facility.


### PR DESCRIPTION
Per issue #520.
The info may not be complete. Especially, the list of needed tools for using the GitHub version is from my memory and is not verified.

This PR also includes separate commits for additional fixes.
The additional main fixes are:
- Typo fixes.
- Adding section headers.
- Change the main README document name title to use `<h1>` instead of `<h2>`.
- Refer to sections by [markdown anchors](https://gist.github.com/asabaylus/3071099)  (both to sections in the same README or in another one). There is a need to convert all the section references to use that.
