### PR TITLE
Avoid crash for garbage input.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Version 5.4.4 (XXX 2018)
  * Fix conjoined questions and conjoined WH-statements.
  * Fix conditional sentences.
  * Fix misc comparatives.
+ * Fix crash on invalid UTF-8 input.
 
 Version 5.4.3 (4 January 2018)
  * Fix man page installation (actually broken from 5.3.0).

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -57,7 +57,13 @@ size_t utf8_strwidth(const char *s)
 	int glyph_width = 0;
 	for (size_t i = 0; i < mblen; i++)
 	{
-		glyph_width += mk_wcwidth(ws[i]);
+		int w = mk_wcwidth(ws[i]);
+
+		// If w<0 then its not vaid UTF8, but garbage.  Many
+		// terminals will print this with a weird boxed font
+		// that is two columns wide, showing the hex value in it.
+		if (w < 0) w = 2;
+		glyph_width += w;
 	}
 	return glyph_width;
 }

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -70,7 +70,8 @@ size_t utf8_strwidth(const char *s)
 
 /**
  * Return the width, in text-column-widths, of the utf8-encoded
- * character.
+ * character. The will return a NEGATIVE VALUE if the character
+ * is not a valid UTF-8 character!
  *
  * The mbstate_t argument is not used, since we convert only from utf-8.
  * FIXME: This function (along with other places that use mbrtowc()) need

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -29,7 +29,7 @@ int append_string(dyn_str *, const char *fmt, ...) GNUC_PRINTF(2,3);
 int vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);
 size_t append_utf8_char(dyn_str *, const char * mbs);
-size_t utf8_num_char(const char *, size_t);
+size_t utf8_chars_in_width(const char *, size_t);
 int utf8_charwidth(const char *);
 
 static inline void patch_subscript_mark(char *s)

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -30,7 +30,7 @@ int vappend_string(dyn_str *, const char *fmt, va_list args)
 	GNUC_PRINTF(2,0);
 size_t append_utf8_char(dyn_str *, const char * mbs);
 size_t utf8_num_char(const char *, size_t);
-size_t utf8_charwidth(const char *);
+int utf8_charwidth(const char *);
 
 static inline void patch_subscript_mark(char *s)
 {

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -746,9 +746,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 		{
 			uwidth = x_screen_width - RIGHT_MARGIN - (c == 0)*word_offset[i] - 1;
 
-			// XXX this is incorrect, it assumes that each character
-			// is width one -- it is not.
-			c += utf8_num_char(linkage->word[i]+c, uwidth);
+			c += utf8_chars_in_width(linkage->word[i]+c, uwidth);
 		}
 
 		if (NULL != pctx) /* PS junk */

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -465,6 +465,16 @@ void dyn_strcat(dyn_str* ds, const char *str)
 	ds->end += l;
 }
 
+/// Trim away trailing whitespace.
+void dyn_trimback(dyn_str* ds)
+{
+	size_t tail = ds->end;
+	while (0 < tail && ' ' == ds->str[--tail]) {}
+
+	ds->end = ++tail;
+	ds->str[tail] = 0x0;
+}
+
 const char * dyn_str_value(dyn_str* s)
 {
 	return s->str;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -441,6 +441,7 @@ typedef struct
 dyn_str* dyn_str_new(void);
 void dyn_str_delete(dyn_str*);
 void dyn_strcat(dyn_str*, const char*);
+void dyn_trimback(dyn_str*);
 char * dyn_str_take(dyn_str*);
 const char * dyn_str_value(dyn_str*);
 


### PR DESCRIPTION
Fixes bug #650 

Adds unit test that attempts to parse garbage.  Unit test does not yet pass; it hangs.