### PR TITLE
Fix idiom string incrementing

### DIFF
--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -185,7 +185,7 @@ static Dict_node * make_idiom_Dict_nodes(Dictionary dict, const char * string)
 
 static void increment_current_name(Dictionary dict)
 {
-	int i = IDIOM_LINK_SZ-1;
+	int i = IDIOM_LINK_SZ-2;
 
 	do
 	{


### PR DESCRIPTION
Without this fix, the idiom names start as:
BUFF=ID
BUFF=ID
BUFF=ID^A
BUFF=ID^A
BUFF=ID^B
BUFF=ID^B
BUFF=ID^C
BUFF=ID^C
because the '\0' at the end is incremented.
At some early point there are even 16 A's and a buffer access violation happens:
idiom.c:210:31: runtime error: index 16 out of bounds for type 'char [16]'