### PR TITLE
Bare word getters

### DIFF
--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -89,6 +89,7 @@ linkage_get_disjunct_str
 linkage_get_disjunct_cost
 linkage_get_disjunct_corpus_score
 linkage_get_word
+linkage_get_bare_word
 linkage_print_constituent_tree
 linkage_free_constituent_tree_str
 linkage_print_diagram

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -322,6 +322,8 @@ link_public_api(double)
      linkage_get_disjunct_corpus_score(const Linkage linkage, WordIdx word_num);
 link_public_api(const char *)
      linkage_get_word(const Linkage linkage, WordIdx word_num);
+link_public_api(const char *)
+     linkage_get_bare_word(const Linkage linkage, WordIdx word_num);
 link_public_api(char *)
      linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle mode);
 link_public_api(void)

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -322,7 +322,7 @@ link_public_api(double)
      linkage_get_disjunct_corpus_score(const Linkage linkage, WordIdx word_num);
 link_public_api(const char *)
      linkage_get_word(const Linkage linkage, WordIdx word_num);
-link_public_api(const char *)
+link_public_api(char *)
      linkage_get_bare_word(const Linkage linkage, WordIdx word_num);
 link_public_api(char *)
      linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle mode);

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -875,6 +875,29 @@ const char * linkage_get_word(const Linkage linkage, WordIdx w)
 	return linkage->word[w];
 }
 
+// Need to free the returned value of this function later:
+// the memory pointed to by bare_word
+const char * linkage_get_bare_word(const Linkage linkage, WordIdx w)
+{
+	if (!linkage) return NULL;
+	if (linkage->num_words <= w) return NULL; /* bounds-check */
+
+	const char delimiter = '.';
+	char *separator_ptr = strchr(linkage->word[w], delimiter);
+
+	if(separator_ptr == NULL)
+	{
+	  return linkage->word[w]; // if there is no separator in the word
+	}
+	// copy and return word without the suffix
+	int position = separator_ptr - linkage->word[w];
+	char* bare_word = (char*) malloc((position + 1) * sizeof(char));
+	memcpy(bare_word, linkage->word[w], position);
+	bare_word[position] = '\0';
+	return bare_word;
+}
+
+
 int linkage_unused_word_cost(const Linkage linkage)
 {
 	/* The sat solver (currently) fails to fill in info */

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -877,17 +877,26 @@ const char * linkage_get_word(const Linkage linkage, WordIdx w)
 
 // Need to free the returned value of this function later:
 // the memory pointed to by bare_word
-const char * linkage_get_bare_word(const Linkage linkage, WordIdx w)
+char * linkage_get_bare_word(const Linkage linkage, WordIdx w)
 {
 	if (!linkage) return NULL;
 	if (linkage->num_words <= w) return NULL; /* bounds-check */
 
-	const char delimiter = '.';
-	char *separator_ptr = strchr(linkage->word[w], delimiter);
+	// first look for unknown word tag
+	char delimiter = '[';
+	char *separator_ptr = strrchr(linkage->word[w], delimiter);
 
 	if(separator_ptr == NULL)
 	{
-	  return linkage->word[w]; // if there is no separator in the word
+	    // look for beginning of word tag
+		delimiter = '.';
+	    separator_ptr = strrchr(linkage->word[w], delimiter);
+	    if(separator_ptr == NULL)
+		{
+			// if no tags are aded, point to the end of the word
+			delimiter = '\0';
+	  		separator_ptr = strrchr(linkage->word[w], delimiter); // if there is no separator in the word
+		}
 	}
 	// copy and return word without the suffix
 	int position = separator_ptr - linkage->word[w];

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -170,7 +170,7 @@ static void print_a_link(dyn_str * s, const Linkage linkage, LinkIdx link)
 	else
 		dyn_strcat(s, "--  ");
 	left_append_string(s, rlabel, "           ");
-	append_string(s, "     %s\n", linkage_get_word(linkage,r));
+	append_string(s, "     %s\n", linkage_get_word(linkage, r));
 }
 
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -170,9 +170,7 @@ static void print_a_link(dyn_str * s, const Linkage linkage, LinkIdx link)
 	else
 		dyn_strcat(s, "--  ");
 	left_append_string(s, rlabel, "           ");
-	char * myword = linkage_get_bare_word(linkage,r);
-	append_string(s, "     %s\n", myword);
-	free(myword);
+	append_string(s, "     %s\n", linkage_get_word(linkage,r));
 }
 
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -170,7 +170,9 @@ static void print_a_link(dyn_str * s, const Linkage linkage, LinkIdx link)
 	else
 		dyn_strcat(s, "--  ");
 	left_append_string(s, rlabel, "           ");
-	append_string(s, "     %s\n", linkage_get_word(linkage, r));
+	char * myword = linkage_get_bare_word(linkage,r);
+	append_string(s, "     %s\n", myword);
+	free(myword);
 }
 
 


### PR DESCRIPTION
Added function
'''
char * linkage_get_bare_word(const Linkage linkage, WordIdx w)
'''
to return the w-th word of a parsed sentence without the tags "[?]", "[!]" for unknow words or the word tag specifying the part of speech it belongs to (e.g. withough ".n" in "dog.n").
Note: one needs to be careful to free the memory allocated in the function by freeing the pointer where its return value is stored.