### PR TITLE
Dictionary read speedup

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -277,7 +277,7 @@ nonCAP.zzz: ZZZ-;
 
 % The use of COa here needs to be carefully re-examined; it is used much too freely.
 % COa+ is used to block links to COd-
-% Xc+ & Ic+: connect to imperatives (infinitve verbs): "Anyhow, don't"
+% Xc+ & Ic+: connect to imperatives (infinitive verbs): "Anyhow, don't"
 % Wc- & Xc+ & Qd+: subject-object inversion: "anyhow, am I right?"
 <directive-opener>:
   {[[Wa-]]} &
@@ -297,7 +297,7 @@ nonCAP.zzz: ZZZ-;
 % in "There they are" tagged as an entity, just because its capitalized.
 % We really do want to force the lower-case usage, because the lower case
 % is in the dict, and its the right word to use. (The only entities that
-% should be tagged as such are those that are in the dicts, in thier
+% should be tagged as such are those that are in the dicts, in their
 % capitalized form, e.g. "Sue.f" female given name as opposed to "sue.v"
 % verb in the sentence "Sue went to the store.")
 %
@@ -324,7 +324,7 @@ INITIALS <entity-singular>:
   or <directive-opener>;
 
 % As above, but with a tiny extra cost, so that a dictionary word is
-% prefered to the regex match (i.e. for a common noun starting a
+% preferred to the regex match (i.e. for a common noun starting a
 % sentence). However, the other regex matches (e.g. MC-NOUN-WORDS)
 % should have a cost that is even higher (so that we take the
 % capitalized version before we take any other matches.)
@@ -356,7 +356,7 @@ PL-CAPITALIZED-WORDS:
 % "Tom" is a given name, but can also be a proper name, so e.g.
 % "The late Mr. Tom will be missed." which needs A-, D- links
 % Wa-: A single exclamation: "Tom!  Hey, Tom! Oh, hello John!"
-% <noun-and-s> is trikcy when used with [[...]] connectors.
+% <noun-and-s> is tricky when used with [[...]] connectors.
 % Careful for bad parses of
 % "This is the dog and cat Pat and I chased and ate"
 % "actress Whoopi Goldberg and singer Michael Jackson attended the ceremony"
@@ -451,7 +451,7 @@ GREEK-LETTER-AND-NUMBER pH.i x.n: <noun-mass-count>;
 
 % Number abbreviations: no.x No.x
 % pp. paragraph, page   art article
-% RR roural route
+% RR rural route
 No.x No..x no.x no..x Nos.x Nos..x nos.x nos..x
 Nr.x Nr..x Nrs.x Nrs..x nr.x nr..x nrs.x nrs..x
 Num.x Num..x num.x num..x pp.x pp..x
@@ -495,7 +495,7 @@ Pty.y Pty..y Ltd.y Ltd..y LTD.y Bldg.y Bldg..y and_Co GmBH.y:
 
 
 % Titles, e.g. Joe Blow, Esq. or Dr. Smarty Pants, Ph.D.
-% Gack. See absurdely large collection at:
+% Gack. See absurdly large collection at:
 % http://en.wikipedia.org/wiki/List_of_post-nominal_letters
 Jr.y Jr..y Sr.y Sr..y Esq.y Esq..y
 AB.y A.B..y AIA.y A.I.A..y
@@ -728,7 +728,7 @@ tawny.n ultramarine.n umber.n yellow.n:
   or Wa-;
 
 % SINGULAR ENTITIES FOR ENTITY EXTRACTION
-% This must appear after other categories so it doesnt interfere with those.
+% This must appear after other categories so it doesn't interfere with those.
 /en/words/entities.national.sing:
 <marker-entity> or <entity-singular>;
 
@@ -1256,7 +1256,7 @@ times.n:
 % ====================================================================
 %PRONOUNS
 
-% MXs+: "he, the shop onwer, ..."
+% MXs+: "he, the shop owner, ..."
 she he:
   {[[R+ & Bs+]]} & (({MXs+} & Ss+ & <CLAUSE>) or SIs- or SJls+);
 
@@ -1312,7 +1312,7 @@ its my.p your their.p our thy.p yisser.p yousser ye'r:
   DP+
   or ({AL-} & {@L+} & (D+ or DD+));
 
-% Possesive version of me
+% Possessive version of me
 % Cost on D, DD: avoids use as determiner on "Make me coffee"
 %suppress: DUP-BASE (for me.p)
 me.p:
@@ -1450,7 +1450,7 @@ this.d:
   or DTn+
   or Wa-;
 
-% [[<noun-main-p>]] costs so that ditranstive verbs don't suffer:
+% [[<noun-main-p>]] costs so that ditransitive verbs don't suffer:
 % "I taught these mice to jump", taught is ditransitive, we don't want
 % "these" to be the object.  See also "those"
 % (Jd- & Dmu- & Op-): "I gave him a number of these"
@@ -1463,7 +1463,7 @@ these:
   or <noun-and-p>
   or Wa-;
 
-% [[<noun-main-p>]] costs so that ditranstive verbs don't suffer,
+% [[<noun-main-p>]] costs so that ditransitive verbs don't suffer,
 % and get the D+ link instead of the O- link.
 % See also "these"
 those:
@@ -1508,8 +1508,8 @@ many:
 
 % A naked <noun-main2-x> costs more than one with other links,
 % so that ditransitive verbs don't get spurious links to all.a
-% XXX can this be tighetend up??
-% <noun-main2-x> costs no mater what, so that Ofd+ is prefered.
+% XXX can this be tightened up??
+% <noun-main2-x> costs no mater what, so that Ofd+ is preferred.
 % [E+]0.5: all modifying a verb probably is not right.
 % Wa-: "All the people!" as a response to a question.
 all.a:
@@ -1615,7 +1615,7 @@ a_couple:
 %  [[<noun-sub-p> & <noun-main-p>]] or
   <noun-and-p> or Wa-;
 
-% NNumeric modifier: "a couple of thousand dollars"
+% Numeric modifier: "a couple of thousand dollars"
 a_couple_of:
   NN+ or ND+ or NIn+;
 
@@ -1674,7 +1674,7 @@ the_most:
   or MVa-;
 
 % "a part.n" should cover most cases.  Perhaps [[OF+ & <noun-main-s>]] should be
-% reomved??  Anyway, its costed to give OFd+ priority. Likewise, should probably
+% removed??  Anyway, its costed to give OFd+ priority. Likewise, should probably
 % retire <adv-of> as well, right?
 part.i:
   (OFd+ & Dm+)
@@ -1697,7 +1697,7 @@ none:
   or [[<adv-of>]]
   or Wa-;
 
-% costly <adv-of> so that OFd+ is prefered.
+% costly <adv-of> so that OFd+ is preferred.
 rest.i:
   [[DD- & <adv-of>]];
 
@@ -2265,7 +2265,7 @@ fiscal.i: TY+ & <noun-main-s>;
 or_so: ND- & {{@L+} & DD-} & (Dmcn+ or (<noun-sub-p> & <noun-main-p>));
 
 % Allows parsing of "dollars per day" or "mL/sec" but is somewhat
-% inconsistent with the equation persing otherwise described below.
+% inconsistent with the equation parsing otherwise described below.
 % XXX overall, eqn parsing could be strengthened.
 per "/.per": Us+ & Mp-;
 
@@ -2284,7 +2284,7 @@ per "/.per": Us+ & Mp-;
 % <verb-wall> : links verb to wall or to controlling phrase.
 % <verb-s>    : links verbs to singular subjects
 % <verb-pl>   : links verbs to plural subjects
-% <verb-i>    : links to infinitve
+% <verb-i>    : links to infinitive
 % <verb-pl,i> : to plural subjects or infinitives
 % <verb-sp>   : to singular or plural subject
 % <verb-pp>   : to past-participles
@@ -2379,7 +2379,7 @@ per "/.per": Us+ & Mp-;
 <verb-sip>:  {@E-} & hPF- & {<verb-wall>} & hSIp+;
 
 % <b-minus> is meant to be a generic replacement in the naked B- in
-% many transitive verb constructions.  For quetions, we need to force
+% many transitive verb constructions.  For questions, we need to force
 % a verb-wall connector; this is what the (B*w- or B*m-) & <verb-wall>
 % part does. For the other B- forms, we don't need the wall.  To force
 % the wall, we just list all the others.
@@ -2444,7 +2444,7 @@ per "/.per": Us+ & Mp-;
 % Iq-: "The big question is did he do it?"
 % Xd- & Iq-: "The big question is, did he do it?"
 <verb-rq>: Rw- or ({{Xd-} & Iq-} & (Qd- or ((Qw- or Qe-) & <verb-wall>))) or [()];
-% Just like above, but no aux, shuld always be anded with I+.
+% Just like above, but no aux, should always be anded with I+.
 % The idea here is that the verb on the other end of the I+ will
 % connect to the wall.
 <verb-rq-aux>: Rw- or ({{Xd-} & Iq-} & (Qd- or Qw- or Qe-)) or [()];
@@ -2466,7 +2466,7 @@ per "/.per": Us+ & Mp-;
 % These are used almost exclusively with auxiliary verbs.
 % This is why they don't have & <verb-wall> in them: we don't want the
 % auxiliary attaching to the wall, we want only the main verb doing this.
-% The Ss- or Sp- prevent attachements to Sa- for "as.e" phrases.
+% The Ss- or Sp- prevent attachments to Sa- for "as.e" phrases.
 <verb-x-pl,i>: {@E-} & (Sp- or SFp- or If- or (RS- & Bp-) or Wi-);
 <verb-x-s>: {@E-} & (Ss- or SFs- or (RS- & Bs-));
 <verb-x-s,u>: {@E-} & (Ss- or SFs- or SFu- or (RS- & Bs-));
@@ -2509,10 +2509,10 @@ per "/.per": Us+ & Mp-;
 % The conjunction should take an object if both verbs are transitive,
 % e.g. "I saw and greeted Sue", which should parse as
 % "I (saw and greeted) Sue".
-% VJ**i == intranstive
+% VJ**i == intransitive
 % VJ**t == transitive
 %
-% s == singluar, pl == plural, sp == singular or plural
+% s == singular, pl == plural, sp == singular or plural
 % g == gerund
 <verb-and-s->: {@E-} & VJrs-;
 <verb-and-s+>: {@E-} & VJls+;
@@ -2562,7 +2562,7 @@ per "/.per": Us+ & Mp-;
 % for example: "We neither ate nor drank for three days"
 
 
-% present tense, but allows transitive connectinos to 'and'
+% present tense, but allows transitive connections to 'and'
 
 
 % past tense macro, intransitive variation
@@ -2775,7 +2775,7 @@ having.v: <verb-pg> & <vc-have>;
 having.g: (<vc-have> & <verb-ge>) or <verb-ge-d>;
 
 % PP is disjoined with <verb-wall> because when PP is used, has/have/had
-% is an auxiliarry verb, an should not get a wall connection!
+% is an auxiliary verb, an should not get a wall connection!
 hasn't hasn’t:
   ((<verb-rq> & (SIs+ or SFIs+)) or (<verb-x-s>))
   & (PP+ or ((([[O+]] & <mv-coord>) or [[()]]) & <verb-wall>));
@@ -2860,7 +2860,7 @@ hadn't.v-d hadn’t.v-d:
 
 % O*m+ allows "If only there were more!"
 % THb+ allows "It is your fault that you're a failure."
-% The cost on @MV+ causes attachements to the object to be prefered
+% The cost on @MV+ causes attachments to the object to be preferred
 % over attachments to the copula; for example, prepositions should
 % almost surely attach via Mp+ link to the object, as opposed to
 % using an MVp+ link to the copula. Example:
@@ -2908,7 +2908,7 @@ is.v:
   or (EQ*r- & S- & <verb-wall> & EQ*r+);
 
 % Similar to above, but no S-O inversion, and no equation.
-% Also, a cost, so that possesive 's is preferred.
+% Also, a cost, so that possessive 's is preferred.
 % Also, this can be a contraction for "has": "he has" -> "he's"
 % <verb-x-s,u> & PP+: "He's gone to Boston"  (viz "He has gone to Boston")
 % But also, some contractions are prohibited:
@@ -2981,7 +2981,7 @@ were.v-d:
   or (<vc-be-and> & <verb-and-sp+>)
   or [[(SI*j+ or SFI**j+) & <vc-be> & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
-% Ss*w-: allows Wh subjets: "Who am I?"
+% Ss*w-: allows Wh subjects: "Who am I?"
 am.v:
   ({@E-} & SX- & <vc-be>)
   or (<verb-rq> & SXI+ & {<vc-be>})
@@ -3155,8 +3155,8 @@ is_less_than_or_equal_to is_gretr_than_or_equal_to:
 % the verb form: 1=plural-infinitive, 2=singular, 3=past("ed"),
 % 4=progressive("-ing"), 5=gerund("-ing".)
 
-% abbreviations for ditransitive and optionally ditranstive verbs
-% ditranstive verbs take a direct and indirect object
+% abbreviations for ditransitive and optionally ditransitive verbs
+% ditransitive verbs take a direct and indirect object
 % e.g. "I gave her a rose"
 % B- & O+ & O*n+: "What are the chances you'll give her a kiss?"
 % O+ & @MV+ & O*n+: "I gave him for his birthday a very expensive present"
@@ -3881,7 +3881,7 @@ bakes.v dictates.v kisses.v slices.v:
   ((<vc-bake>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 
-% A+: "she gave him some slcied bread"
+% A+: "she gave him some sliced bread"
 baked.v-d sliced.v-d:
   
   ((<verb-sp,pp> & (<vc-bake>)) or
@@ -6113,7 +6113,7 @@ reeked.v-d smelled.v-d:
 reeking.g smelling.g: (<vc-smell> & <verb-ge>) or <verb-ge-d>;
 reeking.v smelling.v: <verb-pg> & <vc-smell>;
 
-% <vc-trans> plus partcle and Vt
+% <vc-trans> plus particle and Vt
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
   ({O+} & (OT+ or BT-) & {@MV+} & {<tot-verb> or <toi-verb>}) or
@@ -6233,7 +6233,7 @@ found.v-d:
 finding.v: <verb-pg> & <vc-find>;
 finding.g: (<vc-find> & <verb-ge>) or <verb-ge-d>;
 
-% ditranstive
+% ditransitive
 <vc-get>:
   ((O+ or <b-minus>) & (({K+} & <mv-coord>) or ({@MV+} & (Pa+ or AF- or Pv+))))
   or ((<vc-ditrans>
@@ -6428,7 +6428,7 @@ intending.v: <verb-pg> & <vc-intend>;
 
 % O+ & TO+: "I dare you to!"
 % TO+ & Xc+: "try it if you dare to!"
-% I+: auxilliary: "no one dared say a word"
+% I+: auxiliary: "no one dared say a word"
 % N+ & TO: "I dare not to say the truth"
 <vc-dare>:
   ({N+} & <mv-coord> & {<to-verb> or (TO+ & Xc+)}) or
@@ -6483,7 +6483,7 @@ liked.v-d:
 liking.g: (<vc-like> & <verb-ge>) or <verb-ge-d>;
 liking.v: <verb-pg> & <vc-like>;
 
-% ditranstive
+% ditransitive
 <vc-offer>:
   ((<vc-opt-ditrans> or
     (<b-minus> & {O+})) & <mv-coord>) or
@@ -6859,7 +6859,7 @@ seen.v:
 seeing.g: (<vc-see> & <verb-ge>) or <verb-ge-d>;
 seeing.v: <verb-pg> & <vc-see>;
 
-% ditranstive verbs -- taking direct and indirect objects
+% ditransitive verbs -- taking direct and indirect objects
 <vc-owe>:
   (<vc-opt-ditrans>
     or (B- & {O+})
@@ -7077,7 +7077,7 @@ called.v-d shouted.v-d:
 calling.g shouting.g: (<vc-call> & <verb-ge>) or <verb-ge-d>;
 calling.v shouting.v: <verb-pg> & <vc-call>;
 
-% Minimal ditransitive extenstion of words.v.6
+% Minimal ditransitive extension of words.v.6
 % ditransitive: "Please paint it lime green"
 % (O+ & Pa+): "Please paint it green"
 <vc-color>:
@@ -7115,7 +7115,7 @@ coloring.g colouring.g painting.g:
 % ditransitive
 % Writing -- direct and indirect object are optional:
 % 'he wrote' 'he wrote a letter' 'he wrote me a letter' 'he wrote me'
-% 'he wrote me that blah happend' but '*he drew me that blah happened'
+% 'he wrote me that blah happened' but '*he drew me that blah happened'
 %
 % <vc-opt-ditrans> & TH+: "he wrote her that he loved her"
 <vc-write>:
@@ -8849,7 +8849,7 @@ unlike:
 %
 % Mf-: allows "from the Abbey of Stratford Langthorne" so that "of"
 %      links to "Abbey" instead of something more distant.
-%      XXX The Mp- below should be removed, and all occurances of
+%      XXX The Mp- below should be removed, and all occurrences of
 %      Mp+ elsewhere should be replaced by (Mp+ or Mf+)
 % Mf- & MVp+: "She was a girl of about John's age"
 of:
@@ -8874,7 +8874,7 @@ of_them: (ND- or MF-) & (J+ or Pa+) & Xd- & (MX*x- or MVx-) & Xc+;
 
 % MX-PHRASE: The blah, to be blahed, will be blah.
 % TO- & Xc+: "I'd like to, I want to." (null infinitive)
-% give [J+] a cost, so that numeric intervals are peferred
+% give [J+] a cost, so that numeric intervals are preferred
 % I*t+ & TO-: passes on the TO constraint down the line
 % I+ & MVi-: allows "What is there to do?"
 %            but also incorrectly allows: "He is going to do"
@@ -9960,7 +9960,7 @@ and.j-r or.j-r:
 % "Where is the sickle and hammer?" (SIs-)
 % Op- has a cost, so that "they verbed X and verbed Y" gets the VJ link
 % at zero cost, and the SJ link at higher cost (since a "verbed Y" can be
-% understood as a modified noun).  Acutally, should probably have some
+% understood as a modified noun).  Actually, should probably have some
 % post-processing rule to disallow this XXX to do fix above.  Example of
 % bad SJ usage: "He bangs drums and played piano" i.e "he bangs a played piano"
 %
@@ -9994,7 +9994,7 @@ and.j-r or.j-r:
 %
 % {Jd- & Dm-}: "A number of recommendations and suggestions were made"
 %   with "number of" modifying the and.j-n
-% [[<noun-conj-head>]] costs so that above is prefered: (huh????)
+% [[<noun-conj-head>]] costs so that above is preferred: (huh????)
 % "there was enough of the beer and sandwiches"
 %
 % XJa-: "Both June and Tom are coming"
@@ -10151,7 +10151,7 @@ but.j-r: {Xd-} & XJi- & I+;
 % The costly [[<noun-main-x>]] is quite ugly and unappealing, but is
 % needed to parse "he is either in the 105th nor the 106th battalion".
 % The problem here is that "either in" seems to be order-reversed from
-% "in either", and doing it right would require link-corssing.
+% "in either", and doing it right would require link-crossing.
 either.r:
   Ds+
   or XJo+
@@ -10273,7 +10273,7 @@ frank.a:
 % Add a miniscule cost, so that the noun form is prefered...
 % An older formulation of this used Ah- as the link, but I don't see
 % why.  Generic adjective should be OK. Given a cost of 0.04, so
-% as to give a slight prefernce for the noun-form, if possible.
+% as to give a slight preference for the noun-form, if possible.
 HYPHENATED-WORDS.a:
   [<ordinary-adj>]0.04;
 
@@ -10909,7 +10909,7 @@ as_is: {Xd- & Xc+} & MVs-;
 
 as_possible: MVz-;
 
-% Cc+ & CV+: C links to the head-noun of the followig clause, and CV+
+% Cc+ & CV+: C links to the head-noun of the following clause, and CV+
 %            links to the head verb. Must form a cycle.
 %            Example: "I run more often than Ben climbs"
 than.e:
@@ -12040,7 +12040,7 @@ but.ij and.ij or.ij not.ij also.ij then.ij but_not and_not and_yet:
 % Also -- see above, for handling of 12ft. 12in. not just 12%
 "%" ‰ ‱ : (ND- & {DD-} & <noun-sub-x> & <noun-main-x>) or (ND- & (OD- or AN+));
 
-% See also /en/words/currency for curency names that follow a number.
+% See also /en/words/currency for currency names that follow a number.
 $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 £ ₤ € ¤ ₳ ฿ ¢ ₵ ₡ ₢ ₠ ₫ ৳ ƒ ₣ ₲ ₴ ₭ ₺  ℳ  ₥ ₦ ₧ ₱ ₰ ₹ ₨ ₪ ₸ ₮ ₩ ¥ ៛ 호점
 † †† ‡ § ¶ © ® ℗ № "#":
@@ -12178,7 +12178,7 @@ LY-WORDS.e:
 MC-NOUN-WORDS.n:
   [<noun-mass-count>]0.1;
 
-% guessed nouns that are signular countable (-on, -or)
+% guessed nouns that are singular countable (-on, -or)
 C-NOUN-WORDS.n:
   [<common-noun>]0.1;
 
@@ -12230,7 +12230,7 @@ UNKNOWN-WORD.v:
   {@E-} & ((Sp- & <verb-wall>) or (RS- & Bp-) or (I- & <verb-wall>) or ({Ic-} & Wa- & <verb-wall>)) & {O+ or <b-minus>} & <mv-coord>;
 
 % Add a miniscule cost, so that the noun-form is prefered, when
-% availble.
+% available.
 UNKNOWN-WORD.a: [<ordinary-adj>]0.04;
 
 % These are the link-types that are not subject to the length limit.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -1314,6 +1314,7 @@ its my.p your their.p our thy.p yisser.p yousser ye'r:
 
 % Possesive version of me
 % Cost on D, DD: avoids use as determiner on "Make me coffee"
+%suppress: DUP-BASE (for me.p)
 me.p:
   DP+
   or [{AL-} & {@L+} & (D+ or DD+)];
@@ -2252,6 +2253,7 @@ DAY-ORDINALS.ord ORDINALS.ord :
 % - the strength was in the order of gerE > cotD > yfhP P2 > yfhP P1
 % also remember "-->"
 
+%suppress: DUP-BASE (for a.eq)
 A.eq B.eq C.eq D.eq E.eq F.eq G.eq H.eq I.eq J.eq K.eq L.eq M.eq
 N.eq O.eq P.eq Q.eq R.eq S.eq T.eq U.eq V.eq W.eq X.eq Y.eq Z.eq
 a.eq b.eq c.eq d.eq e.eq f.eq g.eq h.eq i.eq j.eq k.eq l.eq m.eq
@@ -11584,6 +11586,7 @@ maybe.c:
 % Argumentatives (children gain-saying).
 not.intj is_too is_not is_so unh_unh: Wa-;
 
+%suppress: DUP-BASE (for seriously.ij)
 % Openers to directives, commands (Ic+ connection to infinitives)
 % or single-word interjections, exclamations.
 % These are semantically important, so they've got to parse!
@@ -11703,6 +11706,7 @@ necessarily no_longer: E+ or EBm-;
 ever: E+ or EBm- or EC+ or MVa- or <COMP-OPENER>;
 
 never.e always: ({EN-} & (E+ or EB-)) or <COMP-OPENER>;
+%suppress: DUP-BASE (for rarely.e)
 seldom rarely.e: ({EE-} & (E+ or EB-)) or <COMP-OPENER>;
 
 % MVa-: "He did just what you asked."
@@ -11743,6 +11747,7 @@ only:
   or (Rnx+ & <CLAUSE-E>)
   or (MVp+ & Wq- & Q+);
 
+%suppress: DUP-BASE (for rarely.i)
 never.i at_no_time not_once rarely.i since_when:
   {MVp+} & Wq- & Q+;
 
@@ -11981,6 +11986,7 @@ but.ij and.ij or.ij not.ij also.ij then.ij but_not and_not and_yet:
   [{Xd-} & (Xx- or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>]1.1;
 
+%suppress: DUP-BASE (for ..y)
 % (NI- & WV- & W+): Optionally numbered, bulleted lists
 ..y *.j "•" ⁂ ❧ ☞ ◊ ※  "….j" ○  。 ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎:
   (Wd- & W+)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -1323,6 +1323,7 @@ its my.p your their.p our thy.p yisser.p yousser ye'r:
 
 % Possesive version of me
 % Cost on D, DD: avoids use as determiner on "Make me coffee"
+%suppress: DUP-BASE (for me.p)
 me.p:
   DP+
   or [{AL-} & {@L+} & (D+ or DD+)];
@@ -2261,6 +2262,7 @@ DAY-ORDINALS.ord ORDINALS.ord :
 % - the strength was in the order of gerE > cotD > yfhP P2 > yfhP P1
 % also remember "-->"
 
+%suppress: DUP-BASE (for a.eq)
 A.eq B.eq C.eq D.eq E.eq F.eq G.eq H.eq I.eq J.eq K.eq L.eq M.eq
 N.eq O.eq P.eq Q.eq R.eq S.eq T.eq U.eq V.eq W.eq X.eq Y.eq Z.eq
 a.eq b.eq c.eq d.eq e.eq f.eq g.eq h.eq i.eq j.eq k.eq l.eq m.eq
@@ -9517,6 +9519,7 @@ maybe.c:
 % Argumentatives (children gain-saying).
 not.intj is_too is_not is_so unh_unh: Wa-;
 
+%suppress: DUP-BASE (for seriously.ij)
 % Openers to directives, commands (Ic+ connection to infinitives)
 % or single-word interjections, exclamations.
 % These are semantically important, so they've got to parse!
@@ -9636,6 +9639,7 @@ necessarily no_longer: E+ or EBm-;
 ever: E+ or EBm- or EC+ or MVa- or <COMP-OPENER>;
 
 never.e always: ({EN-} & (E+ or EB-)) or <COMP-OPENER>;
+%suppress: DUP-BASE (for rarely.e)
 seldom rarely.e: ({EE-} & (E+ or EB-)) or <COMP-OPENER>;
 
 % MVa-: "He did just what you asked."
@@ -9676,6 +9680,7 @@ only:
   or (Rnx+ & <CLAUSE-E>)
   or (MVp+ & Wq- & Q+);
 
+%suppress: DUP-BASE (for rarely.i)
 never.i at_no_time not_once rarely.i since_when:
   {MVp+} & Wq- & Q+;
 
@@ -9916,6 +9921,7 @@ but.ij and.ij or.ij not.ij also.ij then.ij but_not and_not and_yet:
   [{Xd-} & (Xx- or Wc-) & {Xc+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>]1.1;
 
+%suppress: DUP-BASE (for ..y)
 % (NI- & WV- & W+): Optionally numbered, bulleted lists
 ..y *.j "•" ⁂ ❧ ☞ ◊ ※  "….j" ○  。 ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎:
   (Wd- & W+)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -286,7 +286,7 @@ nonCAP.zzz: ZZZ-;
 
 % The use of COa here needs to be carefully re-examined; it is used much too freely.
 % COa+ is used to block links to COd-
-% Xc+ & Ic+: connect to imperatives (infinitve verbs): "Anyhow, don't"
+% Xc+ & Ic+: connect to imperatives (infinitive verbs): "Anyhow, don't"
 % Wc- & Xc+ & Qd+: subject-object inversion: "anyhow, am I right?"
 <directive-opener>:
   {[[Wa-]]} &
@@ -306,7 +306,7 @@ nonCAP.zzz: ZZZ-;
 % in "There they are" tagged as an entity, just because its capitalized.
 % We really do want to force the lower-case usage, because the lower case
 % is in the dict, and its the right word to use. (The only entities that
-% should be tagged as such are those that are in the dicts, in thier
+% should be tagged as such are those that are in the dicts, in their
 % capitalized form, e.g. "Sue.f" female given name as opposed to "sue.v"
 % verb in the sentence "Sue went to the store.")
 %
@@ -333,7 +333,7 @@ INITIALS <entity-singular>:
   or <directive-opener>;
 
 % As above, but with a tiny extra cost, so that a dictionary word is
-% prefered to the regex match (i.e. for a common noun starting a
+% preferred to the regex match (i.e. for a common noun starting a
 % sentence). However, the other regex matches (e.g. MC-NOUN-WORDS)
 % should have a cost that is even higher (so that we take the
 % capitalized version before we take any other matches.)
@@ -365,7 +365,7 @@ PL-CAPITALIZED-WORDS:
 % "Tom" is a given name, but can also be a proper name, so e.g.
 % "The late Mr. Tom will be missed." which needs A-, D- links
 % Wa-: A single exclamation: "Tom!  Hey, Tom! Oh, hello John!"
-% <noun-and-s> is trikcy when used with [[...]] connectors.
+% <noun-and-s> is tricky when used with [[...]] connectors.
 % Careful for bad parses of
 % "This is the dog and cat Pat and I chased and ate"
 % "actress Whoopi Goldberg and singer Michael Jackson attended the ceremony"
@@ -460,7 +460,7 @@ GREEK-LETTER-AND-NUMBER pH.i x.n: <noun-mass-count>;
 
 % Number abbreviations: no.x No.x
 % pp. paragraph, page   art article
-% RR roural route
+% RR rural route
 No.x No..x no.x no..x Nos.x Nos..x nos.x nos..x
 Nr.x Nr..x Nrs.x Nrs..x nr.x nr..x nrs.x nrs..x
 Num.x Num..x num.x num..x pp.x pp..x
@@ -504,7 +504,7 @@ Pty.y Pty..y Ltd.y Ltd..y LTD.y Bldg.y Bldg..y and_Co GmBH.y:
 
 
 % Titles, e.g. Joe Blow, Esq. or Dr. Smarty Pants, Ph.D.
-% Gack. See absurdely large collection at:
+% Gack. See absurdly large collection at:
 % http://en.wikipedia.org/wiki/List_of_post-nominal_letters
 Jr.y Jr..y Sr.y Sr..y Esq.y Esq..y
 AB.y A.B..y AIA.y A.I.A..y
@@ -737,7 +737,7 @@ tawny.n ultramarine.n umber.n yellow.n:
   or Wa-;
 
 % SINGULAR ENTITIES FOR ENTITY EXTRACTION
-% This must appear after other categories so it doesnt interfere with those.
+% This must appear after other categories so it doesn't interfere with those.
 /en/words/entities.national.sing:
 <marker-entity> or <entity-singular>;
 
@@ -1265,7 +1265,7 @@ times.n:
 % ====================================================================
 %PRONOUNS
 
-% MXs+: "he, the shop onwer, ..."
+% MXs+: "he, the shop owner, ..."
 she he:
   {[[R+ & Bs+]]} & (({MXs+} & Ss+ & <CLAUSE>) or SIs- or SJls+);
 
@@ -1321,7 +1321,7 @@ its my.p your their.p our thy.p yisser.p yousser ye'r:
   DP+
   or ({AL-} & {@L+} & (D+ or DD+));
 
-% Possesive version of me
+% Possessive version of me
 % Cost on D, DD: avoids use as determiner on "Make me coffee"
 %suppress: DUP-BASE (for me.p)
 me.p:
@@ -1459,7 +1459,7 @@ this.d:
   or DTn+
   or Wa-;
 
-% [[<noun-main-p>]] costs so that ditranstive verbs don't suffer:
+% [[<noun-main-p>]] costs so that ditransitive verbs don't suffer:
 % "I taught these mice to jump", taught is ditransitive, we don't want
 % "these" to be the object.  See also "those"
 % (Jd- & Dmu- & Op-): "I gave him a number of these"
@@ -1472,7 +1472,7 @@ these:
   or <noun-and-p>
   or Wa-;
 
-% [[<noun-main-p>]] costs so that ditranstive verbs don't suffer,
+% [[<noun-main-p>]] costs so that ditransitive verbs don't suffer,
 % and get the D+ link instead of the O- link.
 % See also "these"
 those:
@@ -1517,8 +1517,8 @@ many:
 
 % A naked <noun-main2-x> costs more than one with other links,
 % so that ditransitive verbs don't get spurious links to all.a
-% XXX can this be tighetend up??
-% <noun-main2-x> costs no mater what, so that Ofd+ is prefered.
+% XXX can this be tightened up??
+% <noun-main2-x> costs no mater what, so that Ofd+ is preferred.
 % [E+]0.5: all modifying a verb probably is not right.
 % Wa-: "All the people!" as a response to a question.
 all.a:
@@ -1624,7 +1624,7 @@ a_couple:
 %  [[<noun-sub-p> & <noun-main-p>]] or
   <noun-and-p> or Wa-;
 
-% NNumeric modifier: "a couple of thousand dollars"
+% Numeric modifier: "a couple of thousand dollars"
 a_couple_of:
   NN+ or ND+ or NIn+;
 
@@ -1683,7 +1683,7 @@ the_most:
   or MVa-;
 
 % "a part.n" should cover most cases.  Perhaps [[OF+ & <noun-main-s>]] should be
-% reomved??  Anyway, its costed to give OFd+ priority. Likewise, should probably
+% removed??  Anyway, its costed to give OFd+ priority. Likewise, should probably
 % retire <adv-of> as well, right?
 part.i:
   (OFd+ & Dm+)
@@ -1706,7 +1706,7 @@ none:
   or [[<adv-of>]]
   or Wa-;
 
-% costly <adv-of> so that OFd+ is prefered.
+% costly <adv-of> so that OFd+ is preferred.
 rest.i:
   [[DD- & <adv-of>]];
 
@@ -2274,7 +2274,7 @@ fiscal.i: TY+ & <noun-main-s>;
 or_so: ND- & {{@L+} & DD-} & (Dmcn+ or (<noun-sub-p> & <noun-main-p>));
 
 % Allows parsing of "dollars per day" or "mL/sec" but is somewhat
-% inconsistent with the equation persing otherwise described below.
+% inconsistent with the equation parsing otherwise described below.
 % XXX overall, eqn parsing could be strengthened.
 per "/.per": Us+ & Mp-;
 
@@ -2293,7 +2293,7 @@ per "/.per": Us+ & Mp-;
 % <verb-wall> : links verb to wall or to controlling phrase.
 % <verb-s>    : links verbs to singular subjects
 % <verb-pl>   : links verbs to plural subjects
-% <verb-i>    : links to infinitve
+% <verb-i>    : links to infinitive
 % <verb-pl,i> : to plural subjects or infinitives
 % <verb-sp>   : to singular or plural subject
 % <verb-pp>   : to past-participles
@@ -2388,7 +2388,7 @@ per "/.per": Us+ & Mp-;
 <verb-sip>:  {@E-} & hPF- & {<verb-wall>} & hSIp+;
 
 % <b-minus> is meant to be a generic replacement in the naked B- in
-% many transitive verb constructions.  For quetions, we need to force
+% many transitive verb constructions.  For questions, we need to force
 % a verb-wall connector; this is what the (B*w- or B*m-) & <verb-wall>
 % part does. For the other B- forms, we don't need the wall.  To force
 % the wall, we just list all the others.
@@ -2453,7 +2453,7 @@ per "/.per": Us+ & Mp-;
 % Iq-: "The big question is did he do it?"
 % Xd- & Iq-: "The big question is, did he do it?"
 <verb-rq>: Rw- or ({{Xd-} & Iq-} & (Qd- or ((Qw- or Qe-) & <verb-wall>))) or [()];
-% Just like above, but no aux, shuld always be anded with I+.
+% Just like above, but no aux, should always be anded with I+.
 % The idea here is that the verb on the other end of the I+ will
 % connect to the wall.
 <verb-rq-aux>: Rw- or ({{Xd-} & Iq-} & (Qd- or Qw- or Qe-)) or [()];
@@ -2475,7 +2475,7 @@ per "/.per": Us+ & Mp-;
 % These are used almost exclusively with auxiliary verbs.
 % This is why they don't have & <verb-wall> in them: we don't want the
 % auxiliary attaching to the wall, we want only the main verb doing this.
-% The Ss- or Sp- prevent attachements to Sa- for "as.e" phrases.
+% The Ss- or Sp- prevent attachments to Sa- for "as.e" phrases.
 <verb-x-pl,i>: {@E-} & (Sp- or SFp- or If- or (RS- & Bp-) or Wi-);
 <verb-x-s>: {@E-} & (Ss- or SFs- or (RS- & Bs-));
 <verb-x-s,u>: {@E-} & (Ss- or SFs- or SFu- or (RS- & Bs-));
@@ -2518,10 +2518,10 @@ per "/.per": Us+ & Mp-;
 % The conjunction should take an object if both verbs are transitive,
 % e.g. "I saw and greeted Sue", which should parse as
 % "I (saw and greeted) Sue".
-% VJ**i == intranstive
+% VJ**i == intransitive
 % VJ**t == transitive
 %
-% s == singluar, pl == plural, sp == singular or plural
+% s == singular, pl == plural, sp == singular or plural
 % g == gerund
 <verb-and-s->: {@E-} & VJrs-;
 <verb-and-s+>: {@E-} & VJls+;
@@ -2584,7 +2584,7 @@ define(`VERB_x_T',`'
   (($2) & <verb-and-sp-i+>) or
   <verb-and-sp-t>))
 
-% present tense, but allows transitive connectinos to 'and'
+% present tense, but allows transitive connections to 'and'
 define(`VERB_S_T',`'VERB_x_T(<verb-s>, $1))
 
 % past tense macro, intransitive variation
@@ -2788,7 +2788,7 @@ having.v: <verb-pg> & <vc-have>;
 having.g: (<vc-have> & <verb-ge>) or <verb-ge-d>;
 
 % PP is disjoined with <verb-wall> because when PP is used, has/have/had
-% is an auxiliarry verb, an should not get a wall connection!
+% is an auxiliary verb, an should not get a wall connection!
 hasn't hasn’t:
   ((<verb-rq> & (SIs+ or SFIs+)) or (<verb-x-s>))
   & (PP+ or ((([[O+]] & <mv-coord>) or [[()]]) & <verb-wall>));
@@ -2873,7 +2873,7 @@ hadn't.v-d hadn’t.v-d:
 
 % O*m+ allows "If only there were more!"
 % THb+ allows "It is your fault that you're a failure."
-% The cost on @MV+ causes attachements to the object to be prefered
+% The cost on @MV+ causes attachments to the object to be preferred
 % over attachments to the copula; for example, prepositions should
 % almost surely attach via Mp+ link to the object, as opposed to
 % using an MVp+ link to the copula. Example:
@@ -2921,7 +2921,7 @@ is.v:
   or (EQ*r- & S- & <verb-wall> & EQ*r+);
 
 % Similar to above, but no S-O inversion, and no equation.
-% Also, a cost, so that possesive 's is preferred.
+% Also, a cost, so that possessive 's is preferred.
 % Also, this can be a contraction for "has": "he has" -> "he's"
 % <verb-x-s,u> & PP+: "He's gone to Boston"  (viz "He has gone to Boston")
 % But also, some contractions are prohibited:
@@ -2994,7 +2994,7 @@ were.v-d:
   or (<vc-be-and> & <verb-and-sp+>)
   or [[(SI*j+ or SFI**j+) & <vc-be> & ((Xd- & VCq- & Xc+) or VCq- or ({{Xd-} & Xc+} & COp+))]];
 
-% Ss*w-: allows Wh subjets: "Who am I?"
+% Ss*w-: allows Wh subjects: "Who am I?"
 am.v:
   ({@E-} & SX- & <vc-be>)
   or (<verb-rq> & SXI+ & {<vc-be>})
@@ -3168,8 +3168,8 @@ is_less_than_or_equal_to is_gretr_than_or_equal_to:
 % the verb form: 1=plural-infinitive, 2=singular, 3=past("ed"),
 % 4=progressive("-ing"), 5=gerund("-ing".)
 
-% abbreviations for ditransitive and optionally ditranstive verbs
-% ditranstive verbs take a direct and indirect object
+% abbreviations for ditransitive and optionally ditransitive verbs
+% ditransitive verbs take a direct and indirect object
 % e.g. "I gave her a rose"
 % B- & O+ & O*n+: "What are the chances you'll give her a kiss?"
 % O+ & @MV+ & O*n+: "I gave him for his birthday a very expensive present"
@@ -3674,7 +3674,7 @@ bake.v dictate.v kiss.v slice.v:
 bakes.v dictates.v kisses.v slices.v:
   VERB_S_T(<vc-bake>);
 
-% A+: "she gave him some slcied bread"
+% A+: "she gave him some sliced bread"
 baked.v-d sliced.v-d:
   VERB_SPPP_T(<vc-bake>)
   or <verb-pv>
@@ -4971,7 +4971,7 @@ reeked.v-d smelled.v-d: VERB_SPPP_T(<vc-smell>) or <verb-pv> or <verb-phrase-ope
 reeking.g smelling.g: (<vc-smell> & <verb-ge>) or <verb-ge-d>;
 reeking.v smelling.v: <verb-pg> & <vc-smell>;
 
-% <vc-trans> plus partcle and Vt
+% <vc-trans> plus particle and Vt
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
   ({O+} & (OT+ or BT-) & {@MV+} & {<tot-verb> or <toi-verb>}) or
@@ -5044,7 +5044,7 @@ found.v-d: VERB_SPPP_T(<vc-find>) or
 finding.v: <verb-pg> & <vc-find>;
 finding.g: (<vc-find> & <verb-ge>) or <verb-ge-d>;
 
-% ditranstive
+% ditransitive
 <vc-get>:
   ((O+ or <b-minus>) & (({K+} & <mv-coord>) or ({@MV+} & (Pa+ or AF- or Pv+))))
   or ((<vc-ditrans>
@@ -5162,7 +5162,7 @@ intending.v: <verb-pg> & <vc-intend>;
 
 % O+ & TO+: "I dare you to!"
 % TO+ & Xc+: "try it if you dare to!"
-% I+: auxilliary: "no one dared say a word"
+% I+: auxiliary: "no one dared say a word"
 % N+ & TO: "I dare not to say the truth"
 <vc-dare>:
   ({N+} & <mv-coord> & {<to-verb> or (TO+ & Xc+)}) or
@@ -5195,7 +5195,7 @@ liked.v-d: VERB_SPPP_T(<vc-like>) or <verb-pv> or <verb-phrase-opener>;
 liking.g: (<vc-like> & <verb-ge>) or <verb-ge-d>;
 liking.v: <verb-pg> & <vc-like>;
 
-% ditranstive
+% ditransitive
 <vc-offer>:
   ((<vc-opt-ditrans> or
     (<b-minus> & {O+})) & <mv-coord>) or
@@ -5411,7 +5411,7 @@ seen.v:
 seeing.g: (<vc-see> & <verb-ge>) or <verb-ge-d>;
 seeing.v: <verb-pg> & <vc-see>;
 
-% ditranstive verbs -- taking direct and indirect objects
+% ditransitive verbs -- taking direct and indirect objects
 <vc-owe>:
   (<vc-opt-ditrans>
     or (B- & {O+})
@@ -5561,7 +5561,7 @@ called.v-d shouted.v-d:
 calling.g shouting.g: (<vc-call> & <verb-ge>) or <verb-ge-d>;
 calling.v shouting.v: <verb-pg> & <vc-call>;
 
-% Minimal ditransitive extenstion of words.v.6
+% Minimal ditransitive extension of words.v.6
 % ditransitive: "Please paint it lime green"
 % (O+ & Pa+): "Please paint it green"
 <vc-color>:
@@ -5588,7 +5588,7 @@ coloring.g colouring.g painting.g:
 % ditransitive
 % Writing -- direct and indirect object are optional:
 % 'he wrote' 'he wrote a letter' 'he wrote me a letter' 'he wrote me'
-% 'he wrote me that blah happend' but '*he drew me that blah happened'
+% 'he wrote me that blah happened' but '*he drew me that blah happened'
 %
 % <vc-opt-ditrans> & TH+: "he wrote her that he loved her"
 <vc-write>:
@@ -6780,7 +6780,7 @@ unlike:
 %
 % Mf-: allows "from the Abbey of Stratford Langthorne" so that "of"
 %      links to "Abbey" instead of something more distant.
-%      XXX The Mp- below should be removed, and all occurances of
+%      XXX The Mp- below should be removed, and all occurrences of
 %      Mp+ elsewhere should be replaced by (Mp+ or Mf+)
 % Mf- & MVp+: "She was a girl of about John's age"
 of:
@@ -6805,7 +6805,7 @@ of_them: (ND- or MF-) & (J+ or Pa+) & Xd- & (MX*x- or MVx-) & Xc+;
 
 % MX-PHRASE: The blah, to be blahed, will be blah.
 % TO- & Xc+: "I'd like to, I want to." (null infinitive)
-% give [J+] a cost, so that numeric intervals are peferred
+% give [J+] a cost, so that numeric intervals are preferred
 % I*t+ & TO-: passes on the TO constraint down the line
 % I+ & MVi-: allows "What is there to do?"
 %            but also incorrectly allows: "He is going to do"
@@ -7893,7 +7893,7 @@ and.j-r or.j-r:
 % "Where is the sickle and hammer?" (SIs-)
 % Op- has a cost, so that "they verbed X and verbed Y" gets the VJ link
 % at zero cost, and the SJ link at higher cost (since a "verbed Y" can be
-% understood as a modified noun).  Acutally, should probably have some
+% understood as a modified noun).  Actually, should probably have some
 % post-processing rule to disallow this XXX to do fix above.  Example of
 % bad SJ usage: "He bangs drums and played piano" i.e "he bangs a played piano"
 %
@@ -7927,7 +7927,7 @@ and.j-r or.j-r:
 %
 % {Jd- & Dm-}: "A number of recommendations and suggestions were made"
 %   with "number of" modifying the and.j-n
-% [[<noun-conj-head>]] costs so that above is prefered: (huh????)
+% [[<noun-conj-head>]] costs so that above is preferred: (huh????)
 % "there was enough of the beer and sandwiches"
 %
 % XJa-: "Both June and Tom are coming"
@@ -8084,7 +8084,7 @@ but.j-r: {Xd-} & XJi- & I+;
 % The costly [[<noun-main-x>]] is quite ugly and unappealing, but is
 % needed to parse "he is either in the 105th nor the 106th battalion".
 % The problem here is that "either in" seems to be order-reversed from
-% "in either", and doing it right would require link-corssing.
+% "in either", and doing it right would require link-crossing.
 either.r:
   Ds+
   or XJo+
@@ -8206,7 +8206,7 @@ frank.a:
 % Add a miniscule cost, so that the noun form is prefered...
 % An older formulation of this used Ah- as the link, but I don't see
 % why.  Generic adjective should be OK. Given a cost of 0.04, so
-% as to give a slight prefernce for the noun-form, if possible.
+% as to give a slight preference for the noun-form, if possible.
 HYPHENATED-WORDS.a:
   [<ordinary-adj>]0.04;
 
@@ -8842,7 +8842,7 @@ as_is: {Xd- & Xc+} & MVs-;
 
 as_possible: MVz-;
 
-% Cc+ & CV+: C links to the head-noun of the followig clause, and CV+
+% Cc+ & CV+: C links to the head-noun of the following clause, and CV+
 %            links to the head verb. Must form a cycle.
 %            Example: "I run more often than Ben climbs"
 than.e:
@@ -9975,7 +9975,7 @@ but.ij and.ij or.ij not.ij also.ij then.ij but_not and_not and_yet:
 % Also -- see above, for handling of 12ft. 12in. not just 12%
 "%" ‰ ‱ : (ND- & {DD-} & <noun-sub-x> & <noun-main-x>) or (ND- & (OD- or AN+));
 
-% See also /en/words/currency for curency names that follow a number.
+% See also /en/words/currency for currency names that follow a number.
 $ USD.c US$.c C$.c AUD.c AUD$.c HK.c HK$.c
 £ ₤ € ¤ ₳ ฿ ¢ ₵ ₡ ₢ ₠ ₫ ৳ ƒ ₣ ₲ ₴ ₭ ₺  ℳ  ₥ ₦ ₧ ₱ ₰ ₹ ₨ ₪ ₸ ₮ ₩ ¥ ៛ 호점
 † †† ‡ § ¶ © ® ℗ № "#":
@@ -10105,7 +10105,7 @@ LY-WORDS.e:
 MC-NOUN-WORDS.n:
   [<noun-mass-count>]0.1;
 
-% guessed nouns that are signular countable (-on, -or)
+% guessed nouns that are singular countable (-on, -or)
 C-NOUN-WORDS.n:
   [<common-noun>]0.1;
 
@@ -10157,7 +10157,7 @@ UNKNOWN-WORD.v:
   {@E-} & ((Sp- & <verb-wall>) or (RS- & Bp-) or (I- & <verb-wall>) or ({Ic-} & Wa- & <verb-wall>)) & {O+ or <b-minus>} & <mv-coord>;
 
 % Add a miniscule cost, so that the noun-form is prefered, when
-% availble.
+% available.
 UNKNOWN-WORD.a: [<ordinary-adj>]0.04;
 
 % These are the link-types that are not subject to the length limit.

--- a/data/en/words/words.n.2.x
+++ b/data/en/words/words.n.2.x
@@ -1,4 +1,4 @@
-﻿aircraft.p
+aircraft.p
 bacteria.p
 basemen.n
 beano.p

--- a/debug/README.md
+++ b/debug/README.md
@@ -44,7 +44,11 @@ levels include the messages of the lower ones.
 dictionary.  As with levels greater then 4, higher levels include the
 messages of the lower ones.
 
+* 10: Basic dictionary debug.
+
 100-...: Show only messages exactly at the specified level.
+* 103: Show unsubscripted dictionary words and subscripted ones which share
+       the same base word.
 
 ### 2) -debug=LOCATIONS (-de=LOCATIONS)
 Show only messages from these LOCATIONS. The LOCATIONS string is a

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -326,6 +326,7 @@ void dictionary_delete(Dictionary dict)
 	pp_knowledge_close(dict->base_knowledge);
 	pp_knowledge_close(dict->hpsg_knowledge);
 	string_set_delete(dict->string_set);
+	free((void *)dict->suppress_warning);
 	free_regexs(dict->regex_root);
 	free_anysplit(dict);
 	free_dictionary(dict);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -122,6 +122,7 @@ struct Dictionary_s
 	const char    * input;
 	const char    * pin;
 	bool            recursive_error;
+	const char    * suppress_warning;
 	bool            is_special;
 	int             already_got_it; /* For char, but needs to hold EOF */
 	int             line_number;

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -32,6 +32,16 @@
 #define SUBSCRIPT_MARK '\3'
 #define SUBSCRIPT_DOT '.'
 
+/* A dictionary directive to suppress dictionary check warnings.
+ * For example:
+ * %suppress: DUP-BARE SOME-OTHER ... optional comment
+ * The chosen symbols for warning suppression should not overlap,
+ * e.g. if there is a symbol DUP-BARE, there should no symbol "DUP".
+ * Their effect is until the ending ';' of the following expression.
+ */
+#define SUPPRESS "suppress: "
+#define DUP_BASE "DUP-BASE" /* Allow a base-word + subscripted-same-word. */
+
 static inline const char *subscript_mark_str(void)
 {
 	static const char sm[] = { SUBSCRIPT_MARK, '\0' };

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -155,13 +155,13 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 	if (s2)
 	{
 		prt_error("Error: While parsing dictionary %s:\n"
-		          "%s %s\n\t line %d, tokens = %s\n\\",
+		          "%s %s\n\t line %d, tokens = %s\n",
 		          dict->name, s, s2, dict->line_number, tokens);
 	}
 	else
 	{
 		prt_error("Error: While parsing dictionary %s:\n"
-		          "%s\n\t line %d, tokens = %s\n\\",
+		          "%s\n\t line %d, tokens = %s\n",
 		          dict->name, s, dict->line_number, tokens);
 	}
 	dict->recursive_error = false;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -520,7 +520,7 @@ static inline int dict_order_bare(const char *s, const Dict_node * dn)
  * you come to the end of one of them, or until you find unequal
  * characters.  A "*" matches anything before the subscript mark.
  * Otherwise, replace SUBSCRIPT_MARK by "\0", and take the difference.
- * his behavior matches that of the function dict_order_bare().
+ * This behavior matches that of the function dict_order_bare().
  */
 #define D_DOW 6
 static inline int dict_order_wild(const char * s, const Dict_node * dn)
@@ -750,7 +750,7 @@ static Dict_node * abridged_lookup_list(const Dictionary dict, const char *s)
 }
 
 /**
- * strict_lookup_list() - return exact natch in the dictionary
+ * strict_lookup_list() - return exact match in the dictionary
  *
  * Returns a pointer to a lookup list of the words in the dictionary.
  * Excludes any idioms that contain the word.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -541,36 +541,20 @@ static inline int dict_order_wild(const char * s, const Dict_node * dn)
 /**
  * dict_match --  return true if strings match, else false.
  * A "bare" string (one without a subscript) will match any corresponding
- * string with a suffix; so, for example, "make" and "make.n" are
+ * string with a subscript; so, for example, "make" and "make.n" are
  * a match.  If both strings have subscripts, then the subscripts must match.
  *
  * A subscript is the part that follows the SUBSCRIPT_MARK.
  */
 static bool dict_match(const char * s, const char * t)
 {
-	char *ds, *dt;
-	ds = strrchr(s, SUBSCRIPT_MARK);
-	dt = strrchr(t, SUBSCRIPT_MARK);
+	while ((*s != '\0') && (*s == *t)) { s++; t++; }
 
-#if SUBSCRIPT_MARK == '.'
-	/* a dot at the end or a dot followed by a number is NOT
-	 * considered a subscript */
-	if ((dt != NULL) && ((*(dt+1) == '\0') ||
-	    (isdigit((int)*(dt+1))))) dt = NULL;
-	if ((ds != NULL) && ((*(ds+1) == '\0') ||
-	    (isdigit((int)*(ds+1))))) ds = NULL;
-#endif
+	if (*s == *t) return true; /* both are '\0' */
+	if ((*s == 0) && (*t == SUBSCRIPT_MARK)) return true;
+	if ((*s == SUBSCRIPT_MARK) && (*t == 0)) return true;
 
-	/* dt is NULL when there's no prefix ... */
-	if (dt == NULL && ds != NULL) {
-		if (((int)strlen(t)) > (ds-s)) return false;   /* we need to do this to ensure that */
-		return (strncmp(s, t, ds-s) == 0);             /* "i.e." does not match "i.e" */
-	} else if (dt != NULL && ds == NULL) {
-		if (((int)strlen(s)) > (dt-t)) return false;
-		return (strncmp(s, t, dt-t) == 0);
-	} else {
-		return (strcmp(s, t) == 0);
-	}
+	return false;
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1488,11 +1488,8 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	}
 	else if ((dn_head = abridged_lookup_list(dict, dn->string)) != NULL)
 	{
-		char *u;
 		Dict_node *dnx;
 
-		u = strchr(dn->string, SUBSCRIPT_MARK);
-		if (u) *u = SUBSCRIPT_DOT;
 		prt_error("Warning: The word \"%s\" "
 		          "found near line %d of %s matches the following words:",
 	             dn->string, dict->line_number, dict->name);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1030,10 +1030,9 @@ void add_empty_word(Dictionary const dict, X_node *x)
 static bool is_number(const char * str)
 {
 	if ('+' == str[0] || '-' == str[0]) str++;
-	if (strspn(str, "0123456789.") == strlen(str))
-		return true;
+	size_t numlen = strspn(str, "0123456789.");
 
-	return false;
+	return str[numlen] == '\0';
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1424,8 +1424,10 @@ Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 	int comp = dict_order_strict(newnode->string, n);
 	if (0 == comp)
 	{
-		char t[256];
-		snprintf(t, 256, "The word \"%s\" has been multiply defined:", newnode->string);
+		char t[80+MAX_TOKEN_LENGTH];
+		snprintf(t, sizeof(t),
+		         "Ignoring word \"%s\", which has been multiply defined:",
+		         newnode->string);
 		dict_error(dict, t);
 		newnode->exp = &null_exp;
 		comp = -1;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -155,13 +155,13 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 	if (s2)
 	{
 		prt_error("Error: While parsing dictionary %s:\n"
-		          "%s %s\n\t line %d, tokens = %s\n",
+		          "%s %s\n\t Line %d, next tokens: %s\n",
 		          dict->name, s, s2, dict->line_number, tokens);
 	}
 	else
 	{
 		prt_error("Error: While parsing dictionary %s:\n"
-		          "%s\n\t line %d, tokens = %s\n",
+		          "%s\n\t Line %d, next tokens: %s\n",
 		          dict->name, s, dict->line_number, tokens);
 	}
 	dict->recursive_error = false;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1418,11 +1418,19 @@ static Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
  */
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 {
-	int comp;
-
 	if (NULL == n) return newnode;
 
-	comp = dict_order_strict(newnode->string, n);
+	static Exp null_exp = { .type = AND_type, .u.l = NULL };
+	int comp = dict_order_strict(newnode->string, n);
+	if (0 == comp)
+	{
+		char t[256];
+		snprintf(t, 256, "The word \"%s\" has been multiply defined:", newnode->string);
+		dict_error(dict, t);
+		newnode->exp = &null_exp;
+		comp = -1;
+	}
+
 	if (comp < 0)
 	{
 		if (NULL == n->left)
@@ -1431,10 +1439,8 @@ Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 			return n;
 		}
 		n->left = insert_dict(dict, n->left, newnode);
-		return n;
-		/* return rebalance(n); Uncomment to get an AVL tree */
 	}
-	else if (comp > 0)
+	else
 	{
 		if (NULL == n->right)
 		{
@@ -1442,16 +1448,10 @@ Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 			return n;
 		}
 		n->right = insert_dict(dict, n->right, newnode);
-		return n;
-		/* return rebalance(n); Uncomment to get an AVL tree */
 	}
-	else
-	{
-		char t[256];
-		snprintf(t, 256, "The word \"%s\" has been multiply defined\n", newnode->string);
-		dict_error(dict, t);
-		return NULL;
-	}
+
+	return n;
+	/* return rebalance(n); Uncomment to get an AVL tree */
 }
 
 /**

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1445,6 +1445,7 @@ Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 		         "(use verbosity=2 for more details): ",
 		         newnode->string);
 		dict_error(dict, t);
+		/* Too late to skip insertion - insert it with a null expression. */
 		newnode->exp = &null_exp;
 		comp = -1;
 	}

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -128,6 +128,14 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 	if (dict->recursive_error) return;
 	dict->recursive_error = true;
 
+	char token[MAX_TOKEN_LENGTH];
+	strcpy(token, dict->token);
+	bool save_is_special    = dict->is_special;
+	const char * save_input = dict->input;
+	const char * save_pin   = dict->pin;
+	int save_already_got_it = dict->already_got_it;
+	int save_line_number    = dict->line_number;
+
 	tokens[0] = '\0';
 	for (i=0; i<5 && dict->token[0] != '\0' ; i++)
 	{
@@ -136,6 +144,13 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 		link_advance(dict);
 	}
 	tokens[pos] = '\0';
+
+	strcpy(dict->token, token);
+	dict->is_special     = save_is_special;
+	dict->input          = save_input;
+	dict->pin            = save_pin;
+	dict->already_got_it = save_already_got_it;
+	dict->line_number    = save_line_number;
 
 	if (s2)
 	{

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1424,9 +1424,9 @@ static Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
 /* ======================================================================== */
 /**
  * Insert the new node into the dictionary below node n.
- * Give error message if the new element's string is already there.
- * Assumes that the "n" field of new is already set, and the left
- * and right fields of it are NULL.
+ * "newnode" left and right fields are NULL, and its string is already
+ * there.  If the string is already found in the dictionary, give an error
+ * message and effectively ignore it.
  *
  * The resulting tree is highly unbalanced. It needs to be rebalanced
  * before being used.  The DSW algo below is ideal for that.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -299,7 +299,7 @@ static bool link_advance(Dictionary dict)
 	do
 	{
 		bool ok = get_character(dict, false, c);
-		if (false == ok) return false;
+		if (!ok) return false;
 	}
 	while (lg_isspace(c[0]));
 
@@ -363,7 +363,7 @@ static bool link_advance(Dictionary dict)
 			}
 		}
 		bool ok = get_character(dict, quote_mode, c);
-		if (false == ok) return false;
+		if (!ok) return false;
 	}
 	return true;
 }

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -167,8 +167,8 @@ int vappend_string(dyn_str * string, const char *fmt, va_list args)
 
 	if (templen >= TMPLEN)
 	{
-		/* TMPLEN is too small - use a bigger buffer. Couldn't actually
-		 * find any example of entering this code with templen>=1024... */
+		/* TMPLEN is too small - use a bigger buffer. This may happen
+		 * when printing dictionary words using !! with a wildcard. */
 		temp_string = alloca(templen+1);
 		templen = vsnprintf(temp_string, templen+1, fmt, args);
 		if (templen < 0) goto error;

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -1485,7 +1485,11 @@ void print_sentence_word_alternatives(dyn_str *s, Sentence sent, bool debugprint
 					char *info = display(sent->dict, wt);
 
 					if (NULL == info) return;
-					append_string(s, "Token \"%s\" %s", wt, info);
+					append_string(s, "Token \"%s\" ", wt);
+					/* Cannot use append_string() for "info" because it may be
+					 * a multi-MB string due to !!*
+					 * (printing all dictionary words). */
+					dyn_strcat(s, info);
 					free(info);
 				}
 				else if (word_split) append_string(s, " %s", wt);

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1086,10 +1086,6 @@ void altappend(Sentence sent, const char ***altp, const char *w)
 	  then the "." and everything after it is considered to be the subscript
 	  of the word.
 
-	  The dictionary reader does not allow you to have two words that
-	  match according to the criterion below.  (so you can't have
-	  "dog.n" and "dog")
-
 	  Quote marks are used to allow you to define words in the dictionary
 	  which would otherwise be considered part of the dictionary, as in
 
@@ -1113,16 +1109,11 @@ void altappend(Sentence sent, const char ***altp, const char *w)
 
 		   If there is no strippable string, then the process terminates.
 
-	Rule for defining subscripts in input words:
-
-	   The subscript rule is followed just as when reading the dictionary.
-
 	When does a word in the sentence match a word in the dictionary?
 
-	   Matching is done as follows: Two words with subscripts must match
-	   exactly.  If neither has a subscript they must match exactly.  If one
-	   does and one doesn't then they must match when the subscript is
-	   removed.  Notice that this is symmetric.
+		The matching is done disregarding the subscript of the dictionary
+		word. This means a sentence word can match at most one dictionary word
+		that doesn't have a subscript, and many words that have a subscript.
 
 	So, under this system, the dictionary could have the words "Ill" and
 	also the word "Ill."  It could also have the word "i.e.", which could be


### PR DESCRIPTION
See issue #667.

Main fixes:
- Avoid checking (by default), for each dict word, bare identical words.
  Instead, make this check at verbosity 10 (basic dict debug).
- Speed up `get_file_contents()`. Add read error message.
- Speed up dict_match() and is_number().
- Fix a bug in dict_error2() that prevented a further dict parsing (due to location lost).
- Fix error messages, and reword error messages to make them clearer.
- Fix a potential stack overflow when using !! with a wildcard.


In addition:
- Add general dict warning suppression, to be used (also) by a future dict checking program.
- Suppress warnings for know subscripted dict words that also have bare words.
- Add debug level 103 to show all these words without this suppression.
- Document the added check/verbosity level.
- Get rid of  BOM in `en/words/words.n.2.x`.
- Some code cleanup.
- Comment cleanup and reword.
- Jumbo typo fix of en dict comments.

Some speed up (maybe) can be done in dict_order_strict(), but I need to first fully understand the apparent problem I raised in issue #671.

