### PR TITLE
Fix sentence-check.py to support `.#fix`

### DIFF
--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -99,21 +99,35 @@ while True:
         continue
     null_count = sent.null_count()
     if null_count == 0:
-        print("Sentence parsed OK")
+        print("Sentence parsed OK", end='')
+
+    linkages = list(linkages)
+
+    correction_found = False
+    # search for correction suggestions
+    for l in linkages:
+        for word in l.words():
+                if word.find(r'.#') > 0:
+                    correction_found = True
+                    break;
+        if correction_found:
+            break
+
+    if correction_found:
+        print(" - with correction", end='')
+    print(".")
 
     guess_found = False
     if DISPLAY_GUESSES:
-        linkages, check_first = itertools.tee(linkages)
         # Check the first linkage for regexed/unknown words
-        linkage = next(check_first)
-        for word in list(linkage.words()):
+        for word in linkages[0].words():
             # search for something[x]
             if re.search(r'\S+\[[^]]+]', word):
                 guess_found = True
                 break
 
     # Show results with unlinked words or guesses
-    if arg.position or guess_found or null_count != 0:
+    if arg.position or guess_found or correction_found or null_count != 0:
         if arg.position:
             for p in range (0, len(sentence_text)):
                 print(p%10, end="")

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -59,6 +59,8 @@ args.add_argument("-p", "--position", action="store_true",
                   help="show word sentence position")
 args.add_argument("-nm", "--no-morphology", dest='morphology', action='store_false',
                   help="do not display morphology")
+args.add_argument("-i", "--interactive", action="store_true",
+                  help="interactive mode after each result")
 
 arg = args.parse_args()
 
@@ -111,38 +113,40 @@ while True:
                 break
 
     # Show results with unlinked words or guesses
-    if not arg.position and not guess_found and null_count == 0:
-        continue
-
-
-    if arg.position:
-        for p in range (0, len(sentence_text)):
-            print(p%10, end="")
-        print()
-
-    print('Sentence has {} unlinked word{}:'.format(
-        null_count, nsuffix(null_count)))
-    result_no = 0
-    uniqe_parse = {}
-    for linkage in linkages:
-        words = list(linkage.words())
-        if str(words) in uniqe_parse:
-            continue
-        result_no += 1
-        uniqe_parse[str(words)] = True
-
+    if arg.position or guess_found or null_count != 0:
         if arg.position:
-            words_char = []
-            words_byte = []
-            wi = 0
-            for w in words:
-                if sys.version_info < (3, 0):
-                    words[wi] = words[wi].decode('utf-8')
-                words_char.append(words[wi] + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
-                words_byte.append(words[wi] + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
-                wi += 1
+            for p in range (0, len(sentence_text)):
+                print(p%10, end="")
+            print()
 
-            print(u"{}: {}".format(result_no, ' '.join(words_char)))
-            print(u"{}: {}".format(result_no, ' '.join(words_byte)))
-        else:
-            print("{}: {}".format(result_no, ' '.join(words)))
+        print('Sentence has {} unlinked word{}:'.format(
+            null_count, nsuffix(null_count)))
+        result_no = 0
+        uniqe_parse = {}
+        for linkage in linkages:
+            words = list(linkage.words())
+            if str(words) in uniqe_parse:
+                continue
+            result_no += 1
+            uniqe_parse[str(words)] = True
+
+            if arg.position:
+                words_char = []
+                words_byte = []
+                wi = 0
+                for w in words:
+                    if sys.version_info < (3, 0):
+                        words[wi] = words[wi].decode('utf-8')
+                    words_char.append(words[wi] + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
+                    words_byte.append(words[wi] + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
+                    wi += 1
+
+                print(u"{}: {}".format(result_no, ' '.join(words_char)))
+                print(u"{}: {}".format(result_no, ' '.join(words_byte)))
+            else:
+                print("{}: {}".format(result_no, ' '.join(words)))
+
+    if arg.interactive:
+        print("Interactive session (^D to end):")
+        import code
+        code.interact(local=locals())

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -18,14 +18,21 @@ Sentence has 1 unlinked word:
 3: LEFT-WALL this.p is.v [a] the test.n of bfgiuing[!].g and.j-n xxxvfrg[?].a RIGHT-WALL
 4: LEFT-WALL this.p is.v a [the] test.n of bfgiuing[!].g and.j-n xxxvfrg[?].a RIGHT-WALL
 """
+
 from __future__ import print_function
 import sys
 import re
 import itertools
 import argparse
+import readline
 
 from linkgrammar import (Sentence, ParseOptions, Dictionary,
                          LG_Error, LG_TimerExhausted, Clinkgrammar as clg)
+
+get_input = input
+# If this is Python 2, use raw_input()
+if sys.version_info[:2] <= (2, 7):
+    get_input = raw_input
 
 def nsuffix(q):
     return '' if q == 1 else 's'
@@ -67,9 +74,10 @@ po.max_parse_time = 10   # actual parse timeout may be about twice bigger
 po.spell_guess = True if DISPLAY_GUESSES else False
 po.display_morphology = arg.morphology
 
-print("Enter sentences:")
 # iter(): avoid python2 input buffering
-for sentence_text in iter(sys.stdin.readline, ''):
+while True:
+    sentence_text = get_input("sentence-check: ")
+
     if sentence_text.strip() == '':
         continue
     sent = Sentence(str(sentence_text), lgdict, po)

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -47,6 +47,8 @@ class Formatter(argparse.HelpFormatter):
 
 DISPLAY_GUESSES = True   # Display regex and POS guesses
 
+print ("Version:", clg.linkgrammar_get_version())
+
 args = argparse.ArgumentParser(formatter_class=Formatter)
 args.add_argument('lang', nargs='?', default='en',
                   help="language or dictionary location")


### PR DESCRIPTION
The `.#fix` entries have an unexpected behavior (by the user) of supporting complete linkages of incorrect sentences.

The `sentence-check.py` demo intended to display possoble problems in input sentences, but since it was written before the `#.fix` idea actual implementation, it doesn't display sentences with these subscripts which suggest a fix.

Changes in this PR:
- Also display sentences that contain a word with a `#.fix` subscript.
- In the same occasion, two unrelated ones:
 -- Add input line prompt/editing/history (but with no permanent history).
 -- Add new flag `-i / --interactive` to enter interactive python mode after each sentence. This allows to perform manual checks on the parse results in order to test the library.