### PR TITLE
do_count() speed improvements

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -41,7 +41,7 @@ struct count_context_s
 	bool    islands_ok;
 	bool    null_links;
 	bool    exhausted;
-	int     checktimer;  /* Avoid excess system calls */
+	unsigned checktimer;  /* Avoid excess system calls */
 	int     table_size;
 	int     log2_table_size;
 	Table_connector ** table;
@@ -133,11 +133,11 @@ find_table_pointer(count_context_t *ctxt,
 	/* Create a new connector only if resources are exhausted.
 	 * (???) Huh? I guess we're in panic parse mode in that case.
 	 * checktimer is a device to avoid a gazillion system calls
-	 * to get the timer value. On circa-2009 machines, it results
-	 * in maybe 5-10 timer calls per second.
+	 * to get the timer value. On circa-2017 machines, it results
+	 * in about 0.5-1 timer calls per second.
 	 */
 	ctxt->checktimer ++;
-	if (ctxt->exhausted || ((0 == ctxt->checktimer%1450100) &&
+	if (ctxt->exhausted || ((0 == ctxt->checktimer%(1<<21)) &&
 	                       (ctxt->current_resources != NULL) &&
 	                       resources_exhausted(ctxt->current_resources)))
 	{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -217,10 +217,11 @@ static Count_bin do_count(int lineno, fast_matcher_t *mchxt,
 	if (!verbosity_level(8))
 		return do_count1(lineno, mchxt, ctxt, lw, rw, le, re, null_count);
 
-	level++;
-	prt_error("%*sdo_count:%d lw=%d rw=%d le=%s re=%s null_count=%d\n\\",
-		    level*2, "", lineno, lw, rw, V(le), V(re), null_count);
 	Table_connector *t = find_table_pointer(ctxt, lw, rw, le, re, null_count);
+
+	level++;
+	prt_error("%*sdo_count%.*s:%d lw=%d rw=%d le=%s re=%s null_count=%d\n\\",
+		level*2, "", (!t)*3, "(R)", lineno, lw, rw, V(le), V(re), null_count);
 	Count_bin r = do_count1(lineno, mchxt, ctxt, lw, rw, le, re, null_count);
 	prt_error("%*sreturn%.*s:%d=%lld\n", level*2, "", (!!t)*3, "(M)", lineno, r);
 	level--;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -195,7 +195,7 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 }
 
 #ifdef DEBUG
-//#define DO_COUNT_TRACE
+#define DO_COUNT_TRACE
 #endif
 
 #ifdef DO_COUNT_TRACE

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -397,11 +397,16 @@ static Count_bin do_count(
 				/* Now, we determine if (based on table only) we can see that
 				   the current range is not parsable. */
 
-				/* First, perform pseudocounting as an optimization. If
+				/* The result count is a sum of multiplications of
+				 * LHS and RHS counts. If one of them is zero, we can skip
+				 * calculating the other one.
+				 *
+				 * So, first perform pseudocounting as an optimization. If
 				 * the pseudocount is zero, then we know that the true
-				 * count will be zero, and so skip counting entirely,
-				 * in that case.
-				 */
+				 * count will be zero.
+				 *
+				 * Cache the result, so a table lookup can be skipped if we
+				 * actually need  */
 				if (Lmatch)
 				{
 					l_any = pseudocount(ctxt, lw, w, le->next, d->left->next, lnull_cnt);
@@ -471,9 +476,10 @@ static Count_bin do_count(
 	Count_bin count = (hist_total(&c) == NO_COUNT) ? do_count : hist_total(&c); \
 	how_to_count; \
 }
-			/* If pseudototal is zero (false), that implies that
+			 /* If the pseudocounting above indicates one of the terms
+			 * in the count multiplication is zero,
 			 * we know that the true total is zero. So we don't
-			 * bother counting at all, in that case. */
+			 * bother counting the other terms at all, in that case. */
 				Count_bin leftcount = zero;
 				Count_bin rightcount = zero;
 				if (leftpcount &&

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -365,7 +365,7 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 #endif
 		for (; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{
-			unsigned int lnull_cnt, rnull_cnt;
+			int lnull_cnt, rnull_cnt;
 			Disjunct *d = get_match_list_element(mchxt, mle);
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
@@ -373,10 +373,8 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 #ifdef VERIFY_MATCH_LIST
 			assert(id == d->match_id, "Modified id (%d!=%d)", id, d->match_id);
 #endif
-			/* _p1 avoids a gcc warning about unsafe loop opt */
-			unsigned int null_count_p1 = null_count + 1;
 
-			for (lnull_cnt = 0; lnull_cnt < null_count_p1; lnull_cnt++)
+			for (lnull_cnt = 0; lnull_cnt <= null_count; lnull_cnt++)
 			{
 				bool leftpcount = false;
 				bool rightpcount = false;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -357,13 +357,12 @@ static Count_bin do_count(
 
 	for (w = start_word; w < end_word; w++)
 	{
-		size_t mlb, mle;
-		mle = mlb = form_match_list(mchxt, w, le, lw, re, rw);
+		size_t mlb = form_match_list(mchxt, w, le, lw, re, rw);
 #ifdef VERIFY_MATCH_LIST
 		int id = get_match_list_element(mchxt, mlb) ?
 		            get_match_list_element(mchxt, mlb)->match_id : 0;
 #endif
-		for (; get_match_list_element(mchxt, mle) != NULL; mle++)
+		for (size_t mle = mlb; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{
 			int lnull_cnt, rnull_cnt;
 			Disjunct *d = get_match_list_element(mchxt, mle);
@@ -405,8 +404,9 @@ static Count_bin do_count(
 				 * the pseudocount is zero, then we know that the true
 				 * count will be zero.
 				 *
-				 * Cache the result, so a table lookup can be skipped if we
-				 * actually need  */
+				 * Cache the result in the l_* and r_* variables, so a table
+				 * lookup can be skipped in cases we cannot skip the actual
+				 * calculation and a table entry exists. */
 				if (Lmatch)
 				{
 					l_any = pseudocount(ctxt, lw, w, le->next, d->left->next, lnull_cnt);
@@ -479,7 +479,7 @@ static Count_bin do_count(
 			 /* If the pseudocounting above indicates one of the terms
 			 * in the count multiplication is zero,
 			 * we know that the true total is zero. So we don't
-			 * bother counting the other terms at all, in that case. */
+			 * bother counting the other term at all, in that case. */
 				Count_bin leftcount = zero;
 				Count_bin rightcount = zero;
 				if (leftpcount &&

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -510,14 +510,16 @@ static Count_bin do_count(fast_matcher_t *mchxt,
 						CACHE_COUNT(r_dcmulti, hist_accumv(&rightcount, d->cost, count),
 							do_count(mchxt, ctxt, w, rw, d->right, re, rnull_cnt));
 
-					/* Total number where links are used on both sides */
-					hist_muladd(&total, &leftcount, 0.0, &rightcount);
-
-					if ((le == NULL) && (0 < hist_total(&rightcount)))
+					if (0 < hist_total(&rightcount))
 					{
-						/* Evaluate using the right match, but not the left */
-						CACHE_COUNT(r_bnl, hist_muladdv(&total, &rightcount, d->cost, count),
-							do_count(mchxt, ctxt, lw, w, le, d->left, lnull_cnt));
+						/* Total number where links are used on both sides */
+						hist_muladd(&total, &leftcount, 0.0, &rightcount);
+						if (le == NULL)
+						{
+							/* Evaluate using the right match, but not the left */
+							CACHE_COUNT(r_bnl, hist_muladdv(&total, &rightcount, d->cost, count),
+								do_count(mchxt, ctxt, lw, w, le, d->left, lnull_cnt));
+						}
 					}
 				}
 


### PR DESCRIPTION
It turns out do_count() doesn't use its pseudocounting in the most efficient way.
For  example:
1. If `Lmatch=false` but `Rmatch=true`, there is no need to even make pseudocounting unless `le==NULL`.
2. If `pseudototal=true` and  `leftcount=true', there is sometimes still no need to perform LHS counting.
3. If `leftcount=true' and `rightcount=true` (but the "but not" countings are false), there is no need to perform the RHS counting if the actual LHS counting turns put to be false.
4. The pseudocouning table lookups can be cached and used in the real countig if needed.
5. ...

Several more  significant optimizations are be done.
See the commits:
- Optimize the use of the pseudocounting
- Optimize further

Implementing these optimizations and several more smaller ones  makes the `en/corpus-fixes.batch` run 10+% faster.
However, these optimizations affect longer sentences even more, and especially when parsing with null words. For example, in the "The problem is: sentence, the CPU saving is 40% (when `!null=T`).
These optimizations doesn't have much effect on Russian (it seems its execution path doesn't involve the pseudocounting inefficiencies that got corrected here).

Regretfully had to modify some original comments in order to match them to the new code.

In WIP branches I have several more modifications that speed-up the classic parsing.
They all modify the master branch as it is now, so I will need to reimplement/rebase them after each PR (lake this one) is accepted.