### PR TITLE
Bug fixes and cleanup

### DIFF
--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -53,7 +53,7 @@ if sys.version_info < (3, 0):
     import codecs
     #sys.stdout = codecs.getreader('utf-8')(sys.stdout)
 
-print("Enter sentences:");
+print("Enter sentences:")
 # iter(): avoid python2 input buffering
 for sentence_text in iter(sys.stdin.readline, ''):
     if sentence_text.strip() == '':

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -1277,7 +1277,7 @@ It was piping hot.
 It was devilishly hot.
 
 
-% present-continous with prepositions.
+% present-continuous with prepositions.
 Similar legislation is passing state-wide
 The party is happening afterwards.
 It is happening world-wide
@@ -2940,7 +2940,7 @@ He, Joseph, rang the bell
 I, Joseph, rang the bell
 they, the twins, did it.
 He, the shop owner, rang the bell
-he, the shop onwer, ...
+he, the shop owner, ...
 Herbert, the shop owner, rang the bell
 We, the undersigned, declare this statement to be true
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -102,6 +102,7 @@ struct Connector_struct
 };
 
 void sort_condesc_by_uc_constring(Dictionary);
+condesc_t *condesc_add(ConTable *ct, const char *);
 void condesc_delete(Dictionary);
 
 /* GET accessors for connector attributes.
@@ -306,92 +307,4 @@ static inline unsigned int pair_hash(unsigned int table_size,
 
 	return i & (table_size-1);
 }
-
-static inline condesc_t **condesc_find(ConTable *ct, const char *constring, int hash)
-{
-	size_t i = hash & (ct->size-1);
-
-	while ((NULL != ct->hdesc[i]) &&
-	       !string_set_cmp(constring, ct->hdesc[i]->string))
-	{
-		i = (i + 1) & (ct->size-1);
-	}
-
-	return &ct->hdesc[i];
-}
-
-static inline void condesc_table_alloc(ConTable *ct, size_t size)
-{
-	ct->hdesc = (condesc_t **)malloc(size * sizeof(condesc_t *));
-	memset(ct->hdesc, 0, size * sizeof(condesc_t *));
-	ct->size = size;
-}
-
-static inline bool condesc_insert(ConTable *ct, condesc_t **h,
-                                  const char *constring, int hash)
-{
-	*h = (condesc_t *)malloc(sizeof(condesc_t));
-	memset(*h, 0, sizeof(condesc_t));
-	(*h)->str_hash = hash;
-	(*h)->string = constring;
-	ct->num_con++;
-
-	return calculate_connector_info(*h);
-}
-
-#define CONDESC_TABLE_GROW_FACTOR 2
-
-static inline bool condesc_grow(ConTable *ct)
-{
-	size_t old_size = ct->size;
-	condesc_t **old_hdesc = ct->hdesc;
-
-	lgdebug(+11, "Growing ConTable from %zu\n", old_size);
-	condesc_table_alloc(ct, ct->size * CONDESC_TABLE_GROW_FACTOR);
-
-	for (size_t i = 0; i < old_size; i++)
-	{
-		condesc_t *old_h = old_hdesc[i];
-		if (NULL == old_h) continue;
-		condesc_t **new_h = condesc_find(ct, old_h->string, old_h->str_hash);
-
-		if (NULL != *new_h)
-		{
-			prt_error("Fatal Error: condesc_grow(): Internal error\n");
-			free(old_hdesc);
-			return false;
-		}
-		*new_h = old_h;
-	}
-
-	free(old_hdesc);
-	return true;
-}
-
-static inline condesc_t *condesc_add(ConTable *ct, const char *constring)
-{
-	if (0 == ct->size)
-	{
-		condesc_table_alloc(ct, ct->num_con);
-		ct->num_con = 0;
-	}
-
-	int hash = connector_str_hash(constring);
-	condesc_t **h = condesc_find(ct, constring, hash);
-
-	if (NULL == *h)
-	{
-		lgdebug(+11, "Creating connector '%s'\n", constring);
-		if (!condesc_insert(ct, h, constring, hash)) return NULL;
-
-		if ((8 * ct->num_con) > (3 * ct->size))
-		{
-			if (!condesc_grow(ct)) return NULL;
-			h = condesc_find(ct, constring, hash);
-		}
-	}
-
-	return *h;
-}
-
 #endif /* _LINK_GRAMMAR_CONNECTORS_H_ */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -15,7 +15,7 @@
 #define _LINK_GRAMMAR_CONNECTORS_H_
 
 #include <ctype.h>   // for islower()
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdint.h>  // for uint8_t
 

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -316,8 +316,7 @@ char *get_file_contents(const char * dict_name)
 {
 	int fd;
 	size_t tot_size;
-	size_t read_size;
-	size_t tot_read;
+	size_t tot_read = 0;
 	struct stat buf;
 	char * contents;
 
@@ -339,7 +338,7 @@ char *get_file_contents(const char * dict_name)
 	 * Normally, only a single call of fread() is needed. */
 	while (1)
 	{
-		read_size = fread(contents, 1, tot_size+7, fp);
+		size_t read_size = fread(contents, 1, tot_size+7, fp);
 
 		if (0 == read_size)
 		{
@@ -360,14 +359,14 @@ char *get_file_contents(const char * dict_name)
 		tot_read += read_size;
 	}
 
-	if (tot_size > tot_size+6)
+	if (tot_read > tot_size+6)
 	{
 		prt_error("Error: %s: File size is insane (%zu)!\n", dict_name, tot_size);
 		free(contents);
 		return NULL;
 	}
 
-	contents[tot_size] = '\0';
+	contents[tot_read] = '\0';
 	return contents;
 }
 

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -230,10 +230,7 @@ dictionary_six_str(const char * lang,
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	dict->hpsg_knowledge  = pp_knowledge_open(cons_name);
 
-	/* set_connector_unlimited_length() in dictionary_setup_defines()
-	 * depends on this sorting. */
 	sort_condesc_by_uc_constring(dict);
-
 	dictionary_setup_defines(dict);
 
 	// Special-case hack.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -963,7 +963,7 @@ static Exp * make_connector(Dictionary dict)
 		}
 		else
 		{
-			dict_error(dict, "Unknown connector direction type '%c'.");
+			dict_error(dict, "Unknown connector direction type.");
 			return NULL;
 		}
 	}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -112,9 +112,7 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 }
 
 /**
- * The connectors must be exactly equal.  A similar function
- * is connectors_equal_AND(), but that ignores priorities,
- * this does not.
+ * The connectors must be exactly equal.
  */
 static bool connectors_equal_prune(Connector *c1, Connector *c2)
 {

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -673,6 +673,8 @@ count_context_t * alloc_count_context(size_t sent_length)
 
 void free_count_context(count_context_t *ctxt, Sentence sent)
 {
+	if (NULL == ctxt) return;
+
 	DEBUG_TABLE_STAT(if (verbosity_level(D_SPEC+2)) table_stat(ctxt, sent));
 	free_table(ctxt);
 	xfree(ctxt, sizeof(count_context_t));

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -289,7 +289,7 @@ static void pack_sentence(Sentence sent)
 
 #define CONN_ALIGNMENT sizeof(Connector)
 	size_t dsize = dcnt * sizeof(Disjunct);
-	dsize = (dsize+CONN_ALIGNMENT)&~(CONN_ALIGNMENT-1); /* Align connector block. */
+	dsize = ALIGN(dsize, CONN_ALIGNMENT); /* Align connector block. */
 	size_t csize = ccnt * sizeof(Connector);
 	void *memblock = malloc(dsize + csize);
 	Disjunct *dblock = memblock;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -334,7 +334,7 @@ static void pack_sentence(Sentence sent)
 void classic_parse(Sentence sent, Parse_Options opts)
 {
 	fast_matcher_t * mchxt = NULL;
-	count_context_t * ctxt;
+	count_context_t * ctxt = NULL;
 	bool pp_and_power_prune_done = false;
 	Disjunct **disjuncts_copy = NULL;
 	bool is_null_count_0 = (0 == opts->min_null_count);
@@ -343,7 +343,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	/* Build lists of disjuncts */
 	prepare_to_parse(sent, opts);
 	if (resources_exhausted(opts->resources)) return;
-	ctxt = alloc_count_context(sent->length);
 
 	if (is_null_count_0 && (0 < max_null_count))
 	{
@@ -380,8 +379,10 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			if (is_null_count_0) opts->min_null_count = 0;
 			if (resources_exhausted(opts->resources)) break;
 
+			free_count_context(ctxt, sent);
 			free_fast_matcher(mchxt);
 			pack_sentence(sent);
+			ctxt = alloc_count_context(sent->length);
 			mchxt = alloc_fast_matcher(sent);
 			print_time(opts, "Initialized fast matcher");
 		}

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -122,7 +122,7 @@ size_t utf8_chars_in_width(const char *s, size_t max_width)
 		{
 			// If we are here, it was a valid UTF-8 code point,
 			// but we do not know the width of the corresponding
-			// glyph. Just like above, asume a double-wide box
+			// glyph. Just like above, assume a double-wide box
 			// font will be printed.
 			int gw = mk_wcwidth(wc);
 			if (0 <= gw)
@@ -211,7 +211,7 @@ int append_string(dyn_str * string, const char *fmt, ...)
  * number of bytes actually appended. Two things might
  * happen:
  * a) Invalid UTF-8 values are copied, but only one byte,
- *    followed by an addtional blank.
+ *    followed by an additional blank.
  * b) Valid UTF-8 code-points that do not have a known
  *    glyph are copied, followed by an additional blank.
  * This additional blanks allows proper printing of these

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -667,7 +667,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	{
 		for (i = 0; i < (size_t) word_offset[k]; i++) *t++ = ' ';
 
-		// Copy raw bytes. Adjustsments for different widths,
+		// Copy raw bytes. Adjustments for different widths,
 		// invalid utf8 characters, etc. is done later.
 		s = linkage->word[k];
 		while (*s != '\0') { *t++ = *s++; }

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -478,9 +478,9 @@ bool try_locale(const char *);
 /**
  * Returns the smallest power of two that is at least i and at least 1
  */
-static inline unsigned int next_power_of_two_up(unsigned int i)
+static inline size_t next_power_of_two_up(size_t i)
 {
-	unsigned int j=1;
+	size_t j=1;
 	while (j<i) j <<= 1;
 	return j;
 }

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -171,6 +171,9 @@ typedef int locale_t;
 #define freelocale(l)
 #endif /* HAVE_LOCALE_T */
 
+
+#define ALIGN(size, alignment) (((size)+(alignment-1))&~(alignment-1))
+
 #define STR(x) #x
 #define STRINGIFY(x) STR(x)
 

--- a/msvc14/LinkGrammar.vcxproj
+++ b/msvc14/LinkGrammar.vcxproj
@@ -337,6 +337,7 @@
     <ClCompile Include="..\link-grammar\tokenize\spellcheck-aspell.c" />
     <ClCompile Include="..\link-grammar\tokenize\spellcheck-hun.c" />
     <ClCompile Include="..\link-grammar\tokenize\tokenize.c" />
+    <ClCompile Include="..\link-grammar\tokenize\wg-display.c" />
     <ClCompile Include="..\link-grammar\tokenize\wordgraph.c" />
     <ClCompile Include="..\link-grammar\utilities.c" />
   </ItemGroup>

--- a/msvc14/LinkGrammar.vcxproj.filters
+++ b/msvc14/LinkGrammar.vcxproj.filters
@@ -159,6 +159,9 @@
     <ClCompile Include="..\link-grammar\post-process\pp_lexer.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\link-grammar\tokenize\wg-display.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\link-grammar\api-structures.h">


### PR DESCRIPTION
Fix bugs:
- Fix (not) using tot_read in the recent rewrite of `get_file_contents()`.
- Fix alignment of connector block (too aggressive due to off by one).
- Reinitialize the connector table after parsing with 0 nulls.
- Windows: Add wg-display.c.
- ￼EDIT: Fix compilation problem on OSX due to incorrect #include.

Additions from yet unpublished code:
- Next_power_of_two_up(): Change to use size_t.
- Add ALIGN macro.

Fix Typos:
- Remove '%c' from message.

General cleanup:
- Move the condesc functions from connectors.h to connectors.c.
- Fix comment rot.

EDIT: Force push to fix Windows project file.