### PR TITLE
Windows bug fix: Displaying random linkages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,8 +4,9 @@ Version 5.4.3 (XXX 2017)
  * Fix printing inf loop for very narrow screen widths.
  * Some Windows code clean up.
  * Remove trailing blanks from the linkage diagram.
- * Fix square area and cubic volume measurements (English dict)
- * Fix assorted exclamations and responses (English dict)
+ * Fix square area and cubic volume measurements (English dict).
+ * Fix assorted exclamations and responses (English dict).
+ * Fix displaying random linkages on Windows.
 
 Version 5.4.2 (19 October 2017)
  * Fix man page build (broken in 5.4.1)

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -18,6 +18,7 @@
 #include "disjunct-utils.h" // for Disjunct
 #include "extract-links.h"
 #include "fast-match.h"
+#include "utilities.h"                // for Windows rand_r()
 #include "linkage/linkage.h"
 #include "tokenize/word-structures.h" // for Word_Struct
 

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -17,7 +17,6 @@
 #include "count.h"
 #include "disjunct-utils.h" // for Disjunct
 #include "extract-links.h"
-#include "fast-match.h"
 #include "utilities.h"                // for Windows rand_r()
 #include "linkage/linkage.h"
 #include "tokenize/word-structures.h" // for Word_Struct

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -13,6 +13,9 @@
 
 #include <ctype.h>
 #include <limits.h>
+#ifdef _WIN32
+#define _CRT_RAND_S
+#endif /* _WIN32 */
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -170,6 +173,22 @@ size_t lg_mbrtowc(wchar_t *pwc, const char *s, size_t n, mbstate_t *ps)
 	nb2 = MultiByteToWideChar(CP_UTF8, 0, s, nb, pwc, nb2);
 	if (0 == nb2) return (size_t)-1;
 	return nb;
+}
+
+/**
+ * Emulate rand_r() using rand_s() in a way that is enough for our needs.
+ * Windows doesn't have rand_r(), and its rand_s() is different: It
+ * returns an error indication and not the random number like rand_r().
+ * The value its returns is through its argument.
+ *
+ * Note that "#define _CRT_RAND_S" is needed before "#include <stdlib.h>"
+ */
+int rand_r(unsigned int *s)
+{
+	rand_s(s);
+	if (*s > INT_MAX) *s -= INT_MAX;
+
+	return *s;
 }
 #endif /* _WIN32 */
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -19,9 +19,6 @@
 
 #include <ctype.h>
 #include <stdio.h>
-#ifdef _WIN32
-#define _CRT_RAND_S
-#endif /* _WIN32 */
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
@@ -109,9 +106,7 @@ void *alloca (size_t);
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif
-/* Note that "#define _CRT_RAND_S" is needed before "#include <stdlib.h>" */
-#define rand_r(seedp) rand_s(seedp)
-
+int rand_r(unsigned int *);
 #ifndef __MINGW32__
 /* No strtok_s in XP/2003 and their strtok_r is incompatible.
  * Hence HAVE_STRTOK_R will not be defined and our own one will be used. */


### PR DESCRIPTION
It didn't work since rand_s() is different than rand_r() (which Windows doesn't have).
Solve this by emulating rand_r() using rand_s(), closely enough for our purpose (hopefully).