### PR TITLE
Fix buffer overrun due to multiple SUBSCRIPT_MARK

### DIFF
--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -469,7 +469,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 							/* Cannot NULLify the word - we may have links to it. */
 							if (m != mcnt-1) chosen_words[i+m] = "";
 
-							sm =  strrchr(cdjp[i+m]->word_string, SUBSCRIPT_MARK);
+							sm =  strchr(cdjp[i+m]->word_string, SUBSCRIPT_MARK);
 
 							if (NULL != sm)
 							{

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -399,7 +399,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				if (is_idiom_word(t))
 				{
 					s = strdupa(t);
-					sm = strrchr(s, SUBSCRIPT_MARK);
+					sm = strchr(s, SUBSCRIPT_MARK);
 					*sm = '\0';
 					t = string_set_add(s, sent->string_set);
 				}


### PR DESCRIPTION
Per issue #665.
Test input: (G^C=^C
(^C is a SUBSCRIPT_MARK character 0x03.)

The code supposes the last subscript-mark in a stem belong to the stem-mark. This is not correct if the original word already contains a stem-mark that has a subscript-mark after it. Since the code assumes
there is "=\0" after a subscript-mark of a stem, a buffer overrun results.

To prevent this overrun, the fix here is to search for the first subscript mark of the stem. (The result of 
 such a nonsense word can still be nonsense.)

I inspected the other uses of strrchr(..., SUBSCRIPT_MARK), and fixed it in another place to strchr(), this time for consistency (another one in compute_chosen_words() and also one  in add_morpheme_unmarked(), seem harmless).

---
Proposals:
- Maybe we should use word marks access-methods  for manipulating SUBSCRIPT_MARK and other word marks.
- We may consider to filter-out control characters in the input, or maybe better, to convert them to ^X form.
In that case it will be fine to assume there is no more than one subscript-mark in a word, and it is a valid.