### PR TITLE
Convert dict_display_word_info()/expr() to return (char *)

### DIFF
--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -40,6 +40,7 @@ void free_lookup_list(const Dictionary, Dict_node *);
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);
 
 void print_expression(const Exp *);
+char *expression_stringify(const Exp *);
 
 LINK_END_DECLS
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -17,6 +17,7 @@
 #include "dict-common.h"
 #include "dict-defines.h"
 #include "print/print.h"
+#include "print/print-util.h"
 #include "regex-morph.h"
 #include "dict-file/word-file.h"
 #include "dict-file/read-dict.h"
@@ -72,7 +73,8 @@ void print_expression(Exp * n)
 /**
  * print the expression, in infix-style
  */
-static void print_expression_parens(const Exp * n, int need_parens)
+static dyn_str *print_expression_parens(dyn_str *e,
+                                        const Exp * n, int need_parens)
 {
 	E_list * el;
 	int i, icost;
@@ -80,8 +82,8 @@ static void print_expression_parens(const Exp * n, int need_parens)
 
 	if (n == NULL)
 	{
-		err_msg(lg_Debug, "NULL expression");
-		return;
+		append_string(e, "NULL expression");
+		return e;
 	}
 
 	icost = (int) (n->cost);
@@ -99,91 +101,103 @@ static void print_expression_parens(const Exp * n, int need_parens)
 	/* print the connector only */
 	if (n->type == CONNECTOR_type)
 	{
-		for (i=0; i<icost; i++) err_msg(lg_Debug, "[");
-		if (n->multi) err_msg(lg_Debug, "@");
-		err_msg(lg_Debug, "%s%c", n->u.string, n->dir);
-		for (i=0; i<icost; i++) err_msg(lg_Debug, "]");
-		if (0 != dcost) err_msg(lg_Debug, COST_FMT, dcost);
-		return;
+		for (i=0; i<icost; i++) dyn_strcat(e, "[");
+		if (n->multi) dyn_strcat(e, "@");
+		append_string(e, "%s%c", n->u.string, n->dir);
+		for (i=0; i<icost; i++) dyn_strcat(e, "]");
+		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		return e;
 	}
 
 	/* Look for optional, and print only that */
 	el = n->u.l;
 	if (el == NULL)
 	{
-		for (i=0; i<icost; i++) err_msg(lg_Debug, "[");
-		prt_error ("()");
-		for (i=0; i<icost; i++) err_msg(lg_Debug, "]");
-		if (0 != dcost) err_msg(lg_Debug, COST_FMT, dcost);
-		return;
+		for (i=0; i<icost; i++) dyn_strcat(e, "[");
+		append_string(e, "()");
+		for (i=0; i<icost; i++) dyn_strcat(e, "]");
+		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		return e;
 	}
 
-	for (i=0; i<icost; i++) err_msg(lg_Debug, "[");
+	for (i=0; i<icost; i++) dyn_strcat(e, "[");
 	if ((n->type == OR_type) &&
 	    el && el->e && (NULL == el->e->u.l))
 	{
-		prt_error ("{");
-		if (NULL == el->next) err_msg(lg_Debug, "error-no-next");
-		else print_expression_parens(el->next->e, false);
-		prt_error ("}");
-		return;
+		dyn_strcat(e, "{");
+		if (NULL == el->next) dyn_strcat(e, "error-no-next");
+		else print_expression_parens(e, el->next->e, false);
+		append_string(e, "}");
+		return e;
 	}
 
-	if ((icost == 0) && need_parens) err_msg(lg_Debug, "(");
+	if ((icost == 0) && need_parens) dyn_strcat(e, "(");
 
 	/* print left side of binary expr */
-	print_expression_parens(el->e, true);
+	print_expression_parens(e, el->e, true);
 
 	/* get a funny "and optional" when its a named expression thing. */
 	if ((n->type == AND_type) && (el->next == NULL))
 	{
-		for (i=0; i<icost; i++) err_msg(lg_Debug, "]");
-		if (0 != dcost) err_msg(lg_Debug, COST_FMT, dcost);
-		if ((icost == 0) && need_parens) err_msg(lg_Debug, ")");
-		return;
+		for (i=0; i<icost; i++) dyn_strcat(e, "]");
+		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		if ((icost == 0) && need_parens) dyn_strcat(e, ")");
+		return e;
 	}
 
-	if (n->type == AND_type) err_msg(lg_Debug, " & ");
-	if (n->type == OR_type) err_msg(lg_Debug, " or ");
+	if (n->type == AND_type) dyn_strcat(e, " & ");
+	if (n->type == OR_type) dyn_strcat(e, " or ");
 
 	/* print right side of binary expr */
 	el = el->next;
 	if (el == NULL)
 	{
-		prt_error ("()");
+		dyn_strcat(e, "()");
 	}
 	else
 	{
 		if (el->e->type == n->type)
 		{
-			print_expression_parens(el->e, false);
+			print_expression_parens(e, el->e, false);
 		}
 		else
 		{
-			print_expression_parens(el->e, true);
+			print_expression_parens(e, el->e, true);
 		}
 		if (el->next != NULL)
 		{
-			// prt_error ("\nERROR! Unexpected list!\n");
+			// dyn_strcat(e, "\nERROR! Unexpected list!\n");
 			/* The SAT parser just naively joins all X_node expressions
 			 * using "or", and this check used to give an error due to that,
 			 * preventing a convenient debugging.
 			 * Just accept it (but mark it with '!'). */
-			if (n->type == AND_type) err_msg(lg_Debug, " &! ");
-			if (n->type == OR_type) err_msg(lg_Debug, " or! ");
-			print_expression_parens(el->next->e, true);
+			if (n->type == AND_type) dyn_strcat(e, " &! ");
+			if (n->type == OR_type) dyn_strcat(e, " or! ");
+			print_expression_parens(e, el->next->e, true);
 		}
 	}
 
-	for (i=0; i<icost; i++) err_msg(lg_Debug, "]");
-	if (0 != dcost) err_msg(lg_Debug, COST_FMT, dcost);
-	if ((icost == 0) && need_parens) err_msg(lg_Debug, ")");
+	for (i=0; i<icost; i++) dyn_strcat(e, "]");
+	if (0 != dcost) append_string(e, COST_FMT, dcost);
+	if ((icost == 0) && need_parens) dyn_strcat(e, ")");
+
+	return e;
 }
 
 void print_expression(const Exp * n)
 {
-	print_expression_parens(n, false);
-	err_msg(lg_Debug, "\n");
+	dyn_str *e = dyn_str_new();
+
+	char *s = dyn_str_take(print_expression_parens(e, n, false));
+	err_msg(lg_Debug, "%s\n", s);
+	free(s);
+}
+
+char *expression_stringify(const Exp * n)
+{
+	dyn_str *e = dyn_str_new();
+
+	return dyn_str_take(print_expression_parens(e, n, false));
 }
 #endif /* INFIX_NOTATION */
 
@@ -197,36 +211,33 @@ void print_expression(const Exp * n)
  * Wild-card search is supported; the command-line user can type in !!word* or
  * !!word*.sub and get a list of all words that match up to the wild-card.
  * In this case no split is done.
- *
- * FIXME: Errors are printed twice, since display_word_split() is invoked twice
- * per word. One way to fix it is to change display_word_split() to return false
- * on failure. However, this is a big fix, because the failure is several
- * functions deep, all not returning a value or returning a value for another
- * purpose. An easy fix, which has advantages for other things, is to add (and
- * use here) a "char *last_error" field in the Dictionary structure, serving
- * like an "errno" of library calls.
  */
-
-static void display_word_split(Dictionary dict,
+static char *display_word_split(Dictionary dict,
                                const char * word,
                                Parse_Options opts,
-                               void (*display)(Dictionary, const char *))
+                               char * (*display)(Dictionary, const char *))
 {
 	Sentence sent;
 	struct Parse_Options_s display_word_opts = *opts;
+	dyn_str *s = dyn_str_new();
 
-	if ('\0' == word) return; /* avoid trying null strings */
+	if ('\0' == word) return NULL; /* avoid trying null strings */
 
 	parse_options_set_spell_guess(&display_word_opts, 0);
 	sent = sentence_create(word, dict);
 	if (0 == sentence_split(sent, &display_word_opts))
 	{
 		/* List the splits */
-		print_sentence_word_alternatives(sent, false, NULL, NULL);
+		print_sentence_word_alternatives(s, sent, false, NULL, NULL);
 		/* List the disjuncts information. */
-		print_sentence_word_alternatives(sent, false, display, NULL);
+		print_sentence_word_alternatives(s, sent, false, display, NULL);
 	}
 	sentence_delete(sent);
+
+	char *out = dyn_str_take(s);
+	if ('\0' != out[0]) return out;
+	free(out);
+	return NULL; /* no dict entry */
 }
 
 /**
@@ -293,56 +304,48 @@ static unsigned int count_disjunct_for_dict_node(Dict_node *dn)
 /**
  * Display the number of disjuncts associated with this dict node
  */
-static void display_counts(const char *word, Dict_node *dn)
+static char *display_counts(const char *word, Dict_node *dn)
 {
-	printf("matches:\n");
+	dyn_str *s = dyn_str_new();
 
+	append_string(s, "matches:\n");
 	for (; dn != NULL; dn = dn->right)
 	{
-		unsigned int len;
-		char * s;
-		char * t;
+		append_string(s, "    %-*s %8u  disjuncts",
+		              display_width(DJ_COL_WIDTH, dn->string), dn->string,
+		              count_disjunct_for_dict_node(dn));
 
-		len = count_disjunct_for_dict_node(dn);
-		s = strdup(dn->string);
-		t = strrchr(s, SUBSCRIPT_MARK);
-		if (t) *t = SUBSCRIPT_DOT;
-		printf("    ");
-		left_print_string(stdout, s, DJ_COL_WIDTH);
-		free(s);
-		printf(" %8u  disjuncts ", len);
 		if (dn->file != NULL)
 		{
-			printf("<%s>", dn->file->file);
+			append_string(s, " <%s>", dn->file->file);
 		}
-		printf("\n");
+		append_string(s, "\n\n");
 	}
+	return dyn_str_take(s);
 }
 
 /**
  * Display the number of disjuncts associated with this dict node
  */
-static void display_expr(const char *word, Dict_node *dn)
+static char *display_expr(const char *word, Dict_node *dn)
 {
-	printf("expressions:\n");
+	dyn_str *s = dyn_str_new();
+
+	append_string(s, "expressions:\n");
 	for (; dn != NULL; dn = dn->right)
 	{
-		char * s;
-		char * t;
+		char *expstr = expression_stringify(dn->exp);
 
-		s = strdup(dn->string);
-		t = strrchr(s, SUBSCRIPT_MARK);
-		if (t) *t = SUBSCRIPT_DOT;
-		printf("    ");
-		left_print_string(stdout, s, DJ_COL_WIDTH);
-		free(s);
-		print_expression(dn->exp);
-		if (NULL != dn->right) /* avoid extra newlines at the end */
-			printf("\n\n");
+		append_string(s, "    %-*s %s",
+		              display_width(DJ_COL_WIDTH, dn->string), dn->string,
+		              expstr);
+		free(expstr);
+		append_string(s, "\n\n");
 	}
+	return dyn_str_take(s);
 }
 
-static void display_word_info(Dictionary dict, const char * word)
+static char *display_word_info(Dictionary dict, const char * word)
 {
 	const char * regex_name;
 	Dict_node *dn_head;
@@ -350,22 +353,22 @@ static void display_word_info(Dictionary dict, const char * word)
 	dn_head = dictionary_lookup_wild(dict, word);
 	if (dn_head)
 	{
-		display_counts(word, dn_head);
+		char *out = display_counts(word, dn_head);
 		free_lookup(dn_head);
-		return;
+		return out;
 	}
 
 	/* Recurse, if it's a regex match */
 	regex_name = match_regex(dict->regex_root, word);
 	if (regex_name)
 	{
-		display_word_info(dict, regex_name);
-		return;
+		return display_word_info(dict, regex_name);
 	}
-	printf("matches nothing in the dictionary.");
+
+	return NULL;
 }
 
-static void display_word_expr(Dictionary dict, const char * word)
+static char *display_word_expr(Dictionary dict, const char * word)
 {
 	const char * regex_name;
 	Dict_node *dn_head;
@@ -373,34 +376,34 @@ static void display_word_expr(Dictionary dict, const char * word)
 	dn_head = dictionary_lookup_wild(dict, word);
 	if (dn_head)
 	{
-		display_expr(word, dn_head);
+		char *out = display_expr(word, dn_head);
 		free_lookup(dn_head);
-		return;
+		return out;
 	}
 
 	/* Recurse, if it's a regex match */
 	regex_name = match_regex(dict->regex_root, word);
 	if (regex_name)
 	{
-		display_word_expr(dict, regex_name);
-		return;
+		return display_word_expr(dict, regex_name);
 	}
-	printf("matches nothing in the dictionary.");
+
+	return NULL;
 }
 
 /**
  *  dict_display_word_info() - display the information about the given word.
  */
-void dict_display_word_info(Dictionary dict, const char * word,
+char *dict_display_word_info(Dictionary dict, const char * word,
 		Parse_Options opts)
 {
-	display_word_split(dict, word, opts, display_word_info);
+	return display_word_split(dict, word, opts, display_word_info);
 }
 
 /**
  *  dict_display_word_expr() - display the connector info for a given word.
  */
-void dict_display_word_expr(Dictionary dict, const char * word, Parse_Options opts)
+char *dict_display_word_expr(Dictionary dict, const char * word, Parse_Options opts)
 {
-	display_word_split(dict, word, opts, display_word_expr);
+	return display_word_split(dict, word, opts, display_word_expr);
 }

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -240,8 +240,6 @@ static char *display_word_split(Dictionary dict,
 	return NULL; /* no dict entry */
 }
 
-#define DJ_COL_WIDTH sizeof("                         ")
-
 /**
  * Count the number of clauses (disjuncts) for the expression e.
  * Should return the number of disjuncts that would be returned
@@ -289,6 +287,8 @@ static unsigned int count_disjunct_for_dict_node(Dict_node *dn)
 {
 	return (NULL == dn) ? 0 : count_clause(dn->exp);
 }
+
+#define DJ_COL_WIDTH sizeof("                         ")
 
 /**
  * Display the number of disjuncts associated with this dict node

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -240,17 +240,6 @@ static char *display_word_split(Dictionary dict,
 	return NULL; /* no dict entry */
 }
 
-/**
- * Prints string `s`, aligned to the left, in a field width `w`.
- * If the width of `s` is shorter than `w`, then the remainder of
- * field is padded with blanks (on the right).
- */
-static void left_print_string(FILE * fp, const char * s, int w)
-{
-	int width = w + strlen(s) - utf8_strwidth(s);
-	fprintf(fp, "%-*s", width, s);
-}
-
 #define DJ_COL_WIDTH sizeof("                         ")
 
 /**

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -373,9 +373,9 @@ link_public_api(const char *)
 link_public_api(size_t)
      utf8_strwidth(const char *);
 
-link_public_api(void)
+link_public_api(char *)
      dict_display_word_expr(Dictionary dict, const char *, Parse_Options opts);
-link_public_api(void)
+link_public_api(char *)
      dict_display_word_info(Dictionary dict, const char *, Parse_Options opts);
 link_public_api(bool)
      lg_expand_disjunct_list(Sentence sent);

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -224,11 +224,7 @@ static void print_chosen_disjuncts_words(const Linkage lkg)
 		else
 			djw = cdj->string;
 
-		char *djw_tmp = strdupa(djw);
-		char *sm = strrchr(djw_tmp, SUBSCRIPT_MARK);
-		if (NULL != sm) *sm = SUBSCRIPT_DOT;
-
-		dyn_strcat(djwbuf, djw_tmp);
+		dyn_strcat(djwbuf, djw);
 		dyn_strcat(djwbuf, " ");
 	}
 	err_msg(lg_Debug, "%s\n", djwbuf->str);

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -231,7 +231,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			break;
 		}
 
-		if (verbosity_level(D_SLM)) print_with_subscript_dot(cdj->string);
+		if (verbosity_level(D_SLM)) prt_error("%s", cdj->string);
 
 		match_found = false;
 		/* Proceed in all the paths in which the word is found. */

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -80,6 +80,7 @@ void vappend_string(dyn_str * string, const char *fmt, va_list args)
 	}
 	va_end(args);
 
+	patch_subscript_marks(temp_string);
 	dyn_strcat(string, temp_string);
 	return;
 

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -31,4 +31,22 @@ void vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);
 size_t append_utf8_char(dyn_str *, const char * mbs);
 
+static inline void patch_subscript_mark(char *s)
+{
+	s = strchr(s, SUBSCRIPT_MARK);
+	if (NULL != s)
+		*s = SUBSCRIPT_DOT;
+}
+
+static inline void patch_subscript_marks(char *s)
+{
+	while (NULL != (s = strchr(s, SUBSCRIPT_MARK)))
+		*s = SUBSCRIPT_DOT;
+}
+
+static inline int display_width(int width, const char *s)
+{
+	return width + strlen(s) - utf8_strwidth(s);
+}
+
 #endif

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
+#include "dict-common/dict-defines.h" /* SUBSCRIPT_MARK, SUBSCRIPT_DOT */
 #include "utilities.h"
 
 #define MAX_LINE 500          /* maximum width of print area */

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -1180,8 +1180,8 @@ struct tokenpos /* First position of the given token - to prevent duplicates */
 	size_t ai;
 };
 
-void print_sentence_word_alternatives(Sentence sent, bool debugprint,
-     void (*display)(Dictionary, const char *), struct tokenpos * tokenpos)
+void print_sentence_word_alternatives(dyn_str *s, Sentence sent, bool debugprint,
+     char * (*display)(Dictionary, const char *), struct tokenpos * tokenpos)
 {
 	size_t wi;   /* Internal sentence word index */
 	size_t ai;   /* Index of a word alternative */
@@ -1198,8 +1198,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		return;
 	}
 
-	if (debugprint) lgdebug(+0, "\n\\");
-	else if (NULL != tokenpos)
+	if (debugprint || (NULL != tokenpos))
 		; /* Do nothing */
 	else
 	{
@@ -1238,7 +1237,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 			}
 		}
 		/* "String", because it can be a word, morpheme, or (TODO) idiom */
-		if (word_split && (NULL == display)) printf("String splits to:\n");
+		if (word_split && (NULL == display)) dyn_strcat(s, "String splits to:\n");
 		/* We used to print the alternatives of the word here, one per line.
 		 * In the current (Wordgraph) version, the alternatives may look
 		 * like nonsense combination of tokens - not as the strict split
@@ -1270,7 +1269,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		if (debugprint) lgdebug(0, "  word%d %c%c: %s\n   ",
 		 wi, w.firstupper ? 'C' : ' ', sent->post_quote[wi] ? 'Q' : ' ',
 #endif
-		if (debugprint) lgdebug(0, "  word%zu: %s\n\\", wi, w.unsplit_word);
+		if (debugprint) append_string(s, "  word%zu: %s\n", wi, w.unsplit_word);
 
 		/* There should always be at least one alternative */
 		assert((NULL != w.alternatives) && (NULL != w.alternatives[0]) &&
@@ -1292,8 +1291,8 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 		{
 			if (debugprint)
 			{
-				if (0 < ai) lgdebug(0, "\n   ");
-				lgdebug(0, "   alt%zu:", ai);
+				if (0 < ai) dyn_strcat(s, "\n   ");
+				append_string(s, "   alt%zu:", ai);
 			}
 
 			for (wi = w_start; (wi == w_start) ||
@@ -1301,8 +1300,6 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 			{
 				size_t nalts = altlen(sent->word[wi].alternatives);
 				const char *wt;
-				const char *st = NULL;
-				char *wprint = NULL;
 
 				if (ai >= nalts) continue;
 				wt = sent->word[wi].alternatives[ai];
@@ -1318,7 +1315,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 				{
 					struct tokenpos firstpos = { wt };
 
-					print_sentence_word_alternatives(sent, false, NULL, &firstpos);
+					print_sentence_word_alternatives(s, sent, false, NULL, &firstpos);
 					if (((firstpos.wi != wi) || (firstpos.ai != ai)) &&
 					  firstpos.wi >= first_sentence_word) // allow !!LEFT_WORD
 					{
@@ -1329,16 +1326,6 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 					}
 				}
 
-				/* Restore SUBSCRIPT_DOT for printing */
-				st = strrchr(wt, SUBSCRIPT_MARK);
-				if (st)
-				{
-					wprint = malloc(strlen(wt)+1);
-					strcpy(wprint, wt);
-					wprint[st-wt] = SUBSCRIPT_DOT;
-					wt = wprint;
-				}
-
 				if (debugprint)
 				{
 					const char *opt_start = "", *opt_end = "";
@@ -1347,7 +1334,7 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 						opt_start = "{";
 						opt_end = "}";
 					}
-					lgdebug(0, " %s%s%s", opt_start, wt, opt_end);
+					append_string(s, " %s%s%s", opt_start, wt, opt_end);
 				}
 
 				/* Don't try to give info on the empty word. */
@@ -1359,23 +1346,23 @@ void print_sentence_word_alternatives(Sentence sent, bool debugprint,
 					 * Display the features of the token */
 					if ((NULL == tokenpos) && (NULL != display))
 					{
-						printf("Token \"%s\" ", wt);
-						display(sent->dict, wt);
-						printf("\n");
+						char *info = display(sent->dict, wt);
+
+						if (NULL == info) return;
+						append_string(s, "Token \"%s\" %s", wt, info);
+						free(info);
 					}
-					else if (word_split) printf(" %s", wt);
+					else if (word_split) append_string(s, " %s", wt);
 				}
-				free(wprint); /* wprint is NULL if not allocated */
 			}
 
 			/* Commented out - no alternatives for now - print as one line. */
-			//if (word_split && (NULL == display)) printf("\n");
+			//if (word_split && (NULL == display)) dyn_strcat(s, "\n");
 		}
 		wi--;
-		if (debugprint) lgdebug(0, "\n\\");
+		if (debugprint) dyn_strcat(s, "\n");
 	}
-	if (debugprint) lgdebug(0, "\n");
-	else if (word_split) printf("\n\n");
+	if (debugprint) dyn_strcat(s, "\n");
 }
 
 /**

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -19,7 +19,6 @@
 #include "api-structures.h"
 #include "connectors.h"
 #include "corpus/corpus.h"
-#include "dict-common/dict-defines.h"  // For SUBSCRIPT_MARK
 #include "dict-common/dict-utils.h" // For size_of_expression()
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
@@ -258,7 +257,6 @@ char * linkage_print_disjuncts(const Linkage linkage)
 	double score;
 #endif
 	const char * dj;
-	char *mark;
 	int w;
 	dyn_str * s = dyn_str_new();
 	int nwords = linkage->num_words;
@@ -268,14 +266,12 @@ char * linkage_print_disjuncts(const Linkage linkage)
 	{
 		int pad = 21;
 		double cost;
-		char infword[MAX_WORD];
+		const char *infword;
 		Disjunct *disj = linkage->chosen_disjuncts[w];
 		if (NULL == disj) continue;
 
-		/* Cleanup the subscript mark before printing. */
-		strncpy(infword, disj->string, MAX_WORD);
-		mark = strchr(infword, SUBSCRIPT_MARK);
-		if (mark) *mark = SUBSCRIPT_DOT;
+		/* Subscript mark will be cleaned up by append_string(). */
+		infword = disj->string;
 
 		/* Make sure the glyphs align during printing. */
 		pad += strlen(infword) - utf8_strwidth(infword);
@@ -1363,18 +1359,6 @@ void print_sentence_word_alternatives(dyn_str *s, Sentence sent, bool debugprint
 		if (debugprint) dyn_strcat(s, "\n");
 	}
 	if (debugprint) dyn_strcat(s, "\n");
-}
-
-/**
- * Print a word, converting SUBSCRIPT_MARK to SUBSCRIPT_DOT.
- */
-void print_with_subscript_dot(const char *s)
-{
-	const char *mark = strchr(s, SUBSCRIPT_MARK);
-	size_t len = NULL != mark ? (size_t)(mark - s) : strlen(s);
-
-	prt_error("%.*s%s%s ", (int)len,
-			  s, NULL != mark ? "." : "", NULL != mark ? mark+1 : "");
 }
 
 // Use for debug and error printing.

--- a/link-grammar/print/print.h
+++ b/link-grammar/print/print.h
@@ -13,6 +13,7 @@
 #ifndef _PRINT_H
 #define _PRINT_H
 
+#include "print/print-util.h" // For dyn_str
 #include "link-includes.h"
 
 #define LEFT_WALL_DISPLAY  ("LEFT-WALL")  /* the string to use to show the wall */
@@ -20,8 +21,8 @@
 
 void   print_disjunct_counts(Sentence sent);
 struct tokenpos;
-void   print_sentence_word_alternatives(Sentence sent, bool debugprint,
-       void (*display)(Dictionary, const char *), struct tokenpos *);
+void   print_sentence_word_alternatives(dyn_str *, Sentence, bool,
+       char * (*)(Dictionary, const char *), struct tokenpos *);
 void print_with_subscript_dot(const char *);
 
 // Used for debug/error printing

--- a/link-grammar/print/print.h
+++ b/link-grammar/print/print.h
@@ -23,7 +23,6 @@ void   print_disjunct_counts(Sentence sent);
 struct tokenpos;
 void   print_sentence_word_alternatives(dyn_str *, Sentence, bool,
        char * (*)(Dictionary, const char *), struct tokenpos *);
-void print_with_subscript_dot(const char *);
 
 // Used for debug/error printing
 void print_sentence_context(Sentence, dyn_str*);

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -32,7 +32,7 @@
 #include "api-structures.h"
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
+#include "print/print-util.h" // For patch_subscript_mark()
 #include "dict-common/regex-morph.h"
 #include "error.h"
 #include "tokenize.h"
@@ -308,17 +308,13 @@ static Regex_node * regbuild(const char **regstring, int n, int classnum)
 	Regex_node *new_re;
 	int i;
 
-	char *s;
-	char *sm;
-
 	for (i = 0; i < n; i++)
 	{
 		/* read_entry() (read-dict.c) invokes patch_subscript() also for the affix
 		 * file. As a result, if a regex contains a dot it is patched by
 		 * SUBSCRIPT_MARK. We undo it here. */
-		s = strdup(regstring[i]);
-		sm = strrchr(s, SUBSCRIPT_MARK);
-		if (sm) *sm = SUBSCRIPT_DOT;
+		char *s = strdup(regstring[i]);
+		patch_subscript_mark(s);
 
 		/* Create a new Regex_node and add to the list. */
 		new_re = malloc(sizeof(*new_re));

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3099,7 +3099,13 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 	free(wp_new);
 	lgdebug(+D_FW, "sent->length %zu\n", sent->length);
 	if (verbosity_level(D_SW))
-		print_sentence_word_alternatives(sent, true, NULL, NULL);
+	{
+		dyn_str *s = dyn_str_new();
+		print_sentence_word_alternatives(s, sent, true, NULL, NULL);
+		char *out = dyn_str_take(s);
+		prt_error("Debug: Sentence words and alternatives:\n%s", out);
+		free(out);
+	}
 
 	return !error_encountered;
 }

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -304,8 +304,29 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 	if (s[0] == '!')
 	{
-		dict_display_word_info(dict, s+1, opts);
-		dict_display_word_expr(dict, s+1, opts);
+		char *out;
+
+		out = dict_display_word_info(dict, s+1, opts);
+		if (NULL != out)
+		{
+			printf("%s\n", out);
+		   free(out);
+			out = dict_display_word_expr(dict, s+1, opts);
+			if (NULL != out)
+			{
+				printf("%s", out);
+				free(out);
+			}
+			else
+			{
+				prt_error("Error: '%s': Internal Error: Missing expression.\n", s+1);
+			}
+		}
+		else
+		{
+			printf("Token \"%s\" matches nothing in the dictionary.\n", s+1);
+		}
+
 		return 0;
 	}
 #ifdef USE_REGEX_TOKENIZER


### PR DESCRIPTION
This PR is the result of merging the close PRs #556 with #558 + applying minor code cleanups.

From #556:

Convert dict_display_word_info()/expr() to return (char *)
... instead of directly printing the results.

This solves the following problems:

It is not a good idea to print from the library code (it is not flexible, and is not appropriate for a GUI).
It is not consistent with other LG function API.
If a dictionary entry is not found, link-parser prints 2 errors.
This is an API change. However, this seems to me fine since these functions are not externally documented and n addition link-includes.h says they are internal functions.

From #558:
"Automatic" conversion of SUBSCRIPT_MARK to SUBSCRIPT_DOT

After this change, the said conversion can be removed from another place (I will send an additional PR for that ).



