### PR TITLE
SAT parser bug fix: Account for h/d for the link label

### DIFF
--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -1,6 +1,7 @@
 #ifndef __VARIABLES_HPP__
 #define __VARIABLES_HPP__
 
+#include <ctype.h>
 #include <vector>
 #include <map>
 #include <iostream>
@@ -38,6 +39,11 @@ static char* construct_link_label(const char* connector1, const char* connector2
   char* result = (char*)xalloc((std::max(strlen(connector1), strlen(connector2)) + 1)*
                                sizeof(char));
   char* presult = result;
+
+  /* Skip head-dependent indicator in each connector. */
+  if (islower(*connector1)) connector1++;
+  if (islower(*connector2)) connector2++;
+
   while (*connector1 != '\0' && *connector2 != '\0') {
     if (*connector1 == '*')
       *presult++ = *connector2;


### PR DESCRIPTION
The link label is used only for pp pruning.
This bug was somehow hidden until the head-dependent markers change
at commit 00ea60fd, at which point questions stopped to get parsed
by the SAT parser.

Repeat by:
Are John and I invited
Are John or I invited
Are a dog and a cat here
Are neither John nor I invited
etc.