### PR TITLE
Add a warning on dict read if old name "UNKNOWN-WORD" is defined

### DIFF
--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -342,6 +342,14 @@ void dictionary_setup_defines(Dictionary dict)
 	dict->unknown_word_defined = boolean_dictionary_lookup(dict, UNKNOWN_WORD);
 	dict->use_unknown_word = true;
 
+	/* In version 5.5.0 UNKNOWN_WORD has been replaced by <UNKNOWN-WORD>. */
+	if (!dict->unknown_word_defined &&
+	    boolean_dictionary_lookup(dict, "UNKNOWN-WORD"))
+	{
+		prt_error("Warning: Old name \"UNKNOWN-WORD\" is defined in the "
+		          "dictionary. Please use \"<UNKNOWN-WORD>\" instead.\n");
+	}
+
 	dict->shuffle_linkages = false;
 
 	set_all_condesc_length_limit(dict);


### PR DESCRIPTION
See issue #771.

I finally added it when reading the dict and not when generating an error on words that are unknown .

The warning is:
`Warning: Old name "UNKNOWN-WORD" is defined in the dictionary. Please use "<UNKNOWN-WORD>" instead.`
