### PR TITLE
SQL dict fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 5.5.1 (XXX 2018)
  * English dict: Fix clause openers with questions.
  * English dict: Various misc fixes.
  * English dict: Various paraphrasing verbs
+ * Bring the SQL-backed dict to production state.
 
 Version 5.5.0 (29 April 2018)
  * Fix accidental API breakage that impacts OpenCog.

--- a/bindings/python-examples/parses-demo-sql.txt
+++ b/bindings/python-examples/parses-demo-sql.txt
@@ -1,0 +1,19 @@
+% This file contains test sentences to verify that the SQL dict
+% works. It contains more than one sentence to check that memory
+% is freed properly (e.g by using LSAN).
+
+Ithis is a test
+O
+O    +------WV------+--Osm--+
+O    +---Wd---+-Ss*b+  +-Ds-+
+O    |        |     |  |    |
+OLEFT-WALL this.p is.v a test.n
+O
+
+Ithis is another test
+O
+O    +------WV------+-----Osm-----+
+O    +---Wd---+-Ss*b+     +---Ds--+
+O    |        |     |     |       |
+OLEFT-WALL this.p is.v another test.n
+O

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -712,6 +712,19 @@ class HEnglishLinkageTestCase(unittest.TestCase):
 "\nLEFT-WALL we are.v from the planet.n Gorpon[!]"
 "\n\n")
 
+class GSQLDictTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        #clg.parse_options_set_verbosity(clg.parse_options_create(), 3)
+        cls.d, cls.po = Dictionary(lang='demo-sql'), ParseOptions()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.d
+        del cls.po
+
+    def test_getting_links(self):
+        linkage_testfile(self, self.d, self.po)
 
 class ZENLangTestCase(unittest.TestCase):
     @classmethod

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -533,6 +533,9 @@ void sentence_delete(Sentence sent)
 	global_rand_state = sent->rand_state;
 	pool_delete(sent->fm_Match_node);
 	pool_delete(sent->Table_connector_pool);
+	if (IS_DB_DICT(sent->dict))
+		condesc_reuse(sent->dict);
+
 	free(sent);
 }
 
@@ -628,6 +631,11 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 	}
 
 	resources_reset(opts->resources);
+
+	/* When the SQL dict is used, expressions are read on demand, so
+	 * the connector descriptor table is not yet ready at this point. */
+	if (IS_DB_DICT(sent->dict))
+		condesc_setup(sent->dict);
 
 	/* Expressions were set up during the tokenize stage.
 	 * Prune them, and then parse.

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -546,15 +546,6 @@ static bool condesc_grow(ConTable *ct)
 
 condesc_t *condesc_add(ConTable *ct, const char *constring)
 {
-	if (0 == ct->size)
-	{
-		condesc_table_alloc(ct, ct->num_con);
-		ct->num_con = 0;
-		ct->mempool = pool_new(__func__, "ConTable",
-		                       /*num_elements*/1024, sizeof(condesc_t),
-		                       /*zero_out*/true, /*align*/true, /*exact*/false);
-	}
-
 	uint32_t hash = (connector_hash_size)connector_str_hash(constring);
 	condesc_t **h = condesc_find(ct, constring, hash);
 
@@ -573,5 +564,18 @@ condesc_t *condesc_add(ConTable *ct, const char *constring)
 	}
 
 	return *h;
+}
+
+void condesc_init(Dictionary dict, size_t num_con)
+{
+	ConTable *ct = &dict->contable;
+
+	condesc_table_alloc(ct, num_con);
+	ct->mempool = pool_new(__func__, "ConTable",
+								  /*num_elements*/1024, sizeof(condesc_t),
+								  /*zero_out*/true, /*align*/true, /*exact*/false);
+
+	ct->length_limit_def = NULL;
+	ct->length_limit_def_next = &ct->length_limit_def;
 }
 /* ========================= END OF FILE ============================== */

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -249,8 +249,8 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 		return false;
 	}
 
-	desc->lc_mask = lc_mask;
-	desc->lc_letters = lc_value;
+	desc->lc_mask = (lc_mask << 1) + !!(desc->flags & CD_HEAD_DEPENDET);
+	desc->lc_letters = (lc_value << 1) + !!(desc->flags & CD_HEAD);
 
 	return true;
 }

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -546,7 +546,7 @@ static bool condesc_grow(ConTable *ct)
 
 condesc_t *condesc_add(ConTable *ct, const char *constring)
 {
-	uint32_t hash = (connector_hash_size)connector_str_hash(constring);
+	uint32_t hash = (connector_hash_t)connector_str_hash(constring);
 	condesc_t **h = condesc_find(ct, constring, hash);
 
 	if (NULL == *h)

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -420,7 +420,7 @@ static int condesc_by_uc_constring(const void * a, const void * b)
  */
 bool sort_condesc_by_uc_constring(Dictionary dict)
 {
-	if (0 == dict->contable.num_con)
+	if ((0 == dict->contable.num_con) && !IS_DB_DICT(dict))
 	{
 		prt_error("Error: Dictionary %s: No connectors found.\n", dict->name);
 		return false;
@@ -492,7 +492,6 @@ void condesc_delete(Dictionary dict)
 {
 	pool_delete(dict->contable.mempool);
 	free(dict->contable.hdesc);
-	free(dict->contable.sdesc);
 	condesc_length_limit_def_delete(&dict->contable);
 }
 
@@ -581,5 +580,12 @@ void condesc_init(Dictionary dict, size_t num_con)
 
 	ct->length_limit_def = NULL;
 	ct->length_limit_def_next = &ct->length_limit_def;
+}
+
+void condesc_setup(Dictionary dict)
+{
+	sort_condesc_by_uc_constring(dict);
+	set_all_condesc_length_limit(dict);
+	free(dict->contable.sdesc);
 }
 /* ========================= END OF FILE ============================== */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -114,10 +114,12 @@ struct Connector_struct
 };
 
 void condesc_init(Dictionary, size_t);
+void condesc_reset(Dictionary);
 void condesc_setup(Dictionary);
 bool sort_condesc_by_uc_constring(Dictionary);
 condesc_t *condesc_add(ConTable *ct, const char *);
 void condesc_delete(Dictionary);
+void condesc_reuse(Dictionary);
 
 /* GET accessors for connector attributes.
  * Can be used for experimenting with Connector_struct internals in

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -38,9 +38,9 @@
 #define LC_MASK ((1<<LC_BITS)-1)
 typedef uint64_t lc_enc_t;
 
-typedef uint32_t connector_hash_size;
+typedef uint32_t connector_hash_t;
 
-/* When connector_hash_size is uint16_t, the size of the following
+/* When connector_hash_t is uint16_t, the size of the following
  * struct on a 64-bit machine is 32 bytes.
  * FIXME: Make it 16 bytes by separating the info that is not needed
  * by do_count() into another structure (and some other minor changes). */
@@ -53,9 +53,9 @@ struct condesc_struct
 	// double *cost; /* Array of cost by length_limit (cost[0]: default) */
 	union
 	{
-		connector_hash_size str_hash;
-		connector_hash_size uc_hash;
-		connector_hash_size uc_num;
+		connector_hash_t str_hash;
+		connector_hash_t uc_hash;
+		connector_hash_t uc_num;
 	};
 	uint8_t length_limit;
 	                      /* If not 0, it gives the limit of the length of the

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -108,6 +108,7 @@ struct Connector_struct
 	const gword_set *originating_gword;
 };
 
+void condesc_init(Dictionary, size_t);
 bool sort_condesc_by_uc_constring(Dictionary);
 condesc_t *condesc_add(ConTable *ct, const char *);
 void condesc_delete(Dictionary);

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -54,7 +54,6 @@ struct condesc_struct
 	union
 	{
 		connector_hash_t str_hash;
-		connector_hash_t uc_hash;
 		connector_hash_t uc_num;
 	};
 	uint8_t length_limit;
@@ -134,7 +133,7 @@ static inline const condesc_t *connector_desc(const Connector *c)
 
 static inline int connector_uc_hash(const Connector * c)
 {
-	return c->desc->uc_hash;
+	return c->desc->uc_num;
 }
 
 static inline int connector_uc_num(const Connector * c)

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -51,11 +51,7 @@ struct condesc_struct
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
 	// double *cost; /* Array of cost by length_limit (cost[0]: default) */
-	union
-	{
-		connector_hash_t str_hash;
-		connector_hash_t uc_num;
-	};
+	connector_hash_t uc_num; /* uc part enumeration. */
 	uint8_t length_limit;
 	                      /* If not 0, it gives the limit of the length of the
 	                       * link that can be used on this connector type. The
@@ -79,9 +75,15 @@ typedef struct length_limit_def
 	int length_limit;
 } length_limit_def_t;
 
+typedef struct hdesc
+{
+	condesc_t *desc;
+	connector_hash_t str_hash;
+} hdesc_t;
+
 typedef struct
 {
-	condesc_t **hdesc;    /* Hashed connector descriptors table */
+	hdesc_t *hdesc;       /* Hashed connector descriptors table */
 	condesc_t **sdesc;    /* Alphabetically sorted descriptors */
 	size_t size;          /* Allocated size */
 	size_t num_con;       /* Number of connector types */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -40,20 +40,20 @@ typedef uint64_t lc_enc_t;
 
 typedef uint32_t connector_hash_t;
 
-/* When connector_hash_t is uint16_t, the size of the following
- * struct on a 64-bit machine is 32 bytes.
- * FIXME: Make it 16 bytes by separating the info that is not needed
- * by do_count() into another structure (and some other minor changes). */
+/* The size of the following struct on a 64-bit machine is 32 bytes.
+ * It should be kept at this size. If needed, head_dependent, uc_length
+ * and uc_start can be eliminate or moved out. Also, there not enough
+ * space here to implement cost per connector length - an index to a
+ * cost table should be used instead.*/
 struct condesc_struct
 {
 	lc_enc_t lc_letters;
 	lc_enc_t lc_mask;
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
-	// double *cost; /* Array of cost by length_limit (cost[0]: default) */
+	// double *cost; /* Array of cost by connector length (cost[0]: default) */
 	connector_hash_t uc_num; /* uc part enumeration. */
-	uint8_t length_limit;
-	                      /* If not 0, it gives the limit of the length of the
+	uint8_t length_limit; /* If not 0, it gives the limit of the length of the
 	                       * link that can be used on this connector type. The
 	                       * value UNLIMITED_LEN specifies no limit.
 	                       * If 0, short_length (a Parse_Option) is used. If

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -114,6 +114,7 @@ struct Connector_struct
 };
 
 void condesc_init(Dictionary, size_t);
+void condesc_setup(Dictionary);
 bool sort_condesc_by_uc_constring(Dictionary);
 condesc_t *condesc_add(ConTable *ct, const char *);
 void condesc_delete(Dictionary);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -67,6 +67,12 @@ struct Afdict_class_struct
 #define MAX_TOKEN_LENGTH 250     /* Maximum number of chars in a token */
 #define IDIOM_LINK_SZ 5
 
+#ifdef HAVE_SQLITE
+#define IS_DB_DICT(dict) (NULL != dict->db_handle)
+#else
+#define IS_DB_DICT(dict) false
+#endif /* HAVE_SQLITE */
+
 struct Dictionary_s
 {
 	Dict_node *  root;

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -351,8 +351,6 @@ void dictionary_setup_defines(Dictionary dict)
 	}
 
 	dict->shuffle_linkages = false;
-
-	set_all_condesc_length_limit(dict);
 }
 
 /* ======================================================================= */

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -118,9 +118,6 @@ dictionary_six_str(const char * lang,
 	lgdebug(D_USER_FILES, "Debug: Language: %s\n", dict->lang);
 	dict->name = string_set_add(dict_name, dict->string_set);
 
-	memset(dict->current_idiom, 'A', IDIOM_LINK_SZ-1);
-	dict->current_idiom[IDIOM_LINK_SZ-1] = 0;
-
 	/*
 	 * A special setup per dictionary type. The check here assumes the affix
 	 * dictionary name contains "affix". FIXME: For not using this
@@ -135,8 +132,10 @@ dictionary_six_str(const char * lang,
 		if (verbosity_level(D_USER_BASIC) && (NULL == dict->spell_checker))
 			prt_error("Info: %s: Spell checker disabled.\n", dict->lang);
 #endif
-		dict->insert_entry = insert_list;
+		memset(dict->current_idiom, 'A', IDIOM_LINK_SZ-1);
+		dict->current_idiom[IDIOM_LINK_SZ-1] = 0;
 
+		dict->insert_entry = insert_list;
 		dict->lookup_list = file_lookup_list;
 		dict->lookup_wild = file_lookup_wild;
 		dict->free_lookup = free_llist;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -145,7 +145,7 @@ dictionary_six_str(const char * lang,
 		dict->lookup_wild = file_lookup_wild;
 		dict->free_lookup = free_llist;
 		dict->lookup = file_boolean_lookup;
-		dict->contable.num_con = 1<<13;
+		condesc_init(dict, 1<<13);
 	}
 	else
 	{
@@ -155,25 +155,16 @@ dictionary_six_str(const char * lang,
 		afclass_init(dict);
 		dict->insert_entry = load_affix;
 		dict->lookup = return_true;
-		dict->contable.num_con = 1<<9;
+		condesc_init(dict, 1<<9);
 	}
-	dict->affix_table = NULL;
-
-	dict->contable.size = 0;
-	dict->contable.length_limit_def = NULL;
-	dict->contable.length_limit_def_next = &dict->contable.length_limit_def;
 
 	/* Read dictionary from the input string. */
 	dict->input = input;
 	dict->pin = dict->input;
 	if (!read_dictionary(dict))
 	{
-		dict->pin = NULL;
-		dict->input = NULL;
 		goto failure;
 	}
-	dict->pin = NULL;
-	dict->input = NULL;
 
 	if (NULL == affix_name)
 	{

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -92,10 +92,6 @@ static bool return_true(Dictionary dict, const char *name)
 	return true;
 }
 
-static Dictionary
-dictionary_six(const char * lang, const char * dict_name,
-               const char * pp_name, const char * cons_name,
-               const char * affix_name, const char * regex_name);
 /**
  * Read dictionary entries from a wide-character string "input".
  * All other parts are read from files.
@@ -236,7 +232,7 @@ failure:
 /**
  * Use filenames of six different files to put together the dictionary.
  */
-static Dictionary
+Dictionary
 dictionary_six(const char * lang, const char * dict_name,
                const char * pp_name, const char * cons_name,
                const char * affix_name, const char * regex_name)

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -218,8 +218,8 @@ dictionary_six_str(const char * lang,
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	dict->hpsg_knowledge  = pp_knowledge_open(cons_name);
 
-	if (!sort_condesc_by_uc_constring(dict)) goto failure;
 	dictionary_setup_defines(dict);
+	condesc_setup(dict);
 
 	// Special-case hack.
 	if ((0 == strncmp(dict->lang, "any", 3)) ||

--- a/link-grammar/dict-file/read-dict.h
+++ b/link-grammar/dict-file/read-dict.h
@@ -18,7 +18,10 @@
 void print_dictionary_data(Dictionary dict);
 void print_dictionary_words(Dictionary dict);
 
-Dictionary dictionary_create_from_file(const char * lang);
+Dictionary dictionary_six(const char *lang, const char *dict_name,
+                          const char *pp_name, const char *cons_name,
+                          const char *affix_name, const char *regex_name);
+Dictionary dictionary_create_from_file(const char *lang);
 bool read_dictionary(Dictionary dict);
 
 Dict_node * file_lookup_list(const Dictionary dict, const char *s);

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -129,17 +129,17 @@ typedef struct
 
 static void db_free_llist(Dictionary dict, Dict_node *llist)
 {
-   Dict_node * dn;
-   while (llist != NULL)
-   {
+	Dict_node * dn;
+	while (llist != NULL)
+	{
 		Exp *e;
-      dn = llist->right;
+		dn = llist->right;
 		e = llist->exp;
 		// if (e) free_Exp(e);
 		if (e) free(e);
 		free(llist);
-      llist = dn;
-   }
+		llist = dn;
+	}
 }
 
 /* callback -- set bs->exp to the expressions for a class in the dict */

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -23,7 +23,6 @@
 #include "connectors.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h" // for LEFT_WALL_WORD
 #include "dict-common/dict-impl.h"
 #include "dict-common/dict-structures.h"
 #include "dict-common/dict-utils.h"

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -370,8 +370,10 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->lang = string_set_add(t, dict->string_set);
 	lgdebug(D_USER_FILES, "Debug: Language: %s\n", dict->lang);
 
+#if 0 /* FIXME: Spell checking should be done according to the dict locale. */
 	/* To disable spell-checking, just set the checker to NULL */
 	dict->spell_checker = spellcheck_create(dict->lang);
+#endif
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
 		if (verbosity_level(D_USER_BASIC) && (NULL == dict->spell_checker))

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -392,6 +392,7 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->free_lookup = db_free_llist;
 	dict->lookup = db_lookup;
 	dict->close = db_close;
+	condesc_init(dict, 1<<8);
 
 	/* Setup the affix table */
 	dict->affix_table = (Dictionary) malloc(sizeof(struct Dictionary_s));

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -25,7 +25,7 @@
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-impl.h"
 #include "dict-common/dict-structures.h"
-#include "dict-common/dict-utils.h"
+#include "dict-common/dict-utils.h"      // free_Exp()
 #include "dict-common/file-utils.h"
 #include "externs.h"
 #include "lg_assert.h"
@@ -134,8 +134,7 @@ static void db_free_llist(Dictionary dict, Dict_node *llist)
 		Exp *e;
 		dn = llist->right;
 		e = llist->exp;
-		// if (e) free_Exp(e);
-		if (e) free(e);
+		if (e) free_Exp(e);
 		free(llist);
 		llist = dn;
 	}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -101,10 +101,10 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	unsigned int i;
 	i = 0;
 	for (e = d->left ; e != NULL; e = e->next) {
-		i += e->desc->str_hash;
+		i += ((uintptr_t)e->desc) + e->desc->uc_num;
 	}
 	for (e = d->right ; e != NULL; e = e->next) {
-		i += e->desc->str_hash;
+		i += ((uintptr_t)e->desc) + e->desc->uc_num;
 	}
 	i += string_hash(d->word_string);
 	i += (i>>10);
@@ -148,6 +148,26 @@ static bool disjuncts_equal(Disjunct * d1, Disjunct * d2)
 	if (d1->word_string == d2->word_string) return true;
 	return (strcmp(d1->word_string, d2->word_string) == 0);
 }
+
+#if 0
+int de_fp = 0;
+int de_total = 0;
+static void disjuncts_equal_stat(void)
+{
+		fprintf(stderr, "disjuncts_equal FP %d/%d\n", de_fp, de_total);
+}
+
+static bool disjuncts_equal(Disjunct * d1, Disjunct * d2)
+{
+	if (de_total == 0) atexit(disjuncts_equal_stat);
+	de_total++;
+
+	bool rc = disjuncts_equal1(d1, d2);
+	if (!rc) de_fp++;
+
+	return rc;
+}
+#endif
 
 /**
  * Duplicate the given connector chain.

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -1306,6 +1306,7 @@ char * linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle m
 	CNode * root;
 
 	if (!linkage) return NULL;
+	if (!linkage->sent->dict->hpsg_knowledge) return NULL;
 	if (mode == NO_DISPLAY)
 	{
 		return NULL;


### PR DESCRIPTION
SQL dict fixes (see issue #774):
- Adapt the connector descriptor table for the SQL dict.
- Fix a memory leak.
- Avoid a crash if trying to show constituents.
- Actually read the affix file.
- Add a test in tests.py.

Minor changes:
- Check h/d in the same bitwise operation of checking the connector subscript.
- Don't compute uppercase part hash.
- Some code rearrangement.

Other changes:
- Change/rearrange comments.
- Remove unneeded include.
- Fix whitespace.

Note: Force-pushed because it didn't compile with no sqlite3.