### PR TITLE
Bug fixes and cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -376,7 +376,8 @@ if test "x$enable_sat_solver" = xyes; then
 	fi
 
 	AC_LANG([C])
-	CPPFLAGS="$CPPFLAGS_SAVE -DUSE_SAT_SOLVER=1"
+	CPPFLAGS="$CPPFLAGS_SAVE"
+	AC_DEFINE(USE_SAT_SOLVER, 1, [Define for compilation])
 	AC_SUBST(ZLIB_CPPFLAGS)
 fi
 
@@ -393,7 +394,7 @@ AC_ARG_ENABLE( corpus-stats,
 )
 if test "x$enable_corpus_stats" = "xyes"
 then
-	CPPFLAGS="${CPPFLAGS} -DUSE_CORPUS=1"
+	AC_DEFINE(USE_CORPUS, 1, [Define for compilation])
 fi
 
 AM_CONDITIONAL(WITH_CORPUS, test x${enable_corpus_stats} = xyes)
@@ -407,7 +408,7 @@ AC_ARG_ENABLE( wordgraph_display,
 )
 if test "x$enable_wordgraph_display" = "xyes"
 then
-	CPPFLAGS="${CPPFLAGS} -DUSE_WORDGRAPH_DISPLAY=1"
+	AC_DEFINE(USE_WORDGRAPH_DISPLAY, 1, [Define for compilation])
 fi
 
 AM_CONDITIONAL(WITH_ANYSPLIT, test x${enable_wordgraph_display} = xyes)
@@ -426,7 +427,7 @@ fi
 # Which is insane, of course, except that some Apple OSX systems
 # appear to be borken... have header files but no libs ...
 if test "x${SQLiteFound}" = "xyes"; then
-	CPPFLAGS="${CPPFLAGS} -DHAVE_SQLITE=1"
+	AC_DEFINE(HAVE_SQLITE, 1, [Define for compilation])
 fi
 AM_CONDITIONAL(HAVE_SQLITE, test x${SQLiteFound} = xyes)
 AC_SUBST(SQLITE3_LIBS)
@@ -559,7 +560,7 @@ AC_ARG_ENABLE( regex_tokenizer,
 )
 if test "x$enable_regex_tokenizer" = "xyes"
 then
-	CPPFLAGS="${CPPFLAGS} -DUSE_REGEX_TOKENIZER=1"
+	AC_DEFINE(USE_REGEX_TOKENIZER, 1, [Define for compilation])
 	AX_PATH_LIB_PCRE
 fi
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -362,30 +362,24 @@ static int condesc_by_uc_constring(const void * a, const void * b)
  */
 void sort_condesc_by_uc_constring(Dictionary dict)
 {
-	condesc_t **sdesc = malloc(dict->contable.size * sizeof(*dict->contable.hdesc));
-	memcpy(sdesc, dict->contable.hdesc, dict->contable.size * sizeof(*dict->contable.hdesc));
-	qsort(sdesc, dict->contable.size, sizeof(*dict->contable.hdesc),
-	      condesc_by_uc_constring);
-
-	/* Find the number of connectors. */
-	size_t n;
-	for (n = 0; n < dict->contable.size; n++)
-		if (NULL == sdesc[n]) break;
-	dict->contable.num_con = n;
-
-	if (0 == n)
+	if (0 == dict->contable.num_con)
 	{
 		prt_error("Error: Dictionary %s: No connectors found.\n", dict->name);
 		/* FIXME: Generate a dictionary open error. */
 		return;
 	}
 
+	condesc_t **sdesc = malloc(dict->contable.size * sizeof(*dict->contable.hdesc));
+	memcpy(sdesc, dict->contable.hdesc, dict->contable.size * sizeof(*dict->contable.hdesc));
+	qsort(sdesc, dict->contable.size, sizeof(*dict->contable.hdesc),
+	      condesc_by_uc_constring);
+
 	/* Enumerate the connectors according to their UC part. */
 	int uc_num = 0;
 	uint32_t uc_hash = sdesc[0]->uc_hash; /* Will be recomputed */
 
 	sdesc[0]->uc_num = uc_num;
-	for (n = 1; n < dict->contable.num_con; n++)
+	for (size_t n = 1; n < dict->contable.num_con; n++)
 	{
 		condesc_t **condesc = &sdesc[n];
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -223,23 +223,21 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 	lc_enc_t lc_mask = 0;
 	lc_enc_t lc_value = 0;
 	lc_enc_t wildcard = LC_MASK;
-	int lc_pos = 0;
+	const char *s;
 
-	if ('\0' == *lc_string) return true;
-	do
+	for (s = lc_string; '\0' != *s; s++)
 	{
-		if (lc_pos > (int)(CHAR_BIT*sizeof(lc_value)/LC_BITS))
-		{
-			prt_error("Error: Lower-case part '%s' is too long (%d)\n",
-			          lc_string, lc_pos);
-			return false;
-		}
-		lc_value |= (lc_enc_t)(*lc_string & LC_MASK) << (lc_pos*LC_BITS);
-		if (*lc_string != WILD_TYPE) lc_mask |= wildcard;
-		if ('\0' == lc_string[1]) break;
+		lc_value |= (lc_enc_t)(*s & LC_MASK) << ((s-lc_string)*LC_BITS);
+		if (*s != WILD_TYPE) lc_mask |= wildcard;
 		wildcard <<= LC_BITS;
-		lc_pos++;
-	} while (lc_string++);
+	};
+
+	if ((unsigned long)(s-lc_string) > (CHAR_BIT*sizeof(lc_value)/LC_BITS))
+	{
+		prt_error("Error: Lower-case part '%s' is too long (%ld)\n",
+					 lc_string, s-lc_string);
+		return false;
+	}
 
 	desc->lc_mask = lc_mask;
 	desc->lc_letters = lc_value;

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -215,8 +215,8 @@ void set_all_condesc_length_limit(Dictionary dict)
  * character at the same overhead needed for 8-bit packing.
  *
  * Note: The LC part may consist of chars in the range [a-z0-9]
- * (total 36) and there is a gap between the codes of [a-z] and [0-9].
- * So a 6-bit packing will need a more complex algo.
+ * (total 36) so a 6-bit packing is possible (by abs(value-60) on each
+ * character value).
  */
 static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -40,6 +40,10 @@ typedef uint64_t lc_enc_t;
 
 typedef uint16_t connector_hash_size; /* Change to uint32_t if needed. */
 
+/* When connector_hash_size is uint16_t, the size of the following
+ * struct on a 64-bit machine is 32 bytes.
+ * FIXME: Make it 16 bytes by separating the info that is not needed
+ * by do_count() into another structure (and some other minor changes). */
 typedef struct
 {
 	lc_enc_t lc_letters;
@@ -62,7 +66,7 @@ typedef struct
 	                       * is clipped to short_length. */
 	char head_dependent;   /* 'h' for head, 'd' for dependent, or '\0' if none */
 
-	/* The following are used for connector match speedup */
+	/* For connector match speedup when sorting the connector table. */
 	uint8_t uc_length;   /* uc part length */
 	uint8_t uc_start;    /* uc start position */
 } condesc_t;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -121,8 +121,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	}
 
 	for (i=0; i<icost; i++) dyn_strcat(e, "[");
-	if ((n->type == OR_type) &&
-	    el && el->e && (NULL == el->e->u.l))
+	if ((n->type == OR_type) && el->e && (NULL == el->e->u.l))
 	{
 		dyn_strcat(e, "{");
 		if (NULL == el->next) dyn_strcat(e, "error-no-next");

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -365,7 +365,7 @@ static bool link_advance(Dictionary dict)
 		bool ok = get_character(dict, quote_mode, c);
 		if (!ok) return false;
 	}
-	return true;
+	/* unreachable */
 }
 
 /**

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -329,11 +329,9 @@ static void* db_open(const char * fullname, const void * user_data)
 	/* SQLite has a habit of leaving zero-length DB's lying around */
 	fd = fileno(fh);
 	fstat(fd, &buf);
+	fclose(fh);
 	if (0 == buf.st_size)
-	{
-		fclose(fh);
 		return NULL;
-	}
 
 	/* Found a file, of non-zero length. See if that works. */
 	if (sqlite3_open(fullname, &db))

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -687,6 +687,7 @@ static void list_random_links(Linkage lkg, extractor_t * pex, const Parse_set * 
 	for (pc = set->first; pc != NULL; pc = pc->next) {
 		num_pc++;
 	}
+	assert(num_pc != 0, "Couldn't get a random parse choice");
 
 	new_index = rand_r(&pex->rand_state) % num_pc;
 
@@ -696,7 +697,6 @@ static void list_random_links(Linkage lkg, extractor_t * pex, const Parse_set * 
 		num_pc++;
 	}
 
-	assert(pc != NULL, "Couldn't get a random parse choice");
 	issue_links_for_choice(lkg, pc);
 	list_random_links(lkg, pex, pc->set[0]);
 	list_random_links(lkg, pex, pc->set[1]);

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -107,7 +107,6 @@ void free_fast_matcher(Sentence sent, fast_matcher_t *mchxt)
 
 /**
  * Adds the match node m to the sorted list of match nodes l.
- * The parameter dir determines the order of the sorting to be used.
  * Makes the list sorted from smallest to largest.
  */
 static Match_node * add_to_right_table_list(Match_node * m, Match_node * l)
@@ -140,7 +139,6 @@ static Match_node * add_to_right_table_list(Match_node * m, Match_node * l)
 
 /**
  * Adds the match node m to the sorted list of match nodes l.
- * The parameter dir determines the order of the sorting to be used.
  * Makes the list sorted from largest to smallest
  */
 static Match_node * add_to_left_table_list(Match_node * m, Match_node * l)

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -122,9 +122,9 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 	sent->num_valid_linkages = 0;
 	size_t N_invalid_morphism = 0;
 
-	size_t itry = 0;
+	int itry = 0;
 	size_t in = 0;
-	size_t maxtries;
+	int maxtries;
 
 	/* In the case of overflow, which will happen for some long
 	 * sentences, but is particularly common for the amy/ady random
@@ -208,7 +208,7 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 	 * So just pretend that it's shorter than it is */
 	sent->num_linkages_alloced = sent->num_valid_linkages;
 
-	lgdebug(D_PARSE, "Info: sane_morphism(): %zu of %zu linkages had "
+	lgdebug(D_PARSE, "Info: sane_morphism(): %zu of %d linkages had "
 	        "invalid morphology construction\n", N_invalid_morphism,
 	        itry + (itry != maxtries));
 }

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -65,7 +65,7 @@ char *get_console_line(void)
 		return NULL;
 	}
 
-	/* Make sure we don't have conversion problems, by searching for '�'. */
+	/* Make sure we don't have conversion problems, by searching for U+FFFD. */
 	const char *invalid_char  = strstr(utf8inbuf, "\xEF\xBF\xBD");
 	if (NULL != invalid_char)
 		prt_error("Warning: Invalid input character encountered.\n");


### PR DESCRIPTION
The following commits are according to Sonar-scanner:
- Sonar-scanner got confused by this character
- Fix contable memory leak when a dict contains no connectors
- link_advance(): Remove an unreachable "return"
- db_open(): Fix FILE leak
- process_linkages(): Avoid using unary minus with size_t
- connector_encode_lc(): Code cleanup (was done previously but Sonar-scanner also found the while condition that is always true).

EDIT: Added:
- print-dict.c: "el" is never NULL here
