### PR TITLE
Updates for Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_LANG([C])
 
 AC_C_CONST
 
-AC_CHECK_FUNCS(strndup)
+AC_CHECK_FUNCS(strndup strtok_r)
 
 AC_FUNC_ALLOCA
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -129,7 +129,7 @@ struct Dictionary_s
  * and pretty much no one else. If you are not the tokenizer, you
  * probably dont need these. */
 
-bool find_word_in_dict(Dictionary dict, const char *);
+bool find_word_in_dict(const Dictionary dict, const char *);
 
 Exp * Exp_create(Exp_list *);
 void add_empty_word(Dictionary const, X_node *);

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -574,7 +574,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	match_cache mc;
 	gword_cache gc;
 
-	gc.same_alternative = NULL;
+	gc.same_alternative = false;
 
 #ifdef VERIFY_MATCH_LIST
 	static int id = 0;

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -22,6 +22,7 @@
 #include "post-process/post-process.h"
 #include "post-process/pp-structures.h"
 #include "string-set.h"
+#include "utilities.h"
 
 #define D_CONST 8 /* debug level for this file */
 

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -103,6 +103,31 @@ strndup (const char *str, size_t size)
 }
 #endif /* !HAVE_STRNDUP */
 
+#ifndef HAVE_STRTOK_R
+/*
+ * public domain strtok_r() by Charlie Gordon
+ * from comp.lang.c  9/14/2007
+ *     http://groups.google.com/group/comp.lang.c/msg/2ab1ecbb86646684
+ *
+ *     Declaration that it's public domain:
+ *     http://groups.google.com/group/comp.lang.c/msg/7c7b39328fefab9c
+ */
+char* strtok_r(char *str, const char *delim, char **nextp)
+{
+	char *ret;
+
+	if (str == NULL) str = *nextp;
+	str += strspn(str, delim);
+	if (*str == '\0') return NULL;
+	ret = str;
+	str += strcspn(str, delim);
+	if (*str) *str++ = '\0';
+	*nextp = str;
+
+	return ret;
+}
+#endif /* !HAVE_STRTOK_R */
+
 /* ============================================================= */
 /* UTF8 utilities */
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -443,9 +443,9 @@ char *safe_strdup(const char *u);
 /* Simple, cheap, easy dynamic string. */
 typedef struct
 {
-  char *str;
-  size_t end;
-  size_t len;
+	char *str;
+	size_t end;
+	size_t len;
 } dyn_str;
 
 dyn_str* dyn_str_new(void);
@@ -483,9 +483,9 @@ bool try_locale(const char *);
  */
 static inline unsigned int next_power_of_two_up(unsigned int i)
 {
-   unsigned int j=1;
-   while (j<i) j <<= 1;
-   return j;
+	unsigned int j=1;
+	while (j<i) j <<= 1;
+	return j;
 }
 
 #endif /* _LINK_GRAMMAR_UTILITIES_H_ */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -112,8 +112,10 @@ void *alloca (size_t);
 /* Note that "#define _CRT_RAND_S" is needed before "#include <stdlib.h>" */
 #define rand_r(seedp) rand_s(seedp)
 
-#ifndef _WIN32 // windows xp problem : no strtok_s in msvcrt
+/* No strtok_s in these versions and their strtok_r is incompatible. */
+#if _WINVER != 0x501 /* XP */ && _WINVER != 0x502 /* Server 2003 */
 #define strtok_r strtok_s
+#define HAVE_STRTOK_R
 #endif
 
 /* Native windows has locale_t, and hence HAVE_LOCALE_T is defined here.

--- a/msvc14/LinkGrammar.vcxproj
+++ b/msvc14/LinkGrammar.vcxproj
@@ -42,8 +42,6 @@
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="Local.props" />
     <Import Project="LGlib-features.props" />
@@ -68,28 +66,35 @@
     <Import Project="MSVC-common.props" />
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Label="ExtensionSettings" Condition="'$(WINFLEXBISON)'!=''">
+    <Import Project="$(WINFLEXBISON)\custom_build_rules\win_flex_only\win_flex_custom_build.props" />
+  </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>link-grammar-x86</TargetName>
     <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <ExecutablePath>$(WINFLEXBISON);$(VC_ExecutablePath_x86);$(WindowsSDK_ExecutablePath);$(VS_ExecutablePath);$(MSBuild_ExecutablePath);$(SystemRoot)\SysWow64;$(FxCopDir);$(PATH);</ExecutablePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetName>link-grammar-x64</TargetName>
     <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
+    <ExecutablePath>$(WINFLEXBISON);$(VC_ExecutablePath_x64);$(WindowsSDK_ExecutablePath);$(VS_ExecutablePath);$(MSBuild_ExecutablePath);$(FxCopDir);$(PATH);</ExecutablePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetName>link-grammar-x86</TargetName>
     <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <ExecutablePath>$(WINFLEXBISON);$(VC_ExecutablePath_x86);$(WindowsSDK_ExecutablePath);$(VS_ExecutablePath);$(MSBuild_ExecutablePath);$(SystemRoot)\SysWow64;$(FxCopDir);$(PATH);</ExecutablePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>link-grammar-x64</TargetName>
     <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
+    <ExecutablePath>$(WINFLEXBISON);$(VC_ExecutablePath_x64);$(WindowsSDK_ExecutablePath);$(VS_ExecutablePath);$(MSBuild_ExecutablePath);$(FxCopDir);$(PATH);</ExecutablePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -120,6 +125,9 @@
       <Inputs>
       </Inputs>
     </CustomBuildStep>
+    <Flex>
+      <OutputFile>%(Filename).c</OutputFile>
+    </Flex>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -151,6 +159,9 @@
       <Inputs>
       </Inputs>
     </CustomBuildStep>
+    <Flex>
+      <OutputFile>%(Filename).c</OutputFile>
+    </Flex>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -182,6 +193,9 @@
       <Inputs>
       </Inputs>
     </CustomBuildStep>
+    <Flex>
+      <OutputFile>%(Filename).c</OutputFile>
+    </Flex>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -213,93 +227,117 @@
       <Inputs>
       </Inputs>
     </CustomBuildStep>
+    <Flex>
+      <OutputFile>%(Filename).c</OutputFile>
+    </Flex>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\link-grammar\analyze-linkage.h" />
-    <ClInclude Include="..\link-grammar\anysplit.h" />
     <ClInclude Include="..\link-grammar\api-structures.h" />
     <ClInclude Include="..\link-grammar\api-types.h" />
     <ClInclude Include="..\link-grammar\build-disjuncts.h" />
-    <ClInclude Include="..\link-grammar\count.h" />
-    <ClInclude Include="..\link-grammar\dict-api.h" />
-    <ClInclude Include="..\link-grammar\dict-common.h" />
+    <ClInclude Include="..\link-grammar\connectors.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-affix.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-api.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-common.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-defines.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-impl.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-structures.h" />
+    <ClInclude Include="..\link-grammar\dict-common\dict-utils.h" />
+    <ClInclude Include="..\link-grammar\dict-common\file-utils.h" />
+    <ClInclude Include="..\link-grammar\dict-common\idiom.h" />
+    <ClInclude Include="..\link-grammar\dict-common\regex-morph.h" />
     <ClInclude Include="..\link-grammar\dict-file\read-dict.h" />
     <ClInclude Include="..\link-grammar\dict-file\read-regex.h" />
     <ClInclude Include="..\link-grammar\dict-file\word-file.h" />
-    <ClInclude Include="..\link-grammar\dict-structures.h" />
     <ClInclude Include="..\link-grammar\disjunct-utils.h" />
     <ClInclude Include="..\link-grammar\disjuncts.h" />
     <ClInclude Include="..\link-grammar\error.h" />
     <ClInclude Include="..\link-grammar\expand.h" />
     <ClInclude Include="..\link-grammar\externs.h" />
-    <ClInclude Include="..\link-grammar\extract-links.h" />
-    <ClInclude Include="..\link-grammar\fast-match.h" />
     <ClInclude Include="..\link-grammar\idiom.h" />
     <ClInclude Include="..\link-grammar\lg_assert.h" />
     <ClInclude Include="..\link-grammar\link-features.h" />
     <ClInclude Include="..\link-grammar\link-includes.h" />
-    <ClInclude Include="..\link-grammar\linkage.h" />
-    <ClInclude Include="..\link-grammar\post-process.h" />
-    <ClInclude Include="..\link-grammar\pp_knowledge.h" />
-    <ClInclude Include="..\link-grammar\pp_lexer.h" />
-    <ClInclude Include="..\link-grammar\pp_linkset.h" />
-    <ClInclude Include="..\link-grammar\preparation.h" />
-    <ClInclude Include="..\link-grammar\print-util.h" />
-    <ClInclude Include="..\link-grammar\print.h" />
-    <ClInclude Include="..\link-grammar\prune.h" />
-    <ClInclude Include="..\link-grammar\regex-morph.h" />
-    <ClInclude Include="..\link-grammar\regex-tokenizer.h" />
+    <ClInclude Include="..\link-grammar\linkage\analyze-linkage.h" />
+    <ClInclude Include="..\link-grammar\linkage\linkage.h" />
+    <ClInclude Include="..\link-grammar\linkage\lisjuncts.h" />
+    <ClInclude Include="..\link-grammar\linkage\sane.h" />
+    <ClInclude Include="..\link-grammar\linkage\score.h" />
+    <ClInclude Include="..\link-grammar\parse\count.h" />
+    <ClInclude Include="..\link-grammar\parse\extract-links.h" />
+    <ClInclude Include="..\link-grammar\parse\fast-match.h" />
+    <ClInclude Include="..\link-grammar\parse\histogram.h" />
+    <ClInclude Include="..\link-grammar\parse\parse.h" />
+    <ClInclude Include="..\link-grammar\parse\preparation.h" />
+    <ClInclude Include="..\link-grammar\parse\prune.h" />
+    <ClInclude Include="..\link-grammar\post-process\post-process.h" />
+    <ClInclude Include="..\link-grammar\post-process\pp_knowledge.h" />
+    <ClInclude Include="..\link-grammar\post-process\pp_lexer.h" />
+    <ClInclude Include="..\link-grammar\post-process\pp_linkset.h" />
+    <ClInclude Include="..\link-grammar\print\print-util.h" />
+    <ClInclude Include="..\link-grammar\print\print.h" />
     <ClInclude Include="..\link-grammar\resources.h" />
-    <ClInclude Include="..\link-grammar\score.h" />
-    <ClInclude Include="..\link-grammar\spellcheck.h" />
     <ClInclude Include="..\link-grammar\string-set.h" />
     <ClInclude Include="..\link-grammar\structures.h" />
-    <ClInclude Include="..\link-grammar\tokenize.h" />
+    <ClInclude Include="..\link-grammar\tokenize\anysplit.h" />
+    <ClInclude Include="..\link-grammar\tokenize\regex-tokenizer.h" />
+    <ClInclude Include="..\link-grammar\tokenize\spellcheck.h" />
+    <ClInclude Include="..\link-grammar\tokenize\tok-structures.h" />
+    <ClInclude Include="..\link-grammar\tokenize\tokenize.h" />
+    <ClInclude Include="..\link-grammar\tokenize\wordgraph.h" />
     <ClInclude Include="..\link-grammar\utilities.h" />
     <ClInclude Include="..\link-grammar\wcwidth.h" />
     <ClInclude Include="..\link-grammar\word-utils.h" />
-    <ClInclude Include="..\link-grammar\wordgraph.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\link-grammar\analyze-linkage.c" />
-    <ClCompile Include="..\link-grammar\anysplit.c" />
     <ClCompile Include="..\link-grammar\api.c" />
-    <ClCompile Include="..\link-grammar\build-disjuncts.c" />
-    <ClCompile Include="..\link-grammar\constituents.c" />
-    <ClCompile Include="..\link-grammar\count.c" />
-    <ClCompile Include="..\link-grammar\dict-common.c" />
+    <ClCompile Include="..\link-grammar\connectors.c" />
+    <ClCompile Include="..\link-grammar\dict-common\dict-common.c" />
+    <ClCompile Include="..\link-grammar\dict-common\dict-impl.c" />
+    <ClCompile Include="..\link-grammar\dict-common\dict-utils.c" />
+    <ClCompile Include="..\link-grammar\dict-common\file-utils.c" />
+    <ClCompile Include="..\link-grammar\dict-common\idiom.c" />
+    <ClCompile Include="..\link-grammar\dict-common\print-dict.c" />
+    <ClCompile Include="..\link-grammar\dict-common\regex-morph.c" />
     <ClCompile Include="..\link-grammar\dict-file\dictionary.c" />
     <ClCompile Include="..\link-grammar\dict-file\read-dict.c" />
     <ClCompile Include="..\link-grammar\dict-file\read-regex.c" />
     <ClCompile Include="..\link-grammar\dict-file\word-file.c" />
     <ClCompile Include="..\link-grammar\disjunct-utils.c" />
-    <ClCompile Include="..\link-grammar\disjuncts.c" />
     <ClCompile Include="..\link-grammar\error.c" />
-    <ClCompile Include="..\link-grammar\expand.c" />
-    <ClCompile Include="..\link-grammar\extract-links.c" />
-    <ClCompile Include="..\link-grammar\fast-match.c" />
-    <ClCompile Include="..\link-grammar\idiom.c" />
-    <ClCompile Include="..\link-grammar\linkage.c" />
-    <ClCompile Include="..\link-grammar\post-process.c" />
-    <ClCompile Include="..\link-grammar\pp_knowledge.c" />
-    <ClCompile Include="..\link-grammar\pp_lexer.c" />
-    <ClCompile Include="..\link-grammar\pp_linkset.c" />
-    <ClCompile Include="..\link-grammar\preparation.c" />
-    <ClCompile Include="..\link-grammar\print-util.c" />
-    <ClCompile Include="..\link-grammar\print.c" />
-    <ClCompile Include="..\link-grammar\prune.c" />
-    <ClCompile Include="..\link-grammar\regex-morph.c" />
-    <ClCompile Include="..\link-grammar\regex-tokenizer.c" />
+    <ClCompile Include="..\link-grammar\linkage\analyze-linkage.c" />
+    <ClCompile Include="..\link-grammar\linkage\freeli.c" />
+    <ClCompile Include="..\link-grammar\linkage\linkage.c" />
+    <ClCompile Include="..\link-grammar\linkage\lisjuncts.c" />
+    <ClCompile Include="..\link-grammar\linkage\sane.c" />
+    <ClCompile Include="..\link-grammar\linkage\score.c" />
+    <ClCompile Include="..\link-grammar\parse\count.c" />
+    <ClCompile Include="..\link-grammar\parse\extract-links.c" />
+    <ClCompile Include="..\link-grammar\parse\fast-match.c" />
+    <ClCompile Include="..\link-grammar\parse\histogram.c" />
+    <ClCompile Include="..\link-grammar\parse\parse.c" />
+    <ClCompile Include="..\link-grammar\parse\preparation.c" />
+    <ClCompile Include="..\link-grammar\parse\prune.c" />
+    <ClCompile Include="..\link-grammar\post-process\constituents.c" />
+    <ClCompile Include="..\link-grammar\post-process\post-process.c" />
+    <ClCompile Include="..\link-grammar\post-process\pp_knowledge.c" />
+    <ClCompile Include="..\link-grammar\post-process\pp_lexer.c" />
+    <ClCompile Include="..\link-grammar\post-process\pp_linkset.c" />
+    <ClCompile Include="..\link-grammar\prepare\build-disjuncts.c" />
+    <ClCompile Include="..\link-grammar\prepare\expand.c" />
+    <ClCompile Include="..\link-grammar\prepare\exprune.c" />
+    <ClCompile Include="..\link-grammar\print\print-util.c" />
+    <ClCompile Include="..\link-grammar\print\print.c" />
+    <ClCompile Include="..\link-grammar\print\wcwidth.c" />
     <ClCompile Include="..\link-grammar\resources.c" />
-    <ClCompile Include="..\link-grammar\score.c" />
-    <ClCompile Include="..\link-grammar\spellcheck-aspell.c" />
-    <ClCompile Include="..\link-grammar\spellcheck-hun.c" />
     <ClCompile Include="..\link-grammar\string-set.c" />
-    <ClCompile Include="..\link-grammar\tokenize.c" />
+    <ClCompile Include="..\link-grammar\tokenize\anysplit.c" />
+    <ClCompile Include="..\link-grammar\tokenize\regex-tokenizer.c" />
+    <ClCompile Include="..\link-grammar\tokenize\spellcheck-aspell.c" />
+    <ClCompile Include="..\link-grammar\tokenize\spellcheck-hun.c" />
+    <ClCompile Include="..\link-grammar\tokenize\tokenize.c" />
+    <ClCompile Include="..\link-grammar\tokenize\wordgraph.c" />
     <ClCompile Include="..\link-grammar\utilities.c" />
-    <ClCompile Include="..\link-grammar\wcwidth.c" />
-    <ClCompile Include="..\link-grammar\word-utils.c" />
-    <ClCompile Include="..\link-grammar\wordgraph.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\link-grammar\link-features.h.in">
@@ -330,7 +368,13 @@
       <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <Flex Include="..\link-grammar\post-process\pp_lexer.l">
+      <FileType>Document</FileType>
+    </Flex>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
+  <ImportGroup Label="ExtensionTargets" Condition="'$(WINFLEXBISON)'!=''">
+    <Import Project="$(WINFLEXBISON)\custom_build_rules\win_flex_only\win_flex_custom_build.targets" />
   </ImportGroup>
 </Project>

--- a/msvc14/LinkGrammar.vcxproj.filters
+++ b/msvc14/LinkGrammar.vcxproj.filters
@@ -15,25 +15,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\link-grammar\analyze-linkage.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\anysplit.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\link-grammar\api.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\build-disjuncts.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\constituents.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\count.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\dict-common.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\dict-file\dictionary.c">
@@ -51,95 +33,134 @@
     <ClCompile Include="..\link-grammar\disjunct-utils.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\disjuncts.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\link-grammar\error.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\expand.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\extract-links.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\fast-match.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\idiom.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\linkage.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\post-process.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\pp_knowledge.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\pp_lexer.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\pp_linkset.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\preparation.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\print-util.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\print.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\prune.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\regex-morph.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\regex-tokenizer.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\resources.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\score.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\spellcheck-aspell.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\spellcheck-hun.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\link-grammar\string-set.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\link-grammar\tokenize.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\link-grammar\utilities.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\word-utils.c">
+    <ClCompile Include="..\link-grammar\print\print.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\wordgraph.c">
+    <ClCompile Include="..\link-grammar\print\print-util.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\wcwidth.c">
+    <ClCompile Include="..\link-grammar\post-process\post-process.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\post-process\pp_knowledge.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\post-process\pp_linkset.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\anysplit.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\regex-tokenizer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\spellcheck-aspell.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\spellcheck-hun.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\tokenize.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\wordgraph.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\print\wcwidth.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\regex-morph.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\print-dict.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\idiom.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\dict-common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\count.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\extract-links.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\fast-match.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\histogram.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\preparation.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\prune.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage\analyze-linkage.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage\freeli.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage\linkage.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage\lisjuncts.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage\sane.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\linkage\score.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\prepare\build-disjuncts.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\prepare\expand.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\prepare\exprune.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\dict-utils.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\connectors.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\parse\parse.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\dict-impl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-common\file-utils.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\post-process\constituents.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\post-process\pp_lexer.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\link-grammar\analyze-linkage.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\anysplit.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\link-grammar\api-structures.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -149,15 +170,6 @@
     <ClInclude Include="..\link-grammar\build-disjuncts.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\link-grammar\count.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\dict-api.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\dict-common.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\link-grammar\dict-file\read-dict.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -165,9 +177,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\link-grammar\dict-file\word-file.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\dict-structures.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\link-grammar\disjunct-utils.h">
@@ -185,12 +194,6 @@
     <ClInclude Include="..\link-grammar\externs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\link-grammar\extract-links.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\fast-match.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\link-grammar\idiom.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -200,46 +203,7 @@
     <ClInclude Include="..\link-grammar\link-includes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\link-grammar\linkage.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\post-process.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\pp_knowledge.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\pp_lexer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\pp_linkset.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\preparation.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\print-util.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\print.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\prune.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\regex-morph.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\regex-tokenizer.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\link-grammar\resources.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\score.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\spellcheck.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\link-grammar\string-set.h">
@@ -248,16 +212,10 @@
     <ClInclude Include="..\link-grammar\structures.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\link-grammar\tokenize.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\link-grammar\utilities.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\link-grammar\word-utils.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\wordgraph.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\link-grammar\lg_assert.h">
@@ -266,8 +224,118 @@
     <ClInclude Include="..\link-grammar\wcwidth.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\link-grammar\post-process\post-process.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\post-process\pp_knowledge.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\post-process\pp_lexer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\print\print.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\print\print-util.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\post-process\pp_linkset.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tokenize\anysplit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tokenize\regex-tokenizer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tokenize\spellcheck.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tokenize\tokenize.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tokenize\tok-structures.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tokenize\wordgraph.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\count.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\extract-links.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\fast-match.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\histogram.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\preparation.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\prune.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\linkage\analyze-linkage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\linkage\linkage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\linkage\lisjuncts.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\linkage\sane.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\linkage\score.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\connectors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\parse\parse.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-affix.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-api.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-defines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-impl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-structures.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\dict-utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\file-utils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\idiom.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-common\regex-morph.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\link-grammar\link-features.h.in" />
+  </ItemGroup>
+  <ItemGroup>
+    <Flex Include="..\link-grammar\post-process\pp_lexer.l">
+      <Filter>Source Files</Filter>
+    </Flex>
   </ItemGroup>
 </Project>

--- a/msvc14/Local.props
+++ b/msvc14/Local.props
@@ -12,6 +12,7 @@
     <PYTHON3_INCLUDE>$(PYTHON3)\include</PYTHON3_INCLUDE>
     <PYTHON3_LIB>$(PYTHON3)\libs\python34.lib</PYTHON3_LIB>
     <PYTHON3_EXE>$(PYTHON3)\python.exe</PYTHON3_EXE>
+    <WINFLEXBISON>C:\win_flex_bison</WINFLEXBISON>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GNUREGEX)' != '' " />
   <ItemDefinitionGroup>
@@ -50,6 +51,9 @@
     </BuildMacro>
     <BuildMacro Include="PYTHON3_EXE">
       <Value>$(PYTHON3_EXE)</Value>
+    </BuildMacro>
+    <BuildMacro Include="WINFLEXBISON">
+      <Value>$(WINFLEXBISON)</Value>
     </BuildMacro>
   </ItemGroup>
 </Project>

--- a/msvc14/README.md
+++ b/msvc14/README.md
@@ -67,6 +67,12 @@ dlltool -l regex.lib -d libtre/win32/tre.def -D regex.dll libtre/win32/bin/x64_r
    If your JAVA SDK/JDK installation has defined the JAVA_HOME environment
    variable (check it) then there is no need to define this User Macro.
 
+- WINFLEXBISON should be the directory of the "Win flex-bison" project,
+  as downloaded from its [Web site](https://winflexbison.sourceforge.io/).
+  Tested with version 2.5.9.
+  Leave it blank if would like to use a ready **pp_lexer.c** file.
+  The default is **C:\win_flex_bison**.
+
 ### Definitions for Python bindings
 
    |   |

--- a/msvc14/README.md
+++ b/msvc14/README.md
@@ -75,17 +75,16 @@ dlltool -l regex.lib -d libtre/win32/tre.def -D regex.dll libtre/win32/bin/x64_r
 
 ### Definitions for Python bindings
 
-   |   |
+ Macro | Default value |
 ---|---|
-PYTHON2         | The default is: C:\Python27 |
-PYTHON2_INCLUDE | The default is: $(PYTHON2)\include |
-PYTHON2_LIB     | The default is: $(PYTHON2)\lib |
-PYTHON2_EXE     | The default is: $(PYTHON2)\python.exe |
-               |  |
-PYTHON3         | The default is: C:\Python34 |
-PYTHON3_INCLUDE | The default is: $(PYTHON3)\include |
-PYTHON3_LIB     | The default is: $(PYTHON3)\lib |
-PYTHON3_EXE     | The default is: $(PYTHON3)\python.exe |
+PYTHON2         | C:\Python27 |
+PYTHON2_INCLUDE | $(PYTHON2)\include |
+PYTHON2_LIB     | $(PYTHON2)\lib |
+PYTHON2_EXE     | $(PYTHON2)\python.exe |
+PYTHON3         | C:\Python34 |
+PYTHON3_INCLUDE | $(PYTHON3)\include |
+PYTHON3_LIB     | $(PYTHON3)\lib |
+PYTHON3_EXE     | $(PYTHON3)\python.exe |
 
 If you want to build any of the bindings, make sure it is marked for build
 in the configuration manager, or select "build" for the desired bindings in


### PR DESCRIPTION
1. Adapt to the new source structure/files.
2. Add optional Flex support (defined by default).
3. Update the README about Flex usage and fix the broken table for Definitions for Python bindings.
4. Fix compilation breakage due to PR #535.
5. Add utilities.h in constituents.c to get the strtok_r redefinition if needed.
6. Fix 2 improper definitions that got detected by MSVC.