### PR TITLE
 Diagram printing: Eliminate size hard-wired limits

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 5.4.1 (XXX 2017)
  * Add affix-class MPUNC for splitting at intra-word punctuation.
  * Fix crash when there is no PP info.
  * Fix a stack buffer overflow.
+ * Eliminate hard-wired linkage diagram size imitations.
 
 Version 5.4.0 (26 July 2017)
  * Fix for missing locale info in Windows XP.

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Version 5.4.1 (XXX 2017)
  * Fix man page installation (broken in 5.3.8).
  * Add affix-class MPUNC for splitting at intra-word punctuation.
  * Fix crash when there is no PP info.
+ * Fix a stack buffer overflow.
 
 Version 5.4.0 (26 July 2017)
  * Fix for missing locale info in Windows XP.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -10,15 +10,12 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include <stdio.h>
 #include <string.h>
 #include "connectors.h"
 #include "disjunct-utils.h"
-#include "externs.h"
 #include "print/print-util.h"
 #include "string-set.h"
 #include "utilities.h"
-#include "tokenize/wordgraph.h"
 #include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
 
 /* Disjunct utilities ... */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -15,6 +15,7 @@
 #include "connectors.h"
 #include "disjunct-utils.h"
 #include "externs.h"
+#include "print/print-util.h"
 #include "string-set.h"
 #include "utilities.h"
 #include "tokenize/wordgraph.h"
@@ -348,39 +349,29 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * d)
  * Be sure to free the string upon return.
  */
 
-static char * prt_con(Connector *c, char * p, char dir, size_t * bufsz)
+static void prt_con(Connector *c, dyn_str * p, char dir)
 {
-	size_t n;
-
-	if (NULL == c) return p;
-	p = prt_con (c->next, p, dir, bufsz);
+	if (NULL == c) return;
+	prt_con (c->next, p, dir);
 
 	if (c->multi)
 	{
-		n = snprintf(p, *bufsz, "@%s%c ", c->string, dir);
-		*bufsz -= n;
+		append_string(p, "@%s%c ", c->string, dir);
 	}
 	else
 	{
-		n = snprintf(p, *bufsz, "%s%c ", c->string, dir);
-		*bufsz -= n;
+		append_string(p, "%s%c ", c->string, dir);
 	}
-	return p+n;
 }
-
-#define MAX_LINE 500          /* maximum width of print area */
 
 char * print_one_disjunct(Disjunct *dj)
 {
-	char buff[MAX_LINE];
-	char * p = buff;
-	size_t bufsz = MAX_LINE;
+	dyn_str *p = dyn_str_new();
 
-	p = prt_con(dj->left, p, '-', &bufsz);
-	p = prt_con(dj->right, p, '+', &bufsz);
-	buff[MAX_LINE-1] = 0;
+	prt_con(dj->left, p, '-');
+	prt_con(dj->right, p, '+');
 
-	return strdup(buff);
+	return dyn_str_take(p);
 }
 
 /* ============================================================= */

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -63,8 +63,14 @@ size_t utf8_strwidth(const char *s)
 
 /* ============================================================= */
 
-/* Note: As in the rest of the LG library, we assume here C99 compliance. */
-void vappend_string(dyn_str * string, const char *fmt, va_list args)
+/**
+ * Append to a dynamic string with vprintf-like formatting.
+ * @return The number of appended characters.
+ *
+ * Note: As in the rest of the LG library, we assume here C99 library
+ * compliance (without it, this code would be buggy).
+ */
+int vappend_string(dyn_str * string, const char *fmt, va_list args)
 {
 #define TMPLEN 1024 /* Big enough for a possible error message, see below */
 	char temp_buffer[TMPLEN];
@@ -94,7 +100,7 @@ void vappend_string(dyn_str * string, const char *fmt, va_list args)
 
 	patch_subscript_marks(temp_string);
 	dyn_strcat(string, temp_string);
-	return;
+	return templen;
 
 error:
 	{
@@ -104,16 +110,20 @@ error:
 		strerror_r(errno, temp_buffer+sizeof(msg)-1, TMPLEN-sizeof(msg));
 		strcat(temp_buffer, "]");
 		dyn_strcat(string, temp_string);
-		return;
+		return templen;
 	}
 }
 
-void append_string(dyn_str * string, const char *fmt, ...)
+/**
+ * Append to a dynamic string with printf-like formatting.
+ * @return The number of appended characters.
+ */
+int append_string(dyn_str * string, const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
 
-	vappend_string(string, fmt, args);
+	return vappend_string(string, fmt, args);
 }
 
 size_t append_utf8_char(dyn_str * string, const char * mbs)

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -25,8 +25,6 @@
 #include "dict-common/dict-defines.h" /* SUBSCRIPT_MARK, SUBSCRIPT_DOT */
 #include "utilities.h"
 
-#define MAX_LINE 500          /* maximum width of print area */
-
 void append_string(dyn_str *, const char *fmt, ...) GNUC_PRINTF(2,3);
 void vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -25,8 +25,8 @@
 #include "dict-common/dict-defines.h" /* SUBSCRIPT_MARK, SUBSCRIPT_DOT */
 #include "utilities.h"
 
-void append_string(dyn_str *, const char *fmt, ...) GNUC_PRINTF(2,3);
-void vappend_string(dyn_str *, const char *fmt, va_list args)
+int append_string(dyn_str *, const char *fmt, ...) GNUC_PRINTF(2,3);
+int vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);
 size_t append_utf8_char(dyn_str *, const char * mbs);
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -729,7 +729,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 }
 
 /**
- * Print the indicated linkage as utf8-art intp the given string.
+ * Print the indicated linkage as utf8-art into the given string.
  * The width of the diagram is given by the terminal width, taken
  * from the parse options.
  *

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -11,22 +11,14 @@
 /*                                                                       */
 /*************************************************************************/
 
-
-#include <stdint.h>
-#include <stdlib.h>
-
-#include "externs.h"
 #include "api-structures.h"
 #include "connectors.h"
 #include "corpus/corpus.h"
-#include "dict-common/dict-utils.h" // For size_of_expression()
+#include "dict-common/dict-utils.h"   // For size_of_expression()
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
 #include "print.h"
-#include "print-util.h"
-#include "string-set.h"
-#include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
-#include "tokenize/word-structures.h" // for Word_struct
+#include "tokenize/word-structures.h" // For Word_struct
 #include "wcwidth.h"
 
 #define LEFT_WALL_SUPPRESS ("Wd") /* If this connector is used on the wall, */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -571,7 +571,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 	Gword *alternative_id = NULL;   /* to be set to the start subword */
 	bool subword_eq_unsplit_word;
 	bool last_split = false;        /* this is a final token */
-	int *strlen_cache = alloca(token_tot); /* token length cache array */
+	int *strlen_cache = alloca(token_tot * sizeof(int)); /* token length cache */
 #ifdef DEBUG
 	Gword *sole_alternative_of_itself = NULL;
 #endif


### PR DESCRIPTION
Fix issue #582.

Changes:
1) Diagram printing: Eliminate the MAX_HEIGHT and MAX_LINE limits.
2) utf8_strwidth(): Eliminate MAX_LINE limit.
3) print_one_disjunct(): Remove the MAX_LINE limitation. This change was not really needed....
4) Fix a typo.
5) Remove unneeded includes from the touched files. I guess that there is much more "include file rot" elsewhere.
6) Change vappend_string()/append_string() to return the number of appended chars, to be more similar to the *printf functions. Not used for now. In the same occassion I added I added function doc comments.
7) The stack buffer overflow is from the previous PR, and included here so I can update the ChangeLog without creating a conflict.

Also, a possible crash in linkage_print_diagram_ctxt(), due too a double-free when the diagram is too high, gets "automatically" fixed by this change. The reason of the bug was this code:
``` c
			if (2*row+2 > MAX_HEIGHT-1) {
				dyn_strcat(string, "The diagram is too high.\n");
				dyn_str_take(string);
			}
```

It should have been `return dyn_str_take(string)`.
If MAX_HEIGHT is reached, a C library crash results:
`*** Error in `/tmp/link-grammar/master/link-parser/.libs/lt-link-parser': double free or corruption (fasttop): 0x00000000024ec4e0 ***`

