### PR TITLE
Improve the speed of the string-set hash

### DIFF
--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -45,15 +45,16 @@ static unsigned int hash_string(const char *str, const String_set *ss)
 {
 	unsigned int accum = 0;
 	for (;*str != '\0'; str++)
-		accum = ((7 * accum) + ((unsigned char) *str)) % (ss->size);
-	return accum;
+		accum = (7 * accum) + (unsigned char)*str;
+	return accum % (ss->size);
 }
 
 static unsigned int stride_hash_string(const char *str, const String_set *ss)
 {
 	unsigned int accum = 0;
 	for (;*str != '\0'; str++)
-		accum = ((17 * accum) + ((unsigned char) *str)) % (ss->size);
+		accum = (17 * accum) + (unsigned char)*str;
+	accum %= ss->size;
 	/* This is the stride used, so we have to make sure that
 	 * its value is not 0 */
 	if (accum == 0) accum = 1;

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -97,12 +97,16 @@ String_set * string_set_create(void)
  */
 static unsigned int find_place(const char * str, String_set *ss)
 {
-	unsigned int h, s, i;
+	unsigned int h, s;
 	h = hash_string(str, ss);
+
+	if ((ss->table[h] == NULL) || (strcmp(ss->table[h], str) == 0)) return h;
 	s = stride_hash_string(str, ss);
-	for (i=h; true; i = (i + s)%(ss->size))
+	while (true)
 	{
-		if ((ss->table[i] == NULL) || (strcmp(ss->table[i], str) == 0)) return i;
+		h = h + s;
+		if (h >= ss->size) h %= ss->size;
+		if ((ss->table[h] == NULL) || (strcmp(ss->table[h], str) == 0)) return h;
 	}
 }
 


### PR DESCRIPTION
The main speedup is due to making the division once per hash instead of for every character.
A minor speedup is due to avoiding stride hash if possible and making a division only once per search.

The speed up is mainly in the startup (directory read) since a large number of calls  to string_set_add() are done at this step. There is a speedup in the sentence handling but it is negligible.

---
I also did the following tries, which didn't produce a noticeable speedup,so they are not included:
1. Using duff's device hashing.
2. Using a fixed stride of 1.
3. Old try:  String-set allocation from pulls, when the number of malloc calls are drastically reduced (to the point of a single malloc per each string set). At that time my measurement noise was greater than now, so I will have to repeat testing it.

The result is a consistent speedup of 10+% of the dict read, measures by: `link-parser [ru] < /dev/null`
