### PR TITLE
 Fix a crash of double-free of sentence disjuncts

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -517,18 +517,12 @@ int sentence_split(Sentence sent, Parse_Options opts)
 
 static void free_sentence_words(Sentence sent)
 {
-	size_t i;
-
-	for (i = 0; i < sent->length; i++)
+	for (WordIdx i = 0; i < sent->length; i++)
 	{
 		free_X_nodes(sent->word[i].x);
-
-		if (NULL == sent->disjuncts_connectors_memblock)
-			free_disjuncts(sent->word[i].d);
-
 		free(sent->word[i].alternatives);
 	}
-	free(sent->disjuncts_connectors_memblock);
+	free_sentence_disjuncts(sent);
 	free((void *) sent->word);
 	sent->word = NULL;
 }

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -607,22 +607,6 @@ int sentence_link_cost(Sentence sent, LinkageIdx i)
 	return sent->lnkages[i].lifo.link_cost;
 }
 
-static void free_sentence_disjuncts(Sentence sent)
-{
-	size_t i;
-	if (NULL != sent->disjuncts_connectors_memblock)
-	{
-		free(sent->disjuncts_connectors_memblock);
-	}
-	else
-	{
-		for (i = 0; i < sent->length; ++i)
-		{
-			free_disjuncts(sent->word[i].d);
-		}
-	}
-}
-
 int sentence_parse(Sentence sent, Parse_Options opts)
 {
 	int rc;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -11,31 +11,22 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include <limits.h>
-#include <math.h>
 #include <string.h>
-#include <stdint.h>
 
 #include "api-structures.h"
-#include "connectors.h"  // for MAX_SENTENCE
 #include "corpus/corpus.h"
-#include "dict-common/dict-common.h"
 #include "dict-common/dict-utils.h" // for free_X_nodes
 #include "disjunct-utils.h"  // for free_disjuncts
-#include "error.h"
-#include "externs.h"
 #include "linkage/linkage.h"
 #include "parse/histogram.h"  // for PARSE_NUM_OVERFLOW
 #include "parse/parse.h"
 #include "post-process/post-process.h" // for post_process_new()
-#include "print/print.h"
 #include "prepare/exprune.h"
+#include "string-set.h"
 #include "resources.h"
 #include "sat-solver/sat-encoder.h"
-#include "string-set.h"
 #include "tokenize/spellcheck.h"
 #include "tokenize/tokenize.h"
-#include "tokenize/tok-structures.h" // Needed for Gword_struct
 #include "tokenize/word-structures.h" // Needed for Word_struct/free_X_node
 #include "utilities.h"
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -616,6 +616,14 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 		rc = sentence_split(sent, opts);
 		if (rc) return -1;
 	}
+	else
+	{
+		/* During a panic parse, we enter here a second time, with leftover
+		 * garbage. Free it. We really should make the code that is panicking
+		 * do this free, but right now, they have no API for it, so we do it
+		 * as a favor. XXX FIXME someday. */
+		free_sentence_disjuncts(sent);
+	}
 
 	/* Check for bad sentence length */
 	if (MAX_SENTENCE <= sent->length)
@@ -625,11 +633,6 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 		return -2;
 	}
 
-	/* During a panic parse, we enter here a second time, with leftover
-	 * garbage. Free it. We really should make the code that is panicking
-	 * do this free, but right now, they have no PAI for it, so we do it
-	 * as a favor. XXX FIXME someday. */
-	free_sentence_disjuncts(sent);
 	resources_reset(opts->resources);
 
 	/* Expressions were set up during the tokenize stage.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -11,12 +11,15 @@
 /*************************************************************************/
 
 #include <string.h>
+
+#include "link-grammar/api-structures.h" // Sentence
 #include "connectors.h"
 #include "disjunct-utils.h"
 #include "print/print-util.h"
 #include "string-set.h"
 #include "utilities.h"
 #include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
+#include "tokenize/word-structures.h"
 
 /* Disjunct utilities ... */
 
@@ -32,6 +35,22 @@ void free_disjuncts(Disjunct *c)
 		free_connectors(c->left);
 		free_connectors(c->right);
 		xfree((char *)c, sizeof(Disjunct));
+	}
+}
+
+void free_sentence_disjuncts(Sentence sent)
+{
+	if (NULL != sent->disjuncts_connectors_memblock)
+	{
+		free(sent->disjuncts_connectors_memblock);
+		sent->disjuncts_connectors_memblock = NULL;
+	}
+	else
+	{
+		for (WordIdx i = 0; i < sent->length; i++)
+		{
+			free_disjuncts(sent->word[i].d);
+		}
 	}
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -16,7 +16,6 @@
 #include "connectors.h"
 #include "disjunct-utils.h"
 #include "print/print-util.h"
-#include "string-set.h"
 #include "utilities.h"
 #include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
 #include "tokenize/word-structures.h"

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 
 #include "api-types.h"
+#include "link-grammar/api-structures.h" // Sentence
 
 // Can undefine VERIFY_MATCH_LIST when done debugging...
 #define VERIFY_MATCH_LIST
@@ -39,6 +40,7 @@ struct Disjunct_struct
 
 /* Disjunct utilities ... */
 void free_disjuncts(Disjunct *);
+void free_sentence_disjuncts(Sentence);
 unsigned int count_disjuncts(Disjunct *);
 Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct * );

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -359,11 +359,9 @@ void classic_parse(Sentence sent, Parse_Options opts)
 				 * parsed with null_count==0. Restore the save disjuncts. */
 				if (NULL != disjuncts_copy)
 				{
+					free_sentence_disjuncts(sent);
 					for (size_t i = 0; i < sent->length; i++)
-					{
-						free_disjuncts(sent->word[i].d);
 						sent->word[i].d = disjuncts_copy[i];
-					}
 					disjuncts_copy = NULL;
 				}
 			}


### PR DESCRIPTION
See issue [#632](https://github.com/opencog/link-grammar/issues/632#issuecomment-366310669).

At the same opportunity:
- Refactor the touched code.
- Remove unneeded include files from the touched files.
- Avoid trying to free disjuncts from a fresh sentence.