### PR TITLE
Official word-graph support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Version 5.5.0 (XXX 2018)
  * Fix random garbage report if whitespace encountered in a quoted dict word.
  * Add a per-command help in link-parser.
  * Add a command line completion in link-parser.
+ * Default configuration word-graph support + API + link-parser user variable.
 
 Version 5.4.4 (11 March 2018)
  * Dictionary loading now thread safe.

--- a/configure.ac
+++ b/configure.ac
@@ -406,7 +406,7 @@ AM_CONDITIONAL(WITH_CORPUS, test x${enable_corpus_stats} = xyes)
 AC_ARG_ENABLE( wordgraph_display,
   [  --enable-wordgraph-display       enable graphical display of the Wordgraph],
   [],
-  [enable_wordgraph_display=no]
+  [enable_wordgraph_display=yes]
 )
 if test "x$enable_wordgraph_display" = "xyes"
 then

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -234,3 +234,26 @@ Variables can be set as follows:
 
  !<var>          Toggle the specified Boolean variable.
  !<var>=<val>    Assign that value to that variable.
+
+[wordgraph]
+This variable controls displaying the word-graph of the sentence.
+The word-graph is a representation of the relations between the sentence
+tokens, as set by the library tokenizer before the parsing step.
+
+Its value may be:
+ 0      Disabled
+ 1      Default display
+ 2      Display parent tokens as subgraphs
+ 3      Use esoteric display flags as appear in !test=wg:FLAGS
+
+% Below, unsplit-word means a token before getting split.
+% These flags are defined in wordgraph.h.
+%
+% c                 Compact display
+% d             (*) Display debug labels
+% h                 Display hex node numbers (for "dot" commands debug)
+% l             (*) Add a legend
+% p                 Display back-pointing word-graph links
+% s                 Display unsplit-words as subgraphs
+% u             (*) Display unsplit-word links
+% x                 Display using X11 even on Windows (if supported)

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -73,6 +73,7 @@ sentence_num_linkages_post_processed
 sentence_num_violations
 sentence_disjunct_cost
 sentence_link_cost
+sentence_display_wordgraph
 linkage_create
 linkage_delete
 linkage_get_num_words

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -278,6 +278,8 @@ link_public_api(double)
      sentence_disjunct_cost(Sentence sent, LinkageIdx linkage_num);
 link_public_api(int)
      sentence_link_cost(Sentence sent, LinkageIdx linkage_num);
+link_public_api(bool)
+     sentence_display_wordgraph(Sentence sent, const char *modestr);
 
 /**********************************************************************
  *

--- a/link-grammar/tokenize/README.md
+++ b/link-grammar/tokenize/README.md
@@ -1,3 +1,11 @@
+Version 5.5.0 - Official wordgraph support
+==========================================
+
+As of version 5.5.0, the default configuration includes the word-graph
+display. A new API function
+`bool sentence_display_wordgraph(Sentence sent, const char *modestr);`
+has been added, and `link-parser` can use it (controlled by the
+`!wordgraph` user variable).
 
 Version 5.3.0 - Introduction of a word-graph for tokenizing
 ===========================================================

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2978,9 +2978,6 @@ bool separate_sentence(Sentence sent, Parse_Options opts)
 		if ((word->morpheme_type != MT_INFRASTRUCTURE) &&
 		    (word->morpheme_type != MT_WALL))
 		{
-			/* !test=wg or !test=wg:flags (for flags see wordgraph.h) */
-			if (test_enabled("wg"))
-				wordgraph_show(sent, test_enabled("wg"));
 			return true;
 		}
 	}

--- a/link-grammar/tokenize/wordgraph.h
+++ b/link-grammar/tokenize/wordgraph.h
@@ -20,8 +20,6 @@
  * start. See issue_sentence_word. */
 #define IS_SENTENCE_WORD(sent, gword) (gword->unsplit_word == sent->wordgraph)
 
-void wordgraph_show(Sentence, const char *);
-
 Gword *gword_new(Sentence, const char *);
 Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -53,6 +53,7 @@ static struct
 	int display_disjuncts;
 	int display_senses;
 	int display_morphology;
+	int display_wordgraph;
 } local, local_saved;
 
 static const char *value_type[] =
@@ -103,6 +104,7 @@ Switch default_switches[] =
 #endif
 	{"walls",      Bool, "Display wall words",              &local.display_walls},
 	{"width",      Int,  "The width of the display",        &local.screen_width},
+	{"wordgraph",  Int,  "Display sentence word-graph",     &local.display_wordgraph},
 	{"help",       Cmd,  "List the commands and what they do",     help_cmd},
 	{"variables",  Cmd,  "List user-settable variables and their functions", variables_cmd},
 	{"file",       Cmd,  "Read input from the specified filename", file_cmd},
@@ -866,6 +868,7 @@ static void put_opts_in_local_vars(Command_Options* copts)
 	local.display_postscript = copts->display_postscript;
 	local.display_ps_header = copts->display_ps_header;
 	local.display_constituents = copts->display_constituents;
+	local.display_wordgraph = copts->display_wordgraph;
 
 	local.display_bad = copts->display_bad;
 	local.display_disjuncts = copts->display_disjuncts;
@@ -907,6 +910,7 @@ static void put_local_vars_in_opts(Command_Options* copts)
 	copts->display_postscript = local.display_postscript;
 	copts->display_ps_header = local.display_ps_header;
 	copts->display_constituents = local.display_constituents;
+	copts->display_wordgraph = local.display_wordgraph;
 
 	copts->display_bad = local.display_bad;
 	copts->display_disjuncts = local.display_disjuncts;
@@ -964,6 +968,7 @@ Command_Options* command_options_create(void)
 	co->display_disjuncts = false;
 	co->display_links = false;
 	co->display_senses = false;
+	co->display_wordgraph = 0;
 	return co;
 }
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -96,8 +96,8 @@ Switch default_switches[] =
 	{"use-sat",    Bool, "Use Boolean SAT-based parser",    &local.use_sat_solver},
 #endif /* USE_SAT_SOLVER */
 	{"verbosity",  Int,  "Level of detail in output",       &local.verbosity},
-	{"debug",      String, "comma-separated function list to debug", &local.debug},
-	{"test",       String, "comma-separated features to test", &local.test},
+	{"debug",      String, "Comma-separated function names to debug", &local.debug},
+	{"test",       String, "Comma-separated test features", &local.test},
 #ifdef USE_VITERBI
 	{"viterbi",    Bool, "Use Viterbi-based parser",        &local.use_viterbi},
 #endif

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -237,7 +237,10 @@ static const char *switch_value_string(const Switch *as)
 			snprintf(buf, sizeof(buf), "%d", ival(*as));
 			break;
 		case String:
-			snprintf(buf, sizeof(buf), "%s", *(char **)as->ptr);
+			if ((NULL == *(char **)as->ptr) || ('\0' == **(char **)as->ptr))
+				strcpy(buf, "    (not set)");
+			else
+				snprintf(buf, sizeof(buf), "%s", *(char **)as->ptr);
 			break;
 		case Cmd:
 			buf[0] = '\0'; /* No value to print. */

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -45,6 +45,7 @@ typedef struct {
 	bool display_disjuncts; /* if true, print disjuncts that were used */
 	bool display_links;     /* if true, a list o' links is printed out */
 	bool display_senses;    /* if true, sense candidates are printed out */
+	int  display_wordgraph; /* if true, the word-graph is displayed */
 } Command_Options;
 
 typedef enum

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -829,6 +829,32 @@ int main(int argc, char * argv[])
 				sent = NULL;
 				continue;
 			}
+
+			if (0 != copts->display_wordgraph)
+			{
+				const char *wg_display_flags = ""; /* default flags */
+				switch (copts->display_wordgraph)
+				{
+					case 1:     /* default flags */
+						break;
+					case 2:     /* subgraphs with a legend */
+						wg_display_flags = "sl";
+						break;
+					case 3:
+						{
+							/* Use esoteric flags from the test user variable. */
+							const char wg[] = ",wg";
+							const char *s = strstr(test, wg);
+							if (NULL != s) wg_display_flags = s+2;
+						}
+						break;
+					default:
+						prt_error("Warning: wordgraph=%d: Unknown value, using 1\n",
+						          copts->display_wordgraph);
+						copts->display_wordgraph = 1;
+				}
+				sentence_display_wordgraph(sent, wg_display_flags);
+			}
 #if 0
 			/* Try again, this time omitting the requirement for
 			 * definite articles, etc. This should allow for the parsing


### PR DESCRIPTION
Per issue #741.

I was not sure how to officially name what I originally called Wordgraph.
I the help text I used the term word-graph.
If there is a better naming I can send a fix.

The user variable is called `wordgraph` (integer variable).

Initially I made it a String variable that gets the display option flags.
I was about to create the pull request when I realized it is too cumbersome.
The solution was to use values 1 and 2 for the most useful flags settings, and provide a value 3 that honors the previous way of setting that control individual flags (!test=wg:FLAGS).
The left the previous help text (that describes the flags) in the help file, but commented out so it is not displayed.

It may be fun to run
`link-parser -wordgraph=1 < data/en/corpus-fixes.batch`
(not on Windows...) but regretfully sometimes an error may occur because the interface file used for communication with `dot` is rewritten while `dot` has not finished to read it for displaying the previous sentence.  (I guess no solution is needed for that...)

EDIT: Force-pushed a fix.