### PR TITLE
utf8_strwidth(): Fix error detection

### DIFF
--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -37,7 +37,7 @@ size_t utf8_strwidth(const char *s)
 #else
 	mblen = mbsrtowcs(NULL, &s, 0, NULL);
 #endif
-	if (mblen <= 0)
+	if ((int)mblen < 0)
 	{
 		prt_error("Warning: Error in utf8_strwidth(%s)\n", s);
 		return 1 /* XXX */;


### PR DESCRIPTION
I fix here a problem I introduced in the last PR.

An empty string argument is a valid parameter and shouldn't be considered an error.
Also, "mblen" is size_t and hence cannot be less than 0, so an int cast is a must.
XXX: The returned value in case of an error is still 1 instead of -1, because the callers still don't expect a negative value.