### PR TITLE
Fix a stack buffer overflow in the current release (5.4.0)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Version 5.4.1 (XXX 2017)
  * Fix man page installation (broken in 5.3.8).
  * Add affix-class MPUNC for splitting at intra-word punctuation.
  * Fix crash when there is no PP info.
+ * Fix a stack buffer overflow.
 
 Version 5.4.0 (26 July 2017)
  * Fix for missing locale info in Windows XP.

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -571,7 +571,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 	Gword *alternative_id = NULL;   /* to be set to the start subword */
 	bool subword_eq_unsplit_word;
 	bool last_split = false;        /* this is a final token */
-	int *strlen_cache = alloca(token_tot); /* token length cache array */
+	int *strlen_cache = alloca(token_tot * sizeof(int)); /* token length cache */
 #ifdef DEBUG
 	Gword *sole_alternative_of_itself = NULL;
 #endif


### PR DESCRIPTION
This bug has been detected when running on Windows with the debug configuration.
On Linux, both ASAN and valgrind don't detect it. (However, valgrind detected a memory leak in pp_lexer -
 that I will try to fix).