### PR TITLE
Empty-word simulation by null-count range check

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -126,7 +126,7 @@ struct Sentence_s
 
 	/* Parse results */
 	int    num_linkages_found;  /* Total number before postprocessing.  This
-	                               is returned by the count() function */
+	                               is returned by the do_count() function */
 	size_t num_linkages_alloced;/* Total number of linkages allocated.
 	                               the number post-processed might be fewer
 	                               because some are non-canonical */

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -43,7 +43,7 @@
 
 #include "api-types.h"
 #include "corpus/corpus.h"
-#include "error.h"
+//#include "error.h"
 #include "utilities.h"
 
 typedef struct Cost_Model_s Cost_Model;

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -207,7 +207,7 @@ static void remap_linkages(Linkage lkg, const int *remap)
  *  Print the chosen_disjuncts words.
  *  This is used for debug, e.g. for tracking them in the Wordgraph display.
  */
-static void print_chosen_disjuncts_words(const Linkage lkg)
+static void print_chosen_disjuncts_words(const Linkage lkg, bool prt_optword)
 {
 	size_t i;
 	dyn_str *djwbuf = dyn_str_new();
@@ -219,7 +219,7 @@ static void print_chosen_disjuncts_words(const Linkage lkg)
 		const char *djw; /* disjunct word - the chosen word */
 
 		if (NULL == cdj)
-			djw = lkg->sent->word[i].optional ? "{}" : "[]";
+			djw = (prt_optword && lkg->sent->word[i].optional) ? "{}" : "[]";
 		else if ('\0' == cdj->word_string[0])
 			djw = "\\0"; /* null string - something is wrong */
 		else
@@ -247,7 +247,7 @@ void remove_empty_words(Linkage lkg)
 	if (verbosity_level(+D_REE))
 	{
 		err_msg(lg_Debug, "chosen_disjuncts before:\n\\");
-		print_chosen_disjuncts_words(lkg);
+		print_chosen_disjuncts_words(lkg, /*prt_opt*/true);
 	}
 
 	for (i = 0, j = 0; i < lkg->num_words; i++)
@@ -275,7 +275,7 @@ void remove_empty_words(Linkage lkg)
 	if (verbosity_level(+D_REE))
 	{
 		err_msg(lg_Debug, "chosen_disjuncts after:\n\\");
-		print_chosen_disjuncts_words(lkg);
+		print_chosen_disjuncts_words(lkg, /*prt_opt*/false);
 	}
 }
 #undef D_REE

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -204,35 +204,6 @@ static void remap_linkages(Linkage lkg, const int *remap)
 }
 
 /**
- *  Print the chosen_disjuncts words.
- *  This is used for debug, e.g. for tracking them in the Wordgraph display.
- */
-static void print_chosen_disjuncts_words(const Linkage lkg, bool prt_optword)
-{
-	size_t i;
-	dyn_str *djwbuf = dyn_str_new();
-
-	err_msg(lg_Debug, "Linkage %p (%zu words): ", lkg, lkg->num_words);
-	for (i = 0; i < lkg->num_words; i++)
-	{
-		Disjunct *cdj = lkg->chosen_disjuncts[i];
-		const char *djw; /* disjunct word - the chosen word */
-
-		if (NULL == cdj)
-			djw = (prt_optword && lkg->sent->word[i].optional) ? "{}" : "[]";
-		else if ('\0' == cdj->word_string[0])
-			djw = "\\0"; /* null string - something is wrong */
-		else
-			djw = cdj->word_string;
-
-		dyn_strcat(djwbuf, djw);
-		dyn_strcat(djwbuf, " ");
-	}
-	err_msg(lg_Debug, "%s\n", djwbuf->str);
-	dyn_str_delete(djwbuf);
-}
-
-/**
  * Remove unlinked optional words from a linkage.
  * XXX Should we remove here also the dict-cap tokens? In any case, for now they
  * are left for debug.
@@ -323,7 +294,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 
 	memset(show_word, 0, linkage->num_words * sizeof(*show_word));
 
-	if (D_CCW <= opts->verbosity)
+	if (verbosity_level(D_CCW))
 		print_lwg_path(lwg_path, "Linkage");
 
 	for (i = 0; i < linkage->num_words; i++)
@@ -712,7 +683,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 
 	linkage->wg_path_display = n_lwg_path;
 
-	if (D_CCW <= opts->verbosity)
+	if (verbosity_level(D_CCW))
 		print_lwg_path(n_lwg_path, "Display");
 }
 #undef D_CCW

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -237,7 +237,7 @@ static void print_chosen_disjuncts_words(const Linkage lkg)
  * XXX Should we remove here also the dict-cap tokens? In any case, for now they
  * are left for debug.
  */
-#define D_REE 9
+#define D_REE 7
 void remove_empty_words(Linkage lkg)
 {
 	size_t i, j;

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -17,7 +17,6 @@
 #include "disjunct-utils.h"  // for Disjunct_struct
 #include "lg_assert.h"
 #include "linkage.h"
-#include "print/print.h"  // for print_with_subscript_dot
 #include "sane.h"
 #include "tokenize/tok-structures.h" // Needed for Wordgraph_pathpos_s
 #include "tokenize/wordgraph.h"

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -48,8 +48,8 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 	assert(NULL != p, "Tried to add a NULL word to the word queue");
 	if (current_word == p)
 	{
-		lgdebug(D_WPA, "Adding the same word %s again\n", p->subword);
-		print_lwg_path((Gword **)path, "After");
+		lgdebug(D_WPA, "Adding the same word '%s' again\n", p->subword);
+		//print_lwg_path((Gword **)path, "After adding the same word");
 	}
 
 	/* Check if the path queue already contains the word to be added to it. */
@@ -77,7 +77,7 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 					return; /* The shorter path is already in the queue. */
 				}
 				lgdebug(D_WPA, "Longer path is in the queue\n");
-				print_lwg_path((Gword **)wpt->path, "Freeing");
+				//print_lwg_path((Gword **)wpt->path, "Freeing");
 				free(wpt->path); /* To be replaced by a shorter path. */
 				break;
 			}

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -13,11 +13,13 @@
 #include "api-structures.h"  // for Sentence_s
 #include "api-types.h"
 #include "dict-common/regex-morph.h" // for match_regex
+#include "connectors.h" // for MAX_SENTENCE
 #include "disjunct-utils.h"  // for Disjunct_struct
 #include "lg_assert.h"
 #include "linkage.h"
 #include "sane.h"
 #include "tokenize/tok-structures.h" // Needed for Wordgraph_pathpos_s
+#include "tokenize/word-structures.h" // for Word_struct
 #include "tokenize/wordgraph.h"
 #include "utilities.h"
 
@@ -139,6 +141,105 @@ static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
 	free(wp);
 }
 
+#define NO_WORD (MAX_SENTENCE+1)
+
+/**
+ * Return the number of islands in a linkage.
+ * First, each word appears in its own linked list.
+ * Then all the links in the linkage are traversed, and the lists pointed
+ * by each of them are combined.
+ * Finally, the words are traversed and the lists are followed and
+ * numbered. The WG path is used to skip optional words which are null.
+ */
+static size_t num_islands(const Linkage lkg, const Gword **wg_path)
+{
+	struct word
+	{
+		int prev;
+		int next;
+		int inum;
+	};
+	struct word *word = alloca(lkg->sent->length * sizeof(struct word));
+
+	/* Initially, each word is in its own island. */
+	for (WordIdx w = 0; w < lkg->sent->length; w++)
+	{
+		word[w].prev = word[w].next = w;
+	}
+
+	/* Unify the potential islands pointed by each link
+	 * (if they are already unified, they remain so.) */
+	for (LinkIdx li = 0; li < lkg->num_links; li++)
+	{
+		Link *l = &lkg->link_array[li];
+
+		WordIdx iw;
+		for (iw = word[l->lw].next; (iw != l->rw) && (iw != l->lw); iw = word[iw].next)
+			;
+
+		if (iw != l->rw)
+		{
+			int nextl = word[l->lw].next;
+			int prevr = word[l->rw].prev;
+
+			word[l->lw].next = l->rw;
+			word[l->rw].prev = l->lw;
+
+			word[prevr].next = nextl;
+			word[nextl].prev = prevr;
+		}
+
+		if (verbosity_level(+8))
+		{
+			for (WordIdx w = 0; w < lkg->sent->length; w++)
+			{
+				err_msg(lg_Debug, "%d<-%zu->%d ", word[w].prev, w, word[w].next);
+			}
+			err_msg(lg_Debug, "\n");
+		}
+	}
+
+	/* Count islands. */
+	int inum = -1;
+	Disjunct **cdj = lkg->chosen_disjuncts;
+
+	for (WordIdx w = 0; w < lkg->sent->length; w++)
+	{
+		/* Skip null words which are optional words. */
+		if ((NULL == *wg_path) || ((*wg_path)->sent_wordidx != w))
+		{
+			assert(word[w].prev == word[w].next);
+			assert((NULL == cdj[w]) && lkg->sent->word[w].optional);
+
+			word[w].prev = NO_WORD;
+			word[w].inum = -1; /* not belonging to any island */
+			continue;
+		}
+
+		wg_path++;
+		if (NO_WORD == word[w].prev) continue;
+
+		inum++;
+		for (WordIdx iw = w; NO_WORD != word[iw].prev; iw = word[iw].next)
+		{
+			word[iw].prev = NO_WORD;
+			word[iw].inum = inum;
+		}
+	}
+
+	if (verbosity_level(8))
+	{
+		err_msg(lg_Debug, "Island count %d: ", inum);
+		for (WordIdx w = 0; w < lkg->sent->length; w++)
+		{
+			err_msg(lg_Debug, "%d ", word[w].inum);
+		}
+		err_msg(lg_Debug, "\n");
+	}
+
+	return inum;
+}
+
 /* ============================================================== */
 /* A kind of morphism post-processing */
 
@@ -233,29 +334,20 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 			/* A null word matches any word in the Wordgraph -
 			 * so, unconditionally proceed in all paths in parallel. */
 			match_found = false;
+			bool optional_word_found = false;
 			for (wpp = wp_old; NULL != wpp->word; wpp++)
 			{
-				if (NULL == wpp->word->next) // XXX
-					continue; /* This path encountered the Wordgraph end */
-
-				if (wpp->word->sent_wordidx > i)
+				if ((MT_INFRASTRUCTURE == wpp->word->morpheme_type) ||
+				    (wpp->word->sent_wordidx > i))
 				{
 					assert(sent->word[i].optional, "wordindex=%zu", i);
 					lgdebug(D_SLM, " (Optional, index=%zu)\n", i);
 					// Retain the same word in the new path queue.
 					wordgraph_path_append(&wp_new, wpp->path, wpp->word, wpp->word);
 					match_found = true;
+					optional_word_found = true;
 					continue; /* Disregard this chosen disjunct. */
 				}
-
-				null_count_found++;
-				if (null_count_found > lkg->sent->null_count)
-				{
-					lgdebug(D_SLM, " (Extra, count > %zu)\n", lkg->sent->null_count);
-					match_found = false;
-					break;
-				}
-				lgdebug(D_SLM, "\n");
 
 				/* The null words cannot be marked here because wpp->path consists
 				 * of pointers to the Wordgraph words, and these words are common to
@@ -270,6 +362,22 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 					wordgraph_path_append(&wp_new, wpp->path, wpp->word, *next);
 				}
 			}
+
+			if (!optional_word_found)
+			{
+				null_count_found++;
+				/* Note that if all the sentence words are null-words, its
+				 * null_count is only sent->length-1 so this is not a mismatch. */
+				if ((null_count_found > lkg->sent->null_count) &&
+				    (lkg->sent->null_count != sent->length-1))
+				{
+					lgdebug(D_SLM, " (Extra, count > %zu)\n", lkg->sent->null_count);
+					match_found = false;
+					break;
+				}
+				lgdebug(D_SLM, "\n");
+			}
+
 			if (NULL != wpp->word) break; /* Extra null count */
 			continue;
 		}
@@ -332,6 +440,23 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		}
 		if (!match_found)
 		    lgdebug(D_SLM, "%p Missing word(s) at the end of the linkage.\n", lkg);
+	}
+
+	/* Reject found null count that is not consistent with sent->null_count.
+	 * Here islands_ok=1 is handled, and also a lower-than-expected null
+	 * count when islands_ok=0. */
+	if (match_found)
+	{
+		size_t count_found =
+			opts->islands_ok ? num_islands(lkg, wpp->path) : null_count_found;
+
+		if ((count_found != lkg->sent->null_count) &&
+		    (lkg->sent->null_count != sent->length-1) && (count_found != sent->length))
+		{
+			lgdebug(D_SLM, "Null count mismatch: Found %zu != null_count %zu\n",
+					  count_found, lkg->sent->null_count);
+			match_found = false;
+		}
 	}
 
 #define DEBUG_morpheme_type 0

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -10,8 +10,6 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include <stdlib.h>
-
 #include "api-structures.h"  // for Sentence_s
 #include "api-types.h"
 #include "dict-common/dict-structures.h"

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -149,7 +149,7 @@ static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
  *
  * Return true if the linkage is good, else return false.
  */
-#define D_SLM 7
+#define D_SLM 8
 bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 {
 	Wordgraph_pathpos *wp_new = NULL;
@@ -375,13 +375,13 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		{
 			lgdebug(D_SLM, "%p Morpheme type combination '%s'\n", lkg, affix_types);
 		}
-		lgdebug(+D_SLM, "%p SUCCEEDED\n", lkg);
+		lgdebug(+D_SLM-1, "%p SUCCEEDED\n", lkg);
 		lkg->wg_path = lwg_path;
 		return true;
 	}
 
 	/* Oh no ... invalid morpheme combination! */
-	lgdebug(D_SLM, "%p FAILED\n", lkg);
+	lgdebug(+D_SLM-1, "%p FAILED\n", lkg);
 	return false;
 }
 #undef D_SLM

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -12,7 +12,6 @@
 
 #include "api-structures.h"  // for Sentence_s
 #include "api-types.h"
-#include "dict-common/dict-structures.h"
 #include "dict-common/regex-morph.h" // for match_regex
 #include "disjunct-utils.h"  // for Disjunct_struct
 #include "lg_assert.h"

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -193,7 +193,40 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 	return n;
 }
 
+//#define DO_COUNT_TRACE
+
+#ifdef DO_COUNT_TRACE
+#define V(c) (!c?"(nil)":c->string)
+static Count_bin do_count1(int lineno, fast_matcher_t *mchxt,
+                          count_context_t *ctxt,
+                          int lw, int rw,
+                          Connector *le, Connector *re,
+                          int null_count);
+
+static Count_bin do_count(int lineno, fast_matcher_t *mchxt,
+                          count_context_t *ctxt,
+                          int lw, int rw,
+                          Connector *le, Connector *re,
+                          int null_count)
+{
+	static int level;
+
+	level++;
+	printf("%*sdo_count:%d lw=%d rw=%d le=%s re=%s null_count=%d\n",
+		    level*2, "", lineno, lw, rw, V(le), V(re), null_count);
+	Table_connector *t = find_table_pointer(ctxt, lw, rw, le, re, null_count);
+	Count_bin r = do_count1(lineno, mchxt, ctxt, lw, rw, le, re, null_count);
+	printf("%*sreturn%*s:%d=%lld\n", level*2, "", (!!t)*3, "(C)", lineno, r);
+	level--;
+
+	return r;
+}
+
+static Count_bin do_count1(int lineno, fast_matcher_t *mchxt,
+#define do_count(...) do_count(__LINE__, __VA_ARGS__)
+#else
 static Count_bin do_count(fast_matcher_t *mchxt,
+#endif
                           count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -367,31 +367,35 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 		RECOUNT({xt->set.recount = 0;})
 
 		w = lw + 1;
-		for (dis = words[w].d; dis != NULL; dis = dis->next)
+		for (int opt = 0; opt <= !!words[w].optional; opt++)
 		{
-			if (dis->left == NULL)
+			null_count += opt;
+			for (dis = words[w].d; dis != NULL; dis = dis->next)
 			{
-				pset = mk_parse_set(words, mchxt, ctxt,
-				                    dis, NULL, w, rw, dis->right, NULL,
-				                    null_count-1, pex, islands_ok);
-				if (pset == NULL) continue;
+				if (dis->left == NULL)
+				{
+					pset = mk_parse_set(words, mchxt, ctxt,
+											  dis, NULL, w, rw, dis->right, NULL,
+											  null_count-1, pex, islands_ok);
+					if (pset == NULL) continue;
+					dummy = dummy_set(lw, w, null_count-1, pex);
+					record_choice(dummy, NULL, NULL,
+									  pset,  NULL, NULL,
+									  NULL, NULL, NULL, &xt->set);
+					RECOUNT({xt->set.recount += pset->recount;})
+				}
+			}
+			pset = mk_parse_set(words, mchxt, ctxt,
+									  NULL, NULL, w, rw, NULL, NULL,
+									  null_count-1, pex, islands_ok);
+			if (pset != NULL)
+			{
 				dummy = dummy_set(lw, w, null_count-1, pex);
 				record_choice(dummy, NULL, NULL,
-				              pset,  NULL, NULL,
-				              NULL, NULL, NULL, &xt->set);
+								  pset,  NULL, NULL,
+								  NULL, NULL, NULL, &xt->set);
 				RECOUNT({xt->set.recount += pset->recount;})
 			}
-		}
-		pset = mk_parse_set(words, mchxt, ctxt,
-		                    NULL, NULL, w, rw, NULL, NULL,
-		                    null_count-1, pex, islands_ok);
-		if (pset != NULL)
-		{
-			dummy = dummy_set(lw, w, null_count-1, pex);
-			record_choice(dummy, NULL, NULL,
-			              pset,  NULL, NULL,
-			              NULL, NULL, NULL, &xt->set);
-			RECOUNT({xt->set.recount += pset->recount;})
 		}
 		return &xt->set;
 	}

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -167,7 +167,8 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 	sent->num_linkages_alloced = sent->num_valid_linkages;
 
 	lgdebug(D_PARSE, "Info: sane_morphism(): %zu of %zu linkages had "
-	        "invalid morphology construction\n", N_invalid_morphism, itry);
+	        "invalid morphology construction\n", N_invalid_morphism,
+	        itry + (itry != maxtries));
 }
 
 static void sort_linkages(Sentence sent, Parse_Options opts)

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -139,10 +139,11 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 		}
 		extract_links(pex, lkg);
 		compute_link_names(lkg, sent->string_set);
-		remove_empty_words(lkg);
 
 		if (sane_linkage_morphism(sent, lkg, opts))
 		{
+			remove_empty_words(lkg);
+
 			need_init = true;
 			in++;
 			if (in >= sent->num_linkages_alloced) break;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -84,6 +84,7 @@ static void process_linkages(Sentence sent, extractor_t* pex,
                              bool overflowed, Parse_Options opts)
 {
 	if (0 == sent->num_linkages_found) return;
+	if (0 == sent->num_linkages_alloced) return; /* Avoid a later crash. */
 
 	/* Pick random linkages if we get more than what was asked for. */
 	bool pick_randomly = overflowed ||

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -490,7 +490,7 @@ static bool possible_connection(prune_context *pc,
 	}
 	/* If the words are NOT next to each other, then there must be
 	 * at least one intervening connector (i.e. cannot have both
-	 * lc->next amnd rc->next being null).  But we only enforce this
+	 * lc->next and rc->next being null).  But we only enforce this
 	 * when we think its still possible to have a complete parse,
 	 * i.e. before well allow null-linked words.
 	 */

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -91,7 +91,7 @@ int vappend_string(dyn_str * string, const char *fmt, va_list args)
 	if (templen >= TMPLEN)
 	{
 		/* TMPLEN is too small - use a bigger buffer. Couldn't actually
-		 * find any example of entering this code with TMPLEN=1024... */
+		 * find any example of entering this code with templen>=1024... */
 		temp_string = alloca(templen+1);
 		templen = vsnprintf(temp_string, templen+1, fmt, args);
 		if ((int)templen < 0) goto error;

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -65,7 +65,7 @@ size_t utf8_strwidth(const char *s)
 
 /**
  * Append to a dynamic string with vprintf-like formatting.
- * @return The number of appended characters.
+ * @return The number of appended bytes, or a negative value on error.
  *
  * Note: As in the rest of the LG library, we assume here C99 library
  * compliance (without it, this code would be buggy).
@@ -116,7 +116,7 @@ error:
 
 /**
  * Append to a dynamic string with printf-like formatting.
- * @return The number of appended characters.
+ * @return The number of appended bytes, or a negative value on error.
  */
 int append_string(dyn_str * string, const char *fmt, ...)
 {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1428,7 +1428,6 @@ Linkage SATEncoder::create_linkage()
   partial_init_linkage(_sent, linkage, _sent->length);
   sat_extract_links(linkage);
   compute_link_names(linkage, _sent->string_set);
-  remove_empty_words(linkage);  /* Discard optional words. */
   return linkage;
 }
 
@@ -1486,6 +1485,7 @@ Linkage SATEncoder::get_next_linkage()
           free(linkage);
           continue; // skip this linkage
       }
+      remove_empty_words(linkage);  /* Discard optional words. */
     }
 
     if (!connected) {

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 #include "api-types.h"
+#include "link-includes.h"
 
 /* conditional compiling flags */
 #define INFIX_NOTATION
@@ -128,6 +129,10 @@ struct Gword_struct
 
 	/* Disjuncts and connectors point back to their originating Gword(s). */
 	gword_set gword_set_head;
+
+	/* Used by sane_linkage_morphism() and remove_empty_words() for
+	 * locating optional words that should be removed. */
+	WordIdx sent_wordidx; /* Index in the 2D sentence word array. */
 
 	/* For debug and inspiration. */
 	const char *label;   /* Debug label - code locations of tokenization */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2968,6 +2968,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 
 	/* Generate an "alternatives" component. */
 	altappend(sent, &sent->word[wordpos].alternatives, s);
+	w->sent_wordidx = wordpos;
 
 	if (w->status & WS_INDICT)
 	{
@@ -3313,6 +3314,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 	} while ((NULL != wp_new[1].word) ||
 	         (wp_new[0].word->morpheme_type != MT_INFRASTRUCTURE));
 
+	wp_new[0].word->sent_wordidx = sent->length;
 	free(wp_new);
 	lgdebug(+D_FW, "sent->length %zu\n", sent->length);
 	if (verbosity_level(D_SW))


### PR DESCRIPTION
Per issue #527.
This PR is for review. However, it can be applied if desired.
The first 6 commits are a repeat of PR #587, so this PR can be applied cleanly after it.

The relevant changes are in the functions `do_count() `and `mk_parse_set()`.
Their commit is: "Classic parser: Adjust for optional-words that are not null-words".

The changes in `sane_morphism()` and `remove_empty_words()` are to support the removal of optional words that are really optional (and not just regular null words).

The "remove include" commits are just for cleanup.
"The wordgraph_path_append(): Replace longer paths" is for better handling of words which all their morphemes are null words, and is also not related to the main change.

Also there are changes for debug:
Change the verbosity level of sane_morphism and remove_empty_words
Fix printing the chosen disjuncts after removing optional words
Change/add debug code for chosen_disjuncts and GW path
do_count.c(): Add call tracing
