### PR TITLE
 Fix test case EErrorFacilityTestCase

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -296,7 +296,9 @@ static void PythonCallBack(lg_errinfo *lge, void *func_and_data)
       }
 
       if (error) return NULL;
-      $1 = &arg;
+
+      $1 = (int*)malloc(sizeof(int));
+      *$1 = arg;
    }
 }
 
@@ -304,6 +306,7 @@ static void PythonCallBack(lg_errinfo *lge, void *func_and_data)
 void _py_error_default_handler(lg_errinfo *lge, int *pedh_data)
 {
     default_error_handler(lge, (void *)pedh_data);
+    free(pedh_data);
 }
 
 /**

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -209,11 +209,8 @@ static void default_error_handler(lg_errinfo *lge, void *data)
 {
 	FILE *outfile = stdout;
 
-	if (((NULL == data) && (lge->severity <= lg_Debug)) ||
-	    ((NULL != data) && (lge->severity <= *(lg_error_severity *)data) &&
-	     (lg_None !=  lge->severity)))
 	if (((NULL == data) && (lge->severity < lg_Debug)) ||
-	    ((NULL != data) && (lge->severity < *(lg_error_severity *)data) &&
+	    ((NULL != data) && (lge->severity < *(lg_error_severity *)(int *)data) &&
 	     (lg_None !=  lge->severity)))
 	{
 		fflush(stdout); /* Make sure that stdout has been written out first. */


### PR DESCRIPTION
Problem description: When the default library error handler is called by Python code, its data argument points to a variable from a frame that has just got stale.