### PR TITLE
Idiom stuff

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -12245,7 +12245,7 @@ than.#then-r: [then.r]1.65;
 than.#then-i: [then.i]1.65;
 than.#then-ij: [then.ij]0.65;
 
-% rather_then: rather_than;
+rather_then.#rather_than: rather_than;
 
 there.#their: [their.p]0.65;
 % theres.#theirs: [theirs.p]0.65;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -10178,7 +10178,7 @@ than.#then-r: [then.r]1.65;
 than.#then-i: [then.i]1.65;
 than.#then-ij: [then.ij]0.65;
 
-% rather_then: rather_than;
+rather_then.#rather_than: rather_than;
 
 there.#their: [their.p]0.65;
 % theres.#theirs: [theirs.p]0.65;

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -26,13 +26,14 @@
  * length=1 is done because it is not going to be a valid idiom anyway.
  *
  * If the underbar character is preceded by a backslash, it is not
- * considered.
+ * considered. The subscript, if exists, is not checked.
  */
 bool contains_underbar(const char * s)
 {
 	if ((s[0] == '_') || (s[0] == '\0')) return false;
 	while (*++s != '\0')
 	{
+		if (*s == SUBSCRIPT_MARK) return false;
 		if ((*s == '_') && (s[-1] != '\\')) return true;
 	}
 	return false;
@@ -56,6 +57,7 @@ static bool is_idiom_string(const char * s)
 
 	for (t = s; *t != '\0'; t++)
 	{
+		if (*s == SUBSCRIPT_MARK) return true;
 		if ((*t == '_') && (*(t+1) == '_')) return false;
 	}
 	return true;
@@ -143,10 +145,12 @@ static Dict_node * make_idiom_Dict_nodes(Dictionary dict, const char * string)
 	Dict_node * dn = NULL;
 	char * s = strdupa(string);
 	const char * t;
+	const char *sm = strchr(s, SUBSCRIPT_MARK);
 
 	for (t = s; NULL != s; t = s)
 	{
 		s = strchr(s, '_');
+		if ((NULL != sm) && (s > sm)) s = NULL;
 		if (NULL != s) *s++ = '\0';
 		Dict_node *dn_new = (Dict_node *) malloc(sizeof (Dict_node));
 		dn_new->right = dn;

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -40,19 +40,13 @@ bool contains_underbar(const char * s)
 
 /**
  * Returns false if it is not a correctly formed idiom string.
- * Such a string is correct if it:
- *   () contains no SUBSCRIPT_MARK
- *   () non-empty strings separated by _
+ * Such a string is correct if it consists of non-empty strings
+ * separated by '_'.
  */
 static bool is_idiom_string(const char * s)
 {
 	size_t len;
 	const char * t;
-
-	for (t = s; *t != '\0'; t++)
-	{
-		if (*t == SUBSCRIPT_MARK) return false;
-	}
 
 	len = strlen(s);
 	if ((s[0] == '_') || (s[len-1] == '_'))
@@ -85,7 +79,7 @@ static bool is_number(const char *s)
  */
 static int numberfy(const char * s)
 {
-	s = strchr(s, SUBSCRIPT_MARK);
+	s = strrchr(s, SUBSCRIPT_MARK);
 	if (NULL == s) return -1;
 	if (*++s != 'I') return -1;
 	if (!is_number(++s)) return -1;
@@ -121,22 +115,14 @@ static const char * build_idiom_word_name(Dictionary dict, const char * s)
 {
 	char buff[2*MAX_WORD];
 	size_t bufsz = 2*MAX_WORD;
-	char *x;
 	int count;
 
 	Dict_node *dn = dictionary_lookup_list(dict, s);
 	count = max_postfix_found(dn) + 1;
 	free_lookup_list(dict, dn);
 
-	x = buff;
-	while((*s != '\0') && (*s != SUBSCRIPT_MARK) && (0 < bufsz))
-	{
-		*x = *s;
-		x++;
-		s++;
-		bufsz--;
-	}
-	snprintf(x, bufsz, "%cI%d", SUBSCRIPT_MARK, count);
+	size_t l = lg_strlcpy(buff, s, bufsz);
+	snprintf(buff+l, bufsz-l, "%cI%d", SUBSCRIPT_MARK, count);
 
 	return string_set_add(buff, dict->string_set);
 }

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -27,6 +27,9 @@
  *
  * If the underbar character is preceded by a backslash, it is not
  * considered. The subscript, if exists, is not checked.
+ *
+ * FIXME: Words with '\' escaped underbars that contain also unescaped
+ * ones are not supported.
  */
 bool contains_underbar(const char * s)
 {

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -225,14 +225,10 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 		          "\tThis word will be ignored\n",
 		          s, dict->line_number);
 
-		free(dn);
 		return;
 	}
 
 	dn_list = start_dn_list = make_idiom_Dict_nodes(dict, s);
-
-	free(dn);
-	dn = NULL;
 
 	assert(dn_list->right != NULL, "Idiom string with only one connector");
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1453,7 +1453,9 @@ Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 
 	static Exp null_exp = { .type = AND_type, .u.l = NULL };
 	int comp = dict_order_strict(newnode->string, n);
-	if (0 == comp)
+	if (0 == comp &&
+	    /* Suppress reporting duplicate idioms until they are fixed. */
+	    (!contains_underbar(newnode->string) || test_enabled("dup-idioms")))
 	{
 		char t[80+MAX_TOKEN_LENGTH];
 		snprintf(t, sizeof(t),

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1588,6 +1588,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	if (contains_underbar(dn->string))
 	{
 		insert_idiom(dict, dn);
+		free(dn);
 	}
 	else if (is_idiom_word(dn->string))
 	{

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1584,12 +1584,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	dn_second_half = dn->left;
 	dn->left = dn->right = NULL;
 
-	if (contains_underbar(dn->string))
-	{
-		insert_idiom(dict, dn);
-		free(dn);
-	}
-	else if (is_idiom_word(dn->string))
+	if (is_idiom_word(dn->string))
 	{
 		prt_error("Warning: Word \"%s\" found near line %d of %s.\n"
 		        "\tWords ending \".Ix\" (x a number) are reserved for idioms.\n"
@@ -1599,6 +1594,11 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	}
 	else
 	{
+		if (contains_underbar(dn->string))
+		{
+			insert_idiom(dict, dn);
+		}
+
 		dict->root = insert_dict(dict, dict->root, dn);
 		insert_length_limit(dict, dn);
 		dict->num_entries++;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1457,8 +1457,7 @@ Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 	{
 		char t[80+MAX_TOKEN_LENGTH];
 		snprintf(t, sizeof(t),
-		         "Ignoring word \"%s\", which has been multiply defined "
-		         "(use verbosity=2 for more details): ",
+		         "Ignoring word \"%s\", which has been multiply defined:",
 		         newnode->string);
 		dict_error(dict, t);
 		/* Too late to skip insertion - insert it with a null expression. */

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -401,7 +401,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 				if (is_idiom_word(t))
 				{
 					s = strdupa(t);
-					sm = strchr(s, SUBSCRIPT_MARK);
+					sm = strrchr(s, SUBSCRIPT_MARK); /* Possible double subscript. */
 					UNREACHABLE(NULL == sm); /* We know it has a subscript. */
 					*sm = '\0';
 					t = string_set_add(s, sent->string_set);


### PR DESCRIPTION
Main changes:
- Allow subscripted idioms, which is not too useful in general, but it allows to use `.#` corrections.
- Idiom support in the link-parser `!!string` command, such as `!!but_*`.
- Test ability to detect duplicate idioms (comes for free due to the insertion of idioms to the dict).