### PR TITLE
python3 fixes for tests.py

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -968,7 +968,7 @@ class divert_start(object):
         os.close(self.savedfd)
         os.unlink(self.filename)
         self.filename = None
-        return content
+        return str(content)
 
     __del__ = divert_end
 

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -7,6 +7,12 @@ import sys, os
 import locale
 import unittest
 
+# assertRaisesRegexp and assertRegexpMatches have been renamed in
+# unittest for python 3, but not in python 2 (at least yet).
+if hasattr(unittest.TestCase, 'assertRaisesRegex'):
+    unittest.TestCase.assertRaisesRegexp = unittest.TestCase.assertRaisesRegex
+    unittest.TestCase.assertRegexpMatches = unittest.TestCase.assertRegex
+
 import lg_testutils # Found in the same directory of this test script
 
 # Show information on this program run


### PR DESCRIPTION
Fix tests.py errors and warnings when running under python3.
1. Adapt for depreciated unittest method names (currently depreciated in python3 only).
2. python3 cannot compare byte and str objects.