### PR TITLE
Linkparser

### DIFF
--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -247,10 +247,17 @@ static char *display_word_split(Dictionary dict,
 
 	if ('\0' == *word) return NULL; /* avoid trying null strings */
 
+	/* SUBSCRIPT_DOT in a sentence word is not interpreted as SUBSCRIPT_MARK,
+	 * and hence a subscripted word that is found in the dict will not
+	 * get found in the dict if it can split. E.g: 's.v (the info for s.v
+	 * will not be shown). Fix it by replacing it to SUBSCRIPT_MARK. */
+	char *pword = strdupa(word);
+	patch_subscript(pword);
+
 	dyn_str *s = dyn_str_new();
 
 	parse_options_set_spell_guess(&display_word_opts, 0);
-	sent = sentence_create(word, dict);
+	sent = sentence_create(pword, dict);
 	if (0 == sentence_split(sent, &display_word_opts))
 	{
 		/* List the splits */

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -554,7 +554,7 @@ static int help_cmd(const Switch *uc, int n)
 	printf("Special commands always begin with \"!\".  Command and variable names\n");
 	printf("can be abbreviated.  Here is a list of the commands:\n\n");
 
-	printf(" !help command   Show a detailed help for the given command\n");
+	printf(" !help command   Show a detailed help for the given command.\n");
 	for (int i = 0; uc[i].string != NULL; i++)
 	{
 		if (Cmd != uc[i].param_type) continue;

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -789,7 +789,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		{
 			char *err;
 			double val = strtod(y, &err);
-			if ('\0' != *err)
+			if (('\0' == *y) ||('\0' != *err))
 			{
 				prt_error("Error: Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
 				return -1;

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -776,7 +776,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 			if (val < 0)
 			{
-				prt_error("Error: Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
+				prt_error("Error: Invalid value %s for variable \"%s\". Type \"!help\" or \"!variables\"\n", y, as[j].string);
 				return -1;
 			}
 
@@ -791,7 +791,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			double val = strtod(y, &err);
 			if (('\0' == *y) ||('\0' != *err))
 			{
-				prt_error("Error: Invalid value %s for variable %s Type \"!help\" or \"!variables\"\n", y, as[j].string);
+				prt_error("Error: Invalid value %s for variable \"%s\". Type \"!help\" or \"!variables\"\n", y, as[j].string);
 				return -1;
 			}
 


### PR DESCRIPTION
Fix showing info for "string.sub" that can split.
(Plus several minor fixes.)

Proposals: 
1. `dict_display_word_info()` and `dict_display_word_expr()` are documented (in `link-includes.h`) as "not intended for general public use". I suggest to still define them under `Clinkgrammar`, but with an `_` prepended to them (to mark them as "internal use") so they can get tested.
2. To generally test `link-parser`, I propose to create a `link-parser`  invocation test suite.