### PR TITLE
Fix unrepeatable random selection

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -716,7 +716,10 @@ void extract_links(extractor_t * pex, Linkage lkg)
 		if (0 == pex->rand_state) repeatable = true;
 		if (repeatable) pex->rand_state = index;
 		list_random_links(lkg, pex, pex->parse_set);
-		if (repeatable) pex->rand_state = 0;
+		if (repeatable)
+			pex->rand_state = 0;
+		else
+			lkg->sent->rand_state = pex->rand_state;
 	}
 	else {
 		list_links(lkg, pex->parse_set, index);


### PR DESCRIPTION
Issue #752.

The problem was that `sent->rand_state` has never been set to the linkage random state.

On first glance it seems it is more economical to set it once, from the last linkage.
However,  there may be linkages that are not produced after it, and if so the rand_state should be of the last one of them.

So I just added setting `sent->rand_state` in `extract_links()`.

Comments:
1. I don't know if this problem affected anysplit or if this fix interferes with it., since `sent->rand_state` is already assigned there.  **Please check that.**
2. It seems as if `sent->rand_state` is redundant since `globa_rand_state` could be directly used instead.
3. I still don't understand the reason for setting `sent->rand_state` in `sentence_split()`, as it already set in `sentence_create()`. If I try to remove it, it seems non-repeatable rand still works fine.
The comment of this code is somehow misleading and doesn't help to understand its purpose.

