### PR TITLE
Fix errors detected by Coverity

### DIFF
--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -25,7 +25,9 @@ LINK_BEGIN_DECLS
  * the public API to the link-parser system.
  */
 
+#ifdef USE_VITERBI
 Dictionary dictionary_create_from_utf8(const char * input);
+#endif
 
 bool boolean_dictionary_lookup(const Dictionary, const char *);
 

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -307,10 +307,15 @@ Dictionary dictionary_create_from_file(const char * lang)
 }
 
 
+#ifdef USE_VITERBI
 /**
  * Use "string" as the input dictionary. All of the other parts,
  * including post-processing, affix table, etc, are NULL.
  * This routine is intended for unit-testing ONLY.
+ *
+ * FIXME? (Used only by code that is in use for now.)
+ * 1. get_default_locale() returns locale, not language.
+ * 2. "lang" memory leak on success.
  */
 Dictionary dictionary_create_from_utf8(const char * input)
 {
@@ -332,4 +337,5 @@ Dictionary dictionary_create_from_utf8(const char * input)
 
 	return dictionary;
 }
+#endif // USE_VITERBI
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -234,7 +234,7 @@ static bool get_character(Dictionary dict, int quote_mode, utf8char uc)
 			{
 				dict->pin--;
 				uc[i] = 0x0;
-				return uc;
+				return true;
 			}
 			uc[i] = c;
 			i++;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -141,7 +141,7 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 	{
 		pos += snprintf(t, ERRBUFLEN, "\"%s\" ", dict->token);
 		strncat(tokens, t, ERRBUFLEN-1-pos);
-		link_advance(dict);
+		if (!link_advance(dict)) break;
 	}
 	tokens[pos] = '\0';
 

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -402,6 +402,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				{
 					s = strdupa(t);
 					sm = strchr(s, SUBSCRIPT_MARK);
+					UNREACHABLE(NULL == sm); /* We know it has a subscript. */
 					*sm = '\0';
 					t = string_set_add(s, sent->string_set);
 				}

--- a/link-grammar/post-process/pp_lexer.l
+++ b/link-grammar/post-process/pp_lexer.l
@@ -205,7 +205,7 @@ static bool set_label(PPLexTable *lt, const char *label)
   char *label_sans_colon;
 
   /* check for and then slice off the trailing colon */
-  label_sans_colon = strdup(label);
+  label_sans_colon = strdupa(label);
   c=&(label_sans_colon[strlen(label_sans_colon)-1]);
   if (*c != ':')
   {
@@ -230,8 +230,6 @@ static bool set_label(PPLexTable *lt, const char *label)
   }
   lt->labels[i] = string_set_add(label_sans_colon, lt->string_set);
   lt->idx_of_active_label = i;
-
-  free(label_sans_colon);
 
   return true;
 }

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -158,6 +158,7 @@ static bool word_has_alternative(const Gword *word)
 static char *utf8_str1chr(const char *s, const char *xc)
 {
 	int len = utf8_charlen(xc);
+	if (len < 0) return NULL; /* Invalid UTF-8 */
 	char *xc1 = strndupa(xc, len);
 
 	return strstr(s, xc1);
@@ -849,9 +850,10 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 						/* Account for case conversion length difference. */
 						if (subword->status & WS_FIRSTUPPER)
 						{
-							subword->end +=
-								utf8_charlen(unsplit_word->subword) -
-								utf8_charlen(token);
+							int uclen = utf8_charlen(unsplit_word->subword);
+							int lclen = utf8_charlen(token);
+							if ((uclen > 0) && (lclen > 0))
+								subword->end += uclen - lclen;
 						}
 						//printf(">>>SUBWORD '%s' %ld:%ld\n", subword->subword, subword->start-sent->orig_sentence, subword->end-sent->orig_sentence);
 					}

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -339,6 +339,7 @@ static inline size_t utf8_strncpy(char *dest, const char *src, size_t n)
 	while (0 < n)
 	{
 		size_t k = utf8_charlen(src);
+		if (0 > (ssize_t)k) return 0; /* XXX Maybe print error. */
 		b += k;
 		while (0 < k) { *dest = *src; dest++; src++; k--; }
 		n--;


### PR DESCRIPTION
Regarding the action on bad UTF-8: For now it is silently "bypassed" or ignored.
Maybe it will be a good idea to add an error message in DEBUG mode, or check the UTF-8 input and add an "internal error" message on every bad UTF-8 afterwards.