### PR TITLE
expression_prune(): Fix a premature termination bug

### DIFF
--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -422,8 +422,7 @@ void expression_prune(Sentence sent, Parse_Options opts)
 
 	DBG_EXPSIZES("Initial expression sizes\n%s", e);
 
-	int pass = -1;
-	while (pass++)
+	for (int pass = 0; ; pass++)
 	{
 		/* Left-to-right pass */
 		/* For every word */


### PR DESCRIPTION
This is a fix for a strange bug I made 2 versions ago (5.4.3) at commit a595a0546.
After this commit I made improvements that increased the net performance so I didn't notice
the impact of this bug.

The bug causes expression-prune termination after one pass.
With the classic parser, it affects the "en" batch performance by 4% ("ru" by only 1+%).
It effect the SAT parser (with fixes.batch) by ~10%, but apparently this parser has some other regression that I am now checking.

BTW, I found this problem when I tried to adapt the pruning to a wild-card RIGHT-WALL (see issue #259).