### PR TITLE
print_expression() fixes

### DIFF
--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -132,7 +132,6 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		return e;
 	}
 
-	/* Look for optional, and print only that */
 	el = n->u.l;
 	if (el == NULL)
 	{
@@ -144,6 +143,8 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	}
 
 	for (i=0; i<icost; i++) dyn_strcat(e, "[");
+
+	/* look for optional, and print only that */
 	if ((n->type == OR_type) && el->e && el->e->cost == 0 && (NULL == el->e->u.l))
 	{
 		dyn_strcat(e, "{");

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -102,7 +102,16 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		}
 		else
 		{
-			dcost = 0;
+			if (icost > 4)
+			{
+				/* don't print too many [] levels */
+				dcost = icost;
+				icost = 1;
+			}
+			else
+			{
+				dcost = 0;
+			}
 		}
 	}
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -121,7 +121,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	}
 
 	for (i=0; i<icost; i++) dyn_strcat(e, "[");
-	if ((n->type == OR_type) && el->e && (NULL == el->e->u.l))
+	if ((n->type == OR_type) && el->e && el->e->cost == 0 && (NULL == el->e->u.l))
 	{
 		dyn_strcat(e, "{");
 		if (NULL == el->next) dyn_strcat(e, "error-no-next");

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -91,6 +91,12 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		icost = 1;
 		dcost = n->cost;
 	}
+	else if ((n->cost > -10E-4) && (n->cost < 0))
+	{
+		/* avoid [X+]-0.00 */
+		icost = 0;
+		dcost = 0;
+	}
 	else
 	{
 		icost = (int) (n->cost);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -82,7 +82,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 
 	if (n == NULL)
 	{
-		append_string(e, "NULL expression");
+		dyn_strcat(e, "NULL expression");
 		return e;
 	}
 
@@ -122,7 +122,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	if (el == NULL)
 	{
 		for (i=0; i<icost; i++) dyn_strcat(e, "[");
-		append_string(e, "()");
+		dyn_strcat(e, "()");
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
 		if (0 != dcost) append_string(e, COST_FMT, dcost);
 		return e;
@@ -134,7 +134,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		dyn_strcat(e, "{");
 		if (NULL == el->next) dyn_strcat(e, "error-no-next");
 		else print_expression_parens(e, el->next->e, false);
-		append_string(e, "}");
+		dyn_strcat(e, "}");
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
 		if (0 != dcost) append_string(e, COST_FMT, dcost);
 		return e;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -135,6 +135,8 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		if (NULL == el->next) dyn_strcat(e, "error-no-next");
 		else print_expression_parens(e, el->next->e, false);
 		append_string(e, "}");
+		for (i=0; i<icost; i++) dyn_strcat(e, "]");
+		if (0 != dcost) append_string(e, COST_FMT, dcost);
 		return e;
 	}
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -86,16 +86,24 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		return e;
 	}
 
-	icost = (int) (n->cost);
-	dcost = n->cost - icost;
-	if (dcost > 10E-4)
+	if (n->cost < -10E-4)
 	{
-		dcost = n->cost;
 		icost = 1;
+		dcost = n->cost;
 	}
 	else
 	{
-		dcost = 0;
+		icost = (int) (n->cost);
+		dcost = n->cost - icost;
+		if (dcost > 10E-4)
+		{
+			dcost = n->cost;
+			icost = 1;
+		}
+		else
+		{
+			dcost = 0;
+		}
 	}
 
 	/* print the connector only */


### PR DESCRIPTION
Main fixes:
1. Fix printing ([()] or X+) (currently the cost is neglected).
2. Print also negative costs (currently totally neglected).
3.  Fix printing costly optional (e.g. `[{X+}]`).
4. Use dyn_strcat() for all fixed strings (consistency and efficiency).
5. Don't print too many [] levels - use numbers instead (something like `[[[[[[[[X+]]]]]]]]` is not useful).
4. Avoid printing negative-zero costs such as `[X+]-0.00` (may be result of cost arithmetics).