### PR TITLE
Fix a crash when there is no PP info

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Version 5.4.1 (XXX 2017)
  * Fix man page installation (broken in 5.3.8).
  * Add affix-class MPUNC for splitting at intra-word punctuation.
+ * Fix crash when there is no PP info.
 
 Version 5.4.0 (26 July 2017)
  * Fix for missing locale info in Windows XP.

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -392,12 +392,14 @@ static inline bool verify_link_index(const Linkage linkage, LinkIdx index)
 
 int linkage_get_link_num_domains(const Linkage linkage, LinkIdx index)
 {
+	if (NULL == linkage->pp_info) return -1;
 	if (!verify_link_index(linkage, index)) return -1;
 	return linkage->pp_info[index].num_domains;
 }
 
 const char ** linkage_get_link_domain_names(const Linkage linkage, LinkIdx index)
 {
+	if (NULL == linkage->pp_info) return NULL;
 	if (!verify_link_index(linkage, index)) return NULL;
 	return linkage->pp_info[index].domain_name;
 }


### PR DESCRIPTION
Return an error indication in the following API calls when there is no PP info:
linkage_get_link_num_domains()
linkage_get_link_domain_names()

Repeat by:
$ link-parser any -links
...
linkparser> test
...
Segmentation fault (core dumped)

(It also happens with he, lt, etc.)