### PR TITLE
Some tests.py cleanups

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -248,13 +248,11 @@ class CParseOptionsTestCase(unittest.TestCase):
 class DBasicParsingTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.d = Dictionary()
-        cls.po = None
+        cls.d, cls.po = Dictionary(), None
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def parse_sent(self, text, po=None):
         if po is None:
@@ -540,8 +538,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def parse_sent(self, text):
         return list(Sentence(text, self.d, self.po).parse())
@@ -723,8 +720,7 @@ class GSQLDictTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def test_getting_links(self):
         linkage_testfile(self, self.d, self.po)
@@ -744,8 +740,7 @@ class ZENLangTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def test_getting_links(self):
         linkage_testfile(self, self.d, self.po)
@@ -794,8 +789,7 @@ class ZENConstituentsCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def test_a_constiuents_after_parse_list(self):
         """
@@ -813,8 +807,7 @@ class ZDELangTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def parse_sent(self, text):
         return list(Sentence(text, self.d, self.po).parse())
@@ -861,8 +854,7 @@ class ZRULangTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.d
-        del cls.po
+        del cls.d, cls.po
 
     def parse_sent(self, text):
         return list(Sentence(text, self.d, self.po).parse())

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -285,7 +285,7 @@ class DBasicParsingTestCase(unittest.TestCase):
 
     def test_utf8_encoded_string(self):
         result = self.parse_sent("I love going to the café.")
-        self.assertTrue(1 < len(result))
+        self.assertTrue(len(result) > 1)
         self.assertTrue(isinstance(result[0], Linkage))
         self.assertTrue(isinstance(result[1], Linkage))
 
@@ -294,25 +294,25 @@ class DBasicParsingTestCase(unittest.TestCase):
             result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.")
         else:
             result = self.parse_sent(u"I love going to the caf\N{LATIN SMALL LETTER E WITH ACUTE}.".encode('utf8'))
-        self.assertTrue(1 < len(result))
+        self.assertTrue(len(result) > 1)
         self.assertTrue(isinstance(result[0], Linkage))
         self.assertTrue(isinstance(result[1], Linkage))
 
         # def test_unknown_word(self):
         result = self.parse_sent("I love going to the qertfdwedadt.")
-        self.assertTrue(1 < len(result))
+        self.assertTrue(len(result) > 1)
         self.assertTrue(isinstance(result[0], Linkage))
         self.assertTrue(isinstance(result[1], Linkage))
 
         # def test_unknown_euro_utf8_word(self):
         result = self.parse_sent("I love going to the qéáéğíóşúüñ.")
-        self.assertTrue(1 < len(result))
+        self.assertTrue(len(result) > 1)
         self.assertTrue(isinstance(result[0], Linkage))
         self.assertTrue(isinstance(result[1], Linkage))
 
         # def test_unknown_cyrillic_utf8_word(self):
         result = self.parse_sent("I love going to the доктором.")
-        self.assertTrue(1 < len(result))
+        self.assertTrue(len(result) > 1)
         self.assertTrue(isinstance(result[0], Linkage))
         self.assertTrue(isinstance(result[1], Linkage))
 
@@ -391,9 +391,9 @@ class EErrorFacilityTestCase(unittest.TestCase):
         self.gotit = None
         for i in range(0, 2+self.testleaks):
             self.numerr = LG_Error.printall(self.error_handler_test, self)
-            if 0 == i:
+            if i == 0:
                 self.assertEqual(self.numerr, 1)
-            if 1 == i:
+            if i == 1:
                 self.assertEqual(self.numerr, 0)
         self.assertEqual((self.errinfo.severity, self.errinfo.severity_label), (clg.lg_Error, "Error"))
         self.assertEqual(self.gotit, "testit")
@@ -904,7 +904,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
     linkage diagrams / constituent printings.
     """
     self.__class__.longMessage = True
-    if '' != desc:
+    if desc != '':
         desc = desc + '-'
     testfile = clg.test_data_srcdir + "parses-" + desc + clg.dictionary_get_lang(lgdict._obj) + ".txt"
     parses = open(testfile, "rb")
@@ -927,7 +927,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         if sys.version_info > (3, 0):
             line = line.decode('utf-8')
         # Lines starting with I are the input sentences
-        if 'I' == line[0]:
+        if line[0] == 'I':
             validate_opcode(O=True, C=True)
             sent = line[1:]
             diagram = ""
@@ -937,7 +937,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             self.assertTrue(linkage, "at {}:{}: Sentence has no linkages".format(testfile, lineno))
 
         # Generate the next linkage of the last input sentence
-        if 'N' == line[0]:
+        if line[0] == 'N' :
             validate_opcode(O=True, C=True)
             diagram = ""
             constituents = ""
@@ -946,18 +946,18 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line
-        if 'O' == line[0]:
+        if line[0] == 'O' :
             validate_opcode(C=True)
             diagram += line[1:]
-            if '\n' == line[1] and 1 < len(diagram):
+            if line[1] == '\n' and len(diagram) > 1:
                 self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
                 diagram = None
 
         # Lines starting with C are the constituent output (type 1)
         # It ends with an empty line
-        if 'C' == line[0]:
+        if line[0] == 'C':
             validate_opcode(O=True)
-            if '\n' == line[1] and 1 < len(constituents):
+            if line[1] == '\n' and len(constituents) > 1:
                 self.assertEqual(linkage.constituent_tree(), constituents, "at {}:{}".format(testfile, lineno))
                 constituents = None
             else:

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -352,9 +352,11 @@ class EErrorFacilityTestCase(unittest.TestCase):
         "previous": lambda x, y=None: None
     }
 
-    def setUp(self): # pylint: disable=attribute-defined-outside-init,no-member
+    def setUp(self):
         self.testit = "testit"
         self.testleaks = 0  # A repeat count for validating no memory leaks
+        self.numerr = 0
+        self.errinfo = clg.lg_None
 
     @staticmethod
     def error_handler_test(errinfo, data):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -249,13 +249,16 @@ class DBasicParsingTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.d = Dictionary()
+        cls.po = None
 
     @classmethod
     def tearDownClass(cls):
         del cls.d
-        del cls.parse_sent
+        del cls.po
 
-    def parse_sent(self, text, po=ParseOptions()):
+    def parse_sent(self, text, po=None):
+        if po is None:
+            po = ParseOptions()
         return list(Sentence(text, self.d, po).parse())
 
     def test_that_parse_returns_empty_iterator_on_no_linkage(self):


### PR DESCRIPTION
1. Avoid a false-positive memleak message when invoking a particular testcase.
2. Combine del messages for clarity.
3. Reduce the number of pylint messages.
    Much more work in this regard should be done.