### PR TITLE
Handling the PVS-Studio static analysis from #652 ++

### DIFF
--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -123,7 +123,7 @@ struct Dictionary_s
 	const char    * pin;
 	bool            recursive_error;
 	bool            is_special;
-	char            already_got_it;
+	int             already_got_it; /* For char, but needs to hold EOF */
 	int             line_number;
 	char            current_idiom[IDIOM_LINK_SZ];
 	char            token[MAX_TOKEN_LENGTH];

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -149,37 +149,26 @@ static const char * build_idiom_word_name(Dictionary dict, const char * s)
  * correct names (with .Ix suffixes).
  * The list is reversed from the way they occur in the string.
  * A pointer to this list is returned.
+ * This function is called after is_idiom_string() ensures the validity
+ * of the given string.
  */
 static Dict_node * make_idiom_Dict_nodes(Dictionary dict, const char * string)
 {
-	Dict_node * dn, * dn_new;
-	char * t, *s, *p;
-	bool more;
-	unsigned int sz;
-	dn = NULL;
+	Dict_node * dn = NULL;
+	char * s = strdupa(string);
+	const char * t;
 
-	sz = strlen(string)+1;
-	p = s = (char *) malloc(sz);
-	strcpy(s, string);
-
-	while (*s != '\0') {
-		t = s;
-		while ((*s != '\0') && (*s != '_')) s++;
-		if (*s == '_') {
-			more = true;
-			*s = '\0';
-		} else {
-			more = false;
-		}
-		dn_new = (Dict_node *) malloc(sizeof (Dict_node));
+	for (t = s; NULL != s; t = s)
+	{
+		s = strchr(s, '_');
+		if (NULL != s) *s++ = '\0';
+		Dict_node *dn_new = (Dict_node *) malloc(sizeof (Dict_node));
 		dn_new->right = dn;
 		dn = dn_new;
 		dn->string = string_set_add(t, dict->string_set);
 		dn->file = NULL;
-		if (more) s++;
 	}
 
-	free(p);
 	return dn;
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -264,7 +264,7 @@ static bool link_advance(Dictionary dict)
 		if (dict->already_got_it == EOF) {
 			dict->token[0] = '\0';
 		} else {
-			dict->token[0] = dict->already_got_it; /* specials are one byte */
+			dict->token[0] = (char)dict->already_got_it; /* specials are one byte */
 			dict->token[1] = '\0';
 		}
 		dict->already_got_it = '\0';
@@ -1557,7 +1557,7 @@ static bool read_entry(Dictionary dict)
 			bool save_is_special;
 			const char * save_input;
 			const char * save_pin;
-			char save_already_got_it;
+			int save_already_got_it;
 			int save_line_number;
 			size_t skip_slash;
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1564,7 +1564,7 @@ static bool read_entry(Dictionary dict)
 			if (!link_advance(dict)) goto syntax_error;
 
 			skip_slash          = ('/' == dict->token[0]) ? 1 : 0;
-			dict_name           = strdup(dict->token);
+			dict_name           = strdupa(dict->token);
 			save_name           = dict->name;
 			save_is_special     = dict->is_special;
 			save_input          = dict->input;
@@ -1597,7 +1597,6 @@ static bool read_entry(Dictionary dict)
 			dict->line_number    = save_line_number;
 
 			free(instr);
-			free(dict_name);
 			if (!rc) goto syntax_error;
 
 			/* when we return, point to the next entry */

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -85,7 +85,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 		i = 0;
 		do
 		{
-			if (i > MAX_REGEX_NAME_LENGTH-1)
+			if (i >= MAX_REGEX_NAME_LENGTH-1)
 			{
 				prt_error("Error: Regex name too long on line %d\n", line);
 				goto failure;

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -378,7 +378,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 				lgdebug(D_SLM, "\n");
 			}
 
-			if (NULL != wpp->word) break; /* Extra null count */
+			//if (NULL != wpp->word) break; /* Extra null count; XXX always false*/
 			continue;
 		}
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1765,8 +1765,8 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 
   Exp **exp_word = (Exp **)alloca(_sent->length * sizeof(Exp));
   memset(exp_word, 0, _sent->length * sizeof(Exp));
-  const X_node **xnode_word = (const X_node **)alloca(_sent->length * sizeof(X_node));
-  memset(xnode_word, 0, _sent->length * sizeof(X_node));
+  const X_node **xnode_word = (const X_node **)alloca(_sent->length * sizeof(X_node *));
+  memset(xnode_word, 0, _sent->length * sizeof(X_node *));
 
   const std::vector<int>& link_variables = _variables->link_variables();
   std::vector<int>::const_iterator i;

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -283,7 +283,7 @@ static bool morpheme_match(Sentence sent,
 		if (0 == p) re = as->regpre;
 		else if (pl[p] == (int) lutf) re = as->regsuf;
 		else re = as->regmid;
-		lgdebug(D_MM, "re=%s part%d=%s: ", re?"(nil)":re->name, p, prefix_string);
+		lgdebug(D_MM, "re=%s part%d=%s: ", re?re->name:"(nil)", p, prefix_string);
 
 		/* A NULL regex always matches */
 		if ((NULL != re) && (NULL == match_regex(re, prefix_string)))

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2550,7 +2550,6 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 
 	/* Generate random morphology */
 	if ((dict->affix_table && dict->affix_table->anysplit) && !word_can_lrmsplit)
-	if (dict->affix_table && dict->affix_table->anysplit)
 		anysplit(sent, unsplit_word);
 
 	/* OK, now try to strip affixes. */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -956,7 +956,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					if (REPLACEMENT_MARK[0] == label[0])
 					{
 						subword->start = unsplit_word->start;
-						subword->start = unsplit_word->end;
+						subword->end = unsplit_word->end;
 					}
 					else
 					{


### PR DESCRIPTION
Fix problems detected in the PVS-Studio static analysis from #652.

Bug fixed:
- Fix a bug in my previous fix (5d513a0).
- Buffer overrun on long regex names.
- Correct X-node allocation size in the SAt parser.
- Make sure EOF can be represented in dict read
- Fix end location reporting of spell-corrected input word (linkage_get_word_*_end()).

Also:
- Remove redundant duplicate condition (typo).
- Comment out a null-effect loop break and mark iit for review (most probably it remained from a code rewrite).

In this occasion of inspecting the code. I made efficiency fixes in:
- read_entry()
- make_idiom_Dict_nodes()

