### PR TITLE
Dictionary reading fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@ Version 5.4.5 (XXX 2018)
  * Fix memory leak when parsing with null links.
  * Python bindings: Add an optional parse-option argument to parse().
  * Add an extended version API and use it in "link-parser --version".
+ * Fix random errors if the last dict line is a comment.
+ * Fix random garbage report if EOF encountered in a quoted dict word.
+ * Fix random garbage report if whitespace encountered in a quoted dict word.
 
 Version 5.4.4 (11 March 2018)
  * Dictionary loading now thread safe.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -208,6 +208,7 @@ static bool get_character(Dictionary dict, int quote_mode, utf8char uc)
 				}
 			}
 			while ((c != 0x0) && (c != '\n')) c = *(dict->pin++);
+			if (c == 0x0) break;
 			dict->line_number++;
 			continue;
 		}

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -326,6 +326,11 @@ static bool link_advance(Dictionary dict)
 				dict_error(dict, "White space inside of token");
 				return false;
 			}
+			if (c[0] == '\0')
+			{
+				dict_error(dict, "EOF while reading quoted token");
+				return false;
+			}
 
 			nr = 0;
 			while (c[nr]) {dict->token[i] = c[nr]; i++; nr++; }

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1798,7 +1798,8 @@ static bool read_entry(Dictionary dict)
 	/* pass the ; */
 	if (!link_advance(dict))
 	{
-		goto syntax_error;
+		/* Avoid freeing dn, since it is already inserted into the dict. */
+		return false;
 	}
 
 	return true;


### PR DESCRIPTION
These commits fixes bugs that already existed in version 4:
- get_character(): Handle comment at dict end  (fixes issue #735)
- link_advance(): Handle EOF while reading quoted token

These commits fixes a problem that happened when I added the dict error suppression option:
- read_entry(): Avoid heap-use-after-free after syntax error on entry start