### PR TITLE
Main README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ gcc-c++ (for the SAT solver)<br>
 autoconf<br>
 autoconf-archive<br>
 swig (for language bindings)<br>
+flex<br>
 graphviz (if you like to use the word-graph display feature)
 
 The GitHub version doesn't include a `configure` script.

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ autoconf<br>
 autoconf-archive<br>
 swig (for language bindings)<br>
 flex<br>
+ant (for Java bindings)<br>
 graphviz (if you like to use the word-graph display feature)
 
 The GitHub version doesn't include a `configure` script.

--- a/README.md
+++ b/README.md
@@ -269,8 +269,26 @@ the Java bindings by disabling as follows:
 ./configure --disable-java-bindings
 ```
 
-If JAVA_HOME isn't set, if jni.h isn't found, or if ant isn't found,
+If `jni.h` isn't found, or if `ant` isn't found,
 then the java bindings will not be built.
+
+Notes about finding `jni.h`:<br>
+Some common java JVM distributions (most notably, the ones from Sun)
+place this file in unusual locations, where it cannot be
+automatically found.  To remedy this, make sure that environment variable
+JAVA_HOME is set. The configure script looks for jni.h in `$JAVA_HOME/Headers`
+and in `$JAVA_HOME/include`; it also examines corresponding locations
+for $JDK_HOME.  If `jni.h `still cannot be found, specify the location
+with the CPPFLAGS variable: so, for example,
+```
+export CPPFLAGS="-I/opt/jdk1.5/include/:/opt/jdk1.5/include/linux"
+```
+or
+```
+export CPPFLAGS="-I/c/java/jdk1.6.0/include/ -I/c/java/jdk1.6.0/include/win32/"
+```
+Please note that the use of `/opt` is non-standard, and most system
+tools will fail to find packages installed there.
 
 Python2 and Python3 Bindings
 ----------------------------
@@ -596,36 +614,6 @@ Thus, for example, a typical makefile might include the targets:
 $(EXE): $(OBJS)
    cc -g -o $@ $^ `pkg-config --libs link-grammar`
 ```
-
-JAVA bindings
--------------
-This release includes Java bindings.  Their use is optional.
-
-The bindings will be built automatically if `jni.h` can be found.
-Some common java JVM distributions (most notably, the ones from Sun)
-place this file in unusual locations, where it cannot be
-automatically found.  To remedy this, make sure that JAVA_HOME is
-set. The configure script looks for jni.h in `$JAVA_HOME/Headers`
-and in `$JAVA_HOME/include`; it also examines corresponding locations
-for $JDK_HOME.  If `jni.h `still cannot be found, specify the location
-with the CPPFLAGS variable: so, for example,
-```
-export CPPFLAGS="-I/opt/jdk1.5/include/:/opt/jdk1.5/include/linux"
-```
-or
-```
-export CPPFLAGS="-I/c/java/jdk1.6.0/include/ -I/c/java/jdk1.6.0/include/win32/"
-```
-
-Please note that the use of /opt is non-standard, and most system
-tools will fail to find packages installed there.
-
-The building of the Java bindings can be disabled by configuring as
-below:
-```
-./configure --disable-java-bindings
-```
-
 
 Using JAVA
 ----------


### PR DESCRIPTION
1. Add `flex` and `ant` to the list of packages needed for development.
2. Unify the two Java Bindings sections.

I also noted that **all** the links regarding **landmark transitivity** don't work any more.
I wanted to replace them by working ones, but could not find any. I would like to read them in order to have a better insight on implementing landmark transitivity (discussion at PR [#621](https://github.com/opencog/link-grammar/pull/621#issuecomment-352299657)).

BTW, the info on SAT performance (A performance diary) seem to be bogus. The reported times are the times needed to load the dictionary. I tested the mentioned version (5.1.0) and it indeed doesn't actually perform the linkage. I propose to update this info.
In any case, comparing the performance of different library versions needs these considerations:
- Use the same "short" option (older libraries use a smaller value, which cause faster linkages). 
- As the English dictionary becomes bigger and more complex over versions, this increases the linkage times even if the same library version is used.
- The sentence `In vivo studies...` is not good for such a benchmark because it contains "spelling errors". Depending on the spelling package version which is used, there may be different numbers of spelling corrections, which make the linkage time vary. Especially, it becomes very big if no spelling corrections are found, due to the need of linkages with nulls (this what happens when I tested it with the current library version).

All of these need to be considered when comparing the performance.

An  additional proposals: Remove the comment on `libedit` UTF-8 support on Ubuntu 14.04 and Mint 17 after their End of Life (in a few months).