### PR TITLE
Fix man page processing and installation breakage

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 Version 5.4.1 (XXX 2017)
- * Something ...
+ * Fix man page installation (broken in 5.3.8).
 
 Version 5.4.0 (26 July 2017)
  * Fix for missing locale info in Windows XP.

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,9 +1,9 @@
 
 ## Process this file with automake to produce Makefile.in.
 
-dist_man_MANS = link-parser.man1
+dist_man_MANS = link-parser.1
 
 # Change the system dictionary location according the configuration options.
 # This tracks --datadir.
 link-parser.1: link-parser.man1
-	sed 's/%DATA_DIR%/$(datadir)/' $< >$@
+	sed 's,%DATA_DIR%,$(datadir),' $< >$@


### PR DESCRIPTION
(It got broken in 5.3.8.)

- Fix sed command to use "," separator, needed since datadir usually contains slashes (broken in commit 7b5d29ef "Remove obsolete and unused BINRELOC support").

- Fix man page filename (broken in commit 6a516c7a).

P.S. Using autoconf for the replacement doesn't seem straightforward because $(datadir) remains unexpanded.