### PR TITLE
Fix for bug #528 - missing stdatomic

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Version 5.3.16 (XXX 2017)
  * Fix python3 unit tests.
  * Restore tty state after ctrl-C, ctrl-Z of the app.
+ * Check for <stdatomic.h> before use (in Java bindings).
 
 Version 5.3.15 (12 Feb 2017)
  * Fix Windows compilation; the new wcwidth files were omitted.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Link Grammar Parser
 --------------
-***Version 5.3.15***
+***Version 5.3.16***
 
 The Link Grammar Parser implements the Sleator/Temperley/Lafferty
 theory of natural language parsing. This version of the parser is
@@ -183,7 +183,7 @@ corruption of the dataset during download, and to help ensure that
 no malicious changes were made to the code internals by third
 parties. The signatures can be checked with the gpg command:
 
-`gpg --verify link-grammar-5.3.15.tar.gz.asc`
+`gpg --verify link-grammar-5.3.16.tar.gz.asc`
 
 which should generate output identical to (except for the date):
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([link-grammar],[5.3.15],[link-grammar@googlegroups.com])
+AC_INIT([link-grammar],[5.3.16],[link-grammar@googlegroups.com])
 
 dnl Set release number
 dnl This is derived from "Versioning" chapter of info libtool documentation.
@@ -11,7 +11,7 @@ LINK_MINOR_VERSION=3
 dnl     3) Increment when interfaces not changed at all,
 dnl        only bug fixes or internal changes made.
 dnl     4b) Set to zero when adding, removing or changing interfaces.
-LINK_MICRO_VERSION=15
+LINK_MICRO_VERSION=16
 dnl
 dnl     Set this too
 MAJOR_VERSION_PLUS_MINOR_VERSION=`expr $LINK_MAJOR_VERSION + $LINK_MINOR_VERSION`
@@ -186,6 +186,17 @@ AC_MSG_RESULT(no)
 	AC_MSG_RESULT(no)
 	)
 )
+
+# ====================================================================
+
+dnl For stdatomic.h -- missing in gcc-4.8 (Ubuntu Trusty 14.04)
+dnl Its used in the Jva bindings, to avoid an ugly server-init race.
+AC_MSG_CHECKING(for stdatomic.h)
+AC_CHECK_HEADER([stdatomic.h],
+	[AC_DEFINE([HAVE_STDATOMIC_H], 1, [Define to 1 if stdatomic.h exists])],
+	[],
+	[#include <stdatomic.h>
+	])
 
 # ====================================================================
 # TLS support (for per-thread error handling)


### PR DESCRIPTION
Fix unintentional dependency on stdatomic.h which gcc-4.8 (Ubuntu Trusty 14.04) does not have.

Primary users are all on trusty, so this is kind-of a big deal. Hope to release a new version as result.