### PR TITLE
"Automatic" conversion of SUBSCRIPT_MARK to SUBSCRIPT_DOT

### DIFF
--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -224,11 +224,7 @@ static void print_chosen_disjuncts_words(const Linkage lkg)
 		else
 			djw = cdj->string;
 
-		char *djw_tmp = strdupa(djw);
-		char *sm = strrchr(djw_tmp, SUBSCRIPT_MARK);
-		if (NULL != sm) *sm = SUBSCRIPT_DOT;
-
-		dyn_strcat(djwbuf, djw_tmp);
+		dyn_strcat(djwbuf, djw);
 		dyn_strcat(djwbuf, " ");
 	}
 	err_msg(lg_Debug, "%s\n", djwbuf->str);

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -231,7 +231,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			break;
 		}
 
-		if (verbosity_level(D_SLM)) print_with_subscript_dot(cdj->string);
+		if (verbosity_level(D_SLM)) prt_error("%s", cdj->string);
 
 		match_found = false;
 		/* Proceed in all the paths in which the word is found. */

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -77,6 +77,7 @@ void vappend_string(dyn_str * string, const char *fmt, va_list args)
 	}
 	va_end(args);
 
+	patch_subscript_marks(temp_string);
 	dyn_strcat(string, temp_string);
 	return;
 

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#include "dict-common/dict-defines.h" /* SUBSCRIPT_MARK, SUBSCRIPT_DOT */
 #include "utilities.h"
 
 #define MAX_LINE 500          /* maximum width of print area */
@@ -36,5 +37,18 @@ void append_string(dyn_str *, const char *fmt, ...) GNUC_PRINTF(2,3);
 void vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);
 size_t append_utf8_char(dyn_str *, const char * mbs);
+
+static inline void patch_subscript_mark(char *s)
+{
+	s = strchr(s, SUBSCRIPT_MARK);
+	if (NULL != s)
+		*s = SUBSCRIPT_DOT;
+}
+
+static inline void patch_subscript_marks(char *s)
+{
+	while (NULL != (s = strchr(s, SUBSCRIPT_MARK)))
+		*s = SUBSCRIPT_DOT;
+}
 
 #endif

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -258,7 +258,6 @@ char * linkage_print_disjuncts(const Linkage linkage)
 	double score;
 #endif
 	const char * dj;
-	char *mark;
 	int w;
 	dyn_str * s = dyn_str_new();
 	int nwords = linkage->num_words;
@@ -268,14 +267,12 @@ char * linkage_print_disjuncts(const Linkage linkage)
 	{
 		int pad = 21;
 		double cost;
-		char infword[MAX_WORD];
+		const char *infword;
 		Disjunct *disj = linkage->chosen_disjuncts[w];
 		if (NULL == disj) continue;
 
-		/* Cleanup the subscript mark before printing. */
-		strncpy(infword, disj->string, MAX_WORD);
-		mark = strchr(infword, SUBSCRIPT_MARK);
-		if (mark) *mark = SUBSCRIPT_DOT;
+		/* Subscript mark will be cleaned up by append_string(). */
+		infword = disj->string;
 
 		/* Make sure the glyphs align during printing. */
 		pad += strlen(infword) - utf8_strwidth(infword);

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -19,7 +19,6 @@
 #include "api-structures.h"
 #include "connectors.h"
 #include "corpus/corpus.h"
-#include "dict-common/dict-defines.h"  // For SUBSCRIPT_MARK
 #include "dict-common/dict-utils.h" // For size_of_expression()
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
@@ -1373,18 +1372,6 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 	}
 	if (debugprint) lgdebug(0, "\n");
 	else if (word_split) printf("\n\n");
-}
-
-/**
- * Print a word, converting SUBSCRIPT_MARK to SUBSCRIPT_DOT.
- */
-void print_with_subscript_dot(const char *s)
-{
-	const char *mark = strchr(s, SUBSCRIPT_MARK);
-	size_t len = NULL != mark ? (size_t)(mark - s) : strlen(s);
-
-	prt_error("%.*s%s%s ", (int)len,
-			  s, NULL != mark ? "." : "", NULL != mark ? mark+1 : "");
 }
 
 // Use for debug and error printing.

--- a/link-grammar/print/print.h
+++ b/link-grammar/print/print.h
@@ -22,7 +22,6 @@ void   print_disjunct_counts(Sentence sent);
 struct tokenpos;
 void   print_sentence_word_alternatives(Sentence sent, bool debugprint,
        void (*display)(Dictionary, const char *), struct tokenpos *);
-void print_with_subscript_dot(const char *);
 
 // Used for debug/error printing
 void print_sentence_context(Sentence, dyn_str*);

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -32,7 +32,7 @@
 #include "api-structures.h"
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
+#include "print/print-util.h" // For patch_subscript_mark()
 #include "dict-common/regex-morph.h"
 #include "error.h"
 #include "tokenize.h"
@@ -317,8 +317,7 @@ static Regex_node * regbuild(const char **regstring, int n, int classnum)
 		 * file. As a result, if a regex contains a dot it is patched by
 		 * SUBSCRIPT_MARK. We undo it here. */
 		s = strdup(regstring[i]);
-		sm = strrchr(s, SUBSCRIPT_MARK);
-		if (sm) *sm = SUBSCRIPT_DOT;
+		patch_subscript_mark(s);
 
 		/* Create a new Regex_node and add to the list. */
 		new_re = malloc(sizeof(*new_re));


### PR DESCRIPTION
**EDIT: THIS PR SLIGHTLY CONFLICTS...***
If you apply  anyway, it is easy to fix the 2 created conflicts.
But you can apply only the previous ones, and I will  pull and fix the conflicts and then push this PR again in-place (with a fix of a warning on an unused variable).

---
PR #556 doesn't include this needed conversion. Instead, it depends on the change in this PR.

After this PR, the said conversion can be removed from another place (I will send an additional PR for that when all the recent PRs are applied).

**NOTE:**
(Edit) In order to prevent conflicts, the previous pending PRs should be applied in their order.
