### PR TITLE
link-parser: !file: Check stat() returned value

### DIFF
--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -725,8 +725,7 @@ int main(int argc, char * argv[])
 			if ('\n' == filename[fnlen-1]) filename[fnlen-1] = '\0';
 
 			struct stat statbuf;
-			stat(filename, &statbuf);
-			if (statbuf.st_mode & S_IFDIR)
+			if ((0 == stat(filename, &statbuf)) && statbuf.st_mode & S_IFDIR)
 			{
 				fprintf(stderr, "Error: Cannot open %s: %s\n",
 				        filename, strerror(EISDIR));


### PR DESCRIPTION
Strange things may happen when not checking the result of system calls...
In that case a nonexistent file may be considered a directory...
