### PR TITLE
Fixes for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ These packages are:
    You also have to install SWIG from http://www.swig.org/download.html .
 - MacOS:
  * Install the python and python3 packages using [HomeBrew](http://brew.sh/).
+   Alternatively, install
+[Anaconda](https://conda.io/docs/user-guide/install/download.html).
+
+NOTE: Before issuing `configure` (see below) you have to validate that
+the required python versions can be invoked using your `PATH`.
 
 The use of the Python bindings is *OPTIONAL*; you do not need these if
 you do not plan to use link-grammar with python.  If you like
@@ -385,16 +390,6 @@ Plain-vanilla Link Grammar should compile and run on Apple MacOSX
 just fine, as described above.  At this time, there are no reported
 issues.
 
-The language bindings for python and java may require additional
-packages to be installed.  A working editline is nice, since it
-allows you to use the arrow keys in the command-line client.
-See http://www.macports.org/ to find these.
-
-You almost surely do not need a Mac portfile; but you can still
-find one here:
-http://trac.macports.org/browser/trunk/dports/textproc/link-grammar/Portfile .<br>
-It does not currently specify any additional steps to perform.
-
 If you do NOT need the java bindings, you should almost surely
 configure with:
 ```
@@ -409,6 +404,10 @@ variable to wherever `<Headers/jni.h>` is.   Set the JAVA_HOME variable
 to the location of the java compiler.  Make sure you have ant
 installed.
 
+If you would like to build from GitHub
+(see [BUILDING from the GitHub repository](#building-from-the-github-repository))
+you can install the tools that are listed there using
+[HomeBrew](http://brew.sh/).
 
 BUILDING on Windows
 -------------------

--- a/autogen.sh
+++ b/autogen.sh
@@ -23,17 +23,22 @@ if test ! -d `aclocal --print-ac-dir 2>> autogen.err`; then
   exit 1
 fi
 
-libtoolize --force --copy || {
-    echo "error: libtoolize failed"
-    exit 1
-}
-
 # Produce aclocal.m4, so autoconf gets the automake macros it needs
 # 
 case `uname` in
     CYGWIN*)
         include_dir='-I m4' # Needed for Cygwin only.
+        ;;
+    Darwin)
+        [ "$LIBTOOLIZE" = "" ] && LIBTOOLIZE=glibtoolize
+        ;;
 esac
+
+    ${LIBTOOLIZE:=libtoolize} --force --copy || {
+    echo "error: libtoolize failed"
+    exit 1
+}
+
 echo "Creating aclocal.m4: aclocal $include_dir $ACLOCAL_FLAGS"
 
 aclocal $include_dir $ACLOCAL_FLAGS 2>> autogen.err

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -66,14 +66,14 @@ int read_regex_file(Dictionary dict, const char *file_name)
 		{
 			do
 			{
-				c = lg_fgetc(fp);
+				c = fgetc(fp);
 				if (c == '\n') { line++; }
 			}
 			while (lg_isspace(c));
 
 			if (c == '%')
 			{
-				while ((c != EOF) && (c != '\n')) { c = lg_fgetc(fp); }
+				while ((c != EOF) && (c != '\n')) { c = fgetc(fp); }
 				line++;
 			}
 		}
@@ -91,7 +91,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 				goto failure;
 			}
 			name[i++] = c;
-			c = lg_fgetc(fp);
+			c = fgetc(fp);
 		}
 		while ((!lg_isspace(c)) && (c != ':') && (c != EOF));
 		name[i] = '\0';
@@ -100,7 +100,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 		while (lg_isspace(c))
 		{
 			if (c == '\n') { line++; }
-			c = lg_fgetc(fp);
+			c = fgetc(fp);
 		}
 		if (c != ':')
 		{
@@ -112,7 +112,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 		do
 		{
 			if (c == '\n') { line++; }
-			c = lg_fgetc(fp);
+			c = fgetc(fp);
 		}
 		while (lg_isspace(c));
 		if (c == '!')
@@ -121,7 +121,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 			do
 			{
 				if (c == '\n') { line++; }
-				c = lg_fgetc(fp);
+				c = fgetc(fp);
 			}
 			while (lg_isspace(c));
 		}
@@ -142,7 +142,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 				goto failure;
 			}
 			prev = c;
-			c = lg_fgetc(fp);
+			c = fgetc(fp);
 			regex[i++] = c;
 		}
 		while ((c != '/' || prev == '\\') && (c != EOF));

--- a/link-grammar/dict-file/word-file.c
+++ b/link-grammar/dict-file/word-file.c
@@ -52,14 +52,14 @@ static const char * get_a_word(Dictionary dict, FILE * fp)
 	int c, j;
 
 	do {
-		c = lg_fgetc(fp);
+		c = fgetc(fp);
 	} while ((c != EOF) && lg_isspace(c));
 	if (c == EOF) return NULL;
 
 	for (j=0; (j <= MAX_WORD-1) && (!lg_isspace(c)) && (c != EOF); j++)
 	{
 		word[j] = c;
-		c = lg_fgetc(fp);
+		c = fgetc(fp);
 	}
 
 	if (j >= MAX_WORD) {

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -476,7 +476,7 @@ static bool do_match_with_cache(Connector *a, Connector *b, match_cache *c_con)
 		 * enough for not using uninitialized c_con->match because the
 		 * connector desc filed cannot be NULL, as it actually fetched a
 		 * non-empty match list. */
-		PRAGMA_START(GCC diagnostic ignored "-Wmaybe-uninitialized")
+		PRAGMA_MAYBE_UNINITIALIZED
 		return c_con->match;
 		PRAGMA_END
 	}

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -146,15 +146,12 @@ size_t lg_mbrtowc(wchar_t *, const char *, size_t n, mbstate_t *ps);
 #endif /* _WIN32 */
 
 /* MSVC isspace asserts in debug mode, and mingw sometime returns true,
- * when passed utf8. This is because char, which is used for our strings,
- * is (usually) signed. On Linux it just returns junk which may be 0
- * (and doesn't assert unless compiled with memory access check).
- *
- * The manual of isspace() and the other is*() functions states:
- * "These functions check whether c, which must have the value of an
- * unsigned char or EOF, ...").
- * So just enforce it to a non-zero 8-bit value. */
-#define lg_isspace(c) isspace((unsigned char)c)
+ * when passed utf8. Thus, limit to 7 bits for windows. */
+#ifdef _WIN32
+  #define lg_isspace(c) ((0 < c) && (c < 127) && isspace(c))
+#else
+  #define lg_isspace isspace
+#endif
 
 #if __APPLE__
 /* It appears that fgetc on Mac OS 10.11.3 "El Capitan" has a weird

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -146,41 +146,10 @@ size_t lg_mbrtowc(wchar_t *, const char *, size_t n, mbstate_t *ps);
 #endif /* _WIN32 */
 
 /* MSVC isspace asserts in debug mode, and mingw sometime returns true,
- * when passed utf8. Thus, limit to 7 bits for windows. */
-#ifdef _WIN32
-  #define lg_isspace(c) ((0 < c) && (c < 127) && isspace(c))
-#else
-  #define lg_isspace isspace
-#endif
-
-#if __APPLE__
-/* It appears that fgetc on Mac OS 10.11.3 "El Capitan" has a weird
- * or broken version of fgetc() that flubs reads of utf8 chars when
- * the locale is not set to "C" -- in particular, it fails for the
- * en_US.utf8 locale; see bug report #293
- * https://github.com/opencog/link-grammar/issues/293
- */
-static inline int lg_fgetc(FILE *stream)
-{
-	char c[4];  /* general overflow paranoia */
-	size_t nr = fread(c, 1, 1, stream);
-	if (0 == nr) return EOF;
-	return (int) c[0];
-}
-
-static inline int lg_ungetc(int c, FILE *stream)
-{
-	/* This should work, because we never unget past the newline char. */
-	int rc = fseek(stream, -1, SEEK_CUR);
-	if (rc) return EOF;
-	return c;
-}
-
-#else
-#define lg_fgetc   fgetc
-#define lg_ungetc  ungetc
-#endif
-
+ * when passed utf8. OSX returns TRUE on char values 0x85 and 0xa0).
+ * Since it is defined to return TRUE only on 6 characters, all of which
+ * are in the range [0..127], just limit its arguments to 7 bits. */
+#define lg_isspace(c) ((0 < c) && (c < 127) && isspace(c))
 
 #if defined(__sun__)
 int strncasecmp(const char *s1, const char *s2, size_t n);

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -262,7 +262,7 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 #else
 #define PRAGMA_START(x)
 #define PRAGMA_END
-
+#define PRAGMA_MAYBE_UNINITIALIZED
 #endif /* GCC_DIAGNOSTIC */
 
 /**

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -191,11 +191,11 @@ typedef int locale_t;
 #define strdupa(s) strcpy(alloca(strlen(s)+1), s)
 #endif
 #ifndef strndupa
-#define strndupa(s, n) _strndupa3(alloca(MIN(strlen(s), n)+1), s, n)
+#define strndupa(s, n) _strndupa3(alloca((n)+1), s, n)
 static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 {
 	strncpy(new_s, s, n);
-	new_s[MIN(strlen(s), n)] = '\0';
+	new_s[n] = '\0';
 
 	return new_s;
 }


### PR DESCRIPTION
1. Solve the base problem that causes Russian to malfunction (issue #293).
I didn't update the ChangeLog because the last version works fine due to the two bugs which are canceling each other.
2. In the same occasion, fix a problem due to a `libtoolize` rename on MacOS (previously, invoking `autogen.sh` failed, and a manual solution was needed, like exporting a shell function, creating a symlink or editing `autogen.sh`).
3. Fix all the current clang warnings.
4. Update the main README.md.
- Mention Anaconda.
- Remove references to ports - no need for ports profile. BTW, the version provided by MacPorts is
4.6.1 (and it works - I tested it...).

This PR was also tested on Windows.