### PR TITLE
Change the way the help file is opened

### DIFF
--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -1,6 +1,6 @@
 linkgrammar_get_version
 linkgrammar_get_configuration
-linkgrammar_get_data_dir
+linkgrammar_open_data_file
 linkgrammar_get_dict_version
 linkgrammar_get_dict_locale
 dictionary_create_lang

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -113,8 +113,8 @@ link_public_api(void)
      dictionary_set_data_dir(const char * path);
 link_public_api(char *)
      dictionary_get_data_dir(void);
-link_public_api(char *)
-     linkgrammar_get_data_dir(void);
+link_public_api(FILE *)
+	  linkgrammar_open_data_file(const char *);
 
 /**********************************************************************
  *


### PR DESCRIPTION
It now finds the help file even if the uses a private dictionary that doesn't have an help file in its parent directory.

EDIT: Pushed again for a minor fix in the error reporting.