### PR TITLE
A better fix instead of #658

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -266,9 +266,8 @@ static void PythonCallBack(lg_errinfo *lge, void *func_and_data)
 
 /* The second argument of the default callback can be NULL or
    a severity_level integer. Validate that and convert it to C int. */
-%typemap(in) int *pedh_data
+%typemap(in) int *pedh_data (int arg)
 {
-   int arg;
    bool error = false;
    const char errmsg[] = "The default error handler data argument (arg 2) "
                          "must be an integer (0 to lg_None) or None.";
@@ -296,9 +295,7 @@ static void PythonCallBack(lg_errinfo *lge, void *func_and_data)
       }
 
       if (error) return NULL;
-
-      $1 = (int*)malloc(sizeof(int));
-      *$1 = arg;
+      $1 = &arg;
    }
 }
 
@@ -306,7 +303,6 @@ static void PythonCallBack(lg_errinfo *lge, void *func_and_data)
 void _py_error_default_handler(lg_errinfo *lge, int *pedh_data)
 {
     default_error_handler(lge, (void *)pedh_data);
-    free(pedh_data);
 }
 
 /**


### PR DESCRIPTION
Define a temporary variable in the upper stack frame instead of
malloc().