### PR TITLE
Connector descriptor table fixes

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -368,13 +368,12 @@ static int condesc_by_uc_constring(const void * a, const void * b)
  * It replaces the existing connector UC-part hash, and can later serve
  * as table index as if it was a perfect hash.
  */
-void sort_condesc_by_uc_constring(Dictionary dict)
+bool sort_condesc_by_uc_constring(Dictionary dict)
 {
 	if (0 == dict->contable.num_con)
 	{
 		prt_error("Error: Dictionary %s: No connectors found.\n", dict->name);
-		/* FIXME: Generate a dictionary open error. */
-		return;
+		return false;
 	}
 
 	condesc_t **sdesc = malloc(dict->contable.size * sizeof(*dict->contable.hdesc));
@@ -422,6 +421,8 @@ void sort_condesc_by_uc_constring(Dictionary dict)
 
 	dict->contable.sdesc = sdesc;
 	dict->contable.num_uc = uc_num + 1;
+
+	return true;
 }
 
 void condesc_delete(Dictionary dict)

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -323,6 +323,47 @@ bool calculate_connector_info(condesc_t * c)
 
 /* ================= Connector descriptor table. ====================== */
 
+static uint32_t connector_str_hash(const char *s)
+{
+	uint32_t i;
+
+	/* For most situations, all three hashes are very nearly equal;
+	 * as to which is faster depends on the parsed text.
+	 * For both English and Russian, there are about 100 pre-defined
+	 * connectors, and another 2K-4K autogen'ed ones (the IDxxx idiom
+	 * connectors, and the LLxxx suffix connectors for Russian).
+	 * Turns out the cost of setting up the hash table dominates the
+	 * cost of collisions. */
+#ifdef USE_DJB2
+	/* djb2 hash */
+	i = 5381;
+	while (*s)
+	{
+		i = ((i << 5) + i) + *s;
+		s++;
+	}
+	i += i>>14;
+#endif /* USE_DJB2 */
+
+#define USE_JENKINS
+#ifdef USE_JENKINS
+	/* Jenkins one-at-a-time hash */
+	i = 0;
+	while (*s)
+	{
+		i += *s;
+		i += (i<<10);
+		i ^= (i>>6);
+		s++;
+	}
+	i += (i << 3);
+	i ^= (i >> 11);
+	i += (i << 15);
+#endif /* USE_JENKINS */
+
+	return i;
+}
+
 /**
  * Compare connector UC parts, for qsort.
  */

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -432,6 +432,8 @@ bool sort_condesc_by_uc_constring(Dictionary dict)
 	dict->contable.sdesc = sdesc;
 	dict->contable.num_uc = uc_num + 1;
 
+	/* hdesc is not freed here because it is needed for finding ZZZ.
+	 * It could be freed here if we have ZZZ cached in the dict structure. */
 	return true;
 }
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -260,7 +260,7 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
  * This information is used to speed up the parsing stage. It is
  * calculated during the directory creation and doesn't change afterward.
  */
-bool calculate_connector_info(condesc_t * c)
+static bool calculate_connector_info(condesc_t * c)
 {
 	const char *s;
 	uint32_t i;

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -503,7 +503,7 @@ condesc_t *condesc_add(ConTable *ct, const char *constring)
 		                       /*zero_out*/true, /*align*/true, /*exact*/false);
 	}
 
-	int hash = connector_str_hash(constring);
+	uint32_t hash = (connector_hash_size)connector_str_hash(constring);
 	condesc_t **h = condesc_find(ct, constring, hash);
 
 	if (NULL == *h)

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -263,7 +263,7 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 bool calculate_connector_info(condesc_t * c)
 {
 	const char *s;
-	unsigned int i;
+	uint32_t i;
 
 	s = c->string;
 	if (islower((int) *s)) s++; /* ignore head-dependent indicator */
@@ -445,9 +445,9 @@ void condesc_delete(Dictionary dict)
 	condesc_length_limit_def_delete(&dict->contable);
 }
 
-static condesc_t **condesc_find(ConTable *ct, const char *constring, int hash)
+static condesc_t **condesc_find(ConTable *ct, const char *constring, uint32_t hash)
 {
-	size_t i = hash & (ct->size-1);
+	uint32_t i = hash & (ct->size-1);
 
 	while ((NULL != ct->hdesc[i]) &&
 	       !string_set_cmp(constring, ct->hdesc[i]->string))
@@ -466,7 +466,7 @@ static void condesc_table_alloc(ConTable *ct, size_t size)
 }
 
 static void condesc_insert(ConTable *ct, condesc_t **h,
-                                  const char *constring, int hash)
+                                  const char *constring, uint32_t hash)
 {
 	*h = pool_alloc(ct->mempool);
 	(*h)->str_hash = hash;

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -223,7 +223,7 @@ static inline bool easy_match_desc(const condesc_t *c1, const condesc_t *c2)
 	return lc_easy_match(c1, c2);
 }
 
-static inline int string_hash(const char *s)
+static inline uint32_t string_hash(const char *s)
 {
 	unsigned int i;
 
@@ -239,7 +239,7 @@ static inline int string_hash(const char *s)
 
 bool calculate_connector_info(condesc_t *);
 
-static inline int connector_str_hash(const char *s)
+static inline uint32_t connector_str_hash(const char *s)
 {
 	uint32_t i;
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -237,7 +237,6 @@ static inline uint32_t string_hash(const char *s)
 	return i;
 }
 
-bool calculate_connector_info(condesc_t *);
 /**
  * hash function. Based on some tests, this seems to be an almost
  * "perfect" hash, in that almost all hash buckets have the same size!

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -238,48 +238,6 @@ static inline uint32_t string_hash(const char *s)
 }
 
 bool calculate_connector_info(condesc_t *);
-
-static inline uint32_t connector_str_hash(const char *s)
-{
-	uint32_t i;
-
-	/* For most situations, all three hashes are very nearly equal;
-	 * as to which is faster depends on the parsed text.
-	 * For both English and Russian, there are about 100 pre-defined
-	 * connectors, and another 2K-4K autogen'ed ones (the IDxxx idiom
-	 * connectors, and the LLxxx suffix connectors for Russian).
-	 * Turns out the cost of setting up the hash table dominates the
-	 * cost of collisions. */
-#ifdef USE_DJB2
-	/* djb2 hash */
-	i = 5381;
-	while (*s)
-	{
-		i = ((i << 5) + i) + *s;
-		s++;
-	}
-	i += i>>14;
-#endif /* USE_DJB2 */
-
-#define USE_JENKINS
-#ifdef USE_JENKINS
-	/* Jenkins one-at-a-time hash */
-	i = 0;
-	while (*s)
-	{
-		i += *s;
-		i += (i<<10);
-		i ^= (i>>6);
-		s++;
-	}
-	i += (i << 3);
-	i ^= (i >> 11);
-	i += (i << 15);
-#endif /* USE_JENKINS */
-
-	return i;
-}
-
 /**
  * hash function. Based on some tests, this seems to be an almost
  * "perfect" hash, in that almost all hash buckets have the same size!

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -108,7 +108,7 @@ struct Connector_struct
 	const gword_set *originating_gword;
 };
 
-void sort_condesc_by_uc_constring(Dictionary);
+bool sort_condesc_by_uc_constring(Dictionary);
 condesc_t *condesc_add(ConTable *ct, const char *);
 void condesc_delete(Dictionary);
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -38,7 +38,7 @@
 #define LC_MASK ((1<<LC_BITS)-1)
 typedef uint64_t lc_enc_t;
 
-typedef uint16_t connector_hash_size; /* Change to uint32_t if needed. */
+typedef uint32_t connector_hash_size;
 
 /* When connector_hash_size is uint16_t, the size of the following
  * struct on a 64-bit machine is 32 bytes.
@@ -51,9 +51,9 @@ struct condesc_struct
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
 	// double *cost; /* Array of cost by length_limit (cost[0]: default) */
-	connector_hash_size str_hash;
 	union
 	{
+		connector_hash_size str_hash;
 		connector_hash_size uc_hash;
 		connector_hash_size uc_num;
 	};

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -227,7 +227,7 @@ dictionary_six_str(const char * lang,
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	dict->hpsg_knowledge  = pp_knowledge_open(cons_name);
 
-	sort_condesc_by_uc_constring(dict);
+	if (!sort_condesc_by_uc_constring(dict)) goto failure;
 	dictionary_setup_defines(dict);
 
 	// Special-case hack.

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -168,15 +168,21 @@ int vappend_string(dyn_str * string, const char *fmt, va_list args)
 	if (templen >= TMPLEN)
 	{
 		/* TMPLEN is too small - use a bigger buffer. This may happen
-		 * when printing dictionary words using !! with a wildcard. */
-		temp_string = alloca(templen+1);
+		 * when printing dictionary words using !! with a wildcard
+		 * or when debug-printing all the connectors. */
+		temp_string = malloc(templen+1);
 		templen = vsnprintf(temp_string, templen+1, fmt, args);
-		if (templen < 0) goto error;
+		if (templen < 0)
+		{
+			free(temp_string);
+			goto error;
+		}
 	}
 	va_end(args);
 
 	patch_subscript_marks(temp_string);
 	dyn_strcat(string, temp_string);
+	if (templen >= TMPLEN) free(temp_string);
 	return templen;
 
 error:

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -192,7 +192,7 @@ error:
 		strcpy(temp_buffer, msg);
 		strerror_r(errno, temp_buffer+sizeof(msg)-1, TMPLEN-sizeof(msg));
 		strcat(temp_buffer, "]");
-		dyn_strcat(string, temp_string);
+		dyn_strcat(string, temp_buffer);
 		va_end(args);
 		return templen;
 	}


### PR DESCRIPTION
The dict read fails when it contains more than about 25K connectors due to a bug:
The hash value is calculated as 32-bit, but in the connector descriptor entry it is held as 16-bit
in order to keep the descriptor struct at 32-byte (enlarging this struct impacts parsing performance).
However, in one place the full value of the hash (as 32 bits) may be used, a thing that causes a double-entry when the table size is > 64K.

This is fixed here by proper casting, but the main fix here is to hold in the connector descriptor its full 32 bit hash value (until the dict read end - because this field is shared with the UC enumeration number).
This allows for "unlimited" number of connectors in the dict (and also makes parsing somewhat faster).

Tested using a 19MB dict with ~575K connectors (read time under 3 seconds).