### PR TITLE
SAT-parser fixes

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -63,6 +63,7 @@ Connector * connector_new(const condesc_t *desc, Parse_Options opts)
 	c->desc = desc;
 	c->nearest_word = 0;
 	c->multi = false;
+	c->originating_gword = NULL;
 	set_connector_length_limit(c, opts);
 	//assert(0 != c->length_limit, "Connector_new(): Zero length_limit");
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1880,7 +1880,6 @@ extern "C" int sat_parse(Sentence sent, Parse_Options  opts)
     delete encoder;
   }
 
-  // Prepare for parsing - extracted for "preparation.c"
   encoder = new SATEncoderConjunctionFreeSentences(sent, opts);
   sent->hook = encoder;
   encoder->encode();

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1493,18 +1493,9 @@ Linkage SATEncoder::get_next_linkage()
 
   assert(linkage, "No linkage");
 
-  /*
-   * We cannot expand the linkage array on demand, since the API uses
-   * linkage pointers, and they would become invalid if realloc()
-   * changes the address of the memory block. */
-#if 0
-  // Expand the linkage array.
-  int index = _sent->num_linkages_alloced;
-  _sent->num_linkages_alloced++;
-  size_t nbytes = _sent->num_linkages_alloced * sizeof(struct Linkage_s);
-  _sent->lnkages = (Linkage) realloc(_sent->lnkages, nbytes);
-#endif /* 0 */
-
+  /* We cannot expand the linkage array on demand, since the API uses
+   * linkage pointers, and they would become invalid if realloc() changes
+   * the address of the memory block. So it is allocated in advance. */
   if (NULL == _sent->lnkages)
   {
     _sent->num_linkages_alloced = _opts->linkage_limit;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1919,12 +1919,13 @@ extern "C" int sat_parse(Sentence sent, Parse_Options  opts)
                 "parsing with null links.\n");
     }
   } else {
-    /* We found a valid linkage.
-     * XXX However, the following setting is wrong, as we actually don't
-     * know yet the number of linkages...
-     * If we don't return some large number here, then the
-     * Command-line client will fail to print all of the possible
-     * linkages. Work around this by lying... */
+    /* We found a valid linkage. However, we actually don't know yet the
+     * number of linkages, and if we set them too low, the command-line
+     * client will fail to display all of the possible linkages.  Work
+     * around this by lying... return the maximum number of linkages we
+     * are going to produce.
+     * A NULL linkage will be returned by linkage_create() after the last
+     * linkage is produced to signify that there are no more linkages. */
     sent->num_valid_linkages = linkage_limit;
     sent->num_linkages_post_processed = linkage_limit;
   }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1474,11 +1474,6 @@ Linkage SATEncoder::get_next_linkage()
       linkage = create_linkage();
       sane = sane_linkage_morphism(_sent, linkage, _opts);
       if (!sane) {
-          /* We cannot elegantly add this linkage to sent->linkges[] -
-           * to be freed in sentence_delete(), since insane linkages
-           * must be there with index > num_linkages_post_processed - so
-           * they remain hidden, but num_linkages_post_processed is an
-           * arbitrary number.  So we must free it here. */
           free_linkage_connectors_and_disjuncts(linkage);
           free_linkage(linkage);
           free(linkage);

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1361,6 +1361,9 @@ void SATEncoder::pp_prune()
   if (_sent->dict->base_knowledge == NULL)
     return;
 
+  if (!_opts->perform_pp_prune)
+    return;
+
   pp_knowledge * knowledge;
   knowledge = _sent->dict->base_knowledge;
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1910,6 +1910,7 @@ extern "C" int sat_parse(Sentence sent, Parse_Options  opts)
   if (lkg == NULL || k == linkage_limit) {
     // We don't have a valid linkages among the first linkage_limit ones
     sent->num_valid_linkages = 0;
+    sent->num_linkages_found = k;
     sent->num_linkages_post_processed = k;
     if (opts->max_null_count > 0) {
       // The sat solver doesn't support (yet) parsing with nulls.
@@ -1943,8 +1944,8 @@ extern "C" Linkage sat_create_linkage(LinkageIdx k, Sentence sent, Parse_Options
   SATEncoder* encoder = (SATEncoder*) sent->hook;
   if (!encoder) return NULL;
 
-                                                 // linkage index k is:
-  if (k >= encoder->_sent->num_valid_linkages)   // > allocated memory
+                                               // linkage index k is:
+  if (k >= opts->linkage_limit)                  // > allocated memory
     return NULL;
   if(k > encoder->_next_linkage_index)           // skips unproduced linkages
   {

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -162,12 +162,9 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
 }
 #undef D_IC
 
-void WordTag::find_matches(int w, const condesc_t* C, char dir, std::vector<PositionConnector*>& matches)
+void WordTag::find_matches(int w, Connector* search_cntr, char dir, std::vector<PositionConnector*>& matches)
 {
-  //  cout << "Look connection on: ." << _word << ". ." << w << ". " << C << dir << endl;
-  Connector search_cntr;
-  search_cntr.desc = C;
-  set_connector_length_limit(&search_cntr, _opts);
+  // cout << "Look connection on: ." << _word << ". ." << w << ". " << search_cntr << dir << endl;
 
   std::vector<PositionConnector>* connectors;
   switch(dir) {
@@ -183,7 +180,7 @@ void WordTag::find_matches(int w, const condesc_t* C, char dir, std::vector<Posi
 
   std::vector<PositionConnector>::iterator i;
   for (i = connectors->begin(); i != connectors->end(); i++) {
-    if (WordTag::match(w, search_cntr, dir, (*i).word, ((*i).connector))) {
+    if (WordTag::match(w, *search_cntr, dir, (*i).word, ((*i).connector))) {
       matches.push_back(&(*i));
     }
   }
@@ -194,7 +191,7 @@ void WordTag::add_matches_with_word(WordTag& tag)
   std::vector<PositionConnector>::iterator i;
   for (i = _right_connectors.begin(); i != _right_connectors.end(); i++) {
     std::vector<PositionConnector*> connector_matches;
-    tag.find_matches(_word, (*i).connector.desc, '+', connector_matches);
+    tag.find_matches(_word, &(*i).connector, '+', connector_matches);
     std::vector<PositionConnector*>::iterator j;
     for (j = connector_matches.begin(); j != connector_matches.end(); j++) {
       i->matches.push_back(*j);

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -32,28 +32,23 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
   if (exp->type == CONNECTOR_type) {
     dfs_position++;
 
-    Connector connector;
-    connector.multi = exp->multi;
-    connector.desc = exp->u.condesc;
-    set_connector_length_limit(&connector, _opts);
-
     switch (exp->dir) {
     case '+':
       _position.push_back(_right_connectors.size());
       _dir.push_back('+');
       _right_connectors.push_back(
-           PositionConnector(parent_exp, &connector, '+', _word, dfs_position,
-                             exp->cost, cost, leading_right, false,
-                             eps_right, eps_left, word_xnode));
+           PositionConnector(parent_exp, exp, '+', _word, dfs_position,
+                             cost, leading_right, false,
+                             eps_right, eps_left, word_xnode, _opts));
       leading_right = false;
       break;
     case '-':
       _position.push_back(_left_connectors.size());
       _dir.push_back('-');
       _left_connectors.push_back(
-           PositionConnector(parent_exp, &connector, '-', _word, dfs_position,
-                             exp->cost, cost, false, leading_left,
-                             eps_right, eps_left, word_xnode));
+           PositionConnector(parent_exp, exp, '-', _word, dfs_position,
+                             cost, false, leading_left,
+                             eps_right, eps_left, word_xnode, _opts));
       leading_left = false;
       break;
     default:

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -168,7 +168,7 @@ public:
   void add_matches_with_word(WordTag& tag);
 
   // Find matches in this word tag with the connector (name, dir).
-  void find_matches(int w, const condesc_t* C, char dir,  std::vector<PositionConnector*>& matches);
+  void find_matches(int w, Connector* C, char dir,  std::vector<PositionConnector*>& matches);
 
   // A simpler function: Can any connector in this word match a connector wi, pi?
   // It is assumed that

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -16,22 +16,22 @@ extern "C" {
 
 struct PositionConnector
 {
-  PositionConnector(Exp* e, Connector* c, char d, int w, int p, 
-                    double cst, double pcst, bool lr, bool ll,
-                    const std::vector<int>& er, const std::vector<int>& el, const X_node *w_xnode)
-    : exp(e), dir(d), word(w), position(p),
-      cost(cst), parent_cost(pcst),
+  PositionConnector(Exp* pe, Exp* e, char d, int w, int p,
+                    double pcst, bool lr, bool ll,
+                    const std::vector<int>& er, const std::vector<int>& el, const X_node *w_xnode, Parse_Options opts)
+    : exp(pe), dir(d), word(w), position(p),
+      cost(e->cost), parent_cost(pcst),
       leading_right(lr), leading_left(ll),
       eps_right(er), eps_left(el), word_xnode(w_xnode)
   {
     if (word_xnode == NULL) {
-       cerr << "Internal error: Word" << w << ": " << "; connector: '" << connector_string(c) << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << e->u.condesc->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
     }
 
     // Initialize some fields in the connector struct.
-    connector.desc = c->desc;
-    connector.multi = c->multi;
-    connector.length_limit = c->length_limit;
+    connector.desc = e->u.condesc;
+    connector.multi = e->multi;
+    set_connector_length_limit(&connector, opts);
     connector.originating_gword = &w_xnode->word->gword_set_head;
 
     /*

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -228,7 +228,8 @@ static void process_linkage(Linkage linkage, Command_Options* copts)
 	}
 }
 
-static void print_parse_statistics(Sentence sent, Parse_Options opts)
+static void print_parse_statistics(Sentence sent, Parse_Options opts,
+                                   Command_Options* copts)
 {
 	if (sentence_num_linkages_found(sent) > 0)
 	{
@@ -244,10 +245,13 @@ static void print_parse_statistics(Sentence sent, Parse_Options opts)
 		}
 		else
 		{
-			fprintf(stdout, "Found %d linkage%s (%d had no P.P. violations)",
-					sentence_num_linkages_post_processed(sent),
-					sentence_num_linkages_post_processed(sent) == 1 ? "" : "s",
-					sentence_num_valid_linkages(sent));
+			if ((sentence_num_valid_linkages(sent) > 0) || copts->display_bad)
+			{
+				fprintf(stdout, "Found %d linkage%s (%d had no P.P. violations)",
+				        sentence_num_linkages_post_processed(sent),
+				        sentence_num_linkages_post_processed(sent) == 1 ? "" : "s",
+				        sentence_num_valid_linkages(sent));
+			}
 		}
 		if (sentence_null_count(sent) > 0)
 		{
@@ -295,7 +299,7 @@ static const char *process_some_linkages(FILE *in, Sentence sent,
 		auto_next_linkage = true;
 	}
 
-	if (verbosity > 0) print_parse_statistics(sent, opts);
+	if (verbosity > 0) print_parse_statistics(sent, opts, copts);
 	num_to_query = sentence_num_linkages_post_processed(sent);
 	if (!copts->display_bad)
 	{
@@ -446,7 +450,7 @@ static void batch_process_some_linkages(Label label,
 	{
 		if (strstr(test, ",batch_print_parse_statistics,"))
 		{
-			print_parse_statistics(sent, opts);
+			print_parse_statistics(sent, opts, copts);
 		}
 	}
 }


### PR DESCRIPTION
1. Check for alternative-compatibility when doing connector matches.
This speeds up sentences that have many solutions with "insane" morphism.
2. Fix several comments (comment rot).
3. Allow displaying bad linkages (postprocess violations) when there are no good linkages.

BTW, postprocess violations currently extremely slow down the SAT-parser. I will try to fix that by a feedback from the postprocessing into the SAT encoding.
(This fix can be used to also speed up the postprocessing for the classic parser.)