### PR TITLE
macOS: Fix build break due to the removed dictionary_create_from_utf8()

### DIFF
--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -1,7 +1,6 @@
 linkgrammar_get_version
 linkgrammar_get_dict_version
 linkgrammar_get_dict_locale
-dictionary_create_from_utf8
 dictionary_create_lang
 dictionary_create_default_lang
 dictionary_get_lang


### PR DESCRIPTION
The problem happened in PR #704.