### PR TITLE
Hackery for bug #736

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -8683,11 +8683,12 @@ doubling.g tripling.g quadrupling.g quintupling.g:
 % to allow modifiers on conjoined nouns to work well.
 % e.g. "...went to hell yesterday and heaven on Tuesday"
 %
-% [Mp- & MVp-]-0.09 prefers a connection to both the noun and the
-%    verb, helping disambiguate.
+% [Mp- & MVp-]-0.61 prefers a connection to both the noun and the
+%    verb, helping disambiguate.  The weight 0.61 plus 0.4 is greater
+%    than one, to overcome cost on @MV+.
 <prep-main-b>:
   <conjoin-preps>
-  or [Mp-]0.4 or Pp- or MVp- or [Mp- & MVp-]-0.09
+  or [Mp-]0.4 or Pp- or MVp- or [Mp- & MVp-]-0.61
   or [({Xc+ & {Xd-}} & CO+)]
   or (Xd- & Xc+ & (MX*x- or MVx-));
 
@@ -9088,7 +9089,7 @@ later earlier:
     (E+ or
     [Mp-]0.4 or
     Pp- or
-    MVb- or
+    ({[Mp-]-0.09} & MVb-) or
     (Wt- & {Xc+}) or
     [({Xc+ & {Xd-}} & CO+)] or
     (Xd- & Xc+ & (MX*x- or MVx-)) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -9073,10 +9073,11 @@ then.r:
   or [[Mp-]];
 
 % Wt-: "Later."  (all by itself) but also: "Later, he left"
+% [Mp-]0.4:  see notes above <prep-main-b>; prefer MVb- when possible.
 later earlier:
   ({ECa- or Yt-} &
     (E+ or
-    Mp- or
+    [Mp-]0.4 or
     Pp- or
     MVb- or
     (Wt- & {Xc+}) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -8682,9 +8682,12 @@ doubling.g tripling.g quadrupling.g quintupling.g:
 % (using MVp-) is generally preferred.  The cost is small, though,
 % to allow modifiers on conjoined nouns to work well.
 % e.g. "...went to hell yesterday and heaven on Tuesday"
+%
+% [Mp- & MVp-]-0.09 prefers a connection to both the noun and the
+%    verb, helping disambiguate.
 <prep-main-b>:
   <conjoin-preps>
-  or [Mp-]0.4 or Pp- or MVp-
+  or [Mp-]0.4 or Pp- or MVp- or [Mp- & MVp-]-0.09
   or [({Xc+ & {Xd-}} & CO+)]
   or (Xd- & Xc+ & (MX*x- or MVx-));
 
@@ -9031,10 +9034,16 @@ no_matter:
 
 % --------------------------------------------------------
 % Preps that specify time-like relations
+%
+% ({[Mp-]-0.09} & MVp-): If we can identify both the head verb,
+% and the head noun, then do so. It is tempting to think that these
+% should modify the verb, only, but conjunctions prove otherwise:
+% "... went to hell recently, and heaven before that." shows that
+% "recently" has to modify "hell", and not "went".
 
 recently:
   {EE- or EF+} & (
-    ({Xd- & Xc+} & MVp-)
+    ({Xd- & Xc+} & {[Mp-]-0.09} & MVp-)
     or Pp-
     or E+
     or ({Xc+ & {Xd-}} & CO+)
@@ -9047,7 +9056,7 @@ recently:
 % Wc- & Qd+: "Now, am I right?"
 % MJr-: "when, if not now, do you want to do it?"
 now.r:
-  ({Xd- & Xc+} & MVp-)
+  ({Xd- & Xc+} & {[Mp-]-0.09} & MVp-)
   or Pp-
   or E+
   or ({Xc+ & {Xd-}} & CO+)
@@ -9061,7 +9070,7 @@ now.r:
 % JT+ & CO+: "then last week, I changed my mind"
 % JT+: "if not next Tuesday, then when do you want to do it?"
 then.r:
-  ({Xd- & Xc+} & MVp-)
+  ({Xd- & Xc+} & {[Mp-]-0.09} & MVp-)
   or Pp-
   or E+
   or ({JT+} & {Xc+ & {Xd-}} & CO+)

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -292,10 +292,11 @@ nonCAP.zzz: ZZZ-;
 % COa+ is used to block links to COd-
 % Xc+ & Ic+: connect to imperatives (infinitive verbs): "Anyhow, don't"
 % Wc- & Xc+ & Qd+: subject-object inversion: "anyhow, am I right?"
+%       This gets a fairly stiff cost if the comma is missing.
 <directive-opener>:
   {[[Wa-]]} &
     ((Xc+ & Ic+) or
-    (Wc- & (Xc+ or [()]) & Qd+) or
+    (Wc- & (Xc+ or [()]1.2) & Qd+) or
     ({Xd-} & (Xc+ or [[()]]) & [COa+]));
 
 % Just pure singular entities, no mass nouns

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -6613,9 +6613,12 @@ doubling.g tripling.g quadrupling.g quintupling.g:
 % (using MVp-) is generally preferred.  The cost is small, though,
 % to allow modifiers on conjoined nouns to work well.
 % e.g. "...went to hell yesterday and heaven on Tuesday"
+%
+% [Mp- & MVp-]-0.09 prefers a connection to both the noun and the
+%    verb, helping disambiguate.
 <prep-main-b>:
   <conjoin-preps>
-  or [Mp-]0.4 or Pp- or MVp-
+  or [Mp-]0.4 or Pp- or MVp- or [Mp- & MVp-]-0.09
   or [({Xc+ & {Xd-}} & CO+)]
   or (Xd- & Xc+ & (MX*x- or MVx-));
 
@@ -6962,10 +6965,16 @@ no_matter:
 
 % --------------------------------------------------------
 % Preps that specify time-like relations
+%
+% ({[Mp-]-0.09} & MVp-): If we can identify both the head verb,
+% and the head noun, then do so. It is tempting to think that these
+% should modify the verb, only, but conjunctions prove otherwise:
+% "... went to hell recently, and heaven before that." shows that
+% "recently" has to modify "hell", and not "went".
 
 recently:
   {EE- or EF+} & (
-    ({Xd- & Xc+} & MVp-)
+    ({Xd- & Xc+} & {[Mp-]-0.09} & MVp-)
     or Pp-
     or E+
     or ({Xc+ & {Xd-}} & CO+)
@@ -6978,7 +6987,7 @@ recently:
 % Wc- & Qd+: "Now, am I right?"
 % MJr-: "when, if not now, do you want to do it?"
 now.r:
-  ({Xd- & Xc+} & MVp-)
+  ({Xd- & Xc+} & {[Mp-]-0.09} & MVp-)
   or Pp-
   or E+
   or ({Xc+ & {Xd-}} & CO+)
@@ -6992,7 +7001,7 @@ now.r:
 % JT+ & CO+: "then last week, I changed my mind"
 % JT+: "if not next Tuesday, then when do you want to do it?"
 then.r:
-  ({Xd- & Xc+} & MVp-)
+  ({Xd- & Xc+} & {[Mp-]-0.09} & MVp-)
   or Pp-
   or E+
   or ({JT+} & {Xc+ & {Xd-}} & CO+)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -7004,10 +7004,11 @@ then.r:
   or [[Mp-]];
 
 % Wt-: "Later."  (all by itself) but also: "Later, he left"
+% [Mp-]0.4:  see notes above <prep-main-b>; prefer MVb- when possible.
 later earlier:
   ({ECa- or Yt-} &
     (E+ or
-    Mp- or
+    [Mp-]0.4 or
     Pp- or
     MVb- or
     (Wt- & {Xc+}) or

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -301,10 +301,11 @@ nonCAP.zzz: ZZZ-;
 % COa+ is used to block links to COd-
 % Xc+ & Ic+: connect to imperatives (infinitive verbs): "Anyhow, don't"
 % Wc- & Xc+ & Qd+: subject-object inversion: "anyhow, am I right?"
+%       This gets a fairly stiff cost if the comma is missing.
 <directive-opener>:
   {[[Wa-]]} &
     ((Xc+ & Ic+) or
-    (Wc- & (Xc+ or [()]) & Qd+) or
+    (Wc- & (Xc+ or [()]1.2) & Qd+) or
     ({Xd-} & (Xc+ or [[()]]) & [COa+]));
 
 % Just pure singular entities, no mass nouns

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -6614,11 +6614,12 @@ doubling.g tripling.g quadrupling.g quintupling.g:
 % to allow modifiers on conjoined nouns to work well.
 % e.g. "...went to hell yesterday and heaven on Tuesday"
 %
-% [Mp- & MVp-]-0.09 prefers a connection to both the noun and the
-%    verb, helping disambiguate.
+% [Mp- & MVp-]-0.61 prefers a connection to both the noun and the
+%    verb, helping disambiguate.  The weight 0.61 plus 0.4 is greater
+%    than one, to overcome cost on @MV+.
 <prep-main-b>:
   <conjoin-preps>
-  or [Mp-]0.4 or Pp- or MVp- or [Mp- & MVp-]-0.09
+  or [Mp-]0.4 or Pp- or MVp- or [Mp- & MVp-]-0.61
   or [({Xc+ & {Xd-}} & CO+)]
   or (Xd- & Xc+ & (MX*x- or MVx-));
 
@@ -7019,7 +7020,7 @@ later earlier:
     (E+ or
     [Mp-]0.4 or
     Pp- or
-    MVb- or
+    ({[Mp-]-0.09} & MVb-) or
     (Wt- & {Xc+}) or
     [({Xc+ & {Xd-}} & CO+)] or
     (Xd- & Xc+ & (MX*x- or MVx-)) or

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -44,7 +44,6 @@
 #include "api-types.h"
 #include "corpus/corpus.h"
 #include "memory-pool.h"
-//#include "error.h"
 #include "utilities.h"
 
 typedef struct Cost_Model_s Cost_Model;


### PR DESCRIPTION
`Mp/MVp` now form a cycle, so as to disambiguate what is being modified, where. See bug #736 for details.

The core issue is that, in expressions like "... went to hell yesterday, and heaven on Tuesday", the `Mp` is used to modify the noun, not the verb ("yesterday" modifies "hell", not "went"). The `MV` link continues to modify the verb, as  before, and so now, with a cycle, both are clearly indicated.