### PR TITLE
link-parser: Disallow unknown arguments

### DIFF
--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -634,6 +634,11 @@ int main(int argc, char * argv[])
 			if ((var[0] != '!') && issue_special_command(var, copts, NULL))
 				print_usage(argv[0]);
 		}
+		else if (i != 1)
+		{
+			prt_error("Fatal error: Unknown argument '%s'.\n", argv[i]);
+			print_usage(argv[0]);
+		}
 	}
 
 #ifdef _WIN32


### PR DESCRIPTION
This fix disallows the following wrong usages, that are currently silently ignored without performing the apparent intended action:
`link-parser -v=2 ru`
`link-parser ru links=100`

EDIT:
Forced-push: Add printing usage.