### PR TITLE
Address problems discussed in #673

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -47,6 +47,11 @@ messages of the lower ones.
 * 10: Basic dictionary debug.
 
 100-...: Show only messages exactly at the specified level.
+* 101: do_count() memoizing table statistics (in DEBUG mode only).
+
+* 102: Print all the connectors, along with their length limit.
+       A length limit of 0 means the value of the short\_length option is used.
+
 * 103: Show unsubscripted dictionary words and subscripted ones which share
        the same base word.
 
@@ -117,13 +122,6 @@ Or, in order to display the word array:
 7) Debug reading the affix and knowledge files:
 
 `link-parser -v=11`
-
-8) Print all the connectors, along with their length limit.
-
-`link-parser -v=102`
-
-A length limit of 0 means the value of the short\_length option
-is used.
 
 ### -test=...
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -205,6 +205,17 @@ void set_all_condesc_length_limit(Dictionary dict)
 
 /* ======================================================== */
 
+/**
+ * Pack the LC part of a connector into 64 bits, and compute a wild-card mask.
+ * Up to 9 characters can be so packed.
+ *
+ * Because we pack by shifts, we can do it using 7-bit per original
+ * character at the same overhead needed for 8-bit packing.
+ *
+ * Note: The LC part may consist of chars in the range [a-z0-9]
+ * (total 36) and there is a gap between the codes of [a-z] and [0-9].
+ * So a 6-bit packing will need a more complex algo.
+ */
 static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 {
 	lc_enc_t lc_mask = 0;

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -249,9 +249,8 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 
 /**
  * Calculate fixed connector information that only depend on its string.
- * This information is used to speed up the parsing stage.
- * It is calculated during the directory creation and doesn't get
- * changed afterward.
+ * This information is used to speed up the parsing stage. It is
+ * calculated during the directory creation and doesn't change afterward.
  */
 bool calculate_connector_info(condesc_t * c)
 {
@@ -260,7 +259,7 @@ bool calculate_connector_info(condesc_t * c)
 
 	s = c->string;
 	if (islower((int) *s)) s++; /* ignore head-dependent indicator */
-	c->head_depended = (c->string == s)? '\0' : c->string[0];
+	c->head_dependent = (c->string == s)? '\0' : c->string[0];
 
 	/* For most situations, all three hashes are very nearly equal;
 	 * as to which is faster depends on the parsed text.

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -21,6 +21,8 @@
 #include "connectors.h"
 #include "link-includes.h"          // for Parse_Options
 
+#define WILD_TYPE '*'
+
 /**
  * free_connectors() -- free the list of connectors pointed to by e
  * (does not free any strings)
@@ -99,7 +101,7 @@ static int condesc_by_uc_num(const void *a, const void *b)
 	return 0;
 }
 
-#define WILD_TYPE '*'
+#define LENGTH_LINIT_WILD_TYPE WILD_TYPE
 
 static void set_condesc_length_limit(Dictionary dict, const Exp *e, int length_limit)
 {
@@ -136,7 +138,7 @@ static void set_condesc_length_limit(Dictionary dict, const Exp *e, int length_l
 		restart_cn = cn+1;
 
 		const char *wc_str = econlist[en]->string;
-		char *uc_wildcard = strchr(wc_str, WILD_TYPE);
+		char *uc_wildcard = strchr(wc_str, LENGTH_LINIT_WILD_TYPE);
 
 		for (; cn < ct->num_con; cn++)
 		{
@@ -233,7 +235,7 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 			return false;
 		}
 		lc_value |= (lc_enc_t)(*lc_string & LC_MASK) << (lc_pos*LC_BITS);
-		if (*lc_string != '*') lc_mask |= wildcard;
+		if (*lc_string != WILD_TYPE) lc_mask |= wildcard;
 		if ('\0' == lc_string[1]) break;
 		wildcard <<= LC_BITS;
 		lc_pos++;

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -60,7 +60,7 @@ typedef struct
 	                       * If 0, short_length (a Parse_Option) is used. If
 	                       * all_short==true (a Parse_Option), length_limit
 	                       * is clipped to short_length. */
-	char head_depended;   /* 'h' for head, 'd' for depended, or '\0' if none */
+	char head_dependent;   /* 'h' for head, 'd' for dependent, or '\0' if none */
 
 	/* The following are used for connector match speedup */
 	uint8_t uc_length;   /* uc part length */
@@ -202,7 +202,7 @@ static bool lc_easy_match(const condesc_t *c1, const condesc_t *c2)
 {
 	if ((c1->lc_letters ^ c2->lc_letters) & c1->lc_mask & c2->lc_mask)
 		return false;
-	if (('\0' != c1->head_depended) && (c1->head_depended == c2->head_depended))
+	if (('\0' != c1->head_dependent) && (c1->head_dependent == c2->head_dependent))
 		return false;
 
 	return true;

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -32,8 +32,7 @@
 
 /* For faster comparisons, the connector lc part is encoded into a number
  * and a mask. Each letter is encoded using LC_BITS bits. With 7 bits, it
- * is possible to encode up to 9 letters in an uint64_t.
- * FIXME: Validate that lc length <= 9. */
+ * is possible to encode up to 9 letters in an uint64_t. */
 #define LC_BITS 7
 #define LC_MASK ((1<<LC_BITS)-1)
 typedef uint64_t lc_enc_t;
@@ -108,9 +107,7 @@ void condesc_delete(Dictionary);
 /* GET accessors for connector attributes.
  * Can be used for experimenting with Connector_struct internals in
  * non-trivial ways without the need to change most of the code that
- * accesses connectors.
- * FIXME: Maybe remove the _get part of the names, since we don't
- * need SET accessors. */
+ * accesses connectors */
 static inline const char * connector_string(const Connector *c)
 {
 	return c->desc->string;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -276,9 +276,9 @@ static void pack_sentence(Sentence sent)
 		}
 	}
 
-#define CACHELINE 64
+#define CONN_ALIGNMENT sizeof(Connector)
 	size_t dsize = dcnt * sizeof(Disjunct);
-	dsize = (dsize+CACHELINE)&~(CACHELINE-1); /* Align connector block. */
+	dsize = (dsize+CONN_ALIGNMENT)&~(CONN_ALIGNMENT-1); /* Align connector block. */
 	size_t csize = ccnt * sizeof(Connector);
 	void *memblock = malloc(dsize + csize);
 	Disjunct *dblock = memblock;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -251,8 +251,19 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
 /**
  * Pack all disjunct and connectors into one big memory block.
  * This facilitate a better memory caching for long sentences
- * using the fact that now more than one connector can be packed
- * in a cache line of 64 bytes (a performance gain of a few percents).
+ * (a performance gain of a few percents).
+ *
+ * The current Connector struct size is 32 bit, and future ones may be
+ * smaller, but still with a power-of-2 size.
+ * The idea is to put an integral number of connectors in each cache line
+ * (assumed to be >= Connector struct size, e.g. 64 bytes),
+ * so one connector will not need 2 cache lines.
+ *
+ * The allocated memory includes 3 sections , in that order:
+ * 1. A block for disjuncts, when it start is not aligned (the disjunct size
+ * is currently 56 bytes and cannot be reduced much).
+ * 2. A small alignment gap, that ends in a 64-byte boundary.
+ * 3. A block of connectors, which is so aligned to 64-byte boundary.
  *
  * FIXME: 1. Find the "best" value for SHORTEST_SENTENCE_TO_PACK.
  * 2. Maybe this check should be done in too stages, the second one

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -53,10 +53,10 @@ struct connector_table_s
 
 #define CT_BLKSIZE 512
 /* The connector table elements are allocated in a kind of an unrolled
- * linked list with fixed blocks, when the first block is pre-allocated on
- * the stack (this simplifies the handling). Additional blocks are
+ * linked list with fixed blocks, when the first block is pre-allocated
+ * (this simplifies the handling). Additional blocks are
  * dynamically allocated, but they are rarely needed. The existing
- * allocation is reused on each pass, an freed only at the end of the
+ * allocation is reused on each pass, and freed only at the end of the
  * expression pruning. */
 // connector_table_element-> ... CT_BLKSIZE-1 elements
 //                           ...

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -66,8 +66,8 @@ char *get_console_line(void)
 	}
 
 	/* Make sure we don't have conversion problems, by searching for '�'. */
-	const char *invlid_char  = strstr(utf8inbuf, "\xEF\xBF\xBD");
-	if (NULL != invlid_char)
+	const char *invalid_char  = strstr(utf8inbuf, "\xEF\xBF\xBD");
+	if (NULL != invalid_char)
 		prt_error("Warning: Invalid input character encountered.\n");
 
 	/* ^Z is read as a character. Convert it to an EOF indication. */


### PR DESCRIPTION
List of problems (see #673) addressed here:
- get_connectors_from_expression(): Directly return the connector list size.
- connector_encode_lc(): Add function description.
- Fix typo.
- pack_sentence(): Enhance the function description

(Also a few minor changes/additions.)

Not addressed here:
- Copy the connector table to continues memory (to be more CPU cache friendly) - TBD.
- Pool allocation of condesc_t (WIP). I will open an issue about its implementation.