### PR TITLE
Fix unit tokenization to remove ambiguity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ Version 5.4.3 (XXX 2017)
  * Fix square area and cubic volume measurements (English dict).
  * Fix assorted exclamations and responses (English dict).
  * Fix displaying random linkages on Windows.
-
+ * Fix unit tokenization to remove ambiguity.
 
 Version 5.4.2 (19 October 2017)
  * Fix man page build (broken in 5.4.1)

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -60,3 +60,5 @@ y' w/: PRE+;
 % units.6 contains just a single, sole slash in it. This allows units
 % such as mL/s to be split at the slash.
 /en/words/units.6: UNITS+;
+%
+/en/words/units.a: UNITS+;

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -3,18 +3,14 @@
 % i.e. spaces are inserted between the affix and the word itself.
 %
 % Some of the funky UTF-8 parenthesis are used in Asian texts.
-% In order to allow single straight quote ' and double straight quote ''
-% to be stripped off from both the left and the right, they are
-% distinguished by the suffix .x and .y (as as Mr.x Mrs.x or Jr.y Sr.y)
-%
 % 。is an end-of-sentence marker used in Japanese texts.
 
 % Punctuation appearing on the right-side of words.
-% Note: the ellipsis ....y must appear *before* the dot ".", else the
+% Note: the ellipsis "..." must appear *before* the dot ".", else the
 % splitting won't work right.
-")" "}" "]" ">" "".y" » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" ” ''.y '.y `.y
-"%" "," ....y "." 。 ‧ ":" ";" "?" "!" ‽ ؟ ？ ！
-_ ‐ ‑ ‒ – — ― ….y ━.y –.y ー.y ‐.y 、.y
+")" "}" "]" ">" """ » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" ” '' ' `
+"%" "," ... "." 。 ‧ ":" ";" "?" "!" ‽ ؟ ？ ！
+_ ‐ ‑ ‒ – — ― … ━ – ー ‐ 、
 ～ ¢ ₵ ™ ℠
   : RPUNC+;
 
@@ -24,18 +20,18 @@ _ ‐ ‑ ‒ – — ― ….y ━.y –.y ー.y ‐.y 、.y
 % Paragraph marks
 % Assorted bullets and dingbats
 % Dashes of various sorts
-"(" "{" "[" "<" "".x" « 〈 （ 〔 《 【 ［
-『 「 、.x `.x `` „ ‘ “ ''.x '.x ….x ....x
+"(" "{" "[" "<" """ « 〈 （ 〔 《 【 ［
+『 「 、 ` `` „ ‘ “ '' ' … ...
 ¿ ¡ "$" US$ USD C$
 £ ₤ € ¤ ₳ ฿ ₡ ₢ ₠ ₫ ৳ ƒ ₣ ₲ ₴ ₭ ₺  ℳ  ₥ ₦ ₧ ₱ ₰ ₹ ₨ ₪ ﷼ ₸ ₮ ₩ ¥ ៛ 호점
 † †† ‡ § ¶ © ® ℗ № "#"
-* • ⁂ ❧ ☞ ◊ ※  ○  。.x ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎
-_ ‐ ‑ ‒ – — ― ～ –.x ━.x ー.x -- - ‧.x
+* • ⁂ ❧ ☞ ◊ ※  ○  。 ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎
+_ ‐ ‑ ‒ – — ― ～ – ━ ー -- - ‧
 w/
   : LPUNC+;
 
 % Split words at these.
---.xy: MPUNC+;
+--: MPUNC+;
 
 % Suffixes
 's 're 've 'd 'll 'm ’s ’re ’ve ’d ’ll ’m: SUF+;

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -13,7 +13,7 @@
 % Note: the ellipsis ....y must appear *before* the dot ".", else the
 % splitting won't work right.
 ")" "}" "]" ">" "".y" » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" ” ''.y '.y `.y
-"%" "," ....y "." 。 ￼ ￼  .y ‧ ":" ";" "?" "!" ‽ ؟ ？ ！
+"%" "," ....y "." 。 ‧ ":" ";" "?" "!" ‽ ؟ ？ ！
 _ ‐ ‑ ‒ – — ― ….y ━.y –.y ー.y ‐.y 、.y
 ～ ¢ ₵ ™ ℠
   : RPUNC+;

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -6,8 +6,6 @@
 % 。is an end-of-sentence marker used in Japanese texts.
 
 % Punctuation appearing on the right-side of words.
-% Note: the ellipsis "..." must appear *before* the dot ".", else the
-% splitting won't work right.
 ")" "}" "]" ">" """ » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" ” '' ' `
 "%" "," ... "." 。 ‧ ":" ";" "?" "!" ‽ ؟ ？ ！
 _ ‐ ‑ ‒ – — ― … ━ – ー ‐ 、

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -9284,7 +9284,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 UNITS: <units-suffix>;
 
 % Allows "200 sq. ft. of plywood", "200 cu yds of concrete"
-sq.a sq..a cu.a cu..a: A+;
+/en/words/units.a: A+;
 
 % Units abbreviations that can be followed by a period:
 % ft. tbsp. yds.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -7238,7 +7238,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 UNITS: <units-suffix>;
 
 % Allows "200 sq. ft. of plywood", "200 cu yds of concrete"
-sq.a sq..a cu.a cu..a: A+;
+/en/words/units.a: A+;
 
 % Units abbreviations that can be followed by a period:
 % ft. tbsp. yds.

--- a/data/en/words/units.a
+++ b/data/en/words/units.a
@@ -1,0 +1,4 @@
+sq.a
+sq..a
+cu.a
+cu..a

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -32,4 +32,9 @@
 #define SUBSCRIPT_MARK '\3'
 #define SUBSCRIPT_DOT '.'
 
+static inline const char *subscript_mark_str(void)
+{
+	static const char sm[] = { SUBSCRIPT_MARK, '\0' };
+	return sm;
+}
 #endif

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -631,15 +631,20 @@ bool afdict_init(Dictionary dict)
 		        afdict_classname[AFDICT_SANEMORPHISM], sm_re->pattern);
 	}
 
-	/* sort the UNITS list */
+	/* Sort the affix-classes of tokens to be stripped. */
 	/* Longer unit names must get split off before shorter ones.
 	 * This prevents single-letter splits from screwing things
-	 * up. e.g. split 7gram before 7am before 7m
+	 * up. e.g. split 7gram before 7am before 7m.
+	 * Another example: The ellipsis "..." must appear before the dot ".".
 	 */
-	ac = AFCLASS(afdict, AFDICT_UNITS);
-	if (0 < ac->length)
+	afdict_classnum af[] = {AFDICT_UNITS, AFDICT_LPUNC, AFDICT_RPUNC, AFDICT_MPUNC};
+	for (size_t i = 0; i < ARRAY_SIZE(af); i++)
 	{
-		qsort(ac->string, ac->length, sizeof(char *), split_order);
+		ac = AFCLASS(afdict, af[i]);
+		if (0 < ac->length)
+		{
+			qsort(ac->string, ac->length, sizeof(char *), split_order);
+		}
 	}
 
 #ifdef AFDICT_ORDER_NOT_PRESERVED

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -575,23 +575,6 @@ bool afdict_init(Dictionary dict)
 		affix_list_add(afdict, &afdict->afdict_class[AFDICT_INFIXMARK], "");
 	}
 
-	if (verbosity_level(+D_AI))
-	{
-		size_t l;
-
-		for (ac = afdict->afdict_class;
-		     ac < &afdict->afdict_class[ARRAY_SIZE(afdict_classname)]; ac++)
-		{
-				if (0 == ac->length) continue;
-				lgdebug(+0, "Class %s, %zd items:",
-				        afdict_classname[ac-afdict->afdict_class], ac->length);
-				for (l = 0; l < ac->length; l++)
-					lgdebug(0, " '%s'", ac->string[l]);
-				lgdebug(0, "\n");
-		}
-	}
-#undef D_AI
-
 	/* Store the SANEMORPHISM regex in the unused (up to now)
 	 * regex_root element of the affix dictionary, and precompile it */
 	assert(NULL == afdict->regex_root, "SM regex is already assigned");
@@ -632,7 +615,7 @@ bool afdict_init(Dictionary dict)
 			          afdict_classname[AFDICT_SANEMORPHISM], afdict->name, rc);
 			return false;
 		}
-		lgdebug(+5, "%s regex %s\n",
+		lgdebug(+D_AI, "%s regex %s\n",
 		        afdict_classname[AFDICT_SANEMORPHISM], sm_re->pattern);
 	}
 
@@ -662,5 +645,23 @@ bool afdict_init(Dictionary dict)
 	concat_class(afdict, AFDICT_QUOTES);
 	concat_class(afdict, AFDICT_BULLETS);
 
+	if (verbosity_level(D_AI))
+	{
+		size_t l;
+
+		for (ac = afdict->afdict_class;
+		     ac < &afdict->afdict_class[ARRAY_SIZE(afdict_classname)]; ac++)
+		{
+				if (0 == ac->length) continue;
+				lgdebug(+0, "Class %s, %zd items:",
+				        afdict_classname[ac-afdict->afdict_class], ac->length);
+				for (l = 0; l < ac->length; l++)
+					lgdebug(0, " '%s'", ac->string[l]);
+				lgdebug(0, "\n\\");
+		}
+		lg_error_flush();
+	}
+
 	return true;
 }
+#undef D_AI

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -506,12 +506,24 @@ static void concat_class(Dictionary afdict, int classno)
 	dyn_str_delete(qs);
 }
 
-/* Compare lengths of strings, for qsort */
-static int cmplen(const void *a, const void *b)
+/**
+ * Compare lengths of strings, for affix class qsort.
+ * Sort order:
+ * 1. Longest base words first.
+ * 2. Equal base words one after the other.
+ */
+static int split_order(const void *a, const void *b)
 {
 	const char * const *sa = a;
 	const char * const *sb = b;
-	return strlen(*sb) - strlen(*sa);
+
+	size_t len_a = strcspn(*sb, subscript_mark_str());
+	size_t len_b = strcspn(*sa, subscript_mark_str());
+
+	int len_order = (int)(len_a - len_b);
+	if (0 == len_order) return strncmp(*sa, *sb, len_a);
+
+	return len_order;
 }
 
 /**
@@ -627,7 +639,7 @@ bool afdict_init(Dictionary dict)
 	ac = AFCLASS(afdict, AFDICT_UNITS);
 	if (0 < ac->length)
 	{
-		qsort(ac->string, ac->length, sizeof(char *), cmplen);
+		qsort(ac->string, ac->length, sizeof(char *), split_order);
 	}
 
 #ifdef AFDICT_ORDER_NOT_PRESERVED

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -36,28 +36,12 @@
 *
 ****************************************************************/
 
-/* Units will typically have a ".u" at the end. Get
- * rid of it, as otherwise stripping is messed up. */
-static inline char * deinflect(const char * str)
-{
-	size_t len;
-	char *s;
-	char *p = strrchr(str, SUBSCRIPT_MARK);
-	if (!p || (p == str)) return strdup(str);
-
-	len = p - str;
-	s = (char *)malloc(len + 1);
-	strncpy(s, str, len);
-	s[len] = '\0';
-	return s;
-}
-
 static void load_affix(Dictionary afdict, Dict_node *dn, int l)
 {
 	Dict_node * dnx = NULL;
 	for (; NULL != dn; dn = dnx)
 	{
-		char *string;
+		const char *string;
 		const char *con = word_only_connector(dn);
 		if (NULL == con)
 		{
@@ -78,19 +62,19 @@ static void load_affix(Dictionary afdict, Dict_node *dn, int l)
 		if (contains_underbar(dn->string))
 		{
 			char *p;
-			string = strdup(dn->string);
-			p = string+1;
+			char *writeable_string = strdupa(dn->string);
+			p = writeable_string+1;
 			while (*p != '_' && *p != '\0') p++;
 			*p = '\0';
+			string = writeable_string;
 		}
 		else
 		{
-			string = deinflect(dn->string);
+			string = dn->string;
 		}
 
 		affix_list_add(afdict, afdict_find(afdict, con,
 		               /*notify_err*/true), string);
-		free(string);
 
 		dnx = dn->left;
 		xfree((char *)dn, sizeof(Dict_node));

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -462,7 +462,6 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 						 * words with and without subscripts. */
 
 						const char subscript_sep_str[] = { SUBSCRIPT_SEP, '\0'};
-						const char subscript_mark_str[] = { SUBSCRIPT_MARK, '\0'};
 						char *join = calloc(join_len + 1, 1); /* zeroed out */
 
 						join[0] = '\0';
@@ -474,7 +473,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 							                      (*wgaltp)->morpheme_type);
 						}
 
-						strcat(join, subscript_mark_str); /* tentative */
+						strcat(join, subscript_mark_str()); /* tentative */
 
 						/* 2. Join subscripts. */
 						for (wgaltp = wgp, m = 0; m < mcnt; wgaltp++, m++)

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -14,16 +14,13 @@
 /* stuff for transforming a dictionary entry into a disjunct list */
 
 #include <math.h>
-#include "api-structures.h"
 #include "build-disjuncts.h"
 #include "connectors.h"
-#include "dict-common/dict-api.h"        // for print_expression
-#include "dict-common/dict-structures.h" // for Exp_struct
+//#include "dict-common/dict-api.h"        // for print_expression
+#include "dict-common/dict-structures.h"   // for Exp_struct
 #include "disjunct-utils.h"
-#include "string-set.h"
 #include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
-#include "tokenize/word-structures.h" // For Word_struct
-#include "utilities.h" /* For Win32 compatibility features */
+#include "utilities.h"
 
 /* Temporary connectors used while converting expressions into disjunct lists */
 typedef struct Tconnector_struct Tconnector;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -19,7 +19,6 @@
 //#include "dict-common/dict-api.h"        // for print_expression
 #include "dict-common/dict-structures.h"   // for Exp_struct
 #include "disjunct-utils.h"
-#include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
 #include "utilities.h"
 
 /* Temporary connectors used while converting expressions into disjunct lists */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -18,7 +18,6 @@
 #include "build-disjuncts.h"
 #include "connectors.h"
 #include "dict-common/dict-api.h"        // for print_expression
-#include "dict-common/dict-defines.h"    // for SUBSCRIPT_MARK
 #include "dict-common/dict-structures.h" // for Exp_struct
 #include "disjunct-utils.h"
 #include "string-set.h"

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -1439,10 +1439,12 @@ void print_sentence_word_alternatives(dyn_str *s, Sentence sent, bool debugprint
 				else if (word_split) append_string(s, " %s", wt);
 			}
 
-			/* Commented out - no alternatives for now - print as one line. */
-			//if (word_split && (NULL == display)) dyn_strcat(s, "\n");
 		}
 		wi--;
+
+		/* Line separation after the tokens printed by "String splits to:". */
+		if (word_split && (NULL == display)) dyn_strcat(s, "\n\n");
+
 		if (debugprint) dyn_strcat(s, "\n");
 	}
 	if (debugprint) dyn_strcat(s, "\n");

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -1227,20 +1227,20 @@ static const char * header(bool print_ps_header)
 /**
  * Print elements of the 2D-word-array produced for the parsers.
  *
- * - print_sentence_word_alternatives(sent, false, NULL, tokenpos)
+ * - print_sentence_word_alternatives(s, sent, false, NULL, tokenpos)
  * If a pointer to struct "tokenpos" is given, return through it the index of
  * the first occurrence in the sentence of the given token. This is used to
  * prevent duplicate information display for repeated morphemes (if there are
  * multiples splits, each of several morphemes, otherwise some of them may
  * repeat).
  *
- * - print_sentence_word_alternatives(sent, true, NULL, NULL)
+ * - print_sentence_word_alternatives(s, sent, true, NULL, NULL)
  * If debugprint is "true", this is a debug printout of the sentence.  (The
  * debug printouts are with level 0 because this function is invoked for debug
  * on certain positive level.)
  *
  *
- * - print_sentence_word_alternatives(sent, false, display_func, NULL)
+ * - print_sentence_word_alternatives(s, sent, false, display_func, NULL)
  * Iterate over the sentence words and their alternatives.  Handle each
  * alternative using the display_func function if it is supplied, or else (if it
  * is NULL) just print them. It is used to display disjunct information when
@@ -1368,7 +1368,7 @@ void print_sentence_word_alternatives(dyn_str *s, Sentence sent, bool debugprint
 		{
 			if (debugprint)
 			{
-				if (0 < ai) dyn_strcat(s, "\n   ");
+				if (0 < ai) dyn_strcat(s, "\n");
 				append_string(s, "   alt%zu:", ai);
 			}
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -1421,6 +1421,7 @@ void print_sentence_word_alternatives(dyn_str *s, Sentence sent, bool debugprint
 						opt_start = "{";
 						opt_end = "}";
 					}
+					if ('\0' == wt[0]) wt = "'\\0'"; /* Reveal a bogus value. */
 					append_string(s, " %s%s%s", opt_start, wt, opt_end);
 				}
 

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -19,6 +19,8 @@
 #include "api-types.h"
 #include "link-includes.h"
 
+// TODO provide gword access methods!
+
 /* conditional compiling flags */
 #define INFIX_NOTATION
     /* If defined, then we're using infix notation for the dictionary */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -602,10 +602,9 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 		/* This loop computes too things:
 		 * 1. strlen_cache - Token lengths - up to a SUBSCRIPT_MARK if exists.
 		 * 2. maxword      - Maximum such token length.  */
-		const char subscript_mark_string[] = { SUBSCRIPT_MARK, '\0' };
 		for (affix = affixlist[at]; affixnum-- > 0; affix++, ai++)
 		{
-			strlen_cache[ai] = (int)strcspn(*affix, subscript_mark_string);
+			strlen_cache[ai] = (int)strcspn(*affix, subscript_mark_str());
 			//printf("'%s' strlen_cache[%d]=%d\n",*affix,ai,strlen_cache[ai]);
 			maxword = MAX(maxword, strlen_cache[ai]);
 			lgdebug(D_IWA, " %c:%s", morpheme_sym[at],

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -38,9 +38,12 @@
 #include "word-structures.h"
 
 #define MAX_STRIP 10
+#define MAX_STRIP_ALT 5
 #define SYNTHETIC_SENTENCE_MARK '>' /* A marking of a synthetic sentence. */
 #define D_SW 6                      /* debug level for word splits */
 #define D_UN 6                      /* debug level for units/punct */
+
+typedef const char *stripped_t[MAX_STRIP];
 
 /* These are no longer in use, but are read from the 4.0.affix file */
 /* I've left these here, as an example of what to expect. */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1796,13 +1796,13 @@ static bool guess_misspelled_word(Sentence sent, Gword *unsplit_word,
 #endif /* HAVE_HUNSPELL */
 
 static int split_mpunc(Sentence sent, const char *word, char *w,
-                                const char *r_stripped[])
+                                stripped_t stripped)
 {
 	const Dictionary afdict = sent->dict->affix_table;
 	const Afdict_class * mpunc_list;
 	const char * const * mpunc;
 	size_t l_strippable;
-	int n_r_stripped = 0;
+	int n_stripped = 0;
 
 	if (NULL == afdict) return 0;
 	mpunc_list = AFCLASS(afdict, AFDICT_MPUNC);
@@ -1826,11 +1826,11 @@ static int split_mpunc(Sentence sent, const char *word, char *w,
 				if (sep != w)
 				{
 					*sep = '\0';
-					if (n_r_stripped >= MAX_STRIP-1) goto max_strip_ovfl;
-					r_stripped[n_r_stripped++] = w;
+					if (n_stripped >= MAX_STRIP-1) goto max_strip_ovfl;
+					stripped[n_stripped++] = w;
 				}
-				if (n_r_stripped >= MAX_STRIP-1) goto max_strip_ovfl;
-				r_stripped[n_r_stripped++] = mpunc[i];
+				if (n_stripped >= MAX_STRIP-1) goto max_strip_ovfl;
+				stripped[n_stripped++] = mpunc[i];
 
 				w = sep + sz;
 				sep += sz - 1;
@@ -1839,9 +1839,9 @@ static int split_mpunc(Sentence sent, const char *word, char *w,
 		}
 	}
 
-	if (n_r_stripped > 0) r_stripped[n_r_stripped++] = w;
+	if (n_stripped > 0) stripped[n_stripped++] = w;
 
-	return n_r_stripped;
+	return n_stripped;
 
 max_strip_ovfl:
 	lgdebug(+D_SW, "Too many tokens (>%d)\n", MAX_STRIP);

--- a/link-grammar/tokenize/wordgraph.c
+++ b/link-grammar/tokenize/wordgraph.c
@@ -24,7 +24,6 @@
 #endif
 #include <signal.h>    /* SIG* */
 
-#include <dict-common/dict-defines.h>  /* for SUBSCRIPT_MARK */
 #include <print/print-util.h> /* for append_string */
 #include <utilities.h> /* for dyn_str functions */
 #endif /* USE_WORDGRAPH_DISPLAY */
@@ -581,7 +580,7 @@ static void wordgraph_legend(dyn_str *wgd, unsigned int mode)
 }
 
 /**
- * Graph node name: Add "Sentence:" for the main node; Convert SUBSCRIPT_MARK.
+ * Graph node name: Add "Sentence:" for the main node.
  * Also escape " and \ with a \.
  */
 static const char *wlabel(Sentence sent, const Gword *w)
@@ -601,9 +600,6 @@ static const char *wlabel(Sentence sent, const Gword *w)
 	{
 		switch (*s)
 		{
-			case SUBSCRIPT_MARK:
-				dyn_strcat(l, ".");
-				break;
 			case '\"':
 				dyn_strcat(l, "\\\"");
 				break;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -58,11 +58,6 @@ void *alloca (size_t);
 #endif /* _MSC_VER */
 #endif /* !TLS */
 
-#ifndef strdupa
-/* In the following, the argument should not have side effects. */
-#define strdupa(s) strcpy(alloca(strlen(s)+1), s)
-#endif
-
 /* Windows, POSIX and GNU have different ideas about thread-safe strerror(). */
 #ifdef _WIN32
 #define strerror_r(errno, buf, len) strerror_s(buf, len, errno)
@@ -222,6 +217,22 @@ typedef int locale_t;
 #endif
 #if !defined(MAX)
 #define MAX(X,Y)  ( ((X) > (Y)) ? (X) : (Y))
+#endif
+
+/* In the following, the arguments should not have side effects.
+ * FIXME: Detect in "configure" and check HAVE_* */
+#ifndef strdupa
+#define strdupa(s) strcpy(alloca(strlen(s)+1), s)
+#endif
+#ifndef strndupa
+#define strndupa(s, n) _strndupa3(alloca(MIN(strlen(s), n)+1), s, n)
+static inline char *_strndupa3(char *new_s, const char *s, size_t n)
+{
+	strncpy(new_s, s, n);
+	new_s[MIN(strlen(s), n)] = '\0';
+
+	return new_s;
+}
 #endif
 
 /* From ccan array_size.h and build_assert.h, which are under a CC0 license */

--- a/p.txt
+++ b/p.txt
@@ -1,0 +1,1 @@
+It is easier to ignore the problem than it is to solve it


### PR DESCRIPTION
This PR issues units with their subscript. This fixes problems due to a previous ambiguous interpretations of unsubscripted unit strings.

I compared all the linkages of the sentences in data/en/corpus-{basic,fixes}.batch produced
from the current and fixed code. Here my notes on the differences due to this fix.

1) `As` is no more interpreted as `A s`.
Preventing bogus linkages for these sentences from en/corpus-{basic,fixes}.batch:
```
As had been expected, the party was a big success
As guessed, he was lying.
As mentioned before, we are creating a business service.
As promised, she left
```

The prevented bogus linkages:
```
LEFT-WALL a  s.u guessed.q-d , he was.v-d lying .
LEFT-WALL a  s.u mentioned.v before , we are.v creating.v a business.s service.s .
LEFT-WALL a  s.u promised.v-d ,  she left.v-d
```

2) The following sentence and all similar ones now have less linkages, a thing that indicates a shortcoming in the current separation algo:

```
linkparser> We bought 200ft. of lumber.
...
LEFT-WALL we bought.v-d 200[!] ft..u of lumber.n-u .
...
LEFT-WALL we bought.v-d 200[!] ft.u . of lumber.n-u . <-- missing
...
LEFT-WALL we bought.v-d 200[!] ft..u of lumber.n-u .
...
LEFT-WALL we bought.v-d 200[!] ft.u . of lumber.n-u . <-- missing
```

The reason is that without issuing with subscript, `ft.` gets issued, and then at a next tokenization round it get split again in a split_right() of RPUNC to `ft .`. With this new code, after `ft.u` is issued, it cannot get split farther.

In all the cases in en/corpus-fixes.batch it is not harmful since the dict handles both  `ft .` and `ft.` . Moreover, we get half the number of linkages for every unit which has such two versions (with and w/o a dot). However, this indicates that the separation algorithm is not general enough.

Possible FIXME: Use backtracking + remove the units versions with the dot (supposing they are supported with a following dot).

3) In these sentence and additional similar ones:
`the weight was 7grams`

Currently (without this fix) we get these 2 main linkages:
```
LEFT-WALL the weight.n-u was.v-d 7 grams.n
LEFT-WALL the weight.s was.v-d 7 grams.u
```
With this fix, we get only the linkage with `grams.u`. This seems to me better.
(Similarly: `The ferrite core is wrapped with 24gauge wire.` Only `gauge.u` with this fix.)

Similarly for (and additional similar ones):
`It was 10:30AM in the morning.`

Now (without the unit fix) - note the linkage marked with <---:
```
LEFT-WALL it was.v-d 10:30[!HMS-TIME] AM.ti in.r the morning.n-u .
LEFT-WALL it was.v-d 10:30AM[!HMS-TIME] in.r the morning.s .
LEFT-WALL it was.v-d 10:30[!HMS-TIME] AM.l in.r the morning.n-u . <---
```
With this fix, we don't get the `AM.l` one which is clearly wrong.

Here, with this fix we don't get this bogus full linkage:
`It was 10:555:88AM in the morning.`
Before: `LEFT-WALL it was.v-d 10:555:88[?].v AM.l in.r the morning.s .`
With this fix: `LEFT-WALL it was.v-d 10:555:88[?].a [AM] in.r the morning.n-u .`

BTW, maybe including AM etc. in the regex is not needed, as the dict handles it.

4) These words from en/corpus-fixes.batch still get separated to "units", but this time with a unit subscript, so in addition to reducing bogus linkages, the linkages are faster because there are less disjuncts/connectors in the sentence, and less linkages are with bad-morphism.
```
As Ash Kids SAN Sam Shh Shhh TNT TV add all call did lamp lid mall mind minds
mold odd sin sins slid small smidgin (s.u m.u id.u g.u in.u)
bases (base s)
```
The last one is due to `base_pairs` in `units.1`, which only its first word gets to UNITS (as designed).
With this fix it is broken to `base s.u` which has less chase to get misinterpreted.

5) This sentence from en/corpus-fixes.batch still is not handled by the dict:
`Apply 12 ft.lbs. of torque.`
Results in:
`LEFT-WALL apply.v 12 ft..u [lbs.] of torque.n-u .`

6) This sentence has no full parse with this fix, and demonstrates a problem in the dict:
`I can't decide between the 7:30AM and the 9:30AM appointment.`
Before: `LEFT-WALL I.p can't decide.v between the 7:30[!] AM.l and.j-n the 9:30AM[!] appointment.n-u .` 
With this fix: `LEFT-WALL I.p can't decide.v between the 7:30AM[!HMS-TIME] and.j-ru [the] 9:30AM[!HMS-TIME] appointment.n-u .`
