### PR TITLE
Dist he/4.0.dict.m4 debug/README.m4 minisat/LICENSE Python3.vcxproj

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST =            \
 	MAINTAINERS          \
 	NEWS                 \
 	README.md            \
+	debug/README.md                        \
 	docker/docker-build.sh                 \
 	docker/docker-base/Dockerfile          \
 	docker/docker-parser/Dockerfile        \
@@ -46,6 +47,7 @@ EXTRA_DIST =            \
 	msvc14/MSVC-common.props               \
 	msvc14/post-build.bat                  \
 	msvc14/Python2.vcxproj                 \
+	msvc14/Python3.vcxproj                 \
 	msvc14/Python2.vcxproj.filters         \
 	msvc14/Python3.vcxproj.filters         \
 	msvc14/README.md                       \

--- a/data/he/Makefile.am
+++ b/data/he/Makefile.am
@@ -3,6 +3,7 @@ DICTS=                           \
       4.0.affix                  \
       4.0.constituent-knowledge  \
       4.0.dict                   \
+      4.0.dict.m4                \
       4.0.knowledge              \
       4.0.regex
 

--- a/link-grammar/minisat/Makefile.am
+++ b/link-grammar/minisat/Makefile.am
@@ -24,4 +24,4 @@ libminisat_la_SOURCES = \
 	minisat/utils/System.cc \
 	minisat/utils/System.h
 
-EXTRA_DIST= README
+EXTRA_DIST= README LICENSE


### PR DESCRIPTION
Add missing files to the distribution, per issue #765.
BTW, `msvc14/Python3.vcxproj` was also missing...