### PR TITLE
Debug and error facility changes

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -5,10 +5,10 @@ There link-grammar library has API calls to ease debugging and development.
 The `link-parser` program has corresponding options for this API.
 
 Only the `link-parser` options will be discussed here.
-Options to `link-parser` at the command-line are preceded with a '-' sign.
+Options to `link-parser` at the command-line are preceded with a `-` sign.
 You can use a unique prefix of an option name instead of its full name. At
 the **linkparser>** prompt or in batch files, options are preceded with
-a '**!**' character.
+a `!` character.
 
 For info on common options, see the "Special ! options" of the `link-grammar`
 manual. For a general help message use `link-parser -help`.
@@ -22,7 +22,7 @@ Sets the verbosity level of the library to N (a small non-negative integer).
 
 #### Verbosity levels
 0: Certain informative messages are not printed by the
-library. First`link-parser` also doesn't print its usual **linkparser>**
+library. `link-parser` also doesn't print its usual **linkparser>**
 prompt. This is the current default verbosity level for the Python
 binding.
 
@@ -35,14 +35,16 @@ this may help finding out at which step it happened.
 3: Display data file search and locale setup. It can be used to debug
 problems with the locale setup or in finding the dictionary.
 
-4: Not is use for now.
+4: Not in use for now.
 
 5-9: Show trace and debug messages regarding sentence handling. Higher
 levels include the messages of the lower ones.
 
-10-...: Show also trace and debug messages regarding reading the
-dictionary.  As with levels less than 10, higher levels include the
+10-99: Show also trace and debug messages regarding reading the
+dictionary.  As with levels greater then 4, higher levels include the
 messages of the lower ones.
+
+100-...: Show only messages exactly at the specified level.
 
 ### 2) -debug=LOCATIONS (-de=LOCATIONS)
 Show only messages from these LOCATIONS. The LOCATIONS string is a

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -521,7 +521,7 @@ static int cmplen(const void *a, const void *b)
  * needed - especially to first free memory and initialize the affix dict
  * structure.).
  */
-#define D_AI 11
+#define D_AI (D_DICT+1)
 bool afdict_init(Dictionary dict)
 {
 	Afdict_class * ac;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -374,6 +374,31 @@ char * print_one_disjunct(Disjunct *dj)
 /* ============================================================= */
 
 /**
+ * returns the number of connectors in the left lists of the disjuncts.
+ */
+int left_connector_count(Disjunct * d)
+{
+	Connector *c;
+	int i=0;
+	for (;d!=NULL; d=d->next) {
+		for (c = d->left; c!=NULL; c = c->next) i++;
+	}
+	return i;
+}
+
+int right_connector_count(Disjunct * d)
+{
+	Connector *c;
+	int i=0;
+	for (;d!=NULL; d=d->next) {
+	  for (c = d->right; c!=NULL; c = c->next) i++;
+	}
+	return i;
+}
+
+/* ============================================================= */
+
+/**
  * Record the wordgraph word to which the X-node belongs, in each of its
  * disjuncts.
  */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -45,5 +45,7 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * );
 char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);
+int left_connector_count(Disjunct *);
+int right_connector_count(Disjunct *);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -23,6 +23,7 @@
 #define D_USER_FILES 3   /* Display data file search and locale setup. */
 // #define D_USER_X  4   /* Not in use yet. */
 #define D_USER_MAX   4   /* Maximum user verbosity level. */
+#define D_DICT      10   /* Base of dictionary debug levels. */
 #define D_SPEC     100   /* Base of special stand-alone levels. */
 
 typedef struct

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -23,6 +23,7 @@
 #define D_USER_FILES 3   /* Display data file search and locale setup. */
 // #define D_USER_X  4   /* Not in use yet. */
 #define D_USER_MAX   4   /* Maximum user verbosity level. */
+#define D_SPEC     100   /* Base of special stand-alone levels. */
 
 typedef struct
 {
@@ -34,17 +35,22 @@ void err_msgc(err_ctxt *, lg_error_severity, const char *fmt, ...) GNUC_PRINTF(3
 const char *feature_enabled(const char *, ...);
 
 /**
- * Print a debug message at verbosity >= level.
- * Preceding the level number by a + (+level) adds printing of the
- * function name.
- * Level numbers 2 to D_USER_MAX are not printed on verbosity>D_USER_MAX,
- * because they are designed only for extended user information.
- * The !debug variable can be set to a comma-separated list of functions
- * in order to restrict the debug messages to these functions only.
+ * Print a debug message according to their level.
+ * Print the messages at levels <= the specified verbosity, with the
+ * following restrictions:
+ * - Level numbers 2 to D_USER_MAX are not printed on verbosity>D_USER_MAX,
+ *   because they are designed only for extended user information.
+ * - When verbosity > D_SPEC, print messages only when level==verbosity.
+ * - The !debug variable can be set to a comma-separated list of functions
+ *   in order to restrict the debug messages to these functions only.
+ *
+ * Invoking lgdebug() with a level number preceded by a + (+level) adds
+ * printing of the function name.
  */
 #define lgdebug(level, ...) \
-(((verbosity>=(level)) && (((level)<=1) || \
-	!(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
+	(( \
+	(((D_SPEC>=verbosity) && (verbosity>=(level))) || (verbosity==(level))) && \
+	(((level)<=1) || !(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
 	(('\0' == debug[0]) || \
 	feature_enabled(debug, __func__, __FILE__, NULL))) ? \
 	( \
@@ -78,8 +84,9 @@ const char *feature_enabled(const char *, ...);
  * desired message severity.
  */
 #define verbosity_level(level) \
-(((verbosity>=(level)) && (((level)<=1) || \
-	!(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
+	(( \
+	(((D_SPEC>=verbosity) && (verbosity>=(level))) || (verbosity==(level))) && \
+	(((level)<=1) || !(((level)<=D_USER_MAX) && (verbosity>D_USER_MAX))) && \
 	(('\0' == debug[0]) || \
 	feature_enabled(debug, __func__, __FILE__, NULL))) \
 	? ((STRINGIFY(level)[0] == '+' ? prt_error("%s: ", __func__) : 0), true) \

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -193,7 +193,9 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 	return n;
 }
 
+#ifdef DEBUG
 //#define DO_COUNT_TRACE
+#endif
 
 #ifdef DO_COUNT_TRACE
 #define V(c) (!c?"(nil)":c->string)
@@ -211,12 +213,15 @@ static Count_bin do_count(int lineno, fast_matcher_t *mchxt,
 {
 	static int level;
 
+	if (!verbosity_level(8))
+		return do_count1(lineno, mchxt, ctxt, lw, rw, le, re, null_count);
+
 	level++;
-	printf("%*sdo_count:%d lw=%d rw=%d le=%s re=%s null_count=%d\n",
+	prt_error("%*sdo_count:%d lw=%d rw=%d le=%s re=%s null_count=%d\n\\",
 		    level*2, "", lineno, lw, rw, V(le), V(re), null_count);
 	Table_connector *t = find_table_pointer(ctxt, lw, rw, le, re, null_count);
 	Count_bin r = do_count1(lineno, mchxt, ctxt, lw, rw, le, re, null_count);
-	printf("%*sreturn%.*s:%d=%lld\n", level*2, "", (!!t)*3, "(M)", lineno, r);
+	prt_error("%*sreturn%.*s:%d=%lld\n", level*2, "", (!!t)*3, "(M)", lineno, r);
 	level--;
 
 	return r;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -665,10 +665,8 @@ int power_prune(Sentence sent, Parse_Options opts)
 			}
 			sent->word[w].d = nd;
 		}
-		if (verbosity_level(D_PRUNE))
-		{
-			printf("l->r pass changed %d and deleted %zu\n", pc->N_changed, N_deleted);
-		}
+		lgdebug(D_PRUNE, "Debug: l->r pass changed %d and deleted %zu\n",
+		        pc->N_changed, N_deleted);
 
 		if (pc->N_changed == 0) break;
 
@@ -703,11 +701,8 @@ int power_prune(Sentence sent, Parse_Options opts)
 			sent->word[w].d = nd;
 		}
 
-		if (verbosity_level(D_PRUNE))
-		{
-			printf("r->l pass changed %d and deleted %zu\n",
-				pc->N_changed, N_deleted);
-		}
+		lgdebug(D_PRUNE, "Debug: r->l pass changed %d and deleted %zu\n",
+		        pc->N_changed, N_deleted);
 
 		if (pc->N_changed == 0) break;
 		pc->N_changed = N_deleted = 0;
@@ -717,13 +712,13 @@ int power_prune(Sentence sent, Parse_Options opts)
 	pt = NULL;
 	pc->pt = NULL;
 
-	if (verbosity_level(D_PRUNE))
-		printf("power prune cost: %d\n", pc->power_cost);
+	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc->power_cost);
 
 	print_time(opts, "power pruned");
 	if (verbosity_level(D_PRUNE))
 	{
-		printf("\nAfter power_pruning:\n");
+		prt_error("\n\\");
+		prt_error("Debug: After power_pruning:\n\\");
 		print_disjunct_counts(sent);
 	}
 
@@ -1085,15 +1080,15 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			}
 		}
 
-		if (verbosity_level(D_PRUNE))
-			printf("pp_prune pass deleted %d\n", N_deleted);
+		lgdebug(D_PRUNE, "Debug: pp_prune pass deleted %d\n", N_deleted);
 	}
 	delete_unmarked_disjuncts(sent);
 	cms_table_delete(cmt);
 
-	if (verbosity_level(D_PRUNE))
+	if ((0 != N_deleted) && verbosity_level(D_PRUNE))
 	{
-		printf("\nAfter pp_pruning:\n");
+		prt_error("\n\\");
+		prt_error("Debug: After pp_pruning:\n\\");
 		print_disjunct_counts(sent);
 	}
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -181,29 +181,6 @@ struct prune_context_s
    deletable, this is equivalent to RUTHLESS.   --DS, 7/97
 */
 
-/**
- * returns the number of connectors in the left lists of the disjuncts.
- */
-static int left_connector_count(Disjunct * d)
-{
-	Connector *c;
-	int i=0;
-	for (;d!=NULL; d=d->next) {
-		for (c = d->left; c!=NULL; c = c->next) i++;
-	}
-	return i;
-}
-
-static int right_connector_count(Disjunct * d)
-{
-	Connector *c;
-	int i=0;
-	for (;d!=NULL; d=d->next) {
-	  for (c = d->right; c!=NULL; c = c->next) i++;
-	}
-	return i;
-}
-
 static void free_C_list(C_list * t)
 {
 	C_list *xt;

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -804,17 +804,25 @@ void linkage_free_pp_msgs(char * s)
 void print_disjunct_counts(Sentence sent)
 {
 	size_t i;
-	int c;
-	Disjunct *d;
+	int dcnt;
+	int t = 0;
+	int lcnt = 0, rcnt = 0;
+
 	for (i=0; i<sent->length; i++)
 	{
-		c = 0;
-		for (d=sent->word[i].d; d != NULL; d = d->next) c++;
+		Disjunct *d = sent->word[i].d;
+		dcnt = count_disjuncts(d);
+		rcnt += right_connector_count(d);
+		lcnt += left_connector_count(d);
+		t += dcnt;
 
 		/* XXX alternatives[0] is not really correct, here .. */
-		printf("%s(%d) ", sent->word[i].alternatives[0], c);
+		prt_error("%s(%d) ", sent->word[i].alternatives[0], dcnt);
 	}
-	printf("\n\n");
+
+	prt_error("\n\\");
+	prt_error("Total: %d disjuncts, %d (%d+/%d-) connectors\n\n",
+	          t, rcnt+lcnt, rcnt, lcnt);
 }
 
 static const char * trailer(bool print_ps_header)

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -350,7 +350,7 @@ static Regex_node * regbuild(const char **regstring, int n, int classnum)
  * anysplit (its not an error to not use anysplit!).  Return false if
  * init failed.
  */
-#define D_AI 10
+#define D_AI (D_DICT+0)
 bool anysplit_init(Dictionary afdict)
 {
 	anysplit_params *as;


### PR DESCRIPTION
Including:
- Verbosity levels >= 100 for particular debug messages (to be used in upcoming changes).
- Debug print of total disjunct and connector numbers before/after prune.
- Convert the few remaining (active) debug printf() calls to use the error facility.
- More minor changes.