### PR TITLE
make maintainer-clean: Add removing pp_lexer.c from the source tree

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -35,6 +35,7 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) $(WARN_CFLAGS) \
 	$(HUNSPELL_CFLAGS)
 
 post-process/pp_lexer.lo: AM_CPPFLAGS += -I$(top_srcdir)/link-grammar/post-process
+MAINTAINERCLEANFILES = $(top_srcdir)/link-grammar/post-process/pp_lexer.c
 
 lib_LTLIBRARIES = liblink-grammar.la
 


### PR DESCRIPTION
Background:
The automatic maintainer-clean target tries to remove pp_lexer.c from the build directory. However, it is reated in the source directory.
This causes a problem after compiling in Windows even after "make maintainer-clean":
pp_lexer.c:569:16: fatal error: io.h: No such file or directory