### PR TITLE
link-parser: Fix crash due to invalid utf-8 in command

### DIFF
--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -215,6 +215,7 @@ static bool is_number(Dictionary dict, const char * s)
 	while ((*s != 0) && (0 < nb))
 	{
 		nb = mbrtowc(&c, s, MB_CUR_MAX, &mbs);
+		/* XXX check nb < 0 */
 		if (iswdigit_l(dict, c)) { s += nb; }
 
 		/* U+00A0 no break space */

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -135,7 +135,12 @@ static void clean_up_string(char * s)
 	while(*x != '\0')
 	{
 		w = mbrtowc(&p, x, len, &state);
-		if ((0 == w) || ((size_t)-1 == w)) break;
+		if (0 == w) break;
+		if (0 > (ssize_t)w)
+		{
+			prt_error("Unable to process UTF8 command input string.\n");
+			break;
+		}
 		len -= w;
 
 		if (!iswspace(p)) {
@@ -179,7 +184,11 @@ static bool is_numerical_rhs(char *s)
 	{
 		w = mbrtowc(&p, s, len, &state);
 		if (0 == w) break;
-		if ((size_t)-1 == w) return false;
+		if (0 > (ssize_t)w)
+		{
+			prt_error("Unable to process UTF8 command input string.\n");
+			break;
+		}
 		len -= w;
 		if (!iswdigit(p)) return false;
 	}


### PR DESCRIPTION
Also add a comment in the currently unused is_number(), just in case.

Repeat by (supposing a sh-like shell):
echo -e '\!\0335' | link-parser
...
Segmentation fault (core dumped)