### PR TITLE
Spell, and Y' & w/ fixes

### DIFF
--- a/bindings/python-examples/parses-en.txt
+++ b/bindings/python-examples/parses-en.txt
@@ -35,3 +35,13 @@ C   (VP jumped.v-d
 C       (PP over
 C           (NP the lazy.a dog.n))))
 C
+
+% Prefixes
+
+IY'gotta do it this way
+O
+O    +---->WV---->+       +------MVa-----+
+O    +--Wd--+-Sp*i+--I*t--+Osm+    +-Dsu-+
+O    |      |     |       |   |    |     |
+OLEFT-WALL y' gotta.v-d do.v it this.d way.n 
+O

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -24,9 +24,6 @@ _ ‐ ‑ ‒ – — ― ….y ━.y –.y ー.y ‐.y 、.y
 % Paragraph marks
 % Assorted bullets and dingbats
 % Dashes of various sorts
-% "real" English prefixes: Y' w/
-% Y'gotta Y'gonna
-% coffe w/milk
 "(" "{" "[" "<" "".x" « 〈 （ 〔 《 【 ［
 『 「 、.x `.x `` „ ‘ “ ''.x '.x ….x ....x
 ¿ ¡ "$" US$ USD C$
@@ -34,7 +31,7 @@ _ ‐ ‑ ‒ – — ― ….y ━.y –.y ー.y ‐.y 、.y
 † †† ‡ § ¶ © ® ℗ № "#"
 * • ⁂ ❧ ☞ ◊ ※  ○  。.x ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎
 _ ‐ ‑ ‒ – — ― ～ –.x ━.x ー.x -- - ‧.x
-y' w/
+w/
   : LPUNC+;
 
 % Split words at these.
@@ -44,9 +41,10 @@ y' w/
 's 're 've 'd 'll 'm ’s ’re ’ve ’d ’ll ’m: SUF+;
 
 % Prefixes
+% "real" English prefix: y' w/
 % Y'gotta Y'gonna
-% coffe w/milk
-% y' w/: PRE+;
+% coffee w/milk
+y' w/: PRE+;
 
 % The below is a quoted list, used during tokenization. Do NOT put
 % spaces in between the various quotation marks!!

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -497,7 +497,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 							join_alt = false;
 							break;
 						}
-						join_len += strlen(cdjp[j]->word_string);
+						join_len += strlen(cdjp[j]->word_string) + 1;
 						if ((*wgaltp)->morpheme_type & IS_REG_MORPHEME)
 							join_alt = true;
 					}

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -85,11 +85,8 @@ typedef enum
 #define WS_UNSPLIT (1<<5) /* It's an alternative to itself as an unsplit word */
 #define WS_INDICT  (1<<6) /* boolean_dictionary_lookup() is true */
 #define WS_FIRSTUPPER (1<<7) /* Subword is the lc version of its unsplit_word.
-                              The idea of marking subwords this way, in order to
-                              enable restoring their original capitalization,
-                              may be wrong in general, since in some languages
-                              the process is not always reversible. Instead,
-                              the original word may be saved. */
+                                The original word can be restored if needed
+                                through this unsplit_word. */
 /* - Post linkage stage. XXX Experimental. */
 #define WS_PL      (1<<14) /* Post-Linkage, not belonging to tokenization */
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2200,24 +2200,22 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 
 	lgdebug(+D_SW, "Processing word: '%s'\n", word);
 
-	if (unsplit_word->status & (WS_SPELL|WS_RUNON))
+	if (boolean_dictionary_lookup(dict, word))
 	{
-		/* The word is a result of spelling.
-		 * So it it is in the dict, and doesn't need right/left stripping. */
+		lgdebug(+D_SW, "0: Adding '%s' as is, before split tries, status=%s\n",
+		        word, gword_status(sent, unsplit_word));
+		issue_word_alternative(sent, unsplit_word, "W", 0,NULL, 1,&word, 0,NULL);
 		unsplit_word->status |= WS_INDICT;
 		word_is_known = true;
 	}
+
+	if (unsplit_word->status & (WS_SPELL|WS_RUNON))
+	{
+		/* The word is a result of spelling, so it doesn't need right/left
+		 * stripping. Skip it. */
+	}
 	else
 	{
-		if (boolean_dictionary_lookup(dict, word))
-		{
-			lgdebug(+D_SW, "0: Adding '%s' as is, before split tries\n", word);
-			issue_word_alternative(sent, unsplit_word, "W",
-			                       0,NULL, 1,&word, 0,NULL);
-			unsplit_word->status |= WS_INDICT;
-			word_is_known = true;
-		}
-
 		if ((MT_CONTR == unsplit_word->morpheme_type))
 		{
 			/* The word is the contracted part of a contraction. It was most

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2449,6 +2449,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 	        word, word_can_split, word_is_known,
 	        (NULL == unsplit_word->regex_name) ? "" : unsplit_word->regex_name);
 
+	/* FIXME: Handling of capitalized words that are a result of spelling. */
 	if (is_utf8_upper(word, dict->lctype))
 	{
 		if (!test_enabled("dictcap"))

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -988,7 +988,8 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				}
 			}
 #endif
-			return alternative_id;
+
+	return alternative_id;
 }
 #undef D_IWA
 


### PR DESCRIPTION
- Misc. fixes.
- Fix recognizing `Y'` + add a test case.
  (BTW, maybe `wanna` can be added too, and also `D'`).
- Fix a buffer overflow when combining morphemes.
- Recognize W/ too, to account for sentences starting with it (supposing they are valid), e.g.:
`W/milk I don't want it.`
These fix involve moving Y' and w/ from LPUNC to PRE, because LPUNC tokens are terminals.
A drawback of this move is that `w/something` is recombined for display (unless  `!morphology=1`
is used).
Possible solutions:
-- Leave it as is.
-- Always set `!morphology=1` for English (maybe in a per-language flag setting definition, that case be used also to set `cost-max` so it will not be not hard-wired).
-- Don't combine morphemes with non-letters in them (currently needed only for this case).
Note that `y'` doesn't have this problem due to special code in `issue_word_alternatives()` that classifies it as MT_CONTR (even though it is maybe not a real contraction).
