### PR TITLE
Cleanup

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -88,7 +88,7 @@ class BParseOptionsTestCase(unittest.TestCase):
 
     def test_setting_verbosity_to_not_allow_value_raises_value_error(self):
         po = ParseOptions()
-        self.assertRaises(ValueError, setattr, po, "verbosity", 16)
+        self.assertRaises(ValueError, setattr, po, "verbosity", 121)
 
     def test_setting_verbosity_to_non_integer_raises_type_error(self):
         po = ParseOptions()

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -80,8 +80,8 @@ class ParseOptions(object):
     def verbosity(self, value):
         if not isinstance(value, int):
             raise TypeError("Verbosity must be set to an integer")
-        if value not in range(0,15):
-            raise ValueError("Verbosity levels can be any integer between 0 and 15 inclusive")
+        if value not in range(0,120):
+            raise ValueError("Verbosity levels can be any integer between 0 and 120 inclusive")
         clg.parse_options_set_verbosity(self._obj, value)
 
     @property

--- a/debug/README.md
+++ b/debug/README.md
@@ -62,7 +62,7 @@ comma-separated list of source file names (without specifying their
 directory) and function names (fully qualified for C++) from which to
 show the messages.
 
-For example, to only show messages from `flatten_wordgraph()` function
+For example, to only show messages from the `flatten_wordgraph()` function
 or the print.c file:
 
 `link-parser -v=6 -debug=flatten_wordgraph,print.c`

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -367,17 +367,18 @@ char *get_file_contents(const char * dict_name)
 		if (0 == read_size)
 		{
 			bool err = (0 != ferror(fp));
-			fclose(fp);
 
 			if (err)
 			{
 				char errbuf[64];
 
 				strerror_r(errno, errbuf, sizeof(errbuf));
+				fclose(fp);
 				prt_error("Error: %s: Read error (%s)\n", dict_name, errbuf);
 				free(contents);
 				return NULL;
 			}
+			fclose(fp);
 			break;
 		}
 		tot_read += read_size;

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -359,7 +359,7 @@ char *get_file_contents(const char * dict_name)
 	contents = (char *) malloc(sizeof(char) * (tot_size+7));
 
 	/* Now, read the whole file.
-	 * Normally, only a single call of fread() is needed. */
+	 * Normally, a single fread() call below reads the whole file. */
 	while (1)
 	{
 		size_t read_size = fread(contents, 1, tot_size+7, fp);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -15,7 +15,6 @@
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h"  // For LEFT_WORD
 #include "dict-common/dict-impl.h"
 #include "dict-common/dict-utils.h"
 #include "dict-common/file-utils.h"
@@ -24,11 +23,9 @@
 #include "read-dict.h"
 #include "read-regex.h"
 #include "dict-common/regex-morph.h"
+#include "string-set.h"
 #include "tokenize/anysplit.h"        // Initialize anysplit here ...
 #include "tokenize/spellcheck.h"      // Initialize spellcheck here ...
-#include "string-set.h"
-#include "dict-sql/read-sql.h"  /* Temporary hack */
-
 
 /***************************************************************
 *

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -19,10 +19,10 @@
 #include "dict-common/dict-utils.h"
 #include "dict-common/file-utils.h"
 #include "dict-common/idiom.h"
+#include "dict-common/regex-morph.h"
 #include "post-process/pp_knowledge.h"
 #include "read-dict.h"
 #include "read-regex.h"
-#include "dict-common/regex-morph.h"
 #include "string-set.h"
 #include "tokenize/anysplit.h"        // Initialize anysplit here ...
 #include "tokenize/spellcheck.h"      // Initialize spellcheck here ...

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -10,7 +10,6 @@
 
 #include <string.h>
 #include "link-includes.h"
-#include "api-structures.h"
 #include "dict-common/dict-common.h"
 #include "dict-common/file-utils.h"
 #include "read-regex.h"

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -43,7 +43,8 @@ const char *feature_enabled(const char *, ...);
  *   because they are designed only for extended user information.
  * - When verbosity > D_SPEC, print messages only when level==verbosity.
  * - The !debug variable can be set to a comma-separated list of functions
- *   in order to restrict the debug messages to these functions only.
+ *   or source filenames in order to restrict the debug messages to these
+ *   functions or filenames only.
  *
  * Invoking lgdebug() with a level number preceded by a + (+level) adds
  * printing of the function name.

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -853,7 +853,7 @@ static void put_opts_in_local_vars(Command_Options* copts)
 	local.use_sat_solver = parse_options_get_use_sat_parser(opts);
 	local.use_viterbi = parse_options_get_use_viterbi(opts);
 
-	local.screen_width = copts->screen_width;
+	local.screen_width = (int)copts->screen_width;
 	local.echo_on = copts->echo_on;
 	local.batch_mode = copts->batch_mode;
 	local.panic_mode = copts->panic_mode;
@@ -894,7 +894,7 @@ static void put_local_vars_in_opts(Command_Options* copts)
 	parse_options_set_use_viterbi(opts, local.use_viterbi);
 	parse_options_set_display_morphology(opts, local.display_morphology);
 
-	copts->screen_width = local.screen_width;
+	copts->screen_width = (size_t)local.screen_width;
 	copts->echo_on = local.echo_on;
 	copts->batch_mode = local.batch_mode;
 	copts->panic_mode = local.panic_mode;

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -615,10 +615,10 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 	if (NULL != dict)
 	{
 		/* If we are here, it is not a command-line parameter. */
-		s = strtok(line, " \t\n");
+		s = strtok(line, WHITESPACE);
 		if ((s != NULL) && strncasecmp(s, "help", strlen(s)) == 0)
 		{
-			s = strtok(NULL, " \t\n");
+			s = strtok(NULL, WHITESPACE);
 			if (s != NULL)
 			{
 				/* This is a help request for the command name at s. */

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -29,10 +29,6 @@
 #include <histedit.h>
 #include <stdlib.h>
 
-#if !defined(MAX)
-#define MAX(x,y)  (((x) > (y)) ? (x) : (y))
-#endif
-
 #ifdef HAVE_WIDECHAR_EDITLINE
 #include <stdbool.h>
 
@@ -282,7 +278,6 @@ static unsigned char lg_complete(EditLine *el, int ch)
 	for (ctemp = word_end; ctemp < li->lastchar; ctemp++)
 		if (!iswspace(*ctemp)) return CC_ERROR;
 
-	/* Cannot complete if there is non-whitespace after the cursor. */
 	if (is_file_command)
 	{
 		rc = _el_fn_complete(el, ch);

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -64,9 +64,7 @@ static char *complete_command(const wchar_t *input, size_t len, bool is_help)
 	const Switch **match;
 	const char *prev;
 	size_t addlen;
-
-	/* Marking for the help facility. */
-	bool is_assignment = false;
+	bool is_assignment = false; /* marking for the help facility */
 
 	if ((1 < len) && L'=' == input[len-1] && !is_help)
 	{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -343,16 +343,16 @@ static const char *process_some_linkages(FILE *in, Sentence sent,
 			if ((sentence_num_valid_linkages(sent) == 1) &&
 				!copts->display_bad)
 			{
-				fprintf(stdout, "	Unique linkage, ");
+				fprintf(stdout, "\tUnique linkage, ");
 			}
 			else if (copts->display_bad &&
 			         (sentence_num_violations(sent, i) > 0))
 			{
-				fprintf(stdout, "	Linkage %d (bad), ", num_displayed+1);
+				fprintf(stdout, "\tLinkage %d (bad), ", num_displayed+1);
 			}
 			else
 			{
-				fprintf(stdout, "	Linkage %d, ", num_displayed+1);
+				fprintf(stdout, "\tLinkage %d, ", num_displayed+1);
 			}
 
 			corpus_cost = linkage_corpus_cost(linkage);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -525,7 +525,7 @@ static void check_winsize(Command_Options* copts)
 	/* Calculate the size of the console window. */
 	if (GetConsoleScreenBufferInfo(console, &info) == 0) goto fail;
 
-	copts->screen_width = info.srWindow.Right - info.srWindow.Left + 1;
+	copts->screen_width = (size_t)(info.srWindow.Right - info.srWindow.Left + 1);
 	return;
 
 fail:


### PR DESCRIPTION
Some of the changes:
- Python bindings: Allow verbosity values up to 120.
- Remove unneeded include files.
- Fix typos and fix/remove comments.
- Move fclose() after errno just in case.
- Prevent some int  type mix size/sign possible warnings (more ~1000 to fix...).


