### PR TITLE
Fix printing of diagrams containing Chinese or other wide glyphs.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Version 5.4.0 (XXX 2017)
  * Revive the sqlite3 dictionary into operational form.
  * Add double-quotes to splittable punctuation for the "any" language.
  * Add API functions to get linkage word positions in the sentence.
+ * Fix printing of diagrams containing Chinese or other wide glyphs.
 
 Version 5.3.16 (15 April 2017)
  * Fix python3 unit tests.

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -30,15 +30,14 @@
  */
 size_t utf8_strwidth(const char *s)
 {
-	mbstate_t mbss;
 	wchar_t ws[MAX_LINE];
 	size_t mblen, glyph_width=0, i;
-
-	memset(&mbss, 0, sizeof(mbss));
 
 #ifdef _WIN32
 	mblen = MultiByteToWideChar(CP_UTF8, 0, s, -1, ws, MAX_LINE) - 1;
 #else
+	mbstate_t mbss;
+	memset(&mbss, 0, sizeof(mbss));
 	mblen = mbsrtowcs(ws, &s, MAX_LINE, &mbss);
 #endif /* _WIN32 */
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -483,6 +483,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	}
 	top_row = 0;
 
+	// Longer links are printed above the lower links.
 	for (link_length = 1; link_length < N_words_to_print; link_length++)
 	{
 		for (j=0; j<N_links; j++)
@@ -611,8 +612,6 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 
 	/* We've built the picture, now print it out. */
 
-	if (print_word_0) i = 0; else i = 1;
-
 	/* Start locations, for each row.  These may vary, due to different
 	 * utf8 character widths. */
 	top_row_p1 = top_row + 1;
@@ -621,18 +620,21 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	pctx->N_rows = 0;
 	pctx->row_starts[pctx->N_rows] = 0;
 	pctx->N_rows++;
+
+	if (print_word_0) i = 0; else i = 1;
 	while (i < N_words_to_print)
 	{
 		unsigned int revrs;
 		/* Count the column-widths of the words,
 		 * up to the max screen width. */
 		unsigned int uwidth = 0;
+		unsigned int wwid;
 		do {
-			uwidth += word_offset[i] + utf8_strwidth(linkage->word[i]) + 1;
+			wwid = word_offset[i] + utf8_strwidth(linkage->word[i]) + 1;
+			if (x_screen_width <= uwidth + wwid) break;
+			uwidth += wwid;
 			i++;
-		} while ((i < N_words_to_print) &&
-			(uwidth + word_offset[i] + utf8_strwidth(linkage->word[i]) + 1 <
-			                                                      x_screen_width));
+		} while (i < N_words_to_print);
 
 		pctx->row_starts[pctx->N_rows] = i - (!print_word_0);    /* PS junk */
 		if (i < N_words_to_print) pctx->N_rows++;     /* same */


### PR DESCRIPTION
This fixes linkage diagrams that were too wide to fit in the window, and had 
to be wrapped.  The wrapping calculation was being done wrong.