### PR TITLE
Fix memory leaks

### DIFF
--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -80,9 +80,17 @@ char * join_path(const char * prefix, const char * suffix)
  */
 static char * custom_data_dir = NULL;
 
+static void free_custom_data_dir(void)
+{
+	free(custom_data_dir);
+}
+
 void dictionary_set_data_dir(const char * path)
 {
-	if (custom_data_dir) free (custom_data_dir);
+	if (custom_data_dir)
+		free(custom_data_dir);
+	else
+		atexit(free_custom_data_dir);
 	custom_data_dir = safe_strdup(path);
 }
 

--- a/link-grammar/post-process/pp_lexer.l
+++ b/link-grammar/post-process/pp_lexer.l
@@ -71,6 +71,7 @@ void pp_lexer_close(PPLexTable *lt)
   string_set_delete(lt->string_set);
   if (lt->tokens) free(lt->tokens);
   xfree(lt, sizeof(PPLexTable));
+  yylex_destroy();
 }
 
 PPLexTable *pp_lexer_open(FILE *f)


### PR DESCRIPTION
1. In pp_lexer (accumulated - every time a dict is opened/closed).
2. In the same occasion I fixed also the one in `dictionary_set_data_dir()` (minor - not accumulated).

BTW, now we have again the "problem" of pp_lexer exiting on file format errors.
It can be fixed if desired (but maybe it is not important enough).