### PR TITLE
Bug fix in combined null morpheme end position

### DIFF
--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -113,7 +113,7 @@ static Gword *wordgraph_null_join(Sentence sent, Gword **start, Gword **end)
 	new_word->label = "NJ";
 	new_word->null_subwords = NULL;
 	new_word->start = (*start)->start;
-	new_word->end = (*start)->end;
+	new_word->end = (*end)->end;
 
 	/* Link the null_subwords links of the added unifying node to the null
 	 * subwords it unified. */
@@ -281,13 +281,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 	Gword **lwg_path = linkage->wg_path;
 	Gword **n_lwg_path = NULL; /* new Wordgraph path, to match chosen_words */
 
-#if 0 /* FIXME? Not implemented. */
-	size_t len_n_lwg_path = 0;
-	/* For opts->display_morphology==0: Mapping of the chosen_words indexing to
-	 * original parse indexing. */
-	size_t *wg_path_display = alloca(linkage->num_words * sizeof(*lwg_path_display));
-#endif
-
 	Gword **nullblock_start = NULL; /* start of a null block, to be put in [] */
 	size_t nbsize = 0;              /* number of word in a null block */
 	Gword *unsplit_word = NULL;
@@ -353,9 +346,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 					t = join_null_word(sent, wgp, nbsize);
 
 					gwordlist_append(&n_lwg_path, w);
-#if 0 /* Not implemented */
-					lwg_path_display[len_n_lwg_path++] = i;
-#endif
 				}
 				else
 				{
@@ -369,10 +359,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 						t = unsplit_word->subword;
 
 						gwordlist_append(&n_lwg_path, unsplit_word);
-#if 0 /* Not implemented */
-						for (j = 0; j < nbsize; j++)
-							lwg_path_display[len_n_lwg_path++] = i-j+1;
-#endif
 					}
 					else
 					{


### PR DESCRIPTION
This bug happens when a word has sequence of several morphemes which don't have a linkage.