### PR TITLE
tests.py: Fix a false positive memory leak report on parse-options

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -246,12 +246,10 @@ class DBasicParsingTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.d = Dictionary()
-        cls.po = None
 
     @classmethod
     def tearDownClass(cls):
         del cls.d
-        del cls.po
         del cls.parse_sent
 
     def parse_sent(self, text, po=ParseOptions()):
@@ -334,11 +332,10 @@ class DBasicParsingTestCase(unittest.TestCase):
         self.assertEqual(linkage.word(4), '_regex_ive[!].a')
 
     def test_timer_exhausted_exception(self):
-        self.po = ParseOptions(max_parse_time=1)
         self.assertRaises(LG_TimerExhausted,
                           self.parse_sent,
                           "This should take more than one second to parse! " * 20,
-                          self.po)
+                          ParseOptions(max_parse_time=1))
 
 # The tests here are are numbered since their order is important.
 # They depend on the result and state of the previous ones as follows:

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -252,6 +252,7 @@ class DBasicParsingTestCase(unittest.TestCase):
     def tearDownClass(cls):
         del cls.d
         del cls.po
+        del cls.parse_sent
 
     def parse_sent(self, text, po=ParseOptions()):
         return list(Sentence(text, self.d, po).parse())


### PR DESCRIPTION
1. Prevent the following LSAN messages:
```
Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x7fbdf3a00850 in malloc (/lib64/libasan.so.4+0xde850)
    #1 0x7fbde5f847a4 in parse_options_create /usr/local/src/link-grammar-devel/pyleak/link-grammar/api.c:100
    #2 0x7fbde66abe4a in _wrap_parse_options_create /tmp/link-grammar/pyleak/bindings/python/lg_python_wrap.cc:3848
    #3 0x7fbdf292d4dd in PyEval_EvalFrameEx (/lib64/libpython2.7.so.1.0+0x1684dd)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7fbdf3a00850 in malloc (/lib64/libasan.so.4+0xde850)
    #1 0x7fbde6070a50 in xalloc /usr/local/src/link-grammar-devel/pyleak/link-grammar/utilities.c:385
    #2 0x7fbde603e7a9 in resources_create /usr/local/src/link-grammar-devel/pyleak/link-grammar/resources.c:64
    #3 0x7fbde5f84ed7 in parse_options_create /usr/local/src/link-grammar-devel/pyleak/link-grammar/api.c:146
    #4 0x7fbde66abe4a in _wrap_parse_options_create /tmp/link-grammar/pyleak/bindings/python/lg_python_wrap.cc:3848
    #5 0x7fbdf292d4dd in PyEval_EvalFrameEx (/lib64/libpython2.7.so.1.0+0x1684dd)
```
(Currently no other leaks from the LG library as used by tests.py.)

2. At the same opportunity, cleanup an unneeded class and object variables.