### PR TITLE
Diagram generation: Fold long words

### DIFF
--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -11,6 +11,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include <limits.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <errno.h>
@@ -59,6 +60,38 @@ size_t utf8_strwidth(const char *s)
 		glyph_width += mk_wcwidth(ws[i]);
 	}
 	return glyph_width;
+}
+
+/**
+ * Return the number of characters in the longest initial substring
+ * which has a text-column-width of not greater than max_width.
+ */
+size_t utf8_num_char(const char *s, size_t max_width)
+{
+	size_t total_bytes = 0;
+	size_t glyph_width = 0;
+	int n = 0;
+	wchar_t wc;
+
+	do
+	{
+		total_bytes += n;
+		n = mbrtowc(&wc, s+total_bytes, MB_LEN_MAX, NULL);
+		if (n == 0) break;
+		if (n < 0)
+		{
+			prt_error("Warning: Error in utf8_num_char(%s, %zu)\n",
+			          s, max_width);
+			return 1 /* XXX */;
+		}
+
+		glyph_width += mk_wcwidth(wc);
+		//printf("N %zu G %zu;", total_bytes, glyph_width);
+	}
+	while (glyph_width <= max_width);
+	printf("\n");
+
+	return total_bytes;
 }
 
 /* ============================================================= */

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -29,6 +29,7 @@ int append_string(dyn_str *, const char *fmt, ...) GNUC_PRINTF(2,3);
 int vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);
 size_t append_utf8_char(dyn_str *, const char * mbs);
+size_t utf8_num_char(const char *, size_t);
 
 static inline void patch_subscript_mark(char *s)
 {

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -539,8 +539,11 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 				if (k == cr) break;
 			}
 
-			/* We know it fits, so put it in this row */
-			pctx->link_heights[j] = row;
+			if (NULL != pctx->link_heights)
+			{
+				/* We know it fits, so put it in this row */
+				pctx->link_heights[j] = row;
+			}
 
 			if (2*row+2 > max_height-1) {
 				lgdebug(+9, "Extending rows up to %d.\n", (2*row+2)+HEIGHT_INC);
@@ -650,9 +653,13 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	top_row_p1 = top_row + 1;
 	for (row = 0; row < top_row_p1; row++)
 		start[row] = 0;
-	pctx->N_rows = 0;
-	pctx->row_starts[pctx->N_rows] = 0;
-	pctx->N_rows++;
+
+	if (NULL != pctx->row_starts) /* PS junk */
+	{
+		pctx->N_rows = 0;
+		pctx->row_starts[pctx->N_rows] = 0;
+		pctx->N_rows++;
+	}
 
 	if (print_word_0) i = 0; else i = 1;
 	unsigned int c = 0; /* Character offset in the last word on a row. */
@@ -679,8 +686,11 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			c += utf8_num_char(linkage->word[i]+c, uwidth);
 		}
 
-		pctx->row_starts[pctx->N_rows] = i - (!print_word_0);    /* PS junk */
-		if (i < N_words_to_print) pctx->N_rows++;     /* same */
+		if (NULL != pctx->row_starts) /* PS junk */
+		{
+			pctx->row_starts[pctx->N_rows] = i - (!print_word_0);
+			if (i < N_words_to_print) pctx->N_rows++;
+		}
 
 		dyn_strcat(string, "\n");
 		top_row_p1 = top_row + 1;
@@ -748,8 +758,8 @@ char * linkage_print_diagram(const Linkage linkage, bool display_walls, size_t s
 	ps_ctxt_t ctx;
 	if (!linkage) return NULL;
 
-	ctx.link_heights = (int *) alloca(linkage->num_links * sizeof(int));
-	ctx.row_starts = (int *) alloca((linkage->num_words + 1) * sizeof(int));
+	ctx.link_heights = NULL;
+	ctx.row_starts = NULL;
 	return linkage_print_diagram_ctxt(linkage, display_walls, screen_width, &ctx);
 }
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -289,7 +289,18 @@ char * linkage_print_disjuncts(const Linkage linkage)
 }
 
 /**
- * postscript printing ...
+ * Postscript printing ...
+ * FIXME:
+ * 1. It is invoked after a call to linkage_print_diagram_ctxt() with a
+ *    screen width of 8000. But it actually cannot handle a screen width
+ *    greater than a page-width since it doesn't know to fold without the
+ *    help of the row_starts array which tells it on which word each
+ *    folded line starts (a garbled printout results).
+ * 2. It cannot handle utf-8 (garbage is printed).
+ * 3. Due to the added ability of folding long words, the row_starts
+ *    array is not sufficient for telling where to start the next line
+ *    (but this doesn't matter for now and can be fixed along with
+ *    problem no. 1 above).
  */
 static char *
 build_linkage_postscript_string(const Linkage linkage,

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -655,23 +655,28 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	pctx->N_rows++;
 
 	if (print_word_0) i = 0; else i = 1;
+	unsigned int c = 0; /* Character offset in the last word on a row. */
+#define RIGHT_MARGIN 1
 	while (i < N_words_to_print)
 	{
 		unsigned int revrs;
-		unsigned int uwidth;
+		/* Count the column-widths of the words, up to the max screen width.
+		 * Use word_offset only for the initial part of the word. */
+		unsigned int uwidth = 0;
 		unsigned int wwid;
-
-		/* Count the column-widths of the words, up to the max
-		 * screen width. Add at least one word to a line. */
-		uwidth = word_offset[i] + utf8_strwidth(linkage->word[i]) + 1;
-		i++;
-
-		/* Try to add more words to the line, if they fit. */
-		while (i < N_words_to_print) {
-			wwid = word_offset[i] + utf8_strwidth(linkage->word[i]) + 1;
-			if (x_screen_width <= uwidth + wwid) break;
+		do {
+			wwid = (c == 0)*word_offset[i] + utf8_strwidth(linkage->word[i]+c) + 1;
+			if (x_screen_width-RIGHT_MARGIN < uwidth + wwid) break;
 			uwidth += wwid;
+			c = 0;
 			i++;
+		} while (i < N_words_to_print);
+
+		/* The whole word doesn't fit - fit as much as possible from it. */
+		if (0 == uwidth)
+		{
+			uwidth = x_screen_width-RIGHT_MARGIN - (c == 0)*word_offset[i] - 1;
+			c += utf8_num_char(linkage->word[i]+c, uwidth);
 		}
 
 		pctx->row_starts[pctx->N_rows] = i - (!print_word_0);    /* PS junk */


### PR DESCRIPTION
- Fold long words.
- Add a FIXME for the PS generation problems.

Note that the right margin is actually 2 characters (like it was before this fix), because the screen width is set to one less than the real one. Is there a reason for that, or can we set screen_width to the exact real one? (This way it will also match a setting by `!width`.)

FIXME:
1) The last part of the diagram is still sometimes printed in a new row when it actually fits in the previous row (a more complex code is needed to fix that).
2) Maybe the trailing blanks in the diagram should be suppressed.

[ In the same occasion, something about the `!width=X` command. It is now ignored unless writing to file.
It can be changed to always obey a manual setup (when manually setting to 0 will return the current behaviour). This will enable manual adapting of the diagram width.
The change is simple, but it is not elegant in that it needs a special handling of the screen_width option (internally I would represent a manual fixed width by a negative value). It also has a limited usage. ]