### PR TITLE
Windows fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Version 5.4.3 (XXX 2017)
  * Fix man page installation (actually broken from 5.3.0).
  * Add "thither" to the English dictionary.
  * Fix printing inf loop for very narrow screen widths.
+ * Some Windows code clean up.
 
 Version 5.4.2 (19 October 2017)
  * Fix man page build (broken in 5.4.1)

--- a/link-grammar/dict-common/dict-impl.h
+++ b/link-grammar/dict-common/dict-impl.h
@@ -1,5 +1,6 @@
 
 #include "link-includes.h"
+#include "utilities.h"
 
 // Already declared in link-includes.h
 // const char * linkgrammar_get_dict_locale(Dictionary dict);
@@ -11,3 +12,8 @@ void dictionary_setup_defines(Dictionary dict);
 void afclass_init(Dictionary dict);
 bool afdict_init(Dictionary dict);
 void affix_list_add(Dictionary afdict, Afdict_class *, const char *);
+
+#ifdef __MINGW32__
+int callGetLocaleInfoEx(LPCWSTR, LCTYPE, LPWSTR, int);
+
+#endif /* __MINGW32__ */

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -46,7 +46,7 @@ size_t utf8_strwidth(const char *s)
 	wchar_t *ws = alloca((mblen + 1) * sizeof(wchar_t));
 
 #ifdef _WIN32
-	MultiByteToWideChar(CP_UTF8, 0, s, -1, ws, mblen) - 1;
+	MultiByteToWideChar(CP_UTF8, 0, s, -1, ws, mblen);
 #else
 	mbstate_t mbss;
 	memset(&mbss, 0, sizeof(mbss));

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -88,9 +88,7 @@ char *
 strndup (const char *str, size_t size)
 {
 	size_t len;
-	char *result = (char *) NULL;
-
-	if ((char *) NULL == str) return (char *) NULL;
+	char *result;
 
 	len = strlen (str);
 	if (!len) return strdup ("");

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -199,7 +199,7 @@ static int wctomb_check(char *s, wchar_t wc)
  * because the byte-counts might not match up, e.g. German ß and SS.
  * The correct long-term fix is to use ICU or glib g_utf8_strup(), etc.
  */
-void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale_t)
+void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale)
 {
 	wchar_t c;
 	int i, nbl, nbh;
@@ -216,7 +216,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t local
 		prt_error("Error: Invalid UTF-8 string!\n");
 		return;
 	}
-	c = towlower_l(c, locale_t);
+	c = towlower_l(c, locale);
 	nbl = wctomb_check(low, c);
 
 	/* Check for error on an in-place copy */
@@ -245,7 +245,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t local
  * because the byte-counts might not match up, e.g. German ß and SS.
  * The correct long-term fix is to use ICU or glib g_utf8_strup(), etc.
  */
-void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale_t)
+void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale)
 {
 	wchar_t c;
 	int i, nbl, nbh;
@@ -259,7 +259,7 @@ void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale_
 		prt_error("Error: Invalid UTF-8 string!\n");
 		return;
 	}
-	c = towupper_l(c, locale_t);
+	c = towupper_l(c, locale);
 	nbl = wctomb_check(low, c);
 
 	/* Check for error on an in-place copy */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -112,10 +112,13 @@ void *alloca (size_t);
 /* Note that "#define _CRT_RAND_S" is needed before "#include <stdlib.h>" */
 #define rand_r(seedp) rand_s(seedp)
 
-/* No strtok_s in these versions and their strtok_r is incompatible. */
+#ifndef __MINGW32__
+/* No strtok_s in XP/2003 and their strtok_r is incompatible.
+ * Hence HAVE_STRTOK_R will not be defined and our own one will be used. */
 #if _WINVER != 0x501 /* XP */ && _WINVER != 0x502 /* Server 2003 */
 #define strtok_r strtok_s
 #define HAVE_STRTOK_R
+#endif /* _WINVER != XP|2003 */
 #endif
 
 #ifndef __MINGW32__

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -119,18 +119,14 @@ void *alloca (size_t);
 #define strtok_r strtok_s
 #define HAVE_STRTOK_R
 #endif /* _WINVER != XP|2003 */
-#endif
 
-#ifndef __MINGW32__
 /* There is no ssize_t definition in native Windows. */
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
-#endif
 
 /* Native windows has locale_t, and hence HAVE_LOCALE_T is defined here.
  * However, MinGW currently doesn't have locale_t. If/when it has locale_t,
  * "configure" will define HAVE_LOCALE_T for it. */
-#ifndef __MINGW32__
 #define HAVE_LOCALE_T
 #endif
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -118,6 +118,12 @@ void *alloca (size_t);
 #define HAVE_STRTOK_R
 #endif
 
+#ifndef __MINGW32__
+/* There is no ssize_t definition in native Windows. */
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 /* Native windows has locale_t, and hence HAVE_LOCALE_T is defined here.
  * However, MinGW currently doesn't have locale_t. If/when it has locale_t,
  * "configure" will define HAVE_LOCALE_T for it. */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -572,7 +572,7 @@ int main(int argc, char * argv[])
 	isatty_stdout = isatty(fileno(stdout));
 
 #ifdef _WIN32
-	/* If compiled with MSVC/MSYS, we still support running under Cygwin.
+	/* If compiled with MSVC/MinGW, we still support running under Cygwin.
 	 * This is done by checking running_under_cygwin to resolve
 	 * incompatibilities. */
 	const char *ostype = getenv("OSTYPE");

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -682,6 +682,10 @@ int main(int argc, char * argv[])
 		char *input_string;
 		Sentence sent = NULL;
 
+		/* Make sure stderr is shown even when MSVC binary runs under
+		 * Cygwin/MSYS pty (in that case it is fully buffered(!). */
+		fflush(stderr);
+
 		verbosity = parse_options_get_verbosity(opts);
 		debug = parse_options_get_debug(opts);
 		test = parse_options_get_test(opts);

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -184,16 +184,17 @@ int lg_isatty(int fd)
 	/* Now check the name pattern.  The filename of a Cygwin pseudo tty pipe
 	   looks like this:
 
-			 \cygwin-%16llx-pty%d-{to,from}-master
+			 \{cygwin,msys}-%16llx-pty%d-{to,from}-master
 
 		%16llx is the hash of the Cygwin installation, (to support multiple
 		parallel installations), %d id the pseudo tty number, "to" or "from"
 		differs the pipe direction. "from" is a stdin, "to" a stdout-like
 		pipe. */
 	cp = pfni->FileName;
-	if (!wcsncmp(cp, L"\\cygwin-", 8) && !wcsncmp(cp + 24, L"-pty", 4))
+	if ((!wcsncmp(cp, L"\\cygwin-", 8) && !wcsncmp(cp + 24, L"-pty", 4)) ||
+	    (!wcsncmp(cp, L"\\msys-", 6)   && !wcsncmp(cp + 22, L"-pty", 4)))
 	{
-		cp = wcschr(cp + 28, '-');
+		cp = wcschr(cp + 26, '-');
 		if (!cp)
 			goto no_tty;
 		if (!wcscmp(cp, L"-from-master") || !wcscmp(cp, L"-to-master"))

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -22,6 +22,12 @@
 #endif
 
 #ifdef _WIN32
+#ifndef __MINGW32__
+/* There is no ssize_t definition in native Windows. */
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #define strcasecmp _stricmp
 #ifndef strncasecmp
 #define strncasecmp _strnicmp


### PR DESCRIPTION
I wanted to test the long-word split code on Windows, but encountered a compilation error because the `ssize_t` definitions that I recently added were not recognized (it is `SSIZE_T` on MSVC).
I fixed that and in the same occasion also several new (bit rot) compilation warnings.
Also included some other minor fixes for Windows.
An interesting fix for MSVC relates to stderr full buffering when the output is not a console. I noted that when running an MSVC binary under Cygwin X11. This may also cause (again on MSVC) unsync stdout/stderr when the output is a file.