### PR TITLE
Connector enumeration + length-limit setup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Version 5.4.4 (XXX 2018)
  * Fix many predicative adjective uses.
  * Fix many paraphrasing-type constructions.
  * Minor cleanup of word-lists.
+ * New dict definition LENGTH-LIMIT-n to limit connector link length to n.
+ * Improve the parser speed (especially for Russian).
 
 Version 5.4.3 (4 January 2018)
  * Fix man page installation (actually broken from 5.3.0).

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -532,7 +532,7 @@ class FSATsolverTestCase(unittest.TestCase):
 class HEnglishLinkageTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.d, cls.po = Dictionary(), ParseOptions()
+        cls.d, cls.po = Dictionary(), ParseOptions(linkage_limit=300)
 
     @classmethod
     def tearDownClass(cls):

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -12252,6 +12252,7 @@ UNLIMITED-CONNECTORS:
       RW+ & Xp+ & Xx+ & CP+ & SFsx+ & WV+ & CV+ &
       VJ+ & SJ+;
 
+LENGTH-LIMIT-1: YS+ & YP+ & PHv+;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Extensions by Peter Szolovits, psz@mit.edu, as a part of the work for
 % "Adding a Medical Lexicon to an English Parser.  Proc. AMIA 2003 Annual

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -10179,6 +10179,7 @@ UNLIMITED-CONNECTORS:
       RW+ & Xp+ & Xx+ & CP+ & SFsx+ & WV+ & CV+ &
       VJ+ & SJ+;
 
+LENGTH-LIMIT-1: YS+ & YP+ & PHv+;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Extensions by Peter Szolovits, psz@mit.edu, as a part of the work for
 % "Adding a Medical Lexicon to an English Parser.  Proc. AMIA 2003 Annual

--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -1077,6 +1077,8 @@ CAPITALIZED-WORDS: ({Xia-} & {@EI-} & {Xp+} & {G+} & (
 %% Слова с большой буквы
 Вам.m2sd: <мест-sub> & (Jd- or [[MVad-]] or [[MVIad+]] or Nd- or <макро-сущ-d>); % МС,2л,ед,дт
 
+LENGTH-LIMIT-1: LL*+;
+
 % morphology linkages
 #include "/ru/morph.dict";
 

--- a/debug/README.md
+++ b/debug/README.md
@@ -82,54 +82,67 @@ Useful examples
 
 1) See the tokens after flattening into the word array used by the parser:
 
-`echo "Let's test it" | link-parser -v=6 -debug=flatten_wordgraph,print_sentence_word_alternatives`
+```
+echo "Let's test it" | \
+link-parser -v=6 -debug=flatten_wordgraph,print_sentence_word_alternatives
+```
 
 2) Trace the work of `sane_linkage_morphism()`:
 
-`lg -v=7 -debug=sane_linkage_morphism`
+`link-parser -v=8 -debug=sane_linkage_morphism`
 
-3) Same as (2) above, but also see other messages from api.c:
+3) Same as (2) above, but also see other messages from sane.c:
 
-`lg -v=7 -debug=api.c`
+`link-parser -v=8 -debug=sane.c`
 
-(`sane_linkage_morphism()` happens to be in `api.c` so this includes its
-messages too).
+(`sane_linkage_morphism()` happens to be in `sane.c` so this includes its
+messages.)
 
 4) Debug the tokenizer:
 
-`lg -v=7 -debug=tokenizer.c`
+`link-parser -v=7 -debug=tokenizer.c`
 
 Or, in order to display the word array:
 
-`lg -v=7 -debug=tokenize.c,print_sentence_word_alternatives`
+`link-parser -v=7 -debug=tokenize.c,print_sentence_word_alternatives`
 
 5) Debug post-processing:
 
-`lg -v=9 -debug=post-process.c`
+`link-parser -v=9 -debug=post-process.c`
 
 6) Debug expression pruning:
 
-`lg -v=9 -debug=expression_prune`
+`link-parser -v=9 -debug=expression_prune`
 
 7) Debug reading the affix and knowledge files:
 
-`lg -v=11`
+`link-parser -v=11`
+
+8) Print all the connectors, along with their length limit.
+
+`link-parser -v=102`
+
+A length limit of 0 means the value of the short\_length option
+is used.
 
 ### -test=...
 
 1) Automatically show all linkages:
 
-`lg -test=auto-next-linkage`
+`link-parser -test=auto-next-linkage`
 Try to type some sentences at the **linkparser>** prompt to see its action.
 
 2) Print more that 1024 linkages in `link-parser` (this is the maximum
 `link-parser` would print by default), e.g. 20000:
 
-`lg -test=auto-next-linkage:20000`
+`link-parser -test=auto-next-linkage:20000`
 
 3) To print detailed linkages of **data/en/corpus-basic.batch**:
 
-`sed '/^*/d;/^!const/d;/^!batch/d' data/en/corpus-basic.batch | lg -test=auto-next-linkage`
+```
+sed '/^*/d;/^!const/d;/^!batch/d' data/en/corpus-basic.batch | \
+link-parser -test=auto-next-linkage
+```
 
 (If you cut&paste it to a terminal, remember to escape each of the "**!**" characters
 with a backslash.)
@@ -143,17 +156,17 @@ Note that this technique is not very effective if the order to the
 linkages got changed (or if SAT-parser linkages need to be compared to the
 classic-parser linkages). In that case the detailed linkages results need
 to be filtered through a script which sorts them according to some
-"canonical order".
+"canonical order" and also removes duplicates.
 
 4) Display the wordgraph:
 Currently, to use this feature, the library needs to be compiled with
 `--enable-wordgraph-display`.
 
-`lg -test=wg`
+`link-parser -test=wg`
 
 or
 
-`lg -test=wg:OPTIONS`
+`link-parser -test=wg:OPTIONS`
 
 For more examples of how to use the wordgraph display, see
 `link-grammar/README` and `msvc14/README`.
@@ -182,17 +195,20 @@ Use:
 
 `configure --enable-debug --enable-wordgraph-display`
 
+For SAT solver debug:
+`make -DSAT\_DEBUG`
+
 ### --enable-debug
-Its sets the `-g` compiler option, and also the DEBUG definition.
-The DEBUG definition adds various validity checks, test messages, and
-some debug functions (that can be invoked, for example, from the
-debugger).
+Its sets te DEBUG definitions and removes the optimization flags of the
+compiler. The DEBUG definition adds various validity checks, test
+messages, and some debug functions (that can be invoked, for example, from
+the debugger).
 
 ### --enable-wordgraph-display
 If something goes wrong, it is often useful to display the wordgraph.
 The wordgraph display function can be invoked from `gdb` using:
 
-`call wordgraph_show(sent, "")`
+`call wordgraph\_show(sent, "")`
 
 supposing that "sent" is available (the stack can be rolled down for
 that using the "down" or "frame" `gdb` commands).

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -150,6 +150,7 @@ struct Sentence_s
 #ifdef USE_SAT_SOLVER
 	void *hook;                 /* Hook for the SAT solver */
 #endif /* USE_SAT_SOLVER */
+	void *disjuncts_connectors_memblock;
 };
 
 #endif

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -366,7 +366,7 @@ int parse_options_get_spell_guess(Parse_Options opts) {
 }
 
 void parse_options_set_short_length(Parse_Options opts, int short_length) {
-	opts->short_length = short_length;
+	opts->short_length = MIN(short_length, UNLIMITED_LEN);
 }
 
 int parse_options_get_short_length(Parse_Options opts) {

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -657,7 +657,7 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 	/* Expressions were set up during the tokenize stage.
 	 * Prune them, and then parse.
 	 */
-	expression_prune(sent);
+	expression_prune(sent, opts);
 	print_time(opts, "Finished expression pruning");
 	if (opts->use_sat_solver)
 	{

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -459,6 +459,7 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 	sent->dict = dict;
 	sent->string_set = string_set_create();
 	sent->rand_state = global_rand_state;
+	sent->disjuncts_connectors_memblock = NULL;
 
 	sent->postprocessor = post_process_new(dict->base_knowledge);
 
@@ -521,9 +522,13 @@ static void free_sentence_words(Sentence sent)
 	for (i = 0; i < sent->length; i++)
 	{
 		free_X_nodes(sent->word[i].x);
-		free_disjuncts(sent->word[i].d);
+
+		if (NULL == sent->disjuncts_connectors_memblock)
+			free_disjuncts(sent->word[i].d);
+
 		free(sent->word[i].alternatives);
 	}
+	free(sent->disjuncts_connectors_memblock);
 	free((void *) sent->word);
 	sent->word = NULL;
 }
@@ -605,11 +610,16 @@ int sentence_link_cost(Sentence sent, LinkageIdx i)
 static void free_sentence_disjuncts(Sentence sent)
 {
 	size_t i;
-
-	for (i = 0; i < sent->length; ++i)
+	if (NULL != sent->disjuncts_connectors_memblock)
 	{
-		free_disjuncts(sent->word[i].d);
-		sent->word[i].d = NULL;
+		free(sent->disjuncts_connectors_memblock);
+	}
+	else
+	{
+		for (i = 0; i < sent->length; ++i)
+		{
+			free_disjuncts(sent->word[i].d);
+		}
 	}
 }
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -62,7 +62,6 @@ Connector * connector_new(const condesc_t *desc, Parse_Options opts)
 	c->desc = desc;
 	c->nearest_word = 0;
 	c->multi = false;
-	c->tableNext = NULL;
 	set_connector_length_limit(c, opts);
 	//assert(0 != c->length_limit, "Connector_new(): Zero length_limit");
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -17,7 +17,9 @@
 #include <math.h>
 
 #include "dict-common/dict-utils.h" // for size_of_expression()
+#include "api-structures.h"         // for Parse_Options_s
 #include "connectors.h"
+#include "link-includes.h"          // for Parse_Options
 
 /**
  * free_connectors() -- free the list of connectors pointed to by e
@@ -33,115 +35,139 @@ void free_connectors(Connector *e)
 	}
 }
 
-Connector * connector_new(void)
+static void
+set_connector_length_limit(Connector *c, Parse_Options opts)
+{
+	if (NULL == opts)
+	{
+		c->length_limit = UNLIMITED_LEN;
+		return;
+	}
+
+	int short_len = opts->short_length;
+	bool all_short = opts->all_short;
+	int length_limit = c->desc->length_limit;
+	if (short_len > UNLIMITED_LEN) short_len = UNLIMITED_LEN;
+
+	if ((all_short && (length_limit > short_len)) || (0 == length_limit))
+		c->length_limit = short_len;
+	else
+		c->length_limit = length_limit;
+}
+
+Connector * connector_new(const condesc_t *desc, Parse_Options opts)
 {
 	Connector *c = (Connector *) xalloc(sizeof(Connector));
-	init_connector(c);
+
+	c->desc = desc;
 	c->nearest_word = 0;
 	c->multi = false;
-	c->lc_start = 0;
-	c->uc_length = 0;
-	c->uc_start = 0;
-	c->next = NULL;
-	c->string = "";
 	c->tableNext = NULL;
+	set_connector_length_limit(c, opts);
+	//assert(0 != c->length_limit, "Connector_new(): Zero length_limit");
+
 	return c;
 }
 
 /* ======================================================== */
-/* Connector-set utilities ... */
-/**
- * This hash function only looks at the leading upper case letters of
- * the string, and the direction, '+' or '-'.
- */
-static unsigned int connector_set_hash(Connector_set *conset, const char * s, int d)
-{
-	unsigned int i;
-	if (islower((int)*s)) s++; /* skip head-dependent indicator */
+/* UNLIMITED-CONNECTORS handling. */
 
-	/* djb2 hash */
-	i = 5381;
-	i = ((i << 5) + i) + d;
-	while (isupper((int) *s)) /* connector tables cannot contain UTF8, yet */
-	{
-		i = ((i << 5) + i) + *s;
-		s++;
-	}
-	return (i & (conset->table_size-1));
-}
-
-static void build_connector_set_from_expression(Connector_set * conset, Exp * e)
+static void get_connectors_from_expression(condesc_t **conlist, size_t *cl_size,
+                                           Exp *e)
 {
 	E_list * l;
-	Connector * c;
-	unsigned int h;
+
 	if (e->type == CONNECTOR_type)
 	{
-		c = connector_new();
-		c->string = e->u.string;
-		h = connector_set_hash(conset, c->string, e->dir);
-		c->next = conset->hash_table[h];
-		conset->hash_table[h] = c;
+		if (NULL != conlist)
+		{
+			conlist[*cl_size] = e->u.condesc;
+		}
+		(*cl_size)++;
 	} else {
 		for (l=e->u.l; l!=NULL; l=l->next) {
-			build_connector_set_from_expression(conset, l->e);
+			get_connectors_from_expression(conlist, cl_size, l->e);
 		}
 	}
 }
 
-Connector_set * connector_set_create(Exp *e)
+static int condesc_by_uc_num(const void *a, const void *b)
 {
-	unsigned int i;
-	Connector_set *conset;
+	const condesc_t * const * cda = a;
+	const condesc_t * const * cdb = b;
 
-	conset = (Connector_set *) xalloc(sizeof(Connector_set));
-	conset->table_size = next_power_of_two_up(size_of_expression(e));
-	conset->hash_table =
-	  (Connector **) xalloc(conset->table_size * sizeof(Connector *));
-	for (i=0; i<conset->table_size; i++) conset->hash_table[i] = NULL;
-	build_connector_set_from_expression(conset, e);
-	return conset;
+	if ((*cda)->uc_num < (*cdb)->uc_num) return -1;
+	if ((*cda)->uc_num > (*cdb)->uc_num) return 1;
+
+	return 0;
 }
 
-void connector_set_delete(Connector_set * conset)
+void set_condesc_unlimited_length(Dictionary dict, Exp *e)
 {
-	unsigned int i;
-	if (conset == NULL) return;
-	for (i=0; i<conset->table_size; i++) free_connectors(conset->hash_table[i]);
-	xfree(conset->hash_table, conset->table_size * sizeof(Connector *));
-	xfree(conset, sizeof(Connector_set));
-}
+	size_t exp_num_con;
+	ConTable *ct = &dict->contable;
+	condesc_t **sdesc = ct->sdesc;
+	condesc_t **econlist = NULL;
 
-/**
- * Returns TRUE the given connector is in this conset.  FALSE otherwise.
- * d='+' means this connector is on the right side of the disjunct.
- * d='-' means this connector is on the left side of the disjunct.
- */
-
-bool match_in_connector_set(Connector_set *conset, Connector * c)
-{
-	unsigned int h;
-	Connector * c1;
-	if (conset == NULL) return false;
-	h = connector_set_hash(conset, c->string, '+');
-	for (c1 = conset->hash_table[h]; c1 != NULL; c1 = c1->next)
+	if (e)
 	{
-		if (easy_match(c1->string, c->string)) return true;
+		/* Create a connector list from the given expression. */
+		get_connectors_from_expression(NULL, (exp_num_con = 0, &exp_num_con), e);
+		econlist = alloca(exp_num_con * sizeof(*econlist));
+		get_connectors_from_expression(econlist, (exp_num_con = 0, &exp_num_con), e);
 	}
-	return false;
+
+	if ((NULL == econlist) || (NULL == econlist[0]))
+	{
+		/* No connectors are marked as UNLIMITED-CONNECTORS.
+		 * All the connectors are set as unlimited. */
+		for (size_t en = 0; en < ct->num_con; en++)
+			sdesc[en]->length_limit = UNLIMITED_LEN;
+
+		return;
+	}
+
+	qsort(econlist, exp_num_con, sizeof(*econlist), condesc_by_uc_num);
+
+	/* Scan the expression connector list and set UNLIMITED_LEN.
+	 * restart_cn is needed because several connectors in this list
+	 * may match a given UC sequence. */
+	size_t restart_cn = 0, cn = 0, en;
+	for (en = 0; en < exp_num_con; en++)
+	{
+		for (cn = restart_cn; cn < ct->num_con; cn++)
+			if (sdesc[cn]->uc_num >= econlist[en]->uc_num) break;
+
+		for (; en < exp_num_con; en++)
+			if (econlist[en]->uc_num >= sdesc[cn]->uc_num) break;
+
+		if (econlist[en]->uc_num != sdesc[cn]->uc_num) continue;
+		restart_cn = cn+1;
+
+		for (; cn < ct->num_con; cn++)
+		{
+			if (econlist[en]->uc_num != sdesc[cn]->uc_num) break;
+
+			if (easy_match(econlist[en]->string, sdesc[cn]->string))
+				sdesc[cn]->length_limit = UNLIMITED_LEN;
+		}
+	}
 }
 
 /* ======================================================== */
 
 /**
- * This hash function only looks at the leading upper case letters of
- * the connector string, and the label fields.  This ensures that if two
- * strings match (formally), then they must hash to the same place.
+ * Calculate fixed connector information that only depend on its string.
+ * This information is used to speed up the parsing stage.
+ * It is calculated during the directory creation and doesn't get
+ * changed afterward.
  */
-int calculate_connector_hash(Connector * c)
+void calculate_connector_info(condesc_t * c)
 {
 	const char *s;
 	unsigned int i;
+
+	c->str_hash = connector_str_hash(c->string);
 
 	/* For most situations, all three hashes are very nearly equal;
 	 * as to which is faster depends on the parsed text.
@@ -197,8 +223,134 @@ int calculate_connector_hash(Connector * c)
 
 	c->lc_start = ('\0' == *s) ? 0 : s - c->string;
 	c->uc_length = s - c->string - c->uc_start;
-	c->hash = i;
-	return i;
+	c->uc_hash = i;
+}
+
+/* ================= Connector descriptor table. ====================== */
+
+/**
+ * Compare connector UC parts, for qsort.
+ */
+static int condesc_by_uc_constring(const void * a, const void * b)
+{
+	const condesc_t * const * cda = a;
+	const condesc_t * const * cdb = b;
+
+	/* Move the empty slots to the end. */
+	if (NULL == *cda) return (NULL != *cdb);
+	if (NULL == *cdb) return -1;
+
+	const char *sa = &(*cda)->string[(*cda)->uc_start];
+	const char *sb = &(*cdb)->string[(*cdb)->uc_start];
+
+	int la = (*cda)->uc_length;
+	int lb = (*cdb)->uc_length;
+
+	if (la == lb)
+	{
+		//printf("la==lb A=%s b=%s, la=%d lb=%d len=%d\n",sa,sb,la,lb,la);
+		return strncmp(sa, sb, la);
+	}
+
+	if (la < lb)
+	{
+		char *uca = strdupa(sa);
+		uca[la] = '\0';
+		//printf("la<lb A=%s b=%s, la=%d lb=%d len=%d\n",uca,sb,la,lb,lb);
+		return strncmp(uca, sb, lb);
+	}
+	else
+	{
+		char *ucb = strdupa(sb);
+		ucb[lb] = '\0';
+		//printf("la>lb A=%s b=%s, la=%d lb=%d len=%d\n",sa,ucb,la,lb,la);
+		return strncmp(sa, ucb, la);
+	}
+}
+
+/**
+ * Enumerate the connectors by their UC parts - equal parts get the same number.
+ * It replaces the existing connector UC-part hash, and can later serve
+ * as table index as if it was a perfect hash.
+ */
+void sort_condesc_by_uc_constring(Dictionary dict)
+{
+	condesc_t **sdesc = malloc(dict->contable.size * sizeof(*dict->contable.hdesc));
+	memcpy(sdesc, dict->contable.hdesc, dict->contable.size * sizeof(*dict->contable.hdesc));
+	qsort(sdesc, dict->contable.size, sizeof(*dict->contable.hdesc),
+	      condesc_by_uc_constring);
+
+	/* Find the number of connectors. */
+	size_t n;
+	for (n = 0; n < dict->contable.size; n++)
+		if (NULL == sdesc[n]) break;
+	dict->contable.num_con = n;
+
+	if (0 == n)
+	{
+		prt_error("Error: Dictionary %s: No connectors found.\n", dict->name);
+		/* FIXME: Generate a dictionary open error. */
+		return;
+	}
+
+	/* Enumerate the connectors according to their UC part. */
+	int uc_num = 0;
+	uint32_t uc_hash = sdesc[0]->uc_hash; /* Will be recomputed */
+
+	sdesc[0]->uc_num = uc_num;
+	for (n = 1; n < dict->contable.num_con; n++)
+	{
+		condesc_t **condesc = &sdesc[n];
+
+//#define DEBUG_UC_HASH_CHANGE
+#ifndef DEBUG_UC_HASH_CHANGE /* Use a shortcut - not needed for correctness. */
+		if ((condesc[0]->uc_hash != uc_hash) ||
+		   (condesc[0]->uc_length != condesc[-1]->uc_length))
+
+		{
+			/* We know that the UC part has been changed. */
+			uc_num++;
+		}
+		else
+#endif
+		{
+			const char *uc1 = &condesc[0]->string[condesc[0]->uc_start];
+			const char *uc2 = &condesc[-1]->string[condesc[-1]->uc_start];
+			if (0 != strncmp(uc1, uc2, condesc[0]->uc_length))
+			{
+				uc_num++;
+			}
+		}
+
+		uc_hash = condesc[0]->uc_hash;
+		//printf("%5d constring=%s\n", uc_num, condesc[0]->string);
+		condesc[0]->uc_hash = uc_num;
+	}
+
+	if (verbosity_level(D_SPEC+1))
+	{
+		for (n = 0; n < dict->contable.num_con; n++)
+		{
+			printf("%5zu %5d constring=%s\n",
+			       n, sdesc[n]->uc_num, sdesc[n]->string);
+		}
+	}
+
+	lgdebug(+11, "Dictionary %s: %zu different connectors "
+	        "(%d with a different UC part)\n",
+	        dict->name, dict->contable.num_con, uc_num+1);
+
+	dict->contable.sdesc = sdesc;
+	dict->contable.num_uc = uc_num + 1;
+}
+
+void condesc_delete(Dictionary dict)
+{
+	for (size_t i = 0; i < dict->contable.size; i++)
+		free(dict->contable.hdesc[i]);
+
+	free(dict->contable.hdesc);
+	free(dict->contable.sdesc);
 }
 
 /* ========================= END OF FILE ============================== */

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -47,7 +47,6 @@ set_connector_length_limit(Connector *c, Parse_Options opts)
 	int short_len = opts->short_length;
 	bool all_short = opts->all_short;
 	int length_limit = c->desc->length_limit;
-	if (short_len > UNLIMITED_LEN) short_len = UNLIMITED_LEN;
 
 	if ((all_short && (length_limit > short_len)) || (0 == length_limit))
 		c->length_limit = short_len;

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -146,16 +146,17 @@ static void set_condesc_length_limit(Dictionary dict, const Exp *e, int length_l
 				if (econlist[en]->uc_num != sdesc[cn]->uc_num)
 					break;
 				/* The uppercase parts are equal - match only the lowercase ones. */
-				if (lc_easy_match(econlist[en], sdesc[cn]))
-					sdesc[cn]->length_limit = length_limit;
+				if (!lc_easy_match(econlist[en], sdesc[cn]))
+					continue;
 			}
 			else
 			{
 				/* The uppercase part is a prefix. */
 				if (0 != strncmp(wc_str, sdesc[cn]->string, uc_wildcard - wc_str))
 					break;
-				sdesc[cn]->length_limit = length_limit;
 			}
+
+			sdesc[cn]->length_limit = length_limit;
 		}
 	}
 }

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -147,7 +147,8 @@ void set_condesc_unlimited_length(Dictionary dict, Exp *e)
 		{
 			if (econlist[en]->uc_num != sdesc[cn]->uc_num) break;
 
-			if (easy_match(econlist[en]->string, sdesc[cn]->string))
+			/* The uppercase parts are equal - match only the lowercase ones. */
+			if (lc_easy_match(econlist[en], sdesc[cn]))
 				sdesc[cn]->length_limit = UNLIMITED_LEN;
 		}
 	}

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -35,7 +35,7 @@ void free_connectors(Connector *e)
 	}
 }
 
-static void
+void
 set_connector_length_limit(Connector *c, Parse_Options opts)
 {
 	if (NULL == opts)

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -175,6 +175,17 @@ void set_all_condesc_length_limit(Dictionary dict)
 		l_next = l->next;
 		free(l);
 	}
+
+	if (verbosity_level(D_SPEC+1))
+	{
+		printf("%5s %-6s %3s\n", "num", "uc_num", "ll");
+		for (size_t n = 0; n < ct->num_con; n++)
+		{
+			printf("%5zu %6d %3d %s\n", n, ct->sdesc[n]->uc_num,
+			       ct->sdesc[n]->length_limit, ct->sdesc[n]->string);
+		}
+	}
+
 }
 
 /* ======================================================== */
@@ -374,15 +385,6 @@ void sort_condesc_by_uc_constring(Dictionary dict)
 		uc_hash = condesc[0]->uc_hash;
 		//printf("%5d constring=%s\n", uc_num, condesc[0]->string);
 		condesc[0]->uc_hash = uc_num;
-	}
-
-	if (verbosity_level(D_SPEC+1))
-	{
-		for (n = 0; n < dict->contable.num_con; n++)
-		{
-			printf("%5zu %5d constring=%s\n",
-			       n, sdesc[n]->uc_num, sdesc[n]->string);
-		}
 	}
 
 	lgdebug(+11, "Dictionary %s: %zu different connectors "

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -114,6 +114,11 @@ static inline int connector_uc_hash(const Connector * c)
 	return c->desc->uc_hash;
 }
 
+static inline int connector_uc_num(const Connector * c)
+{
+	return c->desc->uc_num;
+}
+
 
 /* Connector utilities ... */
 Connector * connector_new(const condesc_t *, Parse_Options);

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -38,17 +38,19 @@
 #define LC_MASK ((1<<LC_BITS)-1)
 typedef uint64_t lc_enc_t;
 
+typedef uint16_t connector_hash_size; /* Change to uint32_t if needed. */
+
 typedef struct ConDesc
 {
 	lc_enc_t lc_letters;
 	lc_enc_t lc_mask;
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
-	uint16_t str_hash;
+	connector_hash_size str_hash;
 	union
 	{
-		uint16_t uc_hash;
-		uint16_t uc_num;
+		connector_hash_size uc_hash;
+		connector_hash_size uc_num;
 	};
 	uint8_t length_limit;
 	                      /* If not 0, it gives the limit of the length of the

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -145,7 +145,7 @@ void free_connectors(Connector *);
 /* Length-limits for how far connectors can reach out. */
 #define UNLIMITED_LEN 255
 
-void set_condesc_unlimited_length(Dictionary, Exp *);
+void set_all_condesc_length_limit(Dictionary);
 
 /**
  * Returns TRUE if s and t match according to the connector matching

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -127,23 +127,6 @@ void free_connectors(Connector *);
 /* Length-limits for how far connectors can reach out. */
 #define UNLIMITED_LEN 255
 
-#if 0
-static inline Connector * init_connector(Connector *c)
-{
-	c->uc_hash = -1;
-	c->str_hash = -1;
-	c->length_limit = UNLIMITED_LEN;
-	return c;
-}
-#endif
-
-#if 0
-/* Connector-set utilities ... */
-void connector_set_create(Dictionary, Exp *e);
-#endif
-void connector_set_delete(Connector_set * conset);
-bool match_in_connector_set(Connector_set*, Connector*);
-
 void set_condesc_unlimited_length(Dictionary, Exp *);
 
 /**

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -83,10 +83,37 @@ struct Connector_struct
 void sort_condesc_by_uc_constring(Dictionary);
 void condesc_delete(Dictionary);
 
-static inline const char * connector_get_string(Connector *c)
+/* GET accessors for connector attributes.
+ * Can be used for experimenting with Connector_struct internals in
+ * non-trivial ways without the need to change most of the code that
+ * accesses connectors.
+ * FIXME: Maybe remove the _get part of the names, since we don't
+ * need SET accessors. */
+static inline const char * connector_get_string(const Connector *c)
 {
 	return c->desc->string;
 }
+
+static inline int connector_get_lc_start(const Connector *c)
+{
+	return c->desc->lc_start;
+}
+
+static inline int connector_get_uc_start(const Connector *c)
+{
+	return c->desc->uc_start;
+}
+
+static inline const condesc_t *connector_get_desc(const Connector *c)
+{
+	return c->desc;
+}
+
+static inline int connector_uc_hash(const Connector * c)
+{
+	return c->desc->uc_hash;
+}
+
 
 /* Connector utilities ... */
 Connector * connector_new(const condesc_t *, Parse_Options);
@@ -222,11 +249,6 @@ static inline int string_hash(const char *s)
 }
 
 void calculate_connector_info(condesc_t *);
-
-static inline int connector_uc_hash(Connector * c)
-{
-	return c->desc->uc_hash;
-}
 
 static inline uint32_t connector_str_hash(const char *s)
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -40,7 +40,7 @@ typedef uint64_t lc_enc_t;
 
 typedef uint16_t connector_hash_size; /* Change to uint32_t if needed. */
 
-typedef struct ConDesc
+typedef struct
 {
 	lc_enc_t lc_letters;
 	lc_enc_t lc_mask;
@@ -66,7 +66,7 @@ typedef struct ConDesc
 	uint8_t uc_start;    /* uc start position */
 } condesc_t;
 
-typedef struct ConTable
+typedef struct
 {
 	condesc_t **hdesc;    /* Hashed connector descriptors table */
 	condesc_t **sdesc;    /* Alphabetically sorted descriptors */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -99,17 +99,17 @@ void condesc_delete(Dictionary);
  * accesses connectors.
  * FIXME: Maybe remove the _get part of the names, since we don't
  * need SET accessors. */
-static inline const char * connector_get_string(const Connector *c)
+static inline const char * connector_string(const Connector *c)
 {
 	return c->desc->string;
 }
 
-static inline int connector_get_uc_start(const Connector *c)
+static inline int connector_uc_start(const Connector *c)
 {
 	return c->desc->uc_start;
 }
 
-static inline const condesc_t *connector_get_desc(const Connector *c)
+static inline const condesc_t *connector_desc(const Connector *c)
 {
 	return c->desc;
 }
@@ -127,6 +127,7 @@ static inline int connector_uc_num(const Connector * c)
 
 /* Connector utilities ... */
 Connector * connector_new(const condesc_t *, Parse_Options);
+void set_connector_length_limit(Connector *, Parse_Options);
 void free_connectors(Connector *);
 
 /* Length-limits for how far connectors can reach out. */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -33,11 +33,11 @@
 typedef struct ConDesc
 {
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
-	uint32_t str_hash;
+	uint16_t str_hash;
 	union
 	{
-		uint32_t uc_hash;
-		uint32_t uc_num;
+		uint16_t uc_hash;
+		uint16_t uc_num;
 	};
 	uint8_t length_limit;
 	                      /* If not 0, it gives the limit of the length of the
@@ -52,7 +52,7 @@ typedef struct ConDesc
 	uint8_t uc_length;   /* uc part length */
 	uint8_t uc_start;    /* uc start position */
 
-	Connector *next;
+	struct ConDesc * PtableNext; /* For expression prune hash table */
 } condesc_t;
 
 typedef struct ConTable
@@ -77,13 +77,7 @@ struct Connector_struct
 	bool multi;           /* TRUE if this is a multi-connector */
 	const condesc_t *desc;
 	Connector *next;
-
-	/* Hash table next pointer, used only during pruning. */
-	union
-	{
-		Connector * tableNext;
-		const gword_set *originating_gword;
-	};
+	const gword_set *originating_gword;
 };
 
 void sort_condesc_by_uc_constring(Dictionary);

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -32,7 +32,8 @@
 
 /* For faster comparisons, the connector lc part is encoded into a number
  * and a mask. Each letter is encoded using LC_BITS bits. With 7 bits, it
- * is possible to encode up to 9 letters in an uint64_t. */
+ * is possible to encode up to 9 letters in an uint64_t.
+ * FIXME: Validate that lc length <= 9. */
 #define LC_BITS 7
 #define LC_MASK ((1<<LC_BITS)-1)
 typedef uint64_t lc_enc_t;

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -64,8 +64,6 @@ typedef struct ConDesc
 	/* The following are used for connector match speedup */
 	uint8_t uc_length;   /* uc part length */
 	uint8_t uc_start;    /* uc start position */
-
-	struct ConDesc * PtableNext; /* For expression prune hash table */
 } condesc_t;
 
 typedef struct ConTable

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -166,6 +166,52 @@ static inline bool easy_match(const char * s, const char * t)
 	return true;
 }
 
+/**
+ * Compare the lower-case and head/dependent parts of two connector descriptors.
+ * When this function is called, it is assumed that the upper-case
+ * parts are equal, and thus do not need to be checked again.
+ * FIXME: Use lc string descriptors.
+ */
+static bool lc_easy_match(const condesc_t *c1, const condesc_t *c2)
+{
+
+	/* If the connectors are identical, they match. */
+	if (c1 == c2) return true;
+
+	/* If both of the connectors have a lc part, we need to compare them. */
+	if ((0 != c2->lc_start) && (0 != c1->lc_start))
+	{
+
+		/* Compare the lc parts according to the connector matching rules. */
+		const char *a = &c1->string[c1->lc_start];
+		const char *b = &c2->string[c2->lc_start];
+		do
+		{
+			if (*a != *b && (*a != '*') && (*b != '*')) return false;
+			a++;
+			b++;
+		} while (*a != '\0' && *b != '\0');
+	}
+
+	/* Compare the head/dependent parts. */
+	if ((1 == c1->uc_start) && (1 == c2->uc_start) &&
+	    (c1->string[0] == c2->string[0]))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * This function is like easy_match(), but with connector descriptors.
+ * It uses a shortcut comparison of the upper-case parts.
+ */
+static inline bool easy_match_desc(const condesc_t *c1, const condesc_t *c2)
+{
+	if (c1->uc_num != c2->uc_num) return false;
+	return lc_easy_match(c1, c2);
+}
 
 static inline int string_hash(const char *s)
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -46,6 +46,7 @@ typedef struct
 	lc_enc_t lc_mask;
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
+	// double *cost; /* Array of cost by length_limit (cost[0]: default) */
 	connector_hash_size str_hash;
 	union
 	{
@@ -66,6 +67,14 @@ typedef struct
 	uint8_t uc_start;    /* uc start position */
 } condesc_t;
 
+typedef struct length_limit_def
+{
+	const char *defword;
+	const Exp *defexp;
+	struct length_limit_def *next;
+	int length_limit;
+} length_limit_def_t;
+
 typedef struct
 {
 	condesc_t **hdesc;    /* Hashed connector descriptors table */
@@ -73,6 +82,8 @@ typedef struct
 	size_t size;          /* Allocated size */
 	size_t num_con;       /* Number of connector types */
 	size_t num_uc;        /* Number of connector types with different UC part */
+	length_limit_def_t *length_limit_def;
+	length_limit_def_t **length_limit_def_next;
 } ConTable;
 
 /* On a 64-bit machine, this struct should be exactly 4*8=32 bytes long.

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -319,7 +319,7 @@ void dictionary_delete(Dictionary dict)
 		freelocale(dict->lctype);
 	}
 
-	connector_set_delete(dict->unlimited_connector_set);
+	condesc_delete(dict);
 
 	if (dict->close) dict->close(dict);
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -15,6 +15,7 @@
 #define  _LG_DICT_COMMON_H_
 
 #include "api-types.h" // for pp_knowledge
+#include "connectors.h" // for condest_t
 #include "dict-structures.h"
 #include "utilities.h" // for locale_t
 
@@ -110,6 +111,7 @@ struct Dictionary_s
 	Connector_set * unlimited_connector_set; /* NULL=everything is unlimited */
 	String_set *    string_set;        /* Set of link names in the dictionary */
 	Word_file *     word_file_header;
+	ConTable        contable;
 
 	/* exp_list links together all the Exp structs that are allocated
 	 * in reading this dictionary.  Needed for freeing the dictionary

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -21,6 +21,7 @@
 
 #define EMPTY_CONNECTOR "ZZZ"
 #define UNLIMITED_CONNECTORS_WORD ("UNLIMITED-CONNECTORS")
+#define LIMITED_CONNECTORS_WORD ("LENGTH-LIMIT-")
 
 /* Forward decls */
 typedef struct Afdict_class_struct Afdict_class;

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -17,7 +17,6 @@
 #include "connectors.h"
 #include "dict-affix.h"
 #include "dict-api.h"
-#include "dict-common.h"
 #include "dict-defines.h"
 #include "dict-impl.h"
 #include "regex-morph.h"
@@ -337,8 +336,6 @@ void dictionary_setup_locale(Dictionary dict)
 
 void dictionary_setup_defines(Dictionary dict)
 {
-	Dict_node *dict_node;
-
 	dict->left_wall_defined  = boolean_dictionary_lookup(dict, LEFT_WALL_WORD);
 	dict->right_wall_defined = boolean_dictionary_lookup(dict, RIGHT_WALL_WORD);
 
@@ -347,16 +344,7 @@ void dictionary_setup_defines(Dictionary dict)
 
 	dict->shuffle_linkages = false;
 
-	dict_node = dictionary_lookup_list(dict, UNLIMITED_CONNECTORS_WORD);
-	if (dict_node == NULL)
-	{
-		set_condesc_unlimited_length(dict, NULL);
-	}
-	else
-	{
-		set_condesc_unlimited_length(dict, dict_node->exp);
-		dict->free_lookup(dict, dict_node);
-	}
+	set_all_condesc_length_limit(dict);
 }
 
 /* ======================================================================= */

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -185,7 +185,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 		goto locale_error;
 	}
 
-	if (0 == strcmp(dn->exp->u.string, "C"))
+	if (0 == strcmp(dn->exp->u.condesc->string, "C"))
 	{
 		locale = string_set_add("C", dict->string_set);
 	}
@@ -193,7 +193,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 	{
 		char c;
 		char locale_ll[4], locale_cc[3];
-		int locale_numelement = sscanf(dn->exp->u.string, "%3[A-Z]4%2[a-z]%c",
+		int locale_numelement = sscanf(dn->exp->u.condesc->string, "%3[A-Z]4%2[a-z]%c",
 										locale_ll, locale_cc, &c);
 		if (2 != locale_numelement)
 		{
@@ -201,7 +201,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 			          "should be in the form LL4cc+\n"
 						 "\t(LL: language code; cc: territory code) "
 						 "\tor C+ for transliterated dictionaries.\n",
-						 dn->exp->u.string);
+						 dn->exp->u.condesc->string);
 			goto locale_error;
 		}
 
@@ -267,7 +267,7 @@ const char * linkgrammar_get_dict_version(Dictionary dict)
 	if (NULL == dn) return "[unknown]";
 
 	e = dn->exp;
-	ver = strdup(&e->u.string[1]);
+	ver = strdup(&e->u.condesc->string[1]);
 	p = strchr(ver, 'v');
 	while (p)
 	{
@@ -348,10 +348,15 @@ void dictionary_setup_defines(Dictionary dict)
 	dict->shuffle_linkages = false;
 
 	dict_node = dictionary_lookup_list(dict, UNLIMITED_CONNECTORS_WORD);
-	if (dict_node != NULL)
-		dict->unlimited_connector_set = connector_set_create(dict_node->exp);
-
-	dict->free_lookup(dict, dict_node);
+	if (dict_node == NULL)
+	{
+		set_condesc_unlimited_length(dict, NULL);
+	}
+	else
+	{
+		set_condesc_unlimited_length(dict, dict_node->exp);
+		dict->free_lookup(dict, dict_node);
+	}
 }
 
 /* ======================================================================= */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -15,6 +15,7 @@
 #define _LG_DICT_STRUCTURES_H_
 
 #include <link-grammar/link-features.h>
+#include "connectors.h"
 #include "link-includes.h"
 
 LINK_BEGIN_DECLS
@@ -50,7 +51,7 @@ struct Exp_struct
 	bool multi;    /* TRUE if a multi-connector (for connector)  */
 	union {
 		E_list * l;           /* Only needed for non-terminals */
-		const char * string;  /* Only needed if it's a connector */
+		condesc_t * condesc;  /* Only needed if it's a connector */
 	} u;
 	double cost;   /* The cost of using this expression.
 	                  Only used for non-terminals */

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -102,8 +102,8 @@ static bool exp_compare(Exp * e1, Exp * e2)
 	{
 		if (e1->dir != e2->dir)
 			return 0;
-		/* printf("%s %s\n",e1->u.string,e2->u.string); */
-		if (!string_set_cmp(e1->u.string, e2->u.string))
+		/* printf("%s %s\n",e1->u.condesc->string,e2->u.condesc->string); */
+		if (e1->u.condesc != e2->u.condesc)
 			return 0;
 	}
 	else
@@ -234,8 +234,8 @@ static bool exp_has_connector(const Exp * e, int depth, const char * cs,
 	if (e->type == CONNECTOR_type)
 	{
 		if (direction != e->dir) return false;
-		return smart_match ? easy_match(e->u.string, cs)
-		                   : string_set_cmp(e->u.string, cs);
+		return smart_match ? easy_match(e->u.condesc->string, cs)
+		                   : string_set_cmp(e->u.condesc->string, cs);
 	}
 
 	if (depth == 0) return false;
@@ -278,7 +278,7 @@ const char * word_only_connector(Dict_node * dn)
 {
 	Exp * e = dn->exp;
 	if (CONNECTOR_type == e->type)
-		return e->u.string;
+		return e->u.condesc->string;
 	return NULL;
 }
 

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -255,7 +255,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 
 	/* ----- this code just sets up the node fields of the dn_list ----*/
 	nc = Exp_create(&dict->exp_list);
-	nc->u.string = generate_id_connector(dict);
+	nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '-';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;
@@ -279,7 +279,6 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 		/* generate the expression for a middle idiom word */
 
 		n1 = Exp_create(&dict->exp_list);
-		n1->u.string = NULL;
 		n1->type = AND_type;
 		n1->cost = 0;
 		n1->u.l = ell = (E_list *) malloc(sizeof(E_list));
@@ -287,7 +286,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 		elr->next = NULL;
 
 		nc = Exp_create(&dict->exp_list);
-		nc->u.string = generate_id_connector(dict);
+		nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '+';
 		nc->multi = false;
 		nc->type = CONNECTOR_type;
@@ -297,7 +296,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 		increment_current_name(dict);
 
 		nc = Exp_create(&dict->exp_list);
-		nc->u.string = generate_id_connector(dict);
+		nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '-';
 		nc->multi = false;
 		nc->type = CONNECTOR_type;
@@ -312,7 +311,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	/* now generate the last one */
 
 	nc = Exp_create(&dict->exp_list);
-	nc->u.string = generate_id_connector(dict);
+	nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '+';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -103,7 +103,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	{
 		for (i=0; i<icost; i++) dyn_strcat(e, "[");
 		if (n->multi) dyn_strcat(e, "@");
-		append_string(e, "%s%c", n->u.string, n->dir);
+		append_string(e, "%s%c", n->u.condesc?n->u.condesc->string:"(null)", n->dir);
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
 		if (0 != dcost) append_string(e, COST_FMT, dcost);
 		return e;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -148,7 +148,7 @@ dictionary_six_str(const char * lang,
 		dict->lookup_wild = file_lookup_wild;
 		dict->free_lookup = free_llist;
 		dict->lookup = file_boolean_lookup;
-		dict->contable.size = 1<<13;
+		dict->contable.num_con = 1<<13;
 	}
 	else
 	{
@@ -158,12 +158,11 @@ dictionary_six_str(const char * lang,
 		afclass_init(dict);
 		dict->insert_entry = load_affix;
 		dict->lookup = return_true;
-		dict->contable.size = 1<<7;
+		dict->contable.num_con = 1<<9;
 	}
 	dict->affix_table = NULL;
 
-	dict->contable.hdesc = malloc(dict->contable.size * sizeof(condesc_t *));
-	memset(dict->contable.hdesc, 0, dict->contable.size * sizeof(condesc_t *));
+	dict->contable.size = 0;
 	dict->contable.length_limit_def = NULL;
 	dict->contable.length_limit_def_next = &dict->contable.length_limit_def;
 

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -164,6 +164,8 @@ dictionary_six_str(const char * lang,
 
 	dict->contable.hdesc = malloc(dict->contable.size * sizeof(condesc_t *));
 	memset(dict->contable.hdesc, 0, dict->contable.size * sizeof(condesc_t *));
+	dict->contable.length_limit_def = NULL;
+	dict->contable.length_limit_def_next = &dict->contable.length_limit_def;
 
 	/* Read dictionary from the input string. */
 	dict->input = input;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -148,6 +148,7 @@ dictionary_six_str(const char * lang,
 		dict->lookup_wild = file_lookup_wild;
 		dict->free_lookup = free_llist;
 		dict->lookup = file_boolean_lookup;
+		dict->contable.size = 1<<13;
 	}
 	else
 	{
@@ -157,8 +158,12 @@ dictionary_six_str(const char * lang,
 		afclass_init(dict);
 		dict->insert_entry = load_affix;
 		dict->lookup = return_true;
+		dict->contable.size = 1<<7;
 	}
 	dict->affix_table = NULL;
+
+	dict->contable.hdesc = malloc(dict->contable.size * sizeof(condesc_t *));
+	memset(dict->contable.hdesc, 0, dict->contable.size * sizeof(condesc_t *));
 
 	/* Read dictionary from the input string. */
 	dict->input = input;
@@ -223,6 +228,10 @@ dictionary_six_str(const char * lang,
 
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	dict->hpsg_knowledge  = pp_knowledge_open(cons_name);
+
+	/* set_connector_unlimited_length() in dictionary_setup_defines()
+	 * depends on this sorting. */
+	sort_condesc_by_uc_constring(dict);
 
 	dictionary_setup_defines(dict);
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1495,6 +1495,56 @@ static bool is_warning_suppressed(Dictionary dict, const char *warning_symbol)
 }
 
 /**
+ * Remember the length_limit definitions in a list according to their order.
+ * The order is kept to allow later more specific definitions to override
+ * already applied ones.
+ */
+static void add_condesc_length_limit(Dictionary dict, Dict_node *dn,
+                                     int length_limit)
+{
+	length_limit_def_t *lld = malloc(sizeof(*lld));
+	lld->next = NULL;
+	lld->length_limit = length_limit;
+	lld->defexp = dn->exp;
+	lld->defword = dn->string;
+	*dict->contable.length_limit_def_next = lld;
+	dict->contable.length_limit_def_next = &lld->next;
+}
+
+static void insert_length_limit(Dictionary dict, Dict_node *dn)
+{
+	int length_limit;
+
+	if (0 == strcmp(UNLIMITED_CONNECTORS_WORD, dn->string))
+	{
+		length_limit = UNLIMITED_LEN;
+	}
+	else
+	if (0 == strncmp(LIMITED_CONNECTORS_WORD, dn->string,
+	                 sizeof(LIMITED_CONNECTORS_WORD)-1))
+	{
+		char *endp;
+		length_limit =
+			(int)strtol(dn->string + sizeof(LIMITED_CONNECTORS_WORD)-1, &endp, 10);
+		if ((length_limit < 0) || (length_limit > MAX_SENTENCE) ||
+		  (('\0' != *endp) && (SUBSCRIPT_MARK != *endp)))
+		{
+			prt_error("Warning: Word \"%s\" found near line %d of %s.\n"
+					  "\tThis word should end with a number (1-%d).\n"
+					  "\tThis word will be ignored.",
+					  dn->string, dict->line_number, dict->name, MAX_SENTENCE);
+			return;
+		}
+	}
+	else return;
+
+	/* We cannot set the connectors length_limit yet because the
+	 * needed data structure is not defined yet. For now, just
+	 * remember the definitions in their order. */
+	add_condesc_length_limit(dict, dn, length_limit);
+}
+
+/**
  * insert_list() -
  * p points to a list of dict_nodes connected by their left pointers.
  * l is the length of this list (the last ptr may not be NULL).
@@ -1544,6 +1594,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	else
 	{
 		dict->root = insert_dict(dict, dict->root, dn);
+		insert_length_limit(dict, dn);
 		dict->num_entries++;
 
 		if ((verbosity_level(D_DICT+0) && !is_warning_suppressed(dict, DUP_BASE)) ||

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -92,7 +92,8 @@ static Exp * make_expression(Dictionary dict, const char *exp_str)
 	/* We have to use the string set, mostly because copy_Exp
 	 * in build_disjuncts fails to copy the string ...
 	 */
-	e->u.string = string_set_add(constr, dict->string_set);
+	e->u.condesc = condesc_add(&dict->contable,
+	                           string_set_add(constr, dict->string_set));
 	free(constr);
 
 	rest = make_expression(dict, ++p);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -353,11 +353,11 @@ static void prt_con(Connector *c, dyn_str * p, char dir)
 
 	if (c->multi)
 	{
-		append_string(p, "@%s%c ", c->desc->string, dir);
+		append_string(p, "@%s%c ", connector_get_string(c), dir);
 	}
 	else
 	{
-		append_string(p, "%s%c ", c->desc->string, dir);
+		append_string(p, "%s%c ", connector_get_string(c), dir);
 	}
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -83,10 +83,10 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	unsigned int i;
 	i = 0;
 	for (e = d->left ; e != NULL; e = e->next) {
-		i += string_hash(e->string);
+		i += string_hash(e->desc->string);
 	}
 	for (e = d->right ; e != NULL; e = e->next) {
-		i += string_hash(e->string);
+		i += string_hash(e->desc->string);
 	}
 	i += string_hash(d->word_string);
 	i += (i>>10);
@@ -100,7 +100,7 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
  */
 static bool connectors_equal_prune(Connector *c1, Connector *c2)
 {
-	return string_set_cmp(c1->string, c2->string) && (c1->multi == c2->multi);
+	return c1->desc == c2->desc && (c1->multi == c2->multi);
 }
 
 /** returns TRUE if the disjuncts are exactly the same */
@@ -146,7 +146,7 @@ static Connector *connectors_dup(Connector *origc)
 
 	for (t = origc; t != NULL;  t = t->next)
 	{
-		newc = connector_new();
+		newc = connector_new(NULL, NULL);
 		*newc = *t;
 
 		prevc->next = newc;
@@ -353,11 +353,11 @@ static void prt_con(Connector *c, dyn_str * p, char dir)
 
 	if (c->multi)
 	{
-		append_string(p, "@%s%c ", c->string, dir);
+		append_string(p, "@%s%c ", c->desc->string, dir);
 	}
 	else
 	{
-		append_string(p, "%s%c ", c->string, dir);
+		append_string(p, "%s%c ", c->desc->string, dir);
 	}
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -405,11 +405,11 @@ static void prt_con(Connector *c, dyn_str * p, char dir)
 
 	if (c->multi)
 	{
-		append_string(p, "@%s%c ", connector_get_string(c), dir);
+		append_string(p, "@%s%c ", connector_string(c), dir);
 	}
 	else
 	{
-		append_string(p, "%s%c ", connector_get_string(c), dir);
+		append_string(p, "%s%c ", connector_string(c), dir);
 	}
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -184,6 +184,58 @@ Disjunct *disjuncts_dup(Disjunct *origd)
 	return head.next;
 }
 
+static Connector *pack_connectors_dup(Connector *origc, Connector **cblock)
+{
+	Connector head;
+	Connector *prevc = &head;
+	Connector *newc = &head;
+	Connector *t;
+	Connector *lcblock = *cblock; /* Optimization. */
+
+	for (t = origc; t != NULL;  t = t->next)
+	{
+		newc = lcblock++;
+		*newc = *t;
+
+		prevc->next = newc;
+		prevc = newc;
+	}
+	newc->next = NULL;
+
+	*cblock = lcblock;
+	return head.next;
+}
+
+/**
+ * Duplicate the given disjunct chain.
+ * If the argument is NULL, return NULL.
+ */
+Disjunct *pack_disjuncts_dup(Disjunct *origd, Disjunct **dblock, Connector **cblock)
+{
+	Disjunct head;
+	Disjunct *prevd = &head;
+	Disjunct *newd = &head;
+	Disjunct *t;
+	Disjunct *ldblock = *dblock; /* Optimization. */
+
+	for (t = origd; t != NULL; t = t->next)
+	{
+		newd = ldblock++;
+		newd->word_string = t->word_string;
+		newd->cost = t->cost;
+
+		newd->left = pack_connectors_dup(t->left, cblock);
+		newd->right = pack_connectors_dup(t->right, cblock);
+		newd->originating_gword = t->originating_gword;
+		prevd->next = newd;
+		prevd = newd;
+	}
+	newd->next = NULL;
+
+	*dblock = ldblock;
+	return head.next;
+}
+
 static disjunct_dup_table * disjunct_dup_table_new(size_t sz)
 {
 	size_t i;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -83,10 +83,10 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	unsigned int i;
 	i = 0;
 	for (e = d->left ; e != NULL; e = e->next) {
-		i += string_hash(e->desc->string);
+		i += e->desc->str_hash;
 	}
 	for (e = d->right ; e != NULL; e = e->next) {
-		i += string_hash(e->desc->string);
+		i += e->desc->str_hash;
 	}
 	i += string_hash(d->word_string);
 	i += (i>>10);

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -47,5 +47,6 @@ void word_record_in_disjunct(const Gword *, Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
+Disjunct *pack_disjuncts_dup(Disjunct *, Disjunct **, Connector **);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -47,6 +47,7 @@ void word_record_in_disjunct(const Gword *, Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
+
 Disjunct *pack_disjuncts_dup(Disjunct *, Disjunct **, Connector **);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 #include "analyze-linkage.h"
-#include "connectors.h" // Needed for connector_get_string
+#include "connectors.h" // Needed for connector_string
 #include "linkage.h"
 #include "string-set.h"
 
@@ -80,7 +80,7 @@ void compute_link_names(Linkage lkg, String_set *sset)
 	for (i = 0; i < lkg->num_links; i++)
 	{
 		lkg->link_array[i].link_name = intersect_strings(sset,
-			connector_get_string(lkg->link_array[i].lc),
-			connector_get_string(lkg->link_array[i].rc));
+			connector_string(lkg->link_array[i].lc),
+			connector_string(lkg->link_array[i].rc));
 	}
 }

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -738,13 +738,13 @@ const char * linkage_get_link_label(const Linkage linkage, LinkIdx index)
 const char * linkage_get_link_llabel(const Linkage linkage, LinkIdx index)
 {
 	if (!verify_link_index(linkage, index)) return NULL;
-	return linkage->link_array[index].lc->string;
+	return linkage->link_array[index].lc->desc->string;
 }
 
 const char * linkage_get_link_rlabel(const Linkage linkage, LinkIdx index)
 {
 	if (!verify_link_index(linkage, index)) return NULL;
-	return linkage->link_array[index].rc->string;
+	return linkage->link_array[index].rc->desc->string;
 }
 
 const char ** linkage_get_words(const Linkage linkage)

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -738,13 +738,13 @@ const char * linkage_get_link_label(const Linkage linkage, LinkIdx index)
 const char * linkage_get_link_llabel(const Linkage linkage, LinkIdx index)
 {
 	if (!verify_link_index(linkage, index)) return NULL;
-	return connector_get_string(linkage->link_array[index].lc);
+	return connector_string(linkage->link_array[index].lc);
 }
 
 const char * linkage_get_link_rlabel(const Linkage linkage, LinkIdx index)
 {
 	if (!verify_link_index(linkage, index)) return NULL;
-	return connector_get_string(linkage->link_array[index].rc);
+	return connector_string(linkage->link_array[index].rc);
 }
 
 const char ** linkage_get_words(const Linkage linkage)

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -738,13 +738,13 @@ const char * linkage_get_link_label(const Linkage linkage, LinkIdx index)
 const char * linkage_get_link_llabel(const Linkage linkage, LinkIdx index)
 {
 	if (!verify_link_index(linkage, index)) return NULL;
-	return linkage->link_array[index].lc->desc->string;
+	return connector_get_string(linkage->link_array[index].lc);
 }
 
 const char * linkage_get_link_rlabel(const Linkage linkage, LinkIdx index)
 {
 	if (!verify_link_index(linkage, index)) return NULL;
-	return linkage->link_array[index].rc->desc->string;
+	return connector_get_string(linkage->link_array[index].rc);
 }
 
 const char ** linkage_get_words(const Linkage linkage)

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -46,7 +46,7 @@ static char * reversed_conlist_str(Connector* c, char dir, char* buf, size_t sz)
 	if (c->multi)
 		p[len++] = '@';
 
-	len += lg_strlcpy(p+len, connector_get_string(c), sz-len);
+	len += lg_strlcpy(p+len, connector_string(c), sz-len);
 	if (3 < sz-len)
 	{
 		p[len++] = dir;

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -46,7 +46,7 @@ static char * reversed_conlist_str(Connector* c, char dir, char* buf, size_t sz)
 	if (c->multi)
 		p[len++] = '@';
 
-	len += lg_strlcpy(p+len, c->string, sz-len);
+	len += lg_strlcpy(p+len, c->desc->string, sz-len);
 	if (3 < sz-len)
 	{
 		p[len++] = dir;

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -46,7 +46,7 @@ static char * reversed_conlist_str(Connector* c, char dir, char* buf, size_t sz)
 	if (c->multi)
 		p[len++] = '@';
 
-	len += lg_strlcpy(p+len, c->desc->string, sz-len);
+	len += lg_strlcpy(p+len, connector_get_string(c), sz-len);
 	if (3 < sz-len)
 	{
 		p[len++] = dir;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -87,6 +87,7 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 
 	/* Clamp at max 4*(1<<24) == 64 MBytes */
 	if (24 < shift) shift = 24;
+	lgdebug(+5, "Connector table size (1<<%u)*%zu\n", shift, sizeof(Table_connector));
 	ctxt->table_size = (1U << shift);
 	ctxt->log2_table_size = shift;
 	ctxt->table = (Table_connector**)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -206,7 +206,7 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 #endif
 
 #ifdef DO_COUNT_TRACE
-#define V(c) (!c?"(nil)":connector_get_string(c))
+#define V(c) (!c?"(nil)":connector_string(c))
 static Count_bin do_count1(int lineno, count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -605,9 +605,6 @@ Count_bin do_parse(Sentence sent,
 
 	hist = do_count(ctxt, -1, sent->length, NULL, NULL, null_count+1);
 
-	ctxt->local_sent = NULL;
-	ctxt->current_resources = NULL;
-	ctxt->checktimer = 0;
 	return hist;
 }
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -206,7 +206,7 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 #endif
 
 #ifdef DO_COUNT_TRACE
-#define V(c) (!c?"(nil)":connector_string(c))
+#define V(c) (!c?"(nil)":connector_get_string(c))
 static Count_bin do_count1(int lineno, count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -206,7 +206,7 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 #endif
 
 #ifdef DO_COUNT_TRACE
-#define V(c) (!c?"(nil)":c->string)
+#define V(c) (!c?"(nil)":connector_string(c))
 static Count_bin do_count1(int lineno, count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -22,5 +22,5 @@ Count_bin* table_lookup(count_context_t *, int, int, Connector *, Connector *, u
 Count_bin do_parse(Sentence, fast_matcher_t*, count_context_t*, int null_count, Parse_Options);
 
 count_context_t* alloc_count_context(size_t);
-void free_count_context(count_context_t*);
+void free_count_context(count_context_t*, Sentence);
 #endif /* _COUNT_H */

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -195,7 +195,7 @@ static Match_node * add_to_left_table_list(Match_node * m, Match_node * l)
  */
 static bool con_uc_eq(const Connector *c1, const Connector *c2)
 {
-	return (c1->desc->uc_num == c2->desc->uc_num);
+	return (connector_uc_num(c1) == connector_uc_num(c2));
 }
 
 static Match_node **get_match_table_entry(unsigned int size, Match_node **t,

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -296,7 +296,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 		{
 			if (d->left != NULL)
 			{
-				//printf("%s %d\n", connector_get_string(d->left), d->left->length_limit);
+				//printf("%s %d\n", connector_string(d->left), d->left->length_limit);
 				put_into_match_table(size, t, d, d->left, -1);
 			}
 		}
@@ -311,7 +311,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 		{
 			if (d->right != NULL)
 			{
-				//printf("%s %d\n", connector_get_string(d->right), d->right->length_limit);
+				//printf("%s %d\n", connector_string(d->right), d->right->length_limit);
 				put_into_match_table(size, t, d, d->right, 1);
 			}
 		}
@@ -357,7 +357,7 @@ static void match_stats(Connector *c1, Connector *c2)
 
 #ifdef DEBUG
 #undef N
-#define N(c) (c?connector_get_string(c):"")
+#define N(c) (c?connector_string(c):"")
 
 /**
  * Print the match list, including connector match indications.
@@ -410,8 +410,8 @@ static bool do_match_with_cache(Connector *a, Connector *b, match_cache *c_con)
 	/* The following uses a string-set compare - string_set_cmp() cannot
 	 * be used here because c_con->string may be NULL. */
 	match_stats(c_con->string == a->string ? NULL : a, NULL);
-	UNREACHABLE(connector_get_desc(a) == NULL); // clang static analyzer suppression.
-	if (c_con->desc == connector_get_desc(a))
+	UNREACHABLE(connector_desc(a) == NULL); // clang static analyzer suppression.
+	if (c_con->desc == connector_desc(a))
 	{
 		/* The match_cache desc field is initialized to NULL, and this is
 		 * enough because the connector desc filed cannot be NULL, as it
@@ -425,8 +425,8 @@ static bool do_match_with_cache(Connector *a, Connector *b, match_cache *c_con)
 	 * We know that the uc parts of the connectors are the same, because
 	 * we fetch the matching lists according to the uc part or the
 	 * connectors to be matched. So the uc parts are not checked here. */
-	c_con->match = lc_easy_match(connector_get_desc(a), connector_get_desc(b));
-	c_con->desc = connector_get_desc(a);
+	c_con->match = lc_easy_match(connector_desc(a), connector_desc(b));
+	c_con->desc = connector_desc(a);
 
 	return c_con->match;
 }

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -16,6 +16,7 @@
 #include "disjunct-utils.h"
 #include "fast-match.h"
 #include "string-set.h"
+#include "dict-common/dict-common.h"   // For contable
 #include "tokenize/word-structures.h"  // For Word_struct
 #include "tokenize/wordgraph.h"
 #include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
@@ -261,13 +262,11 @@ static void put_into_match_table(unsigned int size, Match_node ** t,
 	}
 }
 
-/* FIXME: Use connector enumeration to limit table sizes. */
-
 fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 {
 	unsigned int size;
 	size_t w;
-	int len;
+	size_t len;
 	Match_node ** t;
 	Disjunct * d;
 	fast_matcher_t *ctxt;
@@ -287,6 +286,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 	for (w=0; w<sent->length; w++)
 	{
 		len = left_disjunct_list_length(sent->word[w].d);
+		len = MIN(sent->dict->contable.num_con, len);
 		size = next_power_of_two_up(len);
 		ctxt->l_table_size[w] = size;
 		t = ctxt->l_table[w] = (Match_node **) xalloc(size * sizeof(Match_node *));
@@ -302,6 +302,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 		}
 
 		len = right_disjunct_list_length(sent->word[w].d);
+		len = MIN(sent->dict->contable.num_con, len);
 		size = next_power_of_two_up(len);
 		ctxt->r_table_size[w] = size;
 		t = ctxt->r_table[w] = (Match_node **) xalloc(size * sizeof(Match_node *));

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -192,30 +192,10 @@ static Match_node * add_to_left_table_list(Match_node * m, Match_node * l)
 /**
  * Compare only the uppercase part of two connectors.
  * Return true if they are the same, else false.
- * FIXME: Use connector enumeration.
  */
 static bool con_uc_eq(const Connector *c1, const Connector *c2)
 {
-#if 0
 	return (c1->desc->uc_num == c2->desc->uc_num);
-#else
-	if (c1->desc == c2->desc) return true;
-	if (c1->desc->uc_hash != c2->desc->uc_hash) return false;
-	if (c1->desc->uc_length != c2->desc->uc_length) return false;
-
-	/* We arrive here for less than 50% of the cases for "en" and
-	 * less then 20% of the cases for "ru", and, in practice, the
-	 * two strings are always equal, because there is almost never
-	 * a hash collision that would lead to a miscompare, because
-	 * we are hashing, at most, a few dozen connectors into a
-	 * 16-bit hash space (65536 slots).
-	 */
-	const char *uc1 = &c1->desc->string[c1->desc->uc_start];
-	const char *uc2 = &c2->desc->string[c2->desc->uc_start];
-	if (0 == strncmp(uc1, uc2, c1->desc->uc_length)) return true;
-
-	return false;
-#endif
 }
 
 static Match_node **get_match_table_entry(unsigned int size, Match_node **t,

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -261,6 +261,8 @@ static void put_into_match_table(unsigned int size, Match_node ** t,
 	}
 }
 
+/* FIXME: Use connector enumeration to limit table sizes. */
+
 fast_matcher_t* alloc_fast_matcher(const Sentence sent)
 {
 	unsigned int size;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -12,7 +12,6 @@
 /*************************************************************************/
 
 #include <limits.h>
-
 #include "api-structures.h"
 #include "count.h"
 #include "dict-common/dict-common.h"   // For Dictionary_s
@@ -418,6 +417,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		for (size_t i = 0; i < sent->length; i++)
 			free_disjuncts(disjuncts_copy[i]);
 	}
-	free_count_context(ctxt);
+	free_count_context(ctxt, sent);
 	free_fast_matcher(mchxt);
 }

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -23,60 +23,6 @@
 #include "string-set.h"
 #include "tokenize/word-structures.h" // for Word_struct
 
-#if 0
-static void
-set_connector_list_length_limit(Connector *c,
-                                Connector_set *conset,
-                                int short_len,
-                                bool all_short,
-                                const char * ZZZ)
-{
-	for (; c!=NULL; c=c->next)
-	{
-		if (string_set_cmp (ZZZ, c->string))
-		{
-			c->length_limit = 1;
-		}
-		else if (all_short ||
-		         (conset != NULL && !match_in_connector_set(conset, c)))
-		{
-			c->length_limit = short_len;
-		}
-	}
-}
-
-static void
-set_connector_length_limits(Sentence sent, Parse_Options opts)
-{
-	size_t i;
-	unsigned int len = opts->short_length;
-	bool all_short = opts->all_short;
-	Connector_set * ucs = sent->dict->unlimited_connector_set;
-	const char * ZZZ = string_set_add("ZZZ", sent->dict->string_set);
-
-	if (0)
-	{
-		/* Not setting the length_limit saves observable time. However, if we
-		 * would like to set the ZZZ connector length_limit to 1 for all
-		 * sentences, we cannot do the following. */
-		if (len >= sent->length) return; /* No point to enforce short_length. */
-	}
-
-	if (len > UNLIMITED_LEN) len = UNLIMITED_LEN;
-
-	for (i=0; i<sent->length; i++)
-	{
-		Disjunct *d;
-		for (d = sent->word[i].d; d != NULL; d = d->next)
-		{
-			set_connector_list_length_limit(d->left, ucs, len, all_short, ZZZ);
-			set_connector_list_length_limit(d->right, ucs, len, all_short, ZZZ);
-		}
-	}
-}
-#endif
-
-
 /**
  * Set c->nearest_word to the nearest word that this connector could
  * possibly connect to.  The connector *might*, in the end,

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -23,6 +23,7 @@
 #include "string-set.h"
 #include "tokenize/word-structures.h" // for Word_struct
 
+#if 0
 static void
 set_connector_list_length_limit(Connector *c,
                                 Connector_set *conset,
@@ -73,6 +74,7 @@ set_connector_length_limits(Sentence sent, Parse_Options opts)
 		}
 	}
 }
+#endif
 
 
 /**
@@ -143,7 +145,8 @@ static void gword_record_in_connector(Sentence sent)
  * Turn sentence expressions into disjuncts.
  * Sentence expressions must have been built, before calling this routine.
  */
-static void build_sentence_disjuncts(Sentence sent, double cost_cutoff)
+static void build_sentence_disjuncts(Sentence sent, double cost_cutoff,
+                                     Parse_Options opts)
 {
 	Disjunct * d;
 	X_node * x;
@@ -153,7 +156,7 @@ static void build_sentence_disjuncts(Sentence sent, double cost_cutoff)
 		d = NULL;
 		for (x = sent->word[w].x; x != NULL; x = x->next)
 		{
-			Disjunct *dx = build_disjuncts_for_exp(x->exp, x->string, cost_cutoff);
+			Disjunct *dx = build_disjuncts_for_exp(x->exp, x->string, cost_cutoff, opts);
 			word_record_in_disjunct(x->word, dx);
 			d = catenate_disjuncts(dx, d);
 		}
@@ -168,7 +171,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 {
 	size_t i;
 
-	build_sentence_disjuncts(sent, opts->disjunct_cost);
+	build_sentence_disjuncts(sent, opts->disjunct_cost, opts);
 	if (verbosity_level(5))
 	{
 		printf("After expanding expressions into disjuncts:\n");
@@ -193,6 +196,5 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 
 	gword_record_in_connector(sent);
-	set_connector_length_limits(sent, opts);
 	setup_connectors(sent);
 }

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -225,7 +225,7 @@ static void put_into_power_table(unsigned int size, C_list ** t, Connector * c, 
 {
 	unsigned int h;
 	C_list * m;
-	h = connector_uc_hash(c) & (size-1);
+	h = connector_uc_num(c) & (size-1);
 	m = (C_list *) xalloc (sizeof(C_list));
 	m->next = t[h];
 	t[h] = m;
@@ -494,7 +494,7 @@ right_table_search(prune_context *pc, int w, Connector *c,
 	power_table *pt = pc->pt;
 
 	size = pt->r_table_size[w];
-	h = connector_uc_hash(c) & (size-1);
+	h = connector_uc_num(c) & (size-1);
 	for (cl = pt->r_table[w][h]; cl != NULL; cl = cl->next)
 	{
 		if (possible_connection(pc, cl->c, c, cl->shallow, shallow, w, word_c, true))
@@ -516,7 +516,7 @@ left_table_search(prune_context *pc, int w, Connector *c,
 	power_table *pt = pc->pt;
 
 	size = pt->l_table_size[w];
-	h = connector_uc_hash(c) & (size-1);
+	h = connector_uc_num(c) & (size-1);
 	for (cl = pt->l_table[w][h]; cl != NULL; cl = cl->next)
 	{
 		if (possible_connection(pc, c, cl->c, shallow, cl->shallow, word_c, w, false))

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -14,6 +14,7 @@
 #include "api-structures.h"
 #include "connectors.h"
 #include "disjunct-utils.h"
+#include "dict-common/dict-common.h"     // For contable
 #include "post-process/post-process.h"
 #include "post-process/pp-structures.h"
 #include "print/print.h"  // For print_disjunct_counts()
@@ -243,6 +244,8 @@ static power_table * power_table_new(Sentence sent)
 	C_list ** t;
 	Disjunct * d;
 	Connector * c;
+#define TOPSZ 32768
+	size_t lr_table_max_usage = MIN(sent->dict->contable.num_con, TOPSZ);
 
 	pt = (power_table *) xalloc (sizeof(power_table));
 	pt->power_table_size = sent->length;
@@ -269,9 +272,7 @@ static power_table * power_table_new(Sentence sent)
 		 * Strong dependence on the hashing algo!
 		 */
 		len = left_connector_count(sent->word[w].d);
-		size = next_power_of_two_up(len);
-#define TOPSZ 32768
-		if (TOPSZ < size) size = TOPSZ;
+		size = next_power_of_two_up(MIN(len, lr_table_max_usage));
 		pt->l_table_size[w] = size;
 		t = pt->l_table[w] = (C_list **) xalloc(size * sizeof(C_list *));
 		for (i=0; i<size; i++) t[i] = NULL;
@@ -287,8 +288,7 @@ static power_table * power_table_new(Sentence sent)
 		}
 
 		len = right_connector_count(sent->word[w].d);
-		size = next_power_of_two_up(len);
-		if (TOPSZ < size) size = TOPSZ;
+		size = next_power_of_two_up(MIN(len, lr_table_max_usage));
 		pt->r_table_size[w] = size;
 		t = pt->r_table[w] = (C_list **) xalloc(size * sizeof(C_list *));
 		for (i=0; i<size; i++) t[i] = NULL;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -224,7 +224,7 @@ static void put_into_power_table(unsigned int size, C_list ** t, Connector * c, 
 {
 	unsigned int h;
 	C_list * m;
-	h = connector_hash(c) & (size-1);
+	h = connector_uc_hash(c) & (size-1);
 	m = (C_list *) xalloc (sizeof(C_list));
 	m->next = t[h];
 	t[h] = m;
@@ -477,7 +477,7 @@ static bool possible_connection(prune_context *pc,
 	if (!alt_consistency(pc, lc, rc, lword, rword, lr)) return false;
 #endif
 
-	return easy_match(lc->string, rc->string);
+	return easy_match(lc->desc->string, rc->desc->string);
 }
 
 /**
@@ -493,7 +493,7 @@ right_table_search(prune_context *pc, int w, Connector *c,
 	power_table *pt = pc->pt;
 
 	size = pt->r_table_size[w];
-	h = connector_hash(c) & (size-1);
+	h = connector_uc_hash(c) & (size-1);
 	for (cl = pt->r_table[w][h]; cl != NULL; cl = cl->next)
 	{
 		if (possible_connection(pc, cl->c, c, cl->shallow, shallow, w, word_c, true))
@@ -515,7 +515,7 @@ left_table_search(prune_context *pc, int w, Connector *c,
 	power_table *pt = pc->pt;
 
 	size = pt->l_table_size[w];
-	h = connector_hash(c) & (size-1);
+	h = connector_uc_hash(c) & (size-1);
 	for (cl = pt->l_table[w][h]; cl != NULL; cl = cl->next)
 	{
 		if (possible_connection(pc, c, cl->c, shallow, cl->shallow, word_c, w, false))
@@ -1007,7 +1007,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 				Connector *c;
 				for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
 				{
-					insert_in_cms_table(cmt, c->string);
+					insert_in_cms_table(cmt, c->desc->string);
 				}
 			}
 		}
@@ -1041,7 +1041,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 
 							if (strchr(selector, '*') != NULL) continue;  /* If it has a * forget it */
 
-							if (!post_process_match(selector, c->string)) continue;
+							if (!post_process_match(selector, c->desc->string)) continue;
 
 							/*
 							printf("pp_prune: trigger ok.  selector = %s  c->string = %s\n", selector, c->string);
@@ -1072,7 +1072,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 						Connector *c;
 						for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
 						{
-							change |= delete_from_cms_table(cmt, c->string);
+							change |= delete_from_cms_table(cmt, c->desc->string);
 						}
 					}
 				}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1008,7 +1008,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 				Connector *c;
 				for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
 				{
-					insert_in_cms_table(cmt, c->desc->string);
+					insert_in_cms_table(cmt, connector_get_string(c));
 				}
 			}
 		}
@@ -1042,7 +1042,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 
 							if (strchr(selector, '*') != NULL) continue;  /* If it has a * forget it */
 
-							if (!post_process_match(selector, c->desc->string)) continue;
+							if (!post_process_match(selector, connector_get_string(c))) continue;
 
 							/*
 							printf("pp_prune: trigger ok.  selector = %s  c->string = %s\n", selector, c->string);
@@ -1073,7 +1073,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 						Connector *c;
 						for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
 						{
-							change |= delete_from_cms_table(cmt, c->desc->string);
+							change |= delete_from_cms_table(cmt, connector_get_string(c));
 						}
 					}
 				}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -440,6 +440,7 @@ static bool possible_connection(prune_context *pc,
 {
 	int dist;
 	if ((!lshallow) && (!rshallow)) return false;
+	if (!easy_match_desc(lc->desc, rc->desc)) return false;
 
 	/* Two deep connectors can't work */
 	if ((lc->nearest_word > rword) || (rc->nearest_word < lword)) return false;
@@ -477,7 +478,7 @@ static bool possible_connection(prune_context *pc,
 	if (!alt_consistency(pc, lc, rc, lword, rword, lr)) return false;
 #endif
 
-	return easy_match_desc(lc->desc, rc->desc);
+	return true;
 }
 
 /**

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -35,7 +35,6 @@
 
 #define D_PRUNE 5
 
-#define CONTABSZ 8192
 typedef Connector * connector_table;
 
 /* Indicator that this connector cannot be used -- that its "obsolete".  */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -477,7 +477,7 @@ static bool possible_connection(prune_context *pc,
 	if (!alt_consistency(pc, lc, rc, lword, rword, lr)) return false;
 #endif
 
-	return easy_match(lc->desc->string, rc->desc->string);
+	return easy_match_desc(lc->desc, rc->desc);
 }
 
 /**

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1008,7 +1008,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 				Connector *c;
 				for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
 				{
-					insert_in_cms_table(cmt, connector_get_string(c));
+					insert_in_cms_table(cmt, connector_string(c));
 				}
 			}
 		}
@@ -1042,7 +1042,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 
 							if (strchr(selector, '*') != NULL) continue;  /* If it has a * forget it */
 
-							if (!post_process_match(selector, connector_get_string(c))) continue;
+							if (!post_process_match(selector, connector_string(c))) continue;
 
 							/*
 							printf("pp_prune: trigger ok.  selector = %s  c->string = %s\n", selector, c->string);
@@ -1073,7 +1073,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 						Connector *c;
 						for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
 						{
-							change |= delete_from_cms_table(cmt, connector_get_string(c));
+							change |= delete_from_cms_table(cmt, connector_string(c));
 						}
 					}
 				}

--- a/link-grammar/post-process/pp_linkset.c
+++ b/link-grammar/post-process/pp_linkset.c
@@ -41,6 +41,7 @@ static void initialize(pp_linkset *ls, int size)
 	clear_hash_table(ls);
 }
 
+/* FIXME: Use connector enumeration to save computing the hash. */
 static unsigned int compute_hash(pp_linkset *ls, const char *str)
 {
 	/* hash is computed from capitalized prefix only */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -240,7 +240,7 @@ static void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
-		printf("%s", e->desc->string);
+		printf("%s", connector_get_string(e));
 		if (e->next != NULL) printf(" ");
 	}
 }

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -240,7 +240,7 @@ static void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
-		printf("%s", connector_get_string(e));
+		printf("%s", connector_string(e));
 		if (e->next != NULL) printf(" ");
 	}
 }

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -28,7 +28,7 @@ struct Tconnector_struct
 	char multi;   /* TRUE if this is a multi-connector */
 	char dir;     /* '-' for left and '+' for right */
 	Tconnector * next;
-	const char * string;
+	const condesc_t * condesc;
 };
 
 typedef struct clause_struct Clause;
@@ -124,7 +124,7 @@ static Tconnector * build_terminal(Exp * e)
 {
 	Tconnector * c;
 	c = (Tconnector *) xalloc(sizeof(Tconnector));
-	c->string = e->u.string;
+	c->condesc = e->u.condesc;
 	c->multi = e->multi;
 	c->dir = e->dir;
 	c->next = NULL;
@@ -220,7 +220,7 @@ static void print_Tconnector_list(Tconnector * e)
 {
 	for (;e != NULL; e=e->next) {
 		if (e->multi) printf("@");
-		printf("%s", e->string);
+		printf("%s", e->condesc->string);
 		printf("%c", e->dir);
 		if (e->next != NULL) printf(" ");
 	}
@@ -240,7 +240,7 @@ static void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
-		printf("%s", e->string);
+		printf("%s", e->desc->string);
 		if (e->next != NULL) printf(" ");
 	}
 }
@@ -263,22 +263,21 @@ GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
  * in the list pointed to by e.  Keep only those whose strings whose
  * direction has the value c.
  */
-static Connector * extract_connectors(Tconnector *e, int c)
+static Connector * extract_connectors(Tconnector *e, int c, Parse_Options opts)
 {
 	Connector *e1;
 	if (e == NULL) return NULL;
 	if (e->dir == c)
 	{
-		e1 = connector_new();
-		e1->next = extract_connectors(e->next,c);
+		e1 = connector_new(e->condesc, opts);
 		e1->multi = e->multi;
-		e1->string = e->string;
 		e1->nearest_word = 0;
+		e1->next = extract_connectors(e->next, c, opts);
 		return e1;
 	}
 	else
 	{
-		return extract_connectors(e->next,c);
+		return extract_connectors(e->next, c, opts);
 	}
 }
 
@@ -287,7 +286,8 @@ static Connector * extract_connectors(Tconnector *e, int c)
  * string is the print name of word that generated this disjunct.
  */
 static Disjunct *
-build_disjunct(Clause * cl, const char * string, double cost_cutoff)
+build_disjunct(Clause * cl, const char * string, double cost_cutoff,
+               Parse_Options opts)
 {
 	Disjunct *dis, *ndis;
 	dis = NULL;
@@ -296,8 +296,8 @@ build_disjunct(Clause * cl, const char * string, double cost_cutoff)
 		if (cl->maxcost <= cost_cutoff)
 		{
 			ndis = (Disjunct *) xalloc(sizeof(Disjunct));
-			ndis->left = reverse(extract_connectors(cl->c, '-'));
-			ndis->right = reverse(extract_connectors(cl->c, '+'));
+			ndis->left = reverse(extract_connectors(cl->c, '-', opts));
+			ndis->right = reverse(extract_connectors(cl->c, '+', opts));
 			ndis->word_string = string;
 			ndis->cost = cl->cost;
 			ndis->next = dis;
@@ -307,14 +307,15 @@ build_disjunct(Clause * cl, const char * string, double cost_cutoff)
 	return dis;
 }
 
-Disjunct * build_disjuncts_for_exp(Exp* exp, const char *word, double cost_cutoff)
+Disjunct * build_disjuncts_for_exp(Exp* exp, const char *word,
+                                   double cost_cutoff, Parse_Options opts)
 {
 	Clause *c ;
 	Disjunct * dis;
 	// print_expression(exp);  printf("\n");
 	c = build_clause(exp);
 	// print_clause_list(c);
-	dis = build_disjunct(c, word, cost_cutoff);
+	dis = build_disjunct(c, word, cost_cutoff, opts);
 	// print_disjunct_list(dis);
 	free_clause_list(c);
 	return dis;
@@ -341,7 +342,7 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	else
 	{
 		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s\n", e->u.string);
+		printf("con=%s\n", e->u.condesc->string);
 	}
 }
 
@@ -384,7 +385,7 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 	else
 	{
 		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s dir=%c multi=%d\n", e->u.string, e->dir, e->multi);
+		printf("con=%s dir=%c multi=%d\n", e->u.condesc->string, e->dir, e->multi);
 	}
 }
 #endif

--- a/link-grammar/prepare/build-disjuncts.h
+++ b/link-grammar/prepare/build-disjuncts.h
@@ -15,8 +15,9 @@
 #define _LINKGRAMMAR_BUILD_DISJUNCTS_H
 
 #include "api-types.h"
+#include "link-includes.h"
 
-Disjunct * build_disjuncts_for_exp(Exp*, const char*, double cost_cutoff);
+Disjunct * build_disjuncts_for_exp(Exp*, const char*, double cost_cutoff, Parse_Options opts);
 
 #ifdef DEBUG
 void prt_exp(Exp *, int);

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -178,7 +178,7 @@ static inline bool matches_S(connector_table *ct, Connector * c)
 
 	for (e = ct[hash_S(c)]; e != NULL; e = e->tableNext)
 	{
-		if (easy_match(e->desc->string, c->desc->string)) return true;
+		if (easy_match_desc(e->desc, c->desc)) return true;
 	}
 	return false;
 }

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -24,15 +24,16 @@
 #define CONTABSZ 8192
 
 #ifdef DEBUG
-#define DBG(X) \
+#define DBG(p, w, X) \
 	if (verbosity_level(+D_EXPRUNE))\
 	{\
 		char *e = expression_stringify(x->exp);\
+		err_msg(lg_Trace, "pass%d w%zu: ", p, w);\
 		err_msg(lg_Trace, X ": %s\n", e);\
 		free(e);\
 	}
 #else /* !DEBUG */
-#define DBG(X)
+#define DBG(p, w, X)
 #endif /* DEBUG */
 
 #define DBG_EXPSIZES(...) \
@@ -327,7 +328,8 @@ void expression_prune(Sentence sent)
 
 	DBG_EXPSIZES("Initial expression sizes\n%s", e);
 
-	while (1)
+	int pass = -1;
+	while (pass++)
 	{
 		/* Left-to-right pass */
 		/* For every word */
@@ -336,15 +338,15 @@ void expression_prune(Sentence sent)
 			/* For every expression in word */
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
-				DBG("l->r pass before marking");
+				DBG(pass, w, "l->r pass before marking");
 				N_deleted += mark_dead_connectors(ct, x->exp, '-');
-				DBG("l->r pass after marking");
+				DBG(pass, w, "l->r pass after marking");
 			}
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
-				DBG("l->r pass before purging");
+				DBG(pass, w, "l->r pass before purging");
 				x->exp = purge_Exp(x->exp);
-				DBG("l->r pass after purging");
+				DBG(pass, w, "l->r pass after purging");
 			}
 
 			/* gets rid of X_nodes with NULL exp */
@@ -370,15 +372,15 @@ void expression_prune(Sentence sent)
 		{
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
-				DBG("r->l pass before marking");
+				DBG(pass, w, "r->l pass before marking");
 				N_deleted += mark_dead_connectors(ct, x->exp, '+');
-				DBG("r->l pass after marking");
+				DBG(pass, w, "r->l pass after marking");
 			}
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
-				DBG("r->l pass before purging");
+				DBG(pass, w, "r->l pass before purging");
 				x->exp = purge_Exp(x->exp);
-				DBG("r->l pass after purging");
+				DBG(pass, w, "r->l pass after purging");
 			}
 			clean_up_expressions(sent, w);  /* gets rid of X_nodes with NULL exp */
 			for (x = sent->word[w].x; x != NULL; x = x->next)

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -43,7 +43,84 @@
 		free(e);\
 	}
 
-typedef condesc_t * connector_table;
+typedef struct connector_table_s connector_table;
+struct connector_table_s
+{
+	condesc_t *condesc;
+	connector_table *next;
+	int farthest_word;
+};
+
+#define CT_BLKSIZE 512
+/* The connector table elements are allocated in a kind of an unrolled
+ * linked list with fixed blocks, when the first block is pre-allocated on
+ * the stack (this simplifies the handling). Additional blocks are
+ * dynamically allocated, but they are rarely needed. The existing
+ * allocation is reused on each pass, an freed only at the end of the
+ * expression pruning. */
+// connector_table_element-> ... CT_BLKSIZE-1 elements
+//                           ...
+//                           ...
+//                           block connecting element ->---+
+//                                                         |
+// (additional block)        CT_BLKSIZE-1 elements     <---+
+//                           ...
+// current_element        -> ...
+//                           ...
+// end_current_block      -> block connecting element ->---+
+//                                                         |
+// (additional block)        CT_BLKSIZE-1 elements     <---+
+//                           ...
+//                           ...
+//                           ...
+//                           block connecting element
+
+typedef struct exprune_context_s exprune_context;
+struct exprune_context_s
+{
+	connector_table **ct;
+	size_t ct_size;
+	Parse_Options opts;
+	connector_table *current_element;
+	connector_table *end_current_block;
+	connector_table connector_table_element[CT_BLKSIZE];
+};
+
+static connector_table *ct_element_new(exprune_context *ctxt)
+{
+	if (ctxt->current_element == ctxt->end_current_block)
+	{
+		if (ctxt->end_current_block->next == NULL)
+		{
+			connector_table *newblock =
+				malloc(CT_BLKSIZE * sizeof(*ctxt->current_element));
+			newblock[CT_BLKSIZE-1].next = NULL;
+			ctxt->end_current_block->next = newblock;
+		} /* else - reuse next block. */
+
+		ctxt->current_element = ctxt->end_current_block->next;
+		ctxt->end_current_block = &ctxt->current_element[CT_BLKSIZE-1];
+	}
+
+	return ctxt->current_element++;
+}
+
+static void free_connector_table(exprune_context *ctxt)
+{
+	connector_table *x;
+	connector_table *t = ctxt->connector_table_element[CT_BLKSIZE-1].next;
+
+	while (t != NULL)
+	{
+			 x = t[CT_BLKSIZE-1].next;
+			 free(t);
+			 t = x;
+	}
+
+	free(ctxt->ct);
+	ctxt->ct = NULL;
+	ctxt->ct_size = 0;
+}
 
 /* ================================================================= */
 /**
@@ -66,7 +143,7 @@ typedef condesc_t * connector_table;
 static Exp* purge_Exp(Exp *);
 
 /**
- * Get rid of the elements with null expressions
+ * Get rid of the current_elements with null expressions
  */
 static E_list * or_purge_E_list(E_list * l)
 {
@@ -170,20 +247,30 @@ static inline unsigned int hash_S(condesc_t * c)
 /**
  * Returns TRUE if c can match anything in the set S (err. the connector table ct).
  */
-static inline bool matches_S(connector_table *ct, condesc_t * c)
+static inline bool matches_S(connector_table **ct, int w, condesc_t * c)
 {
-	condesc_t * e;
+	connector_table *e;
 
-	for (e = ct[hash_S(c)]; e != NULL; e = e->PtableNext)
+	for (e = ct[hash_S(c)]; e != NULL; e = e->next)
 	{
-		if (easy_match_desc(e, c)) return true;
+		if (e->farthest_word <= 0)
+		{
+			if (w < -e->farthest_word) continue;
+		}
+		else
+		{
+			if (w > e->farthest_word) continue;
+		}
+		if (easy_match_desc(e->condesc, c)) return true;
 	}
 	return false;
 }
 
-static void zero_connector_table(connector_table *ct, size_t contab_size)
+static void zero_connector_table(exprune_context *ctxt)
 {
-	memset(ct, 0, sizeof(condesc_t *) * contab_size);
+	memset(ctxt->ct, 0, sizeof(*ctxt->ct) * ctxt->ct_size);
+	ctxt->current_element = ctxt->connector_table_element;
+	ctxt->end_current_block = &ctxt->connector_table_element[CT_BLKSIZE-1];
 }
 
 /**
@@ -191,7 +278,7 @@ static void zero_connector_table(connector_table *ct, size_t contab_size)
  * in e that are not matched by anything in the current set.
  * Returns the number of connectors so marked.
  */
-static int mark_dead_connectors(connector_table *ct, Exp * e, char dir)
+static int mark_dead_connectors(connector_table **ct, int w, Exp * e, char dir)
 {
 	int count;
 	count = 0;
@@ -199,7 +286,7 @@ static int mark_dead_connectors(connector_table *ct, Exp * e, char dir)
 	{
 		if (e->dir == dir)
 		{
-			if (!matches_S(ct, e->u.condesc))
+			if (!matches_S(ct, w, e->u.condesc))
 			{
 				e->u.condesc = NULL;
 				count++;
@@ -211,7 +298,7 @@ static int mark_dead_connectors(connector_table *ct, Exp * e, char dir)
 		E_list *l;
 		for (l = e->u.l; l != NULL; l = l->next)
 		{
-			count += mark_dead_connectors(ct, l->e, dir);
+			count += mark_dead_connectors(ct, w, l->e, dir);
 		}
 	}
 	return count;
@@ -221,34 +308,48 @@ static int mark_dead_connectors(connector_table *ct, Exp * e, char dir)
  * This function puts connector c into the connector table
  * if one like it isn't already there.
  */
-static void insert_connector(connector_table *ct, condesc_t * c)
+static void insert_connector(exprune_context *ctxt, int farthest_word, condesc_t * c)
 {
 	unsigned int h;
-	condesc_t * e;
+	connector_table *e;
 
 	h = hash_S(c);
 
-	for (e = ct[h]; e != NULL; e = e->PtableNext)
+	for (e = ctxt->ct[h]; e != NULL; e = e->next)
 	{
-		if (c == e)
+		if (c == e->condesc)
+		{
+			{
+				if (e->farthest_word < farthest_word) e->farthest_word = farthest_word;
+			}
 			return;
+		}
 	}
-	c->PtableNext = ct[h];
-	ct[h] = c;
+
+	e = ct_element_new(ctxt);
+	e->condesc = c;
+	e->farthest_word = farthest_word;
+	e->next = ctxt->ct[h];
+	ctxt->ct[h] = e;
 }
 /**
  * Put into the set S all of the dir-pointing connectors still in e.
  * Return a list of allocated dummy connectors; these will need to be
  * freed.
  */
-static void insert_connectors(connector_table *ct, Exp * e, int dir)
+static void insert_connectors(exprune_context *ctxt, int w, Exp * e, int dir)
 {
 	if (e->type == CONNECTOR_type)
 	{
 		if (e->dir == dir)
 		{
 			assert(NULL != e->u.condesc, "NULL connector");
-			insert_connector(ct, e->u.condesc);
+			Connector c = { .desc = e->u.condesc };
+
+			set_connector_length_limit(&c, ctxt->opts);
+			int farthest_word = (dir == '-') ? -MAX(0, w-c.length_limit) :
+				                              w+c.length_limit;
+			insert_connector(ctxt, farthest_word, e->u.condesc);
 		}
 	}
 	else
@@ -256,7 +357,7 @@ static void insert_connectors(connector_table *ct, Exp * e, int dir)
 		E_list *l;
 		for (l=e->u.l; l!=NULL; l=l->next)
 		{
-			insert_connectors(ct, l->e, dir);
+			insert_connectors(ctxt, w, l->e, dir);
 		}
 	}
 }
@@ -304,15 +405,18 @@ static char *print_expression_sizes(Sentence sent)
 	return dyn_str_take(e);
 }
 
-void expression_prune(Sentence sent)
+void expression_prune(Sentence sent, Parse_Options opts)
 {
 	int N_deleted;
 	X_node * x;
 	size_t w;
-	size_t contab_size = sent->dict->contable.num_uc;
-	condesc_t **ct = alloca(contab_size * sizeof(*ct));
+	exprune_context ctxt;
 
-	zero_connector_table(ct, contab_size);
+	ctxt.opts = opts;
+	ctxt.ct_size = sent->dict->contable.num_uc;
+	ctxt.ct = malloc(ctxt.ct_size * sizeof(*ctxt.ct));
+	zero_connector_table(&ctxt);
+	ctxt.end_current_block->next = NULL;
 
 	N_deleted = 1;  /* a lie to make it always do at least 2 passes */
 
@@ -329,7 +433,7 @@ void expression_prune(Sentence sent)
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
 				DBG(pass, w, "l->r pass before marking");
-				N_deleted += mark_dead_connectors(ct, x->exp, '-');
+				N_deleted += mark_dead_connectors(ctxt.ct, w, x->exp, '-');
 				DBG(pass, w, "l->r pass after marking");
 			}
 			for (x = sent->word[w].x; x != NULL; x = x->next)
@@ -343,13 +447,13 @@ void expression_prune(Sentence sent)
 			clean_up_expressions(sent, w);
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
-				insert_connectors(ct, x->exp, '+');
+				insert_connectors(&ctxt, w, x->exp, '+');
 			}
 		}
 
 		DBG_EXPSIZES("l->r pass removed %d\n%s", N_deleted, e);
 
-		zero_connector_table(ct, contab_size);
+		zero_connector_table(&ctxt);
 		if (N_deleted == 0) break;
 
 		/* Right-to-left pass */
@@ -359,7 +463,7 @@ void expression_prune(Sentence sent)
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
 				DBG(pass, w, "r->l pass before marking");
-				N_deleted += mark_dead_connectors(ct, x->exp, '+');
+				N_deleted += mark_dead_connectors(ctxt.ct, w, x->exp, '+');
 				DBG(pass, w, "r->l pass after marking");
 			}
 			for (x = sent->word[w].x; x != NULL; x = x->next)
@@ -371,16 +475,18 @@ void expression_prune(Sentence sent)
 			clean_up_expressions(sent, w);  /* gets rid of X_nodes with NULL exp */
 			for (x = sent->word[w].x; x != NULL; x = x->next)
 			{
-				insert_connectors(ct, x->exp, '-');
+				insert_connectors(&ctxt, w, x->exp, '-');
 			}
 		}
 
 		DBG_EXPSIZES("r->l pass removed %d\n%s", N_deleted, e);
 
-		zero_connector_table(ct, contab_size);
+		zero_connector_table(&ctxt);
 		if (N_deleted == 0) break;
 		N_deleted = 0;
 	}
+
+	free_connector_table(&ctxt);
 }
 
 #if 0 // VERY_DEAD_NO_GOOD_IDEA

--- a/link-grammar/prepare/exprune.h
+++ b/link-grammar/prepare/exprune.h
@@ -15,5 +15,5 @@
 
 #include "link-includes.h"
 
-void       expression_prune(Sentence);
+void       expression_prune(Sentence, Parse_Options opts);
 #endif /* _EXPRESSION_PRUNE_H */

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -69,10 +69,10 @@ set_centers(const Linkage linkage, int center[], int word_offset[],
 		if ((l->lw + 1 == l->rw) && (NULL != l->link_name))
 		{
 			link_len[l->rw] = strlen(l->link_name) +
-				(DEPT_CHR == connector_get_string(l->rc)[0]) +
-				(HEAD_CHR == connector_get_string(l->rc)[0]) +
-				(DEPT_CHR == connector_get_string(l->lc)[0]) +
-				(HEAD_CHR == connector_get_string(l->lc)[0]);
+				(DEPT_CHR == connector_string(l->rc)[0]) +
+				(HEAD_CHR == connector_string(l->rc)[0]) +
+				(DEPT_CHR == connector_string(l->lc)[0]) +
+				(HEAD_CHR == connector_string(l->lc)[0]);
 		}
 	}
 
@@ -356,7 +356,7 @@ build_linkage_postscript_string(const Linkage linkage,
 			if (ppla[j].lw == 0) {
 				if (ppla[j].rw == linkage->num_words-1) continue;
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->desc->string, LEFT_WALL_SUPPRESS)) {
+				if (easy_match(connector_string(ppla[j].lc), LEFT_WALL_SUPPRESS)) {
 					suppressor_used = true;
 				}
 			}
@@ -372,7 +372,7 @@ build_linkage_postscript_string(const Linkage linkage,
 		for (j=0; j<N_links; j++) {
 			if (ppla[j].rw == linkage->num_words-1) {
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->desc->string, RIGHT_WALL_SUPPRESS)) {
+				if (easy_match(connector_string(ppla[j].lc), RIGHT_WALL_SUPPRESS)) {
 					suppressor_used = true;
 				}
 			}
@@ -515,7 +515,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			{
 				if (ppla[j].rw == linkage->num_words-1) continue;
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->desc->string, LEFT_WALL_SUPPRESS))
+				if (easy_match(connector_string(ppla[j].lc), LEFT_WALL_SUPPRESS))
 				{
 					suppressor_used = true;
 				}
@@ -536,7 +536,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			if (ppla[j].rw == linkage->num_words-1)
 			{
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->desc->string, RIGHT_WALL_SUPPRESS))
+				if (easy_match(connector_string(ppla[j].lc), RIGHT_WALL_SUPPRESS))
 				{
 					suppressor_used = true;
 				}
@@ -632,17 +632,17 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 
 			/* Add direction indicator */
 			// if (DEPT_CHR == ppla[j]->lc->string[0]) { *(t-1) = '<'; }
-			if (DEPT_CHR == connector_get_string(ppla[j].lc)[0] &&
+			if (DEPT_CHR == connector_string(ppla[j].lc)[0] &&
 			    (t > &picture[row][cl])) { picture[row][cl+1] = '<'; }
-			if (HEAD_CHR == connector_get_string(ppla[j].lc)[0]) { *(t-1) = '>'; }
+			if (HEAD_CHR == connector_string(ppla[j].lc)[0]) { *(t-1) = '>'; }
 
 			/* Copy connector name; stop short if no room */
 			while ((*s != '\0') && (*t == '-')) *t++ = *s++;
 
 			/* Add direction indicator */
 			// if (DEPT_CHR == ppla[j]->rc->string[0]) { *t = '>'; }
-			if (DEPT_CHR == connector_get_string(ppla[j].rc)[0]) { picture[row][cr-1] = '>'; }
-			if (HEAD_CHR == connector_get_string(ppla[j].rc)[0]) { *t = '<'; }
+			if (DEPT_CHR == connector_string(ppla[j].rc)[0]) { picture[row][cr-1] = '>'; }
+			if (HEAD_CHR == connector_string(ppla[j].rc)[0]) { *t = '<'; }
 
 			/* The direction indicators may have clobbered these. */
 			picture[row][cl] = '+';

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -69,10 +69,10 @@ set_centers(const Linkage linkage, int center[], int word_offset[],
 		if ((l->lw + 1 == l->rw) && (NULL != l->link_name))
 		{
 			link_len[l->rw] = strlen(l->link_name) +
-				(DEPT_CHR == l->rc->string[0]) +
-				(HEAD_CHR == l->rc->string[0]) +
-				(DEPT_CHR == l->lc->string[0]) +
-				(HEAD_CHR == l->lc->string[0]);
+				(DEPT_CHR == l->rc->desc->string[0]) +
+				(HEAD_CHR == l->rc->desc->string[0]) +
+				(DEPT_CHR == l->lc->desc->string[0]) +
+				(HEAD_CHR == l->lc->desc->string[0]);
 		}
 	}
 
@@ -356,7 +356,7 @@ build_linkage_postscript_string(const Linkage linkage,
 			if (ppla[j].lw == 0) {
 				if (ppla[j].rw == linkage->num_words-1) continue;
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->string, LEFT_WALL_SUPPRESS)) {
+				if (easy_match(ppla[j].lc->desc->string, LEFT_WALL_SUPPRESS)) {
 					suppressor_used = true;
 				}
 			}
@@ -372,7 +372,7 @@ build_linkage_postscript_string(const Linkage linkage,
 		for (j=0; j<N_links; j++) {
 			if (ppla[j].rw == linkage->num_words-1) {
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->string, RIGHT_WALL_SUPPRESS)) {
+				if (easy_match(ppla[j].lc->desc->string, RIGHT_WALL_SUPPRESS)) {
 					suppressor_used = true;
 				}
 			}
@@ -515,7 +515,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			{
 				if (ppla[j].rw == linkage->num_words-1) continue;
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->string, LEFT_WALL_SUPPRESS))
+				if (easy_match(ppla[j].lc->desc->string, LEFT_WALL_SUPPRESS))
 				{
 					suppressor_used = true;
 				}
@@ -536,7 +536,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			if (ppla[j].rw == linkage->num_words-1)
 			{
 				N_wall_connectors ++;
-				if (easy_match(ppla[j].lc->string, RIGHT_WALL_SUPPRESS))
+				if (easy_match(ppla[j].lc->desc->string, RIGHT_WALL_SUPPRESS))
 				{
 					suppressor_used = true;
 				}
@@ -632,17 +632,17 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 
 			/* Add direction indicator */
 			// if (DEPT_CHR == ppla[j]->lc->string[0]) { *(t-1) = '<'; }
-			if (DEPT_CHR == ppla[j].lc->string[0] &&
+			if (DEPT_CHR == ppla[j].lc->desc->string[0] &&
 			    (t > &picture[row][cl])) { picture[row][cl+1] = '<'; }
-			if (HEAD_CHR == ppla[j].lc->string[0]) { *(t-1) = '>'; }
+			if (HEAD_CHR == ppla[j].lc->desc->string[0]) { *(t-1) = '>'; }
 
 			/* Copy connector name; stop short if no room */
 			while ((*s != '\0') && (*t == '-')) *t++ = *s++;
 
 			/* Add direction indicator */
 			// if (DEPT_CHR == ppla[j]->rc->string[0]) { *t = '>'; }
-			if (DEPT_CHR == ppla[j].rc->string[0]) { picture[row][cr-1] = '>'; }
-			if (HEAD_CHR == ppla[j].rc->string[0]) { *t = '<'; }
+			if (DEPT_CHR == ppla[j].rc->desc->string[0]) { picture[row][cr-1] = '>'; }
+			if (HEAD_CHR == ppla[j].rc->desc->string[0]) { *t = '<'; }
 
 			/* The direction indicators may have clobbered these. */
 			picture[row][cl] = '+';

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -69,10 +69,10 @@ set_centers(const Linkage linkage, int center[], int word_offset[],
 		if ((l->lw + 1 == l->rw) && (NULL != l->link_name))
 		{
 			link_len[l->rw] = strlen(l->link_name) +
-				(DEPT_CHR == l->rc->desc->string[0]) +
-				(HEAD_CHR == l->rc->desc->string[0]) +
-				(DEPT_CHR == l->lc->desc->string[0]) +
-				(HEAD_CHR == l->lc->desc->string[0]);
+				(DEPT_CHR == connector_get_string(l->rc)[0]) +
+				(HEAD_CHR == connector_get_string(l->rc)[0]) +
+				(DEPT_CHR == connector_get_string(l->lc)[0]) +
+				(HEAD_CHR == connector_get_string(l->lc)[0]);
 		}
 	}
 
@@ -632,17 +632,17 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 
 			/* Add direction indicator */
 			// if (DEPT_CHR == ppla[j]->lc->string[0]) { *(t-1) = '<'; }
-			if (DEPT_CHR == ppla[j].lc->desc->string[0] &&
+			if (DEPT_CHR == connector_get_string(ppla[j].lc)[0] &&
 			    (t > &picture[row][cl])) { picture[row][cl+1] = '<'; }
-			if (HEAD_CHR == ppla[j].lc->desc->string[0]) { *(t-1) = '>'; }
+			if (HEAD_CHR == connector_get_string(ppla[j].lc)[0]) { *(t-1) = '>'; }
 
 			/* Copy connector name; stop short if no room */
 			while ((*s != '\0') && (*t == '-')) *t++ = *s++;
 
 			/* Add direction indicator */
 			// if (DEPT_CHR == ppla[j]->rc->string[0]) { *t = '>'; }
-			if (DEPT_CHR == ppla[j].rc->desc->string[0]) { picture[row][cr-1] = '>'; }
-			if (HEAD_CHR == ppla[j].rc->desc->string[0]) { *t = '<'; }
+			if (DEPT_CHR == connector_get_string(ppla[j].rc)[0]) { picture[row][cr-1] = '>'; }
+			if (HEAD_CHR == connector_get_string(ppla[j].rc)[0]) { *t = '<'; }
 
 			/* The direction indicators may have clobbered these. */
 			picture[row][cl] = '+';

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -32,13 +32,10 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
   if (exp->type == CONNECTOR_type) {
     dfs_position++;
 
-    const char* name = exp->u.string;
-
     Connector connector;
-    init_connector(&connector);
     connector.multi = exp->multi;
-    connector.string = name;
-    set_connector_length_limit(&connector);
+    connector.desc = exp->u.condesc;
+    set_connector_length_limit(&connector, _opts);
 
     switch (exp->dir) {
     case '+':
@@ -165,13 +162,12 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
 }
 #undef D_IC
 
-void WordTag::find_matches(int w, const char* C, char dir, std::vector<PositionConnector*>& matches)
+void WordTag::find_matches(int w, const condesc_t* C, char dir, std::vector<PositionConnector*>& matches)
 {
   //  cout << "Look connection on: ." << _word << ". ." << w << ". " << C << dir << endl;
   Connector search_cntr;
-  init_connector(&search_cntr);
-  search_cntr.string = C;
-  set_connector_length_limit(&search_cntr);
+  search_cntr.desc = C;
+  set_connector_length_limit(&search_cntr, _opts);
 
   std::vector<PositionConnector>* connectors;
   switch(dir) {
@@ -198,7 +194,7 @@ void WordTag::add_matches_with_word(WordTag& tag)
   std::vector<PositionConnector>::iterator i;
   for (i = _right_connectors.begin(); i != _right_connectors.end(); i++) {
     std::vector<PositionConnector*> connector_matches;
-    tag.find_matches(_word, (*i).connector.string, '+', connector_matches);
+    tag.find_matches(_word, (*i).connector.desc, '+', connector_matches);
     std::vector<PositionConnector*>::iterator j;
     for (j = connector_matches.begin(); j != connector_matches.end(); j++) {
       i->matches.push_back(*j);

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -23,12 +23,12 @@ struct PositionConnector
       eps_right(er), eps_left(el), word_xnode(w_xnode)
   {
     // Initialize some fields in the connector struct.
-    connector.string = c->string;
+    connector.desc = c->desc;
     connector.multi = c->multi;
     connector.length_limit = c->length_limit;
 
     if (word_xnode == NULL) {
-       cerr << "Internal error: Word" << w << ": " << "; connector: '" << c->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << connector_string(c) << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
     }
 
     /*
@@ -145,26 +145,12 @@ public:
     return NULL;
   }
 
-  void set_connector_length_limit(Connector* c)
-  {
-    unsigned int len = _opts->short_length;
-    Connector_set * conset = _sent->dict->unlimited_connector_set;
-
-    if (len > UNLIMITED_LEN) len = UNLIMITED_LEN;
-
-    if (_opts->all_short ||
-        (conset != NULL && !match_in_connector_set(conset, c)))
-    {
-      c->length_limit = len;
-    }
-  }
-
   bool match(int w1, Connector& cntr1, char dir, int w2, Connector& cntr2)
   {
       int dist = w2 - w1;
       assert(0 < dist, "match() did not receive words in the natural order.");
       if (dist > cntr1.length_limit || dist > cntr2.length_limit) return false;
-      return easy_match(cntr1.string, cntr2.string);
+      return easy_match_desc(cntr1.desc, cntr2.desc);
   }
 
   void insert_connectors(Exp* exp, int& dfs_position,
@@ -182,7 +168,7 @@ public:
   void add_matches_with_word(WordTag& tag);
 
   // Find matches in this word tag with the connector (name, dir).
-  void find_matches(int w, const char* C, char dir,  std::vector<PositionConnector*>& matches);
+  void find_matches(int w, const condesc_t* C, char dir,  std::vector<PositionConnector*>& matches);
 
   // A simpler function: Can any connector in this word match a connector wi, pi?
   // It is assumed that


### PR DESCRIPTION
I could not find (in order to link to it here)  the issue in which I originally proposed the connector enumeration idea (you named this idea "enumeration" there).

For length-limit setup, see issue #632.

Main changes in this PR:
- Connector enumeration (significant speedup).
  While reading the dictionary, put the fixed properties of each connector in a central table, and
  precompute all properties which their value is now computed for each parsed sentence.
  In the connector structure, use a pointer to this table (called in the code the connector descriptor table).
  This also enables using the slot number of a connector in this table as a "perfect hash".
- Compute an encoded value for the lower-case part of connectors, for faster matching.
- Add a facility to define specific length limit for connectors.
- More efficient connector length-limit setup (also for UNLIMITED-CONNECTORS, and the 
  short_length/all_short_connectors parse options).
- Define length limit for LL* in the Russian dict (big speedup - especially for long sentences) and for 
 some connectors in the English dict.
- Add length-limit check to the expression pruning.
  I didn't check if it may improve the result of the power pruning, but it reduces its CPU time.
- Pack the connectors and disjuncts before parsing (notable speedup).
- Code infrastructure: Add connector accessors.

Some additional changes:
- Improve expression pruning debug.
- Add debug print for the parsing connector table at verbosity=102 (in a preparation for reimplementing it 
  \- a WIP).
- List all the connectors,  and their enumeration and length limits at verbosity=101.

Additional possible improvements using the new infrastructure:
- Improve post-processing speed. Deep changes are need to add an argument to many functions, unless 
  a **thread_local** pointer is added, to  point to the connector enumeration table.
- Improve the speed of the fast-matcher by sorting the connector lists according to upper-case strings (to 
  improve the match cache hit ratio).
- Reduce the size of the Connector struct (I intend to try even 4 bytes).
- Reduce the size of a Table_connector element in count.c (made possible by packing the connectors - the connector index can  used instead of its address).

