### PR TITLE
Use prt_error("Debug: ")  instead of printf() for debug messages

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -205,12 +205,13 @@ void set_all_condesc_length_limit(Dictionary dict)
 
 	if (verbosity_level(D_SPEC+1))
 	{
-		printf("%5s %-6s %3s\n", "num", "uc_num", "ll");
+		prt_error("Debug:\n%5s %-6s %3s\n\\", "num", "uc_num", "ll");
 		for (size_t n = 0; n < ct->num_con; n++)
 		{
-			printf("%5zu %6d %3d %s\n", n, ct->sdesc[n]->uc_num,
+			prt_error("%5zu %6d %3d %s\n\\", n, ct->sdesc[n]->uc_num,
 			       ct->sdesc[n]->length_limit, ct->sdesc[n]->string);
 		}
+		prt_error("\n");
 	}
 }
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -120,7 +120,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	build_sentence_disjuncts(sent, opts->disjunct_cost, opts);
 	if (verbosity_level(5))
 	{
-		printf("After expanding expressions into disjuncts:\n");
+		prt_error("Debug: After expanding expressions into disjuncts:\n");
 		print_disjunct_counts(sent);
 	}
 	print_time(opts, "Built disjuncts");
@@ -137,7 +137,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 
 	if (verbosity_level(5))
 	{
-		printf("\nAfter expression pruning and duplicate elimination:\n");
+		prt_error("Debug: After expression pruning and duplicate elimination:\n");
 		print_disjunct_counts(sent);
 	}
 


### PR DESCRIPTION
Also omit the message as one big string with embedded newlines (first commit).
This is especially a problem when  printf() and prt_error() are intermixed (second commit).