### PR TITLE
Restore dict-structures.h to what it used to be

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -131,6 +131,7 @@ liblink_grammar_la_SOURCES =        \
 	api-structures.h                 \
 	api-types.h                      \
 	connectors.h                     \
+	dict-common/dict-affix.h         \
 	dict-common/dict-api.h           \
 	dict-common/dict-common.h        \
 	dict-common/dict-defines.h       \

--- a/link-grammar/dict-common/dict-affix.h
+++ b/link-grammar/dict-common/dict-affix.h
@@ -12,7 +12,7 @@
 #ifndef _LG_DICT_AFFIX_H_
 #define  _LG_DICT_AFFIX_H_
 
-#include "dict-structures.h"
+#include "dict-common.h"
 
 /* The functions here are intended for use by the tokenizer, only,
  * and pretty much no one else. If you are not the tokenizer, you

--- a/link-grammar/dict-common/dict-affix.h
+++ b/link-grammar/dict-common/dict-affix.h
@@ -1,0 +1,86 @@
+/*************************************************************************/
+/* Copyright (c) 2014 Amir Plivatsky                                     */
+/* All rights reserved                                                   */
+/*                                                                       */
+/* Use of the link grammar parsing system is subject to the terms of the */
+/* license set forth in the LICENSE file included with this software.    */
+/* This license allows free redistribution and use in source and binary  */
+/* forms, with or without modification, subject to certain conditions.   */
+/*                                                                       */
+/*************************************************************************/
+
+#ifndef _LG_DICT_AFFIX_H_
+#define  _LG_DICT_AFFIX_H_
+
+#include "dict-structures.h"
+
+/* The functions here are intended for use by the tokenizer, only,
+ * and pretty much no one else. If you are not the tokenizer, you
+ * probably don't need these. */
+
+/* Connector names for the affix class lists in the affix file */
+
+typedef enum {
+	AFDICT_RPUNC=1,
+	AFDICT_LPUNC,
+	AFDICT_UNITS,
+	AFDICT_SUF,
+	AFDICT_PRE,
+	AFDICT_MPRE,
+	AFDICT_QUOTES,
+	AFDICT_BULLETS,
+	AFDICT_INFIXMARK,
+	AFDICT_STEMSUBSCR,
+	AFDICT_SANEMORPHISM,
+
+	/* The below are used only for random morphology via regex */
+	AFDICT_REGPRE,
+	AFDICT_REGMID,
+	AFDICT_REGSUF,
+	AFDICT_REGALTS,
+	AFDICT_REGPARTS,
+
+	/* Have to have one last entry, to get the array size corrrect */
+	AFDICT_LAST_ENTRY,
+	AFDICT_NUM_ENTRIES
+} afdict_classnum;
+
+#define AFDICT_CLASSNAMES1 \
+	"invalid classname", \
+	"RPUNC", \
+	"LPUNC", \
+	"UNITS", \
+	"SUF",         /* SUF is used in the Russian dict */ \
+	"PRE",         /* PRE is not used anywhere, yet... */ \
+	"MPRE",        /* Multi-prefix, currently for Hebrew */ \
+	"QUOTES", \
+	"BULLETS", \
+	"INFIXMARK",   /* Prepended to suffixes, appended to pefixes */ \
+	"STEMSUBSCR",  /* Subscripts for stems */ \
+	"SANEMORPHISM", /* Regex for sane_morphism() */
+
+/* The regexes below are used only for random morphology generation */
+#define AFDICT_CLASSNAMES2 \
+	"REGPRE",      /* Regex for prefix */ \
+	"REGMID",      /* Regex for middle parts */ \
+	"REGSUF",      /* Regex for suffix */ \
+	"REGALTS",     /* Min&max number of alternatives to issue for a word */\
+	"REGPARTS",    /* Max number of word partitions */
+
+#define AFDICT_CLASSNAMES AFDICT_CLASSNAMES1 AFDICT_CLASSNAMES2 "last classname"
+#define AFCLASS(afdict, class) (&afdict->afdict_class[class])
+
+/* Suffixes start with it.
+ * This is needed to distinguish suffixes that were stripped off from
+ * ordinary words that just happen to be the same as the suffix.
+ * Kind-of a weird hack, but I'm not sure what else to do...
+ * Similarly, prefixes end with it.
+ */
+#define INFIX_MARK(afdict) \
+	((NULL == afdict) ? '\0' : (AFCLASS(afdict, AFDICT_INFIXMARK)->string[0][0]))
+
+
+Afdict_class * afdict_find(Dictionary, const char *, bool);
+bool is_stem(const char *);
+
+#endif /* _LG_DICT_AFFIX_H_ */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -12,6 +12,7 @@
 /*************************************************************************/
 
 #include "connectors.h"  // for connector_set_delete
+#include "dict-affix.h"
 #include "dict-api.h"
 #include "dict-common.h"
 #include "dict-defines.h"
@@ -36,27 +37,6 @@
 /* Affix type finding */
 
 /**
- * Return TRUE if the word is a suffix.
- *
- * Suffixes have the form =asdf.asdf or possibly just =asdf without
- * the dot (subscript mark). The "null" suffixes have the form
- * =.asdf (always with the subscript mark, as there are several).
- * Ordinary equals signs appearing in regular text are either = or =[!].
- */
-bool is_suffix(const char infix_mark, const char* w)
-{
-	if (infix_mark != w[0]) return false;
-	if (1 >= strlen(w)) return false;
-	if (0 == strncmp("[!", w+1, 2)) return false;
-#if SUBSCRIPT_MARK == '.'
-	/* Hmmm ... equals signs look like suffixes, but they are not ... */
-	if (0 == strcmp("=.v", w)) return false;
-	if (0 == strcmp("=.eq", w)) return false;
-#endif
-	return true;
-}
-
-/**
  * Return TRUE if the word seems to be in stem form.
  * Stems are signified by including = sign which is preceded by the subscript
  * mark.  Examples (. represented the subscript mark): word.= word.=[!]
@@ -69,28 +49,6 @@ bool is_stem(const char* w)
 	if (subscrmark == w) return false;
 	if (STEM_MARK != subscrmark[1]) return false;
 	return true;
-}
-
-/* ======================================================================== */
-/* Replace the right-most dot with SUBSCRIPT_MARK */
-void patch_subscript(char * s)
-{
-	char *ds, *de;
-	int dp;
-	ds = strrchr(s, SUBSCRIPT_DOT);
-	if (!ds) return;
-
-	/* a dot at the end or a dot followed by a number is NOT
-	 * considered a subscript */
-	de = ds + 1;
-	if (*de == '\0') return;
-	dp = (int) *de;
-
-	/* If its followed by a UTF8 char, its NOT a subscript */
-	if (127 < dp || dp < 0) return;
-	/* assert ((0 < dp) && (dp <= 127), "Bad dictionary entry!"); */
-	if (isdigit(dp)) return;
-	*ds = SUBSCRIPT_MARK;
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -14,8 +14,117 @@
 #ifndef _LG_DICT_COMMON_H_
 #define  _LG_DICT_COMMON_H_
 
+#include "api-types.h" // for pp_knowledge
 #include "dict-structures.h"
+#include "utilities.h" // for locale_t
 
+#define EMPTY_CONNECTOR "ZZZ"
+#define UNLIMITED_CONNECTORS_WORD ("UNLIMITED-CONNECTORS")
+
+/* Forward decls */
+typedef struct Afdict_class_struct Afdict_class;
+typedef struct Exp_list_s Exp_list;
+typedef struct Regex_node_s Regex_node;
+
+/* Used for memory management */
+struct Exp_list_s
+{
+	Exp * exp_list;
+};
+
+typedef struct X_node_struct X_node;
+struct X_node_struct
+{
+	const char * string;       /* the word itself */
+	Exp * exp;
+	X_node *next;
+	const Gword *word;         /* originating Wordgraph word */
+};
+
+/* The regexes are stored as a linked list of the following nodes. */
+struct Regex_node_s
+{
+	char *name;      /* The identifying name of the regex */
+	char *pattern;   /* The regular expression pattern */
+	bool neg;        /* Negate the match */
+	void *re;        /* The compiled regex. void * to avoid
+	                    having re library details invading the
+	                    rest of the LG system; regex-morph.c
+	                    takes care of all matching.
+	                  */
+	Regex_node *next;
+};
+
+struct Afdict_class_struct
+{
+	size_t mem_elems;     /* number of memory elements allocated */
+	size_t length;        /* number of strings */
+	char const ** string;
+};
+
+#define MAX_TOKEN_LENGTH 250     /* Maximum number of chars in a token */
+
+struct Dictionary_s
+{
+	Dict_node *  root;
+	Regex_node * regex_root;
+	const char * name;
+	const char * lang;
+	const char * version;
+	const char * locale;    /* Locale name */
+	locale_t     lctype;    /* Locale argument for the *_l() functions */
+	int          num_entries;
+
+	bool         use_unknown_word;
+	bool         unknown_word_defined;
+	bool         left_wall_defined;
+	bool         right_wall_defined;
+	bool         shuffle_linkages;
+
+	/* Affixes are used during the tokenization stage. */
+	Dictionary      affix_table;
+	Afdict_class *  afdict_class;
+
+	/* Random morphology generator */
+	struct anysplit_params * anysplit;
+
+	/* If not null, then use spelling guesser for unknown words */
+	void *          spell_checker;     /* spell checker handle */
+#if USE_CORPUS
+	Corpus *        corpus;            /* Statistics database */
+#endif
+#ifdef HAVE_SQLITE
+	void *          db_handle;         /* database handle */
+#endif
+
+	void (*insert_entry)(Dictionary, Dict_node *, int);
+	Dict_node* (*lookup_list)(Dictionary, const char*);
+	void (*free_lookup)(Dictionary, Dict_node*);
+	bool (*lookup)(Dictionary, const char*);
+	void (*close)(Dictionary);
+
+	pp_knowledge  * base_knowledge;    /* Core post-processing rules */
+	pp_knowledge  * hpsg_knowledge;    /* Head-Phrase Structure rules */
+	Connector_set * unlimited_connector_set; /* NULL=everything is unlimited */
+	String_set *    string_set;        /* Set of link names in the dictionary */
+	Word_file *     word_file_header;
+
+	/* exp_list links together all the Exp structs that are allocated
+	 * in reading this dictionary.  Needed for freeing the dictionary
+	 */
+	Exp_list        exp_list;
+
+	/* Private data elements that come in play only while the
+	 * dictionary is being read, and are not otherwise used.
+	 */
+	const char    * input;
+	const char    * pin;
+	bool            recursive_error;
+	bool            is_special;
+	char            already_got_it;
+	int             line_number;
+	char            token[MAX_TOKEN_LENGTH];
+};
 /* The functions here are intended for use by the tokenizer, only,
  * and pretty much no one else. If you are not the tokenizer, you
  * probably dont need these. */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -16,80 +16,14 @@
 
 #include "dict-structures.h"
 
-/* The functions here are for link-grammar internal use only.
- * They are not part of the public API. */
+/* The functions here are intended for use by the tokenizer, only,
+ * and pretty much no one else. If you are not the tokenizer, you
+ * probably dont need these. */
 
 bool find_word_in_dict(Dictionary dict, const char *);
-Afdict_class * afdict_find(Dictionary, const char *, bool);
 
 Exp * Exp_create(Exp_list *);
 void add_empty_word(Dictionary const, X_node *);
 void free_Exp_list(Exp_list *);
-
-void patch_subscript(char *);
-
-bool is_suffix(const char, const char *);
-bool is_stem(const char *);
-
-/* Connector names for the affix class lists in the affix file */
-
-typedef enum {
-	AFDICT_RPUNC=1,
-	AFDICT_LPUNC,
-	AFDICT_UNITS,
-	AFDICT_SUF,
-	AFDICT_PRE,
-	AFDICT_MPRE,
-	AFDICT_QUOTES,
-	AFDICT_BULLETS,
-	AFDICT_INFIXMARK,
-	AFDICT_STEMSUBSCR,
-	AFDICT_SANEMORPHISM,
-
-	/* The below are used only for random morphology via regex */
-	AFDICT_REGPRE,
-	AFDICT_REGMID,
-	AFDICT_REGSUF,
-	AFDICT_REGALTS,
-	AFDICT_REGPARTS,
-
-	/* Have to have one last entry, to get the array size corrrect */
-	AFDICT_LAST_ENTRY,
-	AFDICT_NUM_ENTRIES
-} afdict_classnum;
-
-#define AFDICT_CLASSNAMES1 \
-	"invalid classname", \
-	"RPUNC", \
-	"LPUNC", \
-	"UNITS", \
-	"SUF",         /* SUF is used in the Russian dict */ \
-	"PRE",         /* PRE is not used anywhere, yet... */ \
-	"MPRE",        /* Multi-prefix, currently for Hebrew */ \
-	"QUOTES", \
-	"BULLETS", \
-	"INFIXMARK",   /* Prepended to suffixes, appended to pefixes */ \
-	"STEMSUBSCR",  /* Subscripts for stems */ \
-	"SANEMORPHISM", /* Regex for sane_morphism() */
-
-/* The regexes below are used only for random morphology generation */
-#define AFDICT_CLASSNAMES2 \
-	"REGPRE",      /* Regex for prefix */ \
-	"REGMID",      /* Regex for middle parts */ \
-	"REGSUF",      /* Regex for suffix */ \
-	"REGALTS",     /* Min&max number of alternatives to issue for a word */\
-	"REGPARTS",    /* Max number of word partitions */
-
-#define AFDICT_CLASSNAMES AFDICT_CLASSNAMES1 AFDICT_CLASSNAMES2 "last classname"
-#define AFCLASS(afdict, class) (&afdict->afdict_class[class])
-
-/* Suffixes start with it.
- * This is needed to distinguish suffixes that were stripped off from
- * ordinary words that just happen to be the same as the suffix.
- * Kind-of a weird hack, but I'm not sure what else to do...
- * Similarly, prefixes end with it.
- */
-#define INFIX_MARK(afdict) \
-	((NULL == afdict) ? '\0' : (AFCLASS(afdict, AFDICT_INFIXMARK)->string[0][0]))
 
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -15,6 +15,7 @@
 
 #include "api-types.h"
 #include "connectors.h"
+#include "dict-affix.h"
 #include "dict-api.h"
 #include "dict-common.h"
 #include "dict-defines.h"

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -17,20 +17,12 @@
 #include <link-grammar/link-features.h>
 #include <link-grammar/link-includes.h>
 
-#include "api-types.h" // for pp_knowledge
-#include "utilities.h" // for locale_t
-
-#define EMPTY_CONNECTOR "ZZZ"
-#define UNLIMITED_CONNECTORS_WORD ("UNLIMITED-CONNECTORS")
-
 LINK_BEGIN_DECLS
 
 /* Forward decls */
-typedef struct Afdict_class_struct Afdict_class;
 typedef struct Dict_node_struct Dict_node;
-typedef struct Exp_list_s Exp_list;
+typedef struct Exp_struct Exp;
 typedef struct E_list_struct E_list;
-typedef struct Regex_node_s Regex_node;
 typedef struct Word_file_struct Word_file;
 
 /** 
@@ -69,35 +61,6 @@ struct E_list_struct
     Exp * e;
 };
 
-/* Used for memory management */
-struct Exp_list_s
-{
-	Exp * exp_list;
-};
-
-typedef struct X_node_struct X_node;
-struct X_node_struct
-{
-	const char * string;       /* the word itself */
-	Exp * exp;
-	X_node *next;
-	const Gword *word;         /* originating Wordgraph word */
-};
-
-/* The regexes are stored as a linked list of the following nodes. */
-struct Regex_node_s
-{
-	char *name;      /* The identifying name of the regex */
-	char *pattern;   /* The regular expression pattern */
-	bool neg;        /* Negate the match */
-	void *re;        /* The compiled regex. void * to avoid
-	                    having re library details invading the
-	                    rest of the LG system; regex-morph.c
-	                    takes care of all matching.
-	                  */
-	Regex_node *next;
-};
-
 /** 
  * The dictionary is stored as a binary tree comprised of the following
  * nodes.  A list of these (via right pointers) is used to return
@@ -109,78 +72,6 @@ struct Dict_node_struct
     Word_file * file;     /* The file the word came from (NULL if dict file) */
     Exp       * exp;
     Dict_node *left, *right;
-};
-
-
-struct Afdict_class_struct
-{
-	size_t mem_elems;     /* number of memory elements allocated */
-	size_t length;        /* number of strings */
-	char const ** string;
-};
-
-#define MAX_TOKEN_LENGTH 250     /* Maximum number of chars in a token */
-
-struct Dictionary_s
-{
-	Dict_node *  root;
-	Regex_node * regex_root;
-	const char * name;
-	const char * lang;
-	const char * version;
-	const char * locale;    /* Locale name */
-	locale_t     lctype;    /* Locale argument for the *_l() functions */
-	int          num_entries;
-
-	bool         use_unknown_word;
-	bool         unknown_word_defined;
-	bool         left_wall_defined;
-	bool         right_wall_defined;
-	bool         shuffle_linkages;
-
-	/* Affixes are used during the tokenization stage. */
-	Dictionary      affix_table;
-	Afdict_class *  afdict_class;
-
-	/* Random morphology generator */
-	struct anysplit_params * anysplit;
-
-	/* If not null, then use spelling guesser for unknown words */
-	void *          spell_checker;     /* spell checker handle */
-#if USE_CORPUS
-	Corpus *        corpus;            /* Statistics database */
-#endif
-#ifdef HAVE_SQLITE
-	void *          db_handle;         /* database handle */
-#endif
-
-	void (*insert_entry)(Dictionary, Dict_node *, int);
-	Dict_node* (*lookup_list)(Dictionary, const char*);
-	void (*free_lookup)(Dictionary, Dict_node*);
-	bool (*lookup)(Dictionary, const char*);
-	void (*close)(Dictionary);
-
-	pp_knowledge  * base_knowledge;    /* Core post-processing rules */
-	pp_knowledge  * hpsg_knowledge;    /* Head-Phrase Structure rules */
-	Connector_set * unlimited_connector_set; /* NULL=everything is unlimited */
-	String_set *    string_set;        /* Set of link names in the dictionary */
-	Word_file *     word_file_header;
-
-	/* exp_list links together all the Exp structs that are allocated
-	 * in reading this dictionary.  Needed for freeing the dictionary
-	 */
-	Exp_list        exp_list;
-
-	/* Private data elements that come in play only while the
-	 * dictionary is being read, and are not otherwise used.
-	 */
-	const char    * input;
-	const char    * pin;
-	bool            recursive_error;
-	bool            is_special;
-	char            already_got_it;
-	int             line_number;
-	char            token[MAX_TOKEN_LENGTH];
 };
 
 LINK_END_DECLS

--- a/link-grammar/dict-common/dict-utils.h
+++ b/link-grammar/dict-common/dict-utils.h
@@ -14,7 +14,7 @@
 #ifndef _DICT_UTILS_H_
 #define _DICT_UTILS_H_
 
-#include "dict-structures.h"
+#include "dict-common.h"
 
 /* Exp utilities ... */
 void free_Exp(Exp *);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 
+#include "api-structures.h" // for Parse_Options_s  (seems hacky to me)
 #include "dict-common.h"
 #include "dict-defines.h"
 #include "print/print.h"

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -18,6 +18,7 @@
 #include "error.h"          /* verbosity */
 #include "externs.h"        /* lgdebug() */
 #include "dict-api.h"
+#include "dict-common.h"
 #include "link-includes.h"
 #include "regex-morph.h"
 

--- a/link-grammar/dict-common/regex-morph.h
+++ b/link-grammar/dict-common/regex-morph.h
@@ -12,7 +12,7 @@
 #ifndef _REGEX_MORPH_H
 #define _REGEX_MORPH_H
 
-#include "api-structures.h"
+#include "dict-common.h"
 
 int compile_regexs(Regex_node *, Dictionary);
 const char *match_regex(const Regex_node *, const char *);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -12,6 +12,7 @@
 /*************************************************************************/
 
 #include "api-structures.h"
+#include "dict-common/dict-affix.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-defines.h"  // For LEFT_WORD

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 
+#include "dict-common/dict-affix.h"   // For is_stem()
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
 #include "dict-common/file-utils.h"

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include "link-includes.h"
 #include "api-structures.h"
-#include "dict-common/dict-structures.h"
+#include "dict-common/dict-common.h"
 #include "dict-common/file-utils.h"
 #include "read-regex.h"
 

--- a/link-grammar/dict-file/word-file.c
+++ b/link-grammar/dict-file/word-file.c
@@ -18,6 +18,27 @@
 #include "read-dict.h"
 #include "word-file.h"
 
+/** Replace the right-most dot with SUBSCRIPT_MARK */
+void patch_subscript(char * s)
+{
+	char *ds, *de;
+	int dp;
+	ds = strrchr(s, SUBSCRIPT_DOT);
+	if (!ds) return;
+
+	/* a dot at the end or a dot followed by a number is NOT
+	 * considered a subscript */
+	de = ds + 1;
+	if (*de == '\0') return;
+	dp = (int) *de;
+
+	/* If its followed by a UTF8 char, its NOT a subscript */
+	if (127 < dp || dp < 0) return;
+	/* assert ((0 < dp) && (dp <= 127), "Bad dictionary entry!"); */
+	if (isdigit(dp)) return;
+	*ds = SUBSCRIPT_MARK;
+}
+
 /**
  * Reads in one word from the file, allocates space for it,
  * and returns it.

--- a/link-grammar/dict-file/word-file.h
+++ b/link-grammar/dict-file/word-file.h
@@ -25,3 +25,5 @@ void free_Word_file(Word_file * wf);
 
 Dict_node * read_word_file(Dictionary dict, Dict_node * dn, char * filename);
 
+void patch_subscript(char *);
+

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -16,7 +16,7 @@
 
 #include "api-structures.h"
 #include "connectors.h"
-#include "dict-common/dict-common.h"  // for INFIX_MARK from dict.
+#include "dict-common/dict-affix.h"  // for INFIX_MARK from dict.
 #include "dict-common/dict-defines.h" // for SUBSCRIPT_MARK
 #include "dict-common/idiom.h"
 #include "disjunct-utils.h"

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -15,7 +15,7 @@
 
 #include "api-structures.h"
 #include "count.h"
-#include "dict-common/dict-structures.h" // for Dictionary_s
+#include "dict-common/dict-common.h" // for Dictionary_s
 #include "disjunct-utils.h"
 #include "extract-links.h"
 #include "fast-match.h"

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -13,7 +13,7 @@
 #include "api-structures.h"
 #include "prepare/build-disjuncts.h"
 #include "connectors.h"
-#include "dict-common/dict-structures.h" // For Dictionary_s
+#include "dict-common/dict-common.h" // For Dictionary_s
 #include "disjunct-utils.h"
 #include "externs.h"
 #include "preparation.h"

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 #include "api-structures.h"
-#include "dict-common/dict-structures.h" // For Dictionary_s
+#include "dict-common/dict-common.h" // For Dictionary_s
 #include "dict-common/dict-defines.h" // For MAX_WORD
 #include "error.h"
 #include "linkage/linkage.h"

--- a/link-grammar/prepare/expand.c
+++ b/link-grammar/prepare/expand.c
@@ -16,7 +16,7 @@
 
 #include "api-structures.h"
 #include "connectors.h"
-#include "dict-common/dict-structures.h" // for X_node_struct
+#include "dict-common/dict-common.h" // for X_node_struct
 #include "disjunct-utils.h"
 #include "expand.h"
 #include "tokenize/word-structures.h" // For Word_struct

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -7,6 +7,7 @@
 
 extern "C" {
 #include "connectors.h"
+#include "dict-common/dict-common.h"
 };
 
 #include "variables.hpp"

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -29,6 +29,7 @@
 #include <externs.h>
 #include <time.h>
 
+#include "api-structures.h"
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -29,6 +29,7 @@
 #include <externs.h>
 #include <time.h>
 
+#include "dict-common/dict-affix.h"
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
 #include "dict-common/regex-morph.h"

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -18,6 +18,7 @@
 #include <limits.h>
 
 #include "anysplit.h"
+#include "api-structures.h"
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -18,6 +18,7 @@
 #include <limits.h>
 
 #include "anysplit.h"
+#include "dict-common/dict-affix.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-defines.h" // for MAX_WORD

--- a/link-grammar/tokenize/word-structures.h
+++ b/link-grammar/tokenize/word-structures.h
@@ -11,13 +11,12 @@
 /*                                                                       */
 /*************************************************************************/
 
-#ifndef _STRUCTURES_H_
-#define _STRUCTURES_H_
+#ifndef _WORD_STRUCTURE_H_
+#define _WORD_STRUCTURE_H_
 
 #include "api-types.h"
 
 typedef struct X_node_struct X_node;
-
 /**
  * Word, as represented shortly after tokenization, but before parsing.
  *


### PR DESCRIPTION
It's part of the public API, and so should not be messed with.