### PR TITLE
Fix memory pool leak in prasing with null links

### DIFF
--- a/bindings/python-examples/lg_testutils.py
+++ b/bindings/python-examples/lg_testutils.py
@@ -68,9 +68,11 @@ def add_eqcost_linkage_order(original_class):
 
     original_class.original_parse = original_class.parse
 
-    def parse(self):
+    def parse(self, parse_options=None):
         """A decoration for the original Sentence.parse"""
-        linkages = self.original_parse()
+        # parse() has an optional single argument for parse options. If it is not given,
+        # call original_parse() also without arguments in order to test it that way.
+        linkages = self.original_parse() if parse_options is None else self.original_parse(parse_options)
         return eqcost_soretd_parse(linkages)
 
     original_class.parse = parse

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -751,6 +751,16 @@ class ZENLangTestCase(unittest.TestCase):
         #            |          |
         #[about] people.p attended.v-d
 
+    def test_2_step_parsing_with_null_links(self):
+        self.po = ParseOptions(min_null_count=0, max_null_count=0)
+
+        sent = Sentence('about people attended', self.d, self.po)
+        linkages = sent.parse()
+        self.assertEqual(len(linkages), 0)
+        self.po = ParseOptions(min_null_count=1, max_null_count=999)
+        linkages = sent.parse(self.po)
+        self.assertEqual(len(linkages), 2)
+        self.assertEqual(linkages.next().unused_word_cost(), 1)
 
 class ZENConstituentsCase(unittest.TestCase):
     @classmethod

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -505,11 +505,12 @@ class Sentence(object):
         return clg.sentence_null_count(self._obj)
 
     class sentence_parse(object):
-        def __init__(self, sent):
+        def __init__(self, sent, parse_options):
             self.sent = sent
             self.num = 0
-            self.rc = clg.sentence_parse(sent._obj, sent.parse_options._obj)
-            if clg.parse_options_timer_expired(sent.parse_options._obj):
+            self.parse_options = sent.parse_options if parse_options is None else parse_options
+            self.rc = clg.sentence_parse(sent._obj, self.parse_options._obj)
+            if clg.parse_options_timer_expired(self.parse_options._obj):
                 raise LG_TimerExhausted()
 
         def __nonzero__(self):
@@ -529,7 +530,7 @@ class Sentence(object):
         def next(self):
             if self.num == clg.sentence_num_valid_linkages(self.sent._obj):
                 raise StopIteration()
-            linkage = Linkage(self.num, self.sent, self.sent.parse_options._obj)
+            linkage = Linkage(self.num, self.sent, self.parse_options._obj)
             if not linkage:  # SAT sentinel value
                 raise StopIteration()
             self.num += 1
@@ -537,5 +538,5 @@ class Sentence(object):
 
         __next__ = next             # Account python3
 
-    def parse(self):
-        return self.sentence_parse(self)
+    def parse(self, parse_options=None):
+        return self.sentence_parse(self, parse_options)

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -196,7 +196,7 @@ void pool_reuse(Pool_desc *mp)
 	lgdebug(+D_MEMPOOL, "Used %zu elements (pool '%s' created in %s())\n",
 	        mp->curr_elements, mp->name, mp->func);
 	mp->ring = mp->chain;
-	mp->alloc_next = NULL;
+	mp->alloc_next = mp->ring;
 }
 
 #ifdef POOL_FREE


### PR DESCRIPTION
Somehow I neglected to check that.
This leak happen when parsing with null links, and there is no full linkage.
Just running the batches doesn't trigger it.

**I strongly recommend to make a new release soon.**
However, before that I would like to add a test of 2-step parse, see below.

---

The test suit doesn't include a 2-step parsing with null links, like `link-parser` does.
Such a test would reveal this leak (because I run it with ASAN/UBSAN).
The only parse with nulls it includes is 1-step.

However, a 2-step test cannot be added just now because the Python binding of `parse()` doesn't include arguments, so a new `Parse_Options` cannot be used (the `Parse_Options` of `Sentence()` is reused).
This is a deficiency of the Python bindings, because the ability to change the `Parse_Options` without  the overhead of calling `Sentence()` or `sent.Split()` again is desired (for example to change `short_length`).

(BTW, Linkage() already includes `Pasre_Options`. A test for using it to change the `morphology` option should be most probably eventually added too.)

To sum up:
1. I will send a PR for an optional `Parse_options` argument of `parse() and test for a 2-step parse with nulls.
2. After that it will be a good idea to release a new version.