### PR TITLE
Move pp data from PP struct to linkage.

### DIFF
--- a/link-grammar/api-types.h
+++ b/link-grammar/api-types.h
@@ -24,7 +24,6 @@ typedef struct Exp_struct Exp;
 typedef struct Connector_struct Connector;
 typedef struct Linkage_info_struct Linkage_info;
 typedef struct Postprocessor_s Postprocessor;
-typedef struct PP_info_s PP_info;
 typedef struct Resources_s * Resources;
 
 /* Some of the more obscure typedefs */
@@ -39,7 +38,9 @@ typedef struct gword_set gword_set;
 /* Post-processing structures */
 typedef struct pp_knowledge_s pp_knowledge;
 typedef struct pp_linkset_s pp_linkset;
-typedef struct PP_node_struct PP_node;
+typedef struct PP_data_s PP_data;
+typedef struct PP_info_s PP_info;
+typedef struct PP_node_s PP_node;
 
 typedef struct corpus_s Corpus;
 typedef struct sense_s Sense;

--- a/link-grammar/linkage/freeli.c
+++ b/link-grammar/linkage/freeli.c
@@ -83,5 +83,6 @@ void partial_init_linkage(Sentence sent, Linkage lkg, unsigned int N_words)
 #endif
 
 	lkg->pp_info = NULL;
+	lkg->pp_node = NULL;
 	lkg->sent = sent;
 }

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -73,10 +73,8 @@ struct Linkage_s
 	Linkage_info    lifo;         /* Parse_set index and cost information */
 	Sentence        sent;         /* Used for common linkage data */
 
-	PP_data *       pp_data;
 	PP_info *       pp_info;      /* PP domain info, one for each link */
 	PP_node *       pp_node;
-	PP_data *       constituent_pp_data;
 };
 
 struct Link_s

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -73,6 +73,7 @@ struct Linkage_s
 	Linkage_info    lifo;         /* Parse_set index and cost information */
 	Sentence        sent;         /* Used for common linkage data */
 
+	PP_data *       pp_scratch_data;
 	PP_info *       pp_info;      /* PP domain info, one for each link */
 	PP_node *       pp_node;
 };

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -71,10 +71,12 @@ struct Linkage_s
 	Gword **wg_path_display;      /* Wordgraph path after morpheme combining */
 
 	Linkage_info    lifo;         /* Parse_set index and cost information */
+	Sentence        sent;         /* Used for common linkage data */
+
+	PP_data *       pp_data;
 	PP_info *       pp_info;      /* PP domain info, one for each link */
 	PP_node *       pp_node;
-
-	Sentence        sent;         /* Used for common linkage data */
+	PP_data *       constituent_pp_data;
 };
 
 struct Link_s

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -72,6 +72,7 @@ struct Linkage_s
 
 	Linkage_info    lifo;         /* Parse_set index and cost information */
 	PP_info *       pp_info;      /* PP domain info, one for each link */
+	PP_node *       pp_node;
 
 	Sentence        sent;         /* Used for common linkage data */
 };

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -1083,7 +1083,7 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 
 	/** No-op. If we wanted to debug domain names, we could do this...
 	 * linkage_free_pp_info(linkage);
-	 * linkage_set_domain_names(sent->constituent_pp, linkage);
+	 * linkage_set_domain_names(sent->constituent_pp, pp_data, linkage);
 	 */
 	numcon_subl = read_constituents_from_domains(ctxt, pp_data, linkage, numcon_total);
 	numcon_total += numcon_subl;

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -1077,6 +1077,9 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	if (NULL ==  sent->constituent_pp)         /* First time for this sentence */
 		sent->constituent_pp = post_process_new(sent->dict->hpsg_knowledge);
 
+	assert(NULL == linkage->constituent_pp_data,
+	      "Expecting null contituent data");
+	linkage->constituent_pp_data = pp_data_new();
 	do_post_process(sent->constituent_pp, linkage, linkage->is_sent_long);
 
 	/** No-op. If we wanted to debug domain names, we could do this...

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -680,7 +680,7 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 {
 	size_t d, l, w2;
 	int c, w, c2, numcon_subl = 0;
-	PP_data *pp_data = &linkage->sent->constituent_pp->pp_data;
+	PP_data *pp_data = linkage->constituent_pp_data;
 
 	for (d = 0, c = numcon_total; d < pp_data->N_domains; d++, c++)
 	{
@@ -1096,7 +1096,8 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	string_set_delete(ctxt->phrase_ss);
 	ctxt->phrase_ss = NULL;
 
-	post_process_free_data(&sent->constituent_pp->pp_data);
+	post_process_free_data(linkage->constituent_pp_data);
+	linkage->constituent_pp_data = NULL;
 
 	return q;
 }

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -675,12 +675,13 @@ static const char * cons_of_domain(const Linkage linkage, char domain_type)
 	}
 }
 
-static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
+static int read_constituents_from_domains(con_context_t *ctxt,
+                                          PP_data* pp_data,
+                                          Linkage linkage,
                                           int numcon_total)
 {
 	size_t d, l, w2;
 	int c, w, c2, numcon_subl = 0;
-	PP_data *pp_data = linkage->constituent_pp_data;
 
 	for (d = 0, c = numcon_total; d < pp_data->N_domains; d++, c++)
 	{
@@ -1077,16 +1078,14 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	if (NULL ==  sent->constituent_pp)         /* First time for this sentence */
 		sent->constituent_pp = post_process_new(sent->dict->hpsg_knowledge);
 
-	assert(NULL == linkage->constituent_pp_data,
-	      "Expecting null contituent data");
-	linkage->constituent_pp_data = pp_data_new();
-	do_post_process(sent->constituent_pp, linkage, linkage->is_sent_long);
+	PP_data* pp_data = pp_data_new();
+	do_post_process(sent->constituent_pp, pp_data, linkage, linkage->is_sent_long);
 
 	/** No-op. If we wanted to debug domain names, we could do this...
 	 * linkage_free_pp_info(linkage);
 	 * linkage_set_domain_names(sent->constituent_pp, linkage);
 	 */
-	numcon_subl = read_constituents_from_domains(ctxt, linkage, numcon_total);
+	numcon_subl = read_constituents_from_domains(ctxt, pp_data, linkage, numcon_total);
 	numcon_total += numcon_subl;
 	assert (numcon_total < ctxt->conlen, "Too many constituents (c)");
 	numcon_total = merge_constituents(ctxt, linkage, numcon_total);
@@ -1099,8 +1098,7 @@ static char * do_print_flat_constituents(con_context_t *ctxt, Linkage linkage)
 	string_set_delete(ctxt->phrase_ss);
 	ctxt->phrase_ss = NULL;
 
-	post_process_free_data(linkage->constituent_pp_data);
-	linkage->constituent_pp_data = NULL;
+	post_process_free_data(pp_data);
 
 	return q;
 }

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -275,6 +275,8 @@ static void build_type_array(PP_data* pp_data, Linkage lkg)
 	size_t d;
 	List_o_links * lol;
 
+	/* Highly unlikely that the number of links will ever exceed this. */
+	chk_d_type(lkg->pp_node, 2 * pp_data->num_words);
 	for (d = 0; d < pp_data->N_domains; d++)
 	{
 		for (lol = pp_data->domain_array[d].lol; lol != NULL; lol = lol->next)
@@ -317,17 +319,12 @@ static void free_pp_node(Linkage lkg)
 /** set up a fresh pp_node for later use */
 static void alloc_pp_node(PP_data* pp_data, Linkage lkg)
 {
-	size_t dz;
-
 	assert(NULL == lkg->pp_node, "Expecting empty pp_node!");
 	PP_node *ppn = (PP_node *) malloc(sizeof(PP_node));
 
 	/* highly unlikely that the number of links will ever exceed this */
-	ppn->dtsz = 2 * pp_data->num_words;
-	dz = ppn->dtsz * sizeof(D_type_list*);
-	ppn->d_type_array = (D_type_list **) malloc (dz);
-	memset(ppn->d_type_array, 0, dz);
-
+	ppn->dtsz = 0;
+	ppn->d_type_array = NULL;
 	ppn->violation = NULL;
 	lkg->pp_node = ppn;
 }

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -391,9 +391,6 @@ void linkage_set_domain_names(Postprocessor *postprocessor, Linkage linkage)
 	linkage->pp_info = (PP_info *) exalloc(sizeof(PP_info) * linkage->num_links);
 	memset(linkage->pp_info, 0, sizeof(PP_info) * linkage->num_links);
 
-	assert(NULL == linkage->pp_data, "Expecting null pp_data!");
-	linkage->pp_data = pp_data_new();
-
 	/* Copy the post-processing results over into the linkage */
 	pp = linkage->pp_node;
 	if (pp->violation != NULL)
@@ -1273,6 +1270,8 @@ PP_node *do_post_process(Postprocessor *pp, Linkage sublinkage, bool is_long)
 	PP_data *pp_data;
 
 	if (pp == NULL) return NULL;
+	assert(NULL == sublinkage->pp_data, "Expecting empty pp_data");
+	sublinkage->pp_data = pp_data_new();
 	pp_data = sublinkage->pp_data;
 
 	// XXX wtf .. why is this not leaking memory ?

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -346,33 +346,6 @@ static void clear_pp_node(Linkage lkg)
 	}
 }
 
-#define PP_INITLEN 60 /* just starting size, it is expanded if needed */
-
-static void pp_new_domain_array(PP_data *pp_data)
-{
-	pp_data->domlen = PP_INITLEN;
-	pp_data->domain_array = (Domain*) malloc(pp_data->domlen * sizeof(Domain));
-	memset(pp_data->domain_array, 0, pp_data->domlen * sizeof(Domain));
-}
-
-static PP_data* pp_data_new(void)
-{
-	PP_data* pp_data = malloc (sizeof(PP_data));
-
-	pp_data->vlength = PP_INITLEN;
-	pp_data->visited = (bool*) malloc(pp_data->vlength * sizeof(bool));
-	memset(pp_data->visited, 0, pp_data->vlength * sizeof(bool));
-
-	pp_data->links_to_ignore = NULL;
-	pp_new_domain_array(pp_data);
-
-	pp_data->wowlen = PP_INITLEN;
-	pp_data->word_links = (List_o_links **) malloc(pp_data->wowlen * sizeof(List_o_links*));
-	memset(pp_data->word_links, 0, pp_data->wowlen * sizeof(List_o_links *));
-
-	return pp_data;
-}
-
 /* ================ compute the domain names ============= */
 /**
  * Store the domain names in the linkage. These are not needed
@@ -1180,6 +1153,33 @@ void post_process_free(Postprocessor *pp)
 	pp->knowledge = NULL;
 
 	free(pp);
+}
+
+#define PP_INITLEN 60 /* just starting size, it is expanded if needed */
+
+static void pp_new_domain_array(PP_data *pp_data)
+{
+	pp_data->domlen = PP_INITLEN;
+	pp_data->domain_array = (Domain*) malloc(pp_data->domlen * sizeof(Domain));
+	memset(pp_data->domain_array, 0, pp_data->domlen * sizeof(Domain));
+}
+
+PP_data* pp_data_new(void)
+{
+	PP_data* pp_data = malloc (sizeof(PP_data));
+
+	pp_data->vlength = PP_INITLEN;
+	pp_data->visited = (bool*) malloc(pp_data->vlength * sizeof(bool));
+	memset(pp_data->visited, 0, pp_data->vlength * sizeof(bool));
+
+	pp_data->links_to_ignore = NULL;
+	pp_new_domain_array(pp_data);
+
+	pp_data->wowlen = PP_INITLEN;
+	pp_data->word_links = (List_o_links **) malloc(pp_data->wowlen * sizeof(List_o_links*));
+	memset(pp_data->word_links, 0, pp_data->wowlen * sizeof(List_o_links *));
+
+	return pp_data;
 }
 
 /**

--- a/link-grammar/post-process/post-process.h
+++ b/link-grammar/post-process/post-process.h
@@ -38,7 +38,6 @@ bool     post_process_match(const char *, const char *);  /* utility function */
 
 void linkage_free_pp_info(Linkage);
 
-void build_type_array(PP_data *, Linkage);
 void linkage_set_domain_names(Postprocessor*, PP_data *, Linkage);
 void exfree_domain_names(PP_info *);
 

--- a/link-grammar/post-process/post-process.h
+++ b/link-grammar/post-process/post-process.h
@@ -37,7 +37,7 @@ bool     post_process_match(const char *, const char *);  /* utility function */
 
 void linkage_free_pp_info(Linkage);
 
-void build_type_array(Postprocessor*);
+void build_type_array(Postprocessor*, Linkage);
 void linkage_set_domain_names(Postprocessor*, Linkage);
 void exfree_domain_names(PP_info *);
 

--- a/link-grammar/post-process/post-process.h
+++ b/link-grammar/post-process/post-process.h
@@ -28,8 +28,6 @@
 #include "api-types.h"
 #include "link-includes.h"
 
-typedef struct PP_data_s PP_data;
-
 Postprocessor * post_process_new(pp_knowledge *);
 void post_process_free(Postprocessor *);
 

--- a/link-grammar/post-process/post-process.h
+++ b/link-grammar/post-process/post-process.h
@@ -37,7 +37,7 @@ bool     post_process_match(const char *, const char *);  /* utility function */
 
 void linkage_free_pp_info(Linkage);
 
-void build_type_array(Postprocessor*, Linkage);
+void build_type_array(Linkage);
 void linkage_set_domain_names(Postprocessor*, Linkage);
 void exfree_domain_names(PP_info *);
 

--- a/link-grammar/post-process/post-process.h
+++ b/link-grammar/post-process/post-process.h
@@ -31,7 +31,8 @@
 Postprocessor * post_process_new(pp_knowledge *);
 void post_process_free(Postprocessor *);
 
-void     post_process_free_data(PP_data * ppd);
+PP_data* pp_data_new(void);
+void     post_process_free_data(PP_data *);
 PP_node *do_post_process(Postprocessor *, Linkage, bool);
 bool     post_process_match(const char *, const char *);  /* utility function */
 

--- a/link-grammar/post-process/post-process.h
+++ b/link-grammar/post-process/post-process.h
@@ -33,13 +33,13 @@ void post_process_free(Postprocessor *);
 
 PP_data* pp_data_new(void);
 void     post_process_free_data(PP_data *);
-PP_node *do_post_process(Postprocessor *, Linkage, bool);
+PP_node *do_post_process(Postprocessor *, PP_data*, Linkage, bool);
 bool     post_process_match(const char *, const char *);  /* utility function */
 
 void linkage_free_pp_info(Linkage);
 
-void build_type_array(Linkage);
-void linkage_set_domain_names(Postprocessor*, Linkage);
+void build_type_array(PP_data *, Linkage);
+void linkage_set_domain_names(Postprocessor*, PP_data *, Linkage);
 void exfree_domain_names(PP_info *);
 
 void post_process_lkgs(Sentence, Parse_Options);

--- a/link-grammar/post-process/pp-structures.h
+++ b/link-grammar/post-process/pp-structures.h
@@ -87,7 +87,7 @@ struct PP_info_s
 
 /* The following two structs comprise what is returned by post_process(). */
 typedef struct D_type_list_struct D_type_list;
-struct PP_node_struct
+struct PP_node_s
 {
 	size_t dtsz;
 	D_type_list **d_type_array;

--- a/link-grammar/post-process/pp-structures.h
+++ b/link-grammar/post-process/pp-structures.h
@@ -69,10 +69,6 @@ struct Postprocessor_s
 	int *relevant_contains_none_rules;
 	bool q_pruned_rules;       /* don't prune rules more than once in p.p. */
 	String_set *string_set;      /* Link names seen for sentence */
-
-	/* Per-linkage state; this data must be reset prior to processing
-	 * each new linkage. */
-	PP_data pp_data;
 };
 
 struct PP_info_s

--- a/link-grammar/post-process/pp-structures.h
+++ b/link-grammar/post-process/pp-structures.h
@@ -72,7 +72,6 @@ struct Postprocessor_s
 
 	/* Per-linkage state; this data must be reset prior to processing
 	 * each new linkage. */
-	PP_node *pp_node;
 	PP_data pp_data;
 };
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -17,6 +17,7 @@
 #include "dict-common/dict-utils.h"   // For size_of_expression()
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
+#include "post-process/post-process.h" // for linkage_set_domain_names()
 #include "print.h"
 #include "tokenize/word-structures.h" // For Word_struct
 #include "wcwidth.h"
@@ -178,6 +179,14 @@ char * linkage_print_links_and_domains(const Linkage linkage)
 	int N_links = linkage_get_num_links(linkage);
 	dyn_str * s = dyn_str_new();
 	const char ** dname;
+
+	// If there's no pp_data, there was a PP violation, and
+	// so there are no dmoanin names.
+	PP_data* pp_data = linkage->pp_scratch_data;
+	if (NULL == pp_data) return s;
+
+	// Compute the link names
+	linkage_set_domain_names(linkage->sent->postprocessor, pp_data, linkage);
 
 	longest = 0;
 	for (link=0; link<N_links; link++)

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1543,9 +1543,9 @@ Linkage SATEncoder::get_next_linkage()
     //_sent->num_valid_linkages++;
   }
 
-  build_type_array(_sent->postprocessor, lkg);
+  build_type_array(lkg);
   linkage_set_domain_names(_sent->postprocessor, lkg);
-  post_process_free_data(&_sent->postprocessor->pp_data);
+  post_process_free_data(lkg->pp_data);
   linkage_score(lkg, _opts);
 
   //if (NULL == ppn->violation && verbosity > 1)

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1531,7 +1531,8 @@ Linkage SATEncoder::get_next_linkage()
     lkg[1].lifo.N_violations = 0;
 
   // Perform the rest of the post-processing
-  PP_node *ppn = do_post_process(_sent->postprocessor, lkg, false);
+  PP_data* pp_data = pp_data_new();
+  PP_node *ppn = do_post_process(_sent->postprocessor, pp_data, lkg, false);
   if (NULL != ppn->violation) {
     lkg->lifo.N_violations++;
     lkg->lifo.pp_violation_msg = ppn->violation;
@@ -1543,9 +1544,9 @@ Linkage SATEncoder::get_next_linkage()
     //_sent->num_valid_linkages++;
   }
 
-  build_type_array(lkg);
-  linkage_set_domain_names(_sent->postprocessor, lkg);
-  post_process_free_data(lkg->pp_data);
+  build_type_array(pp_data, lkg);
+  linkage_set_domain_names(_sent->postprocessor, pp_data, lkg);
+  post_process_free_data(pp_data);
   linkage_score(lkg, _opts);
 
   //if (NULL == ppn->violation && verbosity > 1)

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1531,9 +1531,11 @@ Linkage SATEncoder::get_next_linkage()
     lkg[1].lifo.N_violations = 0;
 
   // Perform the rest of the post-processing
+  assert(nullptr == linkage->pp_scratch_data, "Expecting nul pp_data");
   PP_data* pp_data = pp_data_new();
+  linkage->pp_scratch_data = pp_data;
   PP_node *ppn = do_post_process(_sent->postprocessor, pp_data, lkg, false);
-  if (NULL != ppn->violation) {
+  if (nullptr != ppn->violation) {
     lkg->lifo.N_violations++;
     lkg->lifo.pp_violation_msg = ppn->violation;
     lgdebug(+D_SAT, "Postprocessing error: %s\n", lkg->lifo.pp_violation_msg);
@@ -1544,9 +1546,6 @@ Linkage SATEncoder::get_next_linkage()
     //_sent->num_valid_linkages++;
   }
 
-  build_type_array(pp_data, lkg);
-  linkage_set_domain_names(_sent->postprocessor, pp_data, lkg);
-  post_process_free_data(pp_data);
   linkage_score(lkg, _opts);
 
   //if (NULL == ppn->violation && verbosity > 1)

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1543,7 +1543,7 @@ Linkage SATEncoder::get_next_linkage()
     //_sent->num_valid_linkages++;
   }
 
-  build_type_array(_sent->postprocessor);
+  build_type_array(_sent->postprocessor, lkg);
   linkage_set_domain_names(_sent->postprocessor, lkg);
   post_process_free_data(&_sent->postprocessor->pp_data);
   linkage_score(lkg, _opts);


### PR DESCRIPTION
The goal of this change was to gain a minor amount of performance by avoiding the computation of domain names, unless they are printed. However, to accomplish this, one hs to create a per-linkage copy of PP_data, which creates a lot of memory-pool churn, almost surely increasing RAM usage significantly, and, in general making things slower rather than faster.

I will probably reject this pull request.  Its here temporarily, for further review.