### PR TITLE
Add file completion for !file

### DIFF
--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -103,8 +103,8 @@ char *lg_readline(const char *mb_prompt)
 		/* By default, it comes up in vi mode, with the editor not in
 		 * insert mode; and even when in insert mode, it drops back to
 		 * command mode at the drop of a hat. Totally confusing/lame. */
-		el_wset(el, EL_EDITOR, L"emacs");
-		el_wset(el, EL_PROMPT_ESC, prompt, '\1'); /* Set the prompt function */
+		el_set(el, EL_EDITOR, "emacs");
+		el_wset(el, EL_PROMPT, prompt); /* Set the prompt function */
 
 		el_set(el, EL_ADDFN, "fn_complete", "file completion", lg_fn_complete);
 		el_set(el, EL_BIND, "^I", "fn_complete", NULL);

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -96,7 +96,6 @@ char *lg_readline(const char *mb_prompt)
 		el = el_init("link-parser", stdin, stdout, stderr);
 		history_w(hist, &ev, H_SETSIZE, 20);   /* Remember 20 events */
 		el_wset(el, EL_HIST, history_w, hist);
-		el_source(el, NULL);       /* Source the user's defaults file. */
 		history_w(hist, &ev, H_LOAD, HFILE);
 
 		el_set(el, EL_SIGNAL, 1); /* Restore tty setting on returning to shell */
@@ -109,6 +108,8 @@ char *lg_readline(const char *mb_prompt)
 
 		el_set(el, EL_ADDFN, "fn_complete", "file completion", lg_fn_complete);
 		el_set(el, EL_BIND, "^I", "fn_complete", NULL);
+
+		el_source(el, NULL); /* Source the user's defaults file. */
 	}
 
 	wc_line = el_wgets(el, &numc);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -723,8 +723,8 @@ int main(int argc, char * argv[])
 			if (NULL == input_fh)
 			{
 				int perr = errno;
-				fprintf(stderr, "Error: %s (%d) %s\n",
-				        filename, perr, strerror(perr));
+				fprintf(stderr, "Error: Cannot open %s: %s\n",
+				        filename, strerror(perr));
 				input_fh = stdin;
 				continue;
 			}


### PR DESCRIPTION
Comments:
- Filenames with spaces are not supported well, but no point to fix that since they are not handled well also by editline.
-  FIXME: The file completion knows about ~ and ~user. However, I don't know how to force their expanding, so they are not useful for now.
- TODO: Variable completion.
