### PR TITLE
Manual page fixes

### DIFF
--- a/man/link-parser.man1
+++ b/man/link-parser.man1
@@ -260,7 +260,7 @@ Disabled
 .IP 1
 Treebank-style constituent tree
 .PP
-.IP 1
+.IP 2
 Flat, bracketed tree [A like [B this B] A]
 .IP 3
 Flat, treebank-style tree (A like (B this))

--- a/man/link-parser.man1
+++ b/man/link-parser.man1
@@ -48,10 +48,12 @@
 ..
 .\" define .EX/.EE (for multiline user-command examples; normal Courier font)
 .de EX
+.Vb
 .nf
 .ft CW
 ..
 .de EE
+.Ve
 .ft P
 .fi
 ..


### PR DESCRIPTION
1. Fix typo in !constituents variable value.
2. Many online manuals like http://manpages.ubuntu.com/manpages/artful/man1/link-parser.1.html show the diagram distorted (some others show it OK).
In a try to fix that I added `.Vb`/`.Ve` (nroff verbatim mode).
We will need to wait and see if this helps (or find the exact command they use in order to generate HTML).