### PR TITLE
link-parser usability fixes

### DIFF
--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -669,7 +669,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 	if (count > 1)
 	{
-		printf("Ambiguous command.  Type \"!help\" or \"!variables\"\n");
+		prt_error("Ambiguous command \"%s\".  Type \"!help\" or \"!variables\"\n", s);
 		return -1;
 	}
 	else if (count == 1)
@@ -752,13 +752,13 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 		if (j<0)
 		{
-			printf("There is no user variable called \"%s\".\n", x);
+			prt_error("Error: There is no user variable called \"%s\".\n", x);
 			return -1;
 		}
 
 		if (count > 1)
 		{
-			printf("Ambiguous variable.  Type \"!help\" or \"!variables\"\n");
+			prt_error("Error: Ambiguous variable \"%s\".  Type \"!help\" or \"!variables\"\n", x);
 			return -1;
 		}
 
@@ -772,7 +772,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 			if (val < 0)
 			{
-				printf("Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
+				prt_error("Error: Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
 				return -1;
 			}
 
@@ -787,7 +787,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			double val = strtod(y, &err);
 			if ('\0' != *err)
 			{
-				printf("Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
+				prt_error("Error: Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
 				return -1;
 			}
 
@@ -825,11 +825,11 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 	if (0 < count)
 	{
-		printf("Variable \"%s\" requires a value.  Try \"!help\".\n", as[j].string);
+		prt_error("Error: Variable \"%s\" requires a value.  Try \"!help\".\n", as[j].string);
 		return -1;
 	}
 
-	printf("I can't interpret \"%s\" as a command.  Try \"!help\".\n", line);
+	prt_error("Error: I can't interpret \"%s\" as a command.  Try \"!help\".\n", line);
 	return -1;
 }
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -662,6 +662,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		if (((Bool == as[i].param_type) || (Cmd == as[i].param_type)) &&
 		    strncasecmp(s, as[i].string, strlen(s)) == 0)
 		{
+			if ((UNDOC[0] == as[i].description[0]) &&
+			    (strlen(as[i].string) != strlen(s))) continue;
 			count++;
 			j = i;
 		}
@@ -745,6 +747,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if (Cmd == as[i].param_type) continue;
 			if (strncasecmp(x, as[i].string, strlen(x)) == 0)
 			{
+				if ((UNDOC[0] == as[i].description[0]) &&
+				    (strlen(as[i].string) != strlen(x))) continue;
 				j = i;
 				count ++;
 			}
@@ -818,6 +822,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		if ((Bool != as[i].param_type) && (Cmd != as[i].param_type) &&
 		    strncasecmp(s, as[i].string, strlen(s)) == 0)
 		{
+			if ((UNDOC[0] == as[i].description[0]) &&
+			    (strlen(as[i].string) != strlen(s))) continue;
 			j = i;
 			count++;
 		}

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -677,7 +677,7 @@ int main(int argc, char * argv[])
 	{
 		if ((argv[i][0] == '-') && (argv[i][1] == '!'))
 		{
-			if (issue_special_command(argv[i]+1, copts, dict))
+			if (0 > issue_special_command(argv[i]+1, copts, dict))
 				print_usage(argv[0], -1);
 		}
 	}

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -492,16 +492,30 @@ static void setup_panic_parse_options(Parse_Options opts)
 	parse_options_set_spell_guess(opts, 0);
 }
 
-static void print_usage(char *str, int exit_value)
+static int divert_stdio(FILE *from, FILE *to)
+{
+	const int origfd = dup(fileno(from));
+	dup2(fileno(to), fileno(from));
+	return origfd;
+}
+
+#if 0 // Unused for now
+static void restore_stdio(FILE *from, int origfd)
+{
+	dup2(fileno(from), origfd);
+}
+#endif
+
+static void print_usage(FILE *out, char *str, int exit_value)
 {
 	Command_Options *copts;
-	fprintf(stderr,
-			"Usage: %s [language|dictionary location]\n"
-			"                   [-<special \"!\" command>]\n"
-			"                   [--version]\n", str);
+	fprintf(out, "Usage: %s [language|dictionary location]\n"
+			 "                   [-<special \"!\" command>]\n"
+			 "                   [--version]\n", str);
 
-	fprintf(stderr, "\nSpecial commands are:\n");
+	fprintf(out, "\nSpecial commands are:\n");
 	copts = command_options_create();
+	divert_stdio(stdout, stderr);
 	issue_special_command("var", copts, NULL);
 	exit(exit_value);
 }
@@ -600,7 +614,7 @@ int main(int argc, char * argv[])
 
 	if ((i < argc) && strcmp("--help", argv[i]) == 0)
 	{
-		print_usage(argv[0], 0);
+		print_usage(stdout, argv[0], 0);
 	}
 
 	for (; i<argc; i++)
@@ -633,19 +647,19 @@ int main(int argc, char * argv[])
 
 	save_default_opts(copts); /* Options so far are the defaults */
 
-	/* Process command line variable-setting commands (only) */
+	/* Process command line variable-setting commands (only). */
 	for (i = 1; i < argc; i++)
 	{
 		if (argv[i][0] == '-')
 		{
 			const char *var = argv[i] + ((argv[i][1] != '-') ? 1 : 2);
 			if ((var[0] != '!') && (0 > issue_special_command(var, copts, NULL)))
-				print_usage(argv[0], -1);
+				print_usage(stderr, argv[0], -1);
 		}
 		else if (i != 1)
 		{
 			prt_error("Fatal error: Unknown argument '%s'.\n", argv[i]);
-			print_usage(argv[0], -1);
+			print_usage(stderr, argv[0], -1);
 		}
 	}
 
@@ -678,7 +692,7 @@ int main(int argc, char * argv[])
 		if ((argv[i][0] == '-') && (argv[i][1] == '!'))
 		{
 			if (0 > issue_special_command(argv[i]+1, copts, dict))
-				print_usage(argv[0], -1);
+				print_usage(stderr, argv[0], -1);
 		}
 	}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -197,8 +197,8 @@ static void process_linkage(Linkage linkage, Command_Options* copts)
 		else
 		{
 			copts->display_constituents = 0;
-			fprintf(stderr, "Can't generate constituents.\n");
-			fprintf(stderr, "Constituent processing has been turned off.\n");
+			prt_error("Error: Can't generate constituents.\n"
+			          "Constituent processing has been turned off.\n");
 		}
 	}
 	if (copts->display_links)
@@ -766,7 +766,7 @@ int main(int argc, char * argv[])
 			struct stat statbuf;
 			if ((0 == stat(filename, &statbuf)) && statbuf.st_mode & S_IFDIR)
 			{
-				fprintf(stderr, "Error: Cannot open %s: %s\n",
+				prt_error("Error: Cannot open %s: %s\n",
 				        filename, strerror(EISDIR));
 				continue;
 			}
@@ -775,8 +775,7 @@ int main(int argc, char * argv[])
 
 			if (NULL == input_fh)
 			{
-				fprintf(stderr, "Error: Cannot open %s: %s\n",
-				        filename, strerror(errno));
+				prt_error("Error: Cannot open %s: %s\n", filename, strerror(errno));
 				input_fh = stdin;
 				continue;
 			}
@@ -793,7 +792,7 @@ int main(int argc, char * argv[])
 			{
 				fflush(stdout);
 				/* Remind the developer this is a test mode. */
-				fprintf(stderr, "Warning: Tests enabled: %s\n", test);
+				prt_error("Warning: Tests enabled: %s\n", test);
 				if (copts->batch_mode) batch_in_progress = true;
 			}
 		}


### PR DESCRIPTION
Currently `link-parser` uses stdout/stderr inconsistently. Especially, it uses both at once.
See the problem by:
`link-parser --help > /tmp/help`
`link-parser -xyz > /tmp/err`
(On Windows the problem is even more severe, as the stderr output is printed before the stdout one.)

stdout/stderr Fixes:
1. Send `link-parser --help` to stdout only (for the reason see the commit).
2. Send `link-parser -BOGUSARG` messages to stderr only.
3. Send user variable/command errors only to stderr.

Fix also 2 problems:
1. Prevent bogus usage message on `-!word` argument.
2. Require full command name for undocumented (hidden) commands. This allows to specify `!cost=x`.
(Maybe these hidden commands, which are not useful for now, should just ifdef'ed out.)