### PR TITLE
Windows: Fix a Unicode linkage graph rendering problem

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Version 5.4.3 (XXX 2017)
  * Fix assorted exclamations and responses (English dict).
  * Fix displaying random linkages on Windows.
  * Fix unit tokenization to remove ambiguity.
+ * Fix utf8-related bug on Windows that could affect printing.
 
 Version 5.4.2 (19 October 2017)
  * Fix man page build (broken in 5.4.1)

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -186,7 +186,7 @@ size_t append_utf8_char(dyn_str * string, const char * mbs)
 {
 	/* Copy exactly one multi-byte character to buf */
 	char buf[10];
-	size_t n = utf8_next(mbs);
+	size_t n = utf8_charlen(mbs);
 
 	assert(n<10, "Multi-byte character is too long!");
 	strncpy(buf, mbs, n);

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -68,7 +68,8 @@ size_t utf8_strwidth(const char *s)
  *
  * The mbstate_t argument is not used, since we convert only from utf-8.
  * FIXME: This function (along with other places that use mbrtowc()) need
- * to be fixed for Windows utf-16 wchar_t).
+ * to be fixed for Windows (utf-16 wchar_t).
+ * Use char32_t with mbrtoc32() instead of mbrtowc().
  */
 size_t utf8_charwidth(const char *s)
 {

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -78,7 +78,7 @@ size_t utf8_charwidth(const char *s)
 	if (n == 0) return 0;
 	if (n < 0)
 	{
-		prt_error("Error: charwidth(%s): utf-8 to wide-char failed.\n", s);
+		prt_error("Error: charwidth(%s): mbrtowc() returned %d\n", s, n);
 		return 1 /* XXX */;
 	}
 
@@ -103,8 +103,8 @@ size_t utf8_num_char(const char *s, size_t max_width)
 		if (n == 0) break;
 		if (n < 0)
 		{
-			prt_error("Warning: Error in utf8_num_char(%s, %zu)\n",
-			          s, max_width);
+			prt_error("Error: utf8_num_char(%s, %zu): mbrtowc() returned %d\n",
+			          s, max_width, n);
 			return 1 /* XXX */;
 		}
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -116,8 +116,8 @@ static void left_append_string(dyn_str * string, const char * s, const char * t)
 		else
 			append_utf8_char(string, t);
 
-		s += utf8_next(s);
-		t += utf8_next(t);
+		s += utf8_charlen(s);
+		t += utf8_charlen(t);
 	}
 }
 
@@ -725,7 +725,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 				/* Update the printable column width */
 				glyph_width += utf8_charwidth(&xpicture[row][j]);
 
-				j += utf8_next(&xpicture[row][j]);
+				j += utf8_charlen(&xpicture[row][j]);
 			}
 			start[row] = j;
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -157,11 +157,8 @@ static bool word_has_alternative(const Gword *word)
  */
 static char *utf8_str1chr(const char *s, const char *xc)
 {
-	/* FIXME use strndupa() */
 	int len = utf8_charlen(xc);
-	char *xc1 = alloca(len+1);
-	strncpy(xc1, xc, len);
-	xc1[len] = '\0';
+	char *xc1 = strndupa(xc, len);
 
 	return strstr(s, xc1);
 }

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -132,25 +132,6 @@ char* strtok_r(char *str, const char *delim, char **nextp)
 /* ============================================================= */
 /* UTF8 utilities */
 
-/** Returns length of UTF8 character.
- * Current algo is based on the first character only.
- * If pointer is not pointing at first char, or not a valid value, returns -1.
- * Returns 0 for NULL.
- */
-int utf8_charlen(const char *xc)
-{
-	unsigned char c;
-
-	c = (unsigned char) *xc;
-
-	if (c == 0) return 0;
-	if (c < 0x80) return 1;
-	if ((c >= 0xc2) && (c < 0xe0)) return 2; /* First byte of a code point U +0080 - U +07FF */
-	if ((c >= 0xe0) && (c < 0xf0)) return 3; /* First byte of a code point U +0800 - U +FFFF */
-	if ((c >= 0xf0) && (c <= 0xf4)) return 4; /* First byte of a code point U +10000 - U +10FFFF */
-	return -1; /* Fallthrough -- not the first byte of a code-point. */
-}
-
 #ifdef _WIN32
 /**
  * (Experimental) Implementation of mbrtowc for Windows.

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -329,19 +329,6 @@ static inline size_t utf8_next(const char *s)
 }
 
 /**
- * Return the length, in codepoints/glyphs, of the utf8-encoded
- * string.  The string is assumed to be at least `len` code-points
- * long. This is needed when splitting words into morphemes.
- */
-static inline size_t utf8_strnlen(const char *s, size_t len)
-{
-	size_t by = 0;
-	while (0 < len) { by += utf8_next(&s[by]); }
-	return by;
-}
-
-
-/**
  * Copy `n` utf8 characters from `src` to `dest`.
  * Return the number of bytes actually copied.
  * The `dest` must have enough room to hold the copy.


### PR DESCRIPTION
The main fix in this PR is for a bug in the recently new change in `utf8_next()` for Windows: It just always returns 1 for valid utf-8 characters (on invalid chars it skips to their end).  By chance the rendering is still done reasonably well on Windows even with this bug.
Recently I refactored the character width computation to its own function and added there error checking. I then noticed that this error actually happens.

In the same occasion I added some minor changes.
I also added a FIXME proposal for fixing character width finding on Windows (badly fails for code points that need 2 wchar_t to represent them - as mentioned in needed fix#3 mentioned in PR #601 ): Just use char32_t with wcstoc32() (POSIX, added on C11).


(Pushed again to refix.)