### PR TITLE
More cleanups ++

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -6,7 +6,7 @@
 
 SWIG_SOURCES = ../swig/link_grammar.i
 SWIG_INCLUDES = ../../link-grammar/link-includes.h
-built_c_sources = ../../bindings/python/lg_python_wrap.cc
+built_c_sources = lg_python_wrap.cc
 built_py_sources = $(top_builddir)/bindings/python/clinkgrammar.py
 
 # Over-ride the install location, so as to remove the dash in the

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -6,9 +6,8 @@
 
 SWIG_SOURCES = ../swig/link_grammar.i
 SWIG_INCLUDES = ../../link-grammar/link-includes.h
-# BUILT_C_SOURCES = $(top_builddir)/bindings/python/lg_python_wrap.cc
-BUILT_C_SOURCES = ../../bindings/python/lg_python_wrap.cc
-BUILT_PY_SOURCES = $(top_builddir)/bindings/python/clinkgrammar.py
+built_c_sources = ../../bindings/python/lg_python_wrap.cc
+built_py_sources = $(top_builddir)/bindings/python/clinkgrammar.py
 
 # Over-ride the install location, so as to remove the dash in the
 # directory "link-grammar".  Turns out python cannot tolerate dashes.
@@ -29,8 +28,8 @@ uninstall-hook:
 
 # These are packaged in the tarball; make clean should not remove them.
 maintainer-clean-local:
-	-rm -f $(BUILT_C_SOURCES)
-	-rm -f $(BUILT_PY_SOURCES)
+	-rm -f $(built_c_sources)
+	-rm -f $(built_py_sources)
 
 # Don't remove __init__.py; it is built by configure!
 DISTCLEANFILES =                                   \
@@ -38,12 +37,12 @@ DISTCLEANFILES =                                   \
 
 if HAVE_SWIG
 # Swig builds these ....
-$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_INCLUDES)
-$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_SOURCES)
+$(built_c_sources) $(built_py_sources): $(SWIG_INCLUDES)
+$(built_c_sources) $(built_py_sources): $(SWIG_SOURCES)
 	$(SWIG) -python -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 else
-$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES):
-	touch $(BUILT_C_SOURCES) $(BUILT_PY_SOURCES)
+$(built_c_sources) $(built_py_sources):
+	touch $(built_c_sources) $(built_py_sources)
 endif
 
 # The la MUST have the same name as the pm,
@@ -52,7 +51,7 @@ endif
 # interfaces.
 pkgpyexec_LTLIBRARIES = _clinkgrammar.la
 
-_clinkgrammar_la_SOURCES = $(BUILT_C_SOURCES) $(SWIG_SOURCES)
+_clinkgrammar_la_SOURCES = $(built_c_sources) $(SWIG_SOURCES)
 
 # $(top_builddir) to pick up autogen'ed link-grammar/link-features.h
 _clinkgrammar_la_CPPFLAGS =       \

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -302,7 +302,19 @@ class LG_Error(Exception):
 
     @staticmethod
     def message(msg):
-        return clg._prt_error(msg)
+        """Print a message through the LG error facility"""
+        # Propagate a possible ending "\n" into the format, from which the LG
+        # error facility determine if this is a partial or a complete message.
+        if msg[-1:] == "\n":      # a newline-ended complete message
+            _local_eol = "\n";
+            msg = msg[:-1]
+        elif msg[-2:] == "\n\\":  # a newline-ended partial message
+            _local_eol = "";
+            msg = msg[:-1]
+        else:
+            _local_eol = ""       # a partial message
+
+        return clg._prt_error('%s'+_local_eol, msg)
 
     @staticmethod
     def _default_handler(errinfo, data):

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -8,9 +8,8 @@ PYTHON = $(PYTHON3) # For py-compile.
 
 SWIG_SOURCES = ../swig/link_grammar.i
 SWIG_INCLUDES = ../../link-grammar/link-includes.h
-# BUILT_C_SOURCES = $(top_builddir)/bindings/python3/lg_python_wrap.cc
-BUILT_C_SOURCES = ../../bindings/python3/lg_python_wrap.cc
-BUILT_PY_SOURCES = $(top_builddir)/bindings/python3/clinkgrammar.py
+built_c_sources = ../../bindings/python3/lg_python_wrap.cc
+built_py_sources = $(top_builddir)/bindings/python3/clinkgrammar.py
 
 # Over-ride the install location, so as to remove the dash in the
 # directory "link-grammar".  Turns out python cannot tolerate dashes.
@@ -40,8 +39,8 @@ uninstall-hook:
 
 # These are packaged in the tarball; make clean should not remove them.
 maintainer-clean-local:
-	-rm -f $(BUILT_C_SOURCES)
-	-rm -f $(BUILT_PY_SOURCES)
+	-rm -f $(built_c_sources)
+	-rm -f $(built_py_sources)
 
 # Don't remove __init__.py; it is built by configure!
 DISTCLEANFILES =                                   \
@@ -49,12 +48,12 @@ DISTCLEANFILES =                                   \
 
 if HAVE_SWIG
 # Swig builds these ....
-$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_INCLUDES)
-$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES): $(SWIG_SOURCES)
+$(built_c_sources) $(built_py_sources): $(SWIG_INCLUDES)
+$(built_c_sources) $(built_py_sources): $(SWIG_SOURCES)
 	$(SWIG) -python -py3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 else
-$(BUILT_C_SOURCES) $(BUILT_PY_SOURCES):
-	touch $(BUILT_C_SOURCES) $(BUILT_PY_SOURCES)
+$(built_c_sources) $(built_py_sources):
+	touch $(built_c_sources) $(built_py_sources)
 endif
 
 # The la MUST have the same name as the pm,
@@ -63,7 +62,7 @@ endif
 # interfaces.
 pkgpyexec_LTLIBRARIES = _clinkgrammar.la
 
-_clinkgrammar_la_SOURCES = $(BUILT_C_SOURCES) $(SWIG_SOURCES)
+_clinkgrammar_la_SOURCES = $(built_c_sources) $(SWIG_SOURCES)
 
 # $(top_builddir) to pick up autogen'ed link-grammar/link-features.h
 _clinkgrammar_la_CPPFLAGS =       \

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -8,7 +8,7 @@ PYTHON = $(PYTHON3) # For py-compile.
 
 SWIG_SOURCES = ../swig/link_grammar.i
 SWIG_INCLUDES = ../../link-grammar/link-includes.h
-built_c_sources = ../../bindings/python3/lg_python_wrap.cc
+built_c_sources = lg_python_wrap.cc
 built_py_sources = $(top_builddir)/bindings/python3/clinkgrammar.py
 
 # Over-ride the install location, so as to remove the dash in the
@@ -19,8 +19,8 @@ pkgpythondir=$(python3dir)/linkgrammar
 pkgpyexecdir=$(python3dir)/linkgrammar
 
 # Files that get installed in $pkgpythondir
-pkgpython_PYTHON =                                 \
-   ../../bindings/python/linkgrammar.py             \
+pkgpython_PYTHON =                                  \
+   ../python/linkgrammar.py                         \
    $(top_builddir)/bindings/python3/__init__.py     \
    $(top_builddir)/bindings/python3/clinkgrammar.py
 

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -199,7 +199,9 @@ const char * linkage_get_violation_name(Linkage linkage);
 char * lg_error_formatmsg(lg_errinfo *lge);
 int lg_error_clearall(void);
 %rename(_prt_error) prt_error;
-int prt_error(const char * , ...);
+/* For security, the first argument should always contain a single "%s"
+ * (e.g. "%s\n"), and the second one should always be a C string. */
+int prt_error(const char *, const char *);
 bool lg_error_flush(void);
 /*
  * void *lg_error_set_handler_data(void *);

--- a/configure.ac
+++ b/configure.ac
@@ -909,7 +909,7 @@ MAYBE_WARN_CXX="-Wall -Wextra \
 -Wsign-compare -Werror-implicit-function-declaration \
 -Wpointer-arith -Wwrite-strings -Wmissing-declarations \
 -Wpacked -Wswitch-enum -Wmissing-format-attribute \
--Wstrict-aliasing -Winit-self \
+-Wstrict-aliasing -Winit-self -Wshadow \
 -Wno-missing-field-initializers -Wno-unused-parameter \
 -Wno-attributes -Wno-long-long -Winline"
 

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -224,7 +224,7 @@ locale_error:
 	{
 		dict->free_lookup(dict, dn);
 
-		const char *locale = get_default_locale();
+		locale = get_default_locale();
 		if (NULL == locale) return NULL;
 		const char *sslocale = string_set_add(locale, dict->string_set);
 		free((void *)locale);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -266,7 +266,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 		{
 			t->count = zero;
 			Disjunct * d;
-			int w = lw + 1;
+			w = lw + 1;
 			for (d = ctxt->local_sent[w].d; d != NULL; d = d->next)
 			{
 				if (d->left == NULL)

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -557,7 +557,6 @@ static bool alt_connection_possible(Connector *c1, Connector *c2,
  * not included again when processing the mr list.
  *
  * Note that if both lc and rc match the corresponding connectors of w,
-	gc.word = NULL;
  * match_left is set to true when the ml list is processed and the
  * disjunct is then added to the result list, and match_right of the
  * same disjunct is set to true when the mr list is processed, and this

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1053,6 +1053,8 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 	change = true;
 	while (change)
 	{
+		char dir;
+
 		change = false;
 		N_deleted = 0;
 		for (w = 0; w < sent->length; w++)
@@ -1060,7 +1062,6 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			Disjunct *d;
 			for (d = sent->word[w].d; d != NULL; d = d->next)
 			{
-				char dir;
 				if (!d->marked) continue;
 				deleteme = false;
 				for (dir = 0; dir < 2; dir++)
@@ -1099,7 +1100,6 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 
 				if (deleteme)         /* now we delete this disjunct */
 				{
-					char dir;
 					N_deleted++;
 					total_deleted++;
 					d->marked = false; /* mark for deletion later */

--- a/link-grammar/prepare/exprune.h
+++ b/link-grammar/prepare/exprune.h
@@ -11,9 +11,9 @@
 /*************************************************************************/
 
 #ifndef _EXPRESSION_PRUNE_H
-#define _EXPRESION_PRUNE_H
+#define _EXPRESSION_PRUNE_H
 
 #include "link-includes.h"
 
 void       expression_prune(Sentence);
-#endif /* _EXPRESION_PRUNE_H */
+#endif /* _EXPRESSION_PRUNE_H */

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -131,11 +131,11 @@ bool resources_memory_exhausted(Resources r)
 #define RES_COL_WIDTH sizeof("                                     ")
 
 /** print out the cpu ticks since this was last called */
-static void resources_print_time(int verbosity, Resources r, const char * s)
+static void resources_print_time(int verbosity_opt, Resources r, const char * s)
 {
 	double now;
 	now = current_usage_time();
-	if (verbosity >= D_USER_TIMES)
+	if (verbosity_opt >= D_USER_TIMES)
 	{
 		prt_error("++++ %-36s %7.2f seconds\n", s, now - r->when_last_called);
 	}
@@ -143,12 +143,12 @@ static void resources_print_time(int verbosity, Resources r, const char * s)
 }
 
 /** print out the cpu ticks since this was last called */
-static void resources_print_total_time(int verbosity, Resources r)
+static void resources_print_total_time(int verbosity_opt, Resources r)
 {
 	double now;
 	now = current_usage_time();
 	r->cumulative_time += (now - r->time_when_parse_started) ;
-	if (verbosity >= D_USER_BASIC)
+	if (verbosity_opt >= D_USER_BASIC)
 	{
 		prt_error("++++ %-36s %7.2f seconds (%.2f total)\n", "Time",
 		          now - r->time_when_parse_started, r->cumulative_time);
@@ -156,9 +156,9 @@ static void resources_print_total_time(int verbosity, Resources r)
 	r->time_when_parse_started = now;
 }
 
-static void resources_print_total_space(int verbosity, Resources r)
+static void resources_print_total_space(int verbosity_opt, Resources r)
 {
-	if (verbosity >= D_USER_TIMES)
+	if (verbosity_opt >= D_USER_TIMES)
 	{
 		prt_error("++++ %-36s %zu bytes (%zu max)\n", "Total space",
 		          get_space_in_use(), get_max_space_used());

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1372,10 +1372,10 @@ void SATEncoder::pp_prune()
 
 
     vec<Lit> triggers;
-    for (size_t i = 0; i < link_variables.size(); i++) {
-      const Variables::LinkVar* var = _variables->link_variable(link_variables[i]);
+    for (size_t vi = 0; vi < link_variables.size(); vi++) {
+      const Variables::LinkVar* var = _variables->link_variable(link_variables[vi]);
       if (post_process_match(rule.selector, var->label)) {
-        triggers.push(Lit(link_variables[i]));
+        triggers.push(Lit(link_variables[vi]));
       }
     }
 
@@ -1398,8 +1398,8 @@ void SATEncoder::pp_prune()
     DEBUG_print("---pp_pruning--");
     for (int k = 0; k < triggers.size(); k++) {
       vec<Lit> clause(criterions.size() + 1);
-      for (int i = 0; i < criterions.size(); i++)
-        clause[i] = criterions[i];
+      for (int ci = 0; ci < criterions.size(); ci++)
+        clause[ci] = criterions[ci];
       clause[criterions.size()] = (~triggers[k]);
       add_clause(clause);
     }

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -84,8 +84,8 @@ public:
       }
     }
 
-    for (size_t i = 0; i < _linked_variables.size(); i++)
-      delete _linked_variables[i];
+    for (size_t vi = 0; vi < _linked_variables.size(); vi++)
+      delete _linked_variables[vi];
 
     delete _guiding;
   }

--- a/link-grammar/tokenize/wordgraph.c
+++ b/link-grammar/tokenize/wordgraph.c
@@ -874,26 +874,26 @@ static void x_popen(const char *cmd, const char *wgds)
 	}
 }
 #else
-static void x_forkexec(const char *const argv[], pid_t *pid)
+static void x_forkexec(const char *const argv[], pid_t *vpid)
 {
 	/* Fork/exec a graph viewer, and leave it in the background until we exit.
 	 * On exit, send SIGHUP. If prctl() is not available and the program
 	 * crashes, then it is left to the user to exit the viewer. */
-	if (0 < *pid)
+	if (0 < *vpid)
 	{
-		pid_t rpid = waitpid(*pid, NULL, WNOHANG);
+		pid_t rpid = waitpid(*vpid, NULL, WNOHANG);
 
 		if (0 == rpid) return; /* viewer still active */
 		if (-1 == rpid)
 		{
-			prt_error("Error: waitpid(%d): %s\n", *pid, strerror(errno));
-			*pid = 0;
+			prt_error("Error: waitpid(%d): %s\n", *vpid, strerror(errno));
+			*vpid = 0;
 			return;
 		}
 	}
 
-	*pid = fork();
-	switch (*pid)
+	*vpid = fork();
+	switch (*vpid)
 	{
 		case -1:
 			prt_error("Error: fork(): %s\n", strerror(errno));

--- a/link-grammar/tokenize/wordgraph.c
+++ b/link-grammar/tokenize/wordgraph.c
@@ -99,6 +99,7 @@ void gwordlist_append(Gword ***arrp, Gword *p)
 	(*arrp)[n] = p;
 }
 
+#if 0
 /**
  * Append a Gword list to a given Gword list (w/o duplicates).
  */
@@ -119,7 +120,6 @@ void gwordlist_append_list(const Gword ***to_word, const Gword **from_word)
 	}
 }
 
-#if 0
 /**
  * Replace "count" words from the position "start" by word "wnew".
  */

--- a/link-grammar/tokenize/wordgraph.c
+++ b/link-grammar/tokenize/wordgraph.c
@@ -1025,7 +1025,7 @@ void wordgraph_show(Sentence sent, const char *modestr)
 		}
 	}
 
-#if _WIN32
+#ifdef _WIN32
 #define EXITKEY "ALT-F4"
 #elif __APPLE__
 #define EXITKEY "⌘-Q"

--- a/link-grammar/tokenize/wordgraph.h
+++ b/link-grammar/tokenize/wordgraph.h
@@ -26,9 +26,11 @@ Gword *gword_new(Sentence, const char *);
 Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);
 void gwordlist_append(Gword ***, Gword *);
-void gwordlist_append_list(const Gword ***, const Gword **);
 void gword_set_print(const gword_set *);
 void print_lwg_path(Gword **, const char *);
+#if 0
+void gwordlist_append_list(const Gword ***, const Gword **);
+#endif
 
 const Gword **wordgraph_hier_position(Gword *);
 void print_hier_position(const Gword *);

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -239,6 +239,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t local
 	safe_strcpy(to, from, usize-nbl);
 }
 
+#if 0
 /**
  * Upcase the first letter of the word.
  * XXX FIXME This works 'most of the time', but is not technically correct.
@@ -280,6 +281,7 @@ void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale_
 	to += nbl;
 	safe_strcpy(to, from, usize-nbl);
 }
+#endif
 
 /* ============================================================= */
 /* Memory alloc routines below. These routines attempt to keep

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -434,7 +434,9 @@ static inline bool utf8_upper_match(const char * s, const char * t,
 #endif /* Not in use. */
 
 void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t);
+#if 0
 void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t);
+#endif
 int utf8_charlen(const char *);
 
 size_t lg_strlcpy(char * dest, const char *src, size_t size);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -266,10 +266,10 @@ static void print_parse_statistics(Sentence sent, Parse_Options opts)
  * the following can be used:
  * link-parser -limit=30000 -test=auto-next-linkage:20000 < file.batch
  */
-static int auto_next_linkage_test(const char *test)
+static int auto_next_linkage_test(const char *test_opt)
 {
 	char auto_next_linkage_str[] = ",auto-next-linkage";
-	char *auto_next_linkage_pos = strstr(test, auto_next_linkage_str);
+	char *auto_next_linkage_pos = strstr(test_opt, auto_next_linkage_str);
 	int max_display;
 
 	if (auto_next_linkage_pos == NULL) return 0;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -607,12 +607,12 @@ int main(int argc, char * argv[])
 	}
 
 	copts = command_options_create();
-	opts = copts->popts;
-	if (copts == NULL || opts == NULL || copts->panic_opts == NULL)
+	if (copts == NULL || copts->panic_opts == NULL)
 	{
 		prt_error("Fatal error: unable to create parse options\n");
 		exit(-1);
 	}
+	opts = copts->popts;
 
 	setup_panic_parse_options(copts->panic_opts);
 	copts->panic_mode = true;


### PR DESCRIPTION
Main changes:
- Fix macro definition typos
- Fix a potential NULL dereference
- Fix a security hole in the `prt_error()` Python interface implementation
- Ifdef out unused functions
- Add compiler flag `-Wshadow` to detect variable shadowing by parameters or local variables
-- Fix all the warnings due to `-Wshadow`
-- Clean up SUBSCRIPT_MARK patching in compute_chosen_words()
- Clean up the Python Makefiles
-- Avoid automake errors
-- Shorten paths
(The only remaining automake errors are from `corpus/Makefile.am`.)

[BTW, I'm still working on more important changes...].