### PR TITLE
Unrepeatable random

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -450,7 +450,16 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 
 	sent->dict = dict;
 	sent->string_set = string_set_create();
-	sent->rand_state = global_rand_state;
+
+	if (0 == global_rand_state)
+	{
+		sent->rand_state = 0;
+	}
+	else
+	{
+		sent->rand_state = (unsigned int)current_usage_time()*1000000;
+	}
+
 	sent->disjuncts_connectors_memblock = NULL;
 
 	sent->postprocessor = post_process_new(dict->base_knowledge);

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -45,7 +45,7 @@ int getrusage(int who, struct rusage *rusage);
 #define MAX_MEMORY_UNLIMITED ((size_t) -1)
 
 /** returns the current usage time clock in seconds */
-static double current_usage_time(void)
+double current_usage_time(void)
 {
 #if !defined(_WIN32)
 	struct rusage u;

--- a/link-grammar/resources.h
+++ b/link-grammar/resources.h
@@ -25,4 +25,5 @@ bool      resources_memory_exhausted(Resources r);
 bool      resources_exhausted(Resources r);
 Resources resources_create(void);
 void      resources_delete(Resources ti);
+double    current_usage_time(void);
 #endif /* _RESOURCES_H */


### PR DESCRIPTION
Use random seed when repeatable_random=false (!rand=0).
I checked it by setting linkage_limit=1 and inspecting several linkages.

Note:
I didn't understand the following code in `sentence_split()`, so I don't know if any change is needed regarding it:
``` c
	/* 0 == global_rand_state denotes "repeatable rand".
	 * If non-zero, set it here so that anysplit can use it.
	 */
	if (false == opts->repeatable_rand && 0 == sent->rand_state)
	{
		if (0 == global_rand_state) global_rand_state = 42;
		sent->rand_state = global_rand_state;
	}
```
(I also didn't understand the comment.)
