### PR TITLE
Bug fix: Restore disjunct order repeatability in duplicate disjunct elimination

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -101,10 +101,10 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	unsigned int i;
 	i = 0;
 	for (e = d->left ; e != NULL; e = e->next) {
-		i += ((uintptr_t)e->desc) + e->desc->uc_num;
+		i = (5 * (i + e->desc->uc_num)) + (unsigned int)e->desc->lc_letters + 7;
 	}
 	for (e = d->right ; e != NULL; e = e->next) {
-		i += ((uintptr_t)e->desc) + e->desc->uc_num;
+		i = (5 * (i + e->desc->uc_num)) + (unsigned int)e->desc->lc_letters + 7;
 	}
 	i += string_hash(d->word_string);
 	i += (i>>10);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -108,6 +108,8 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	}
 	i += string_hash(d->word_string);
 	i += (i>>10);
+
+	d->dup_hash = i;
 	return (i & (dt->dup_table_size-1));
 }
 
@@ -391,6 +393,7 @@ Disjunct * eliminate_duplicate_disjuncts(Disjunct * d)
 
 		for (dx = dt->dup_table[h]; dx != NULL; dx = dx->next)
 		{
+			if (d->dup_hash != dx->dup_hash) continue;
 			if (disjuncts_equal(dx, d)) break;
 		}
 		if (dx == NULL)

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -106,7 +106,9 @@ static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt, Disjunct * 
 	for (e = d->right ; e != NULL; e = e->next) {
 		i = (5 * (i + e->desc->uc_num)) + (unsigned int)e->desc->lc_letters + 7;
 	}
+#if 0 /* Redundant - the connector hashing has enough entropy. */
 	i += string_hash(d->word_string);
+#endif
 	i += (i>>10);
 
 	d->dup_hash = i;

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -31,9 +31,11 @@ struct Disjunct_struct
 	/* match_left, right used only during parsing, for the match list. */
 	bool match_left, match_right;
 
-#ifdef VERIFY_MATCH_LIST
-	int match_id;              /* verify the match list integrity */
-#endif
+	union
+	{
+		unsigned int match_id;     /* verify the match list integrity */
+		unsigned int dup_hash;     /* hash value for duplicate elimination */
+	};
 	gword_set *originating_gword; /* Set of originating gwords */
 	const char * word_string;     /* subscripted dictionary word */
 };

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -417,8 +417,8 @@ static Count_bin do_count(
 	{
 		size_t mlb = form_match_list(mchxt, w, le, lw, re, rw);
 #ifdef VERIFY_MATCH_LIST
-		int id = get_match_list_element(mchxt, mlb) ?
-		            get_match_list_element(mchxt, mlb)->match_id : 0;
+		unsigned int id = get_match_list_element(mchxt, mlb) ?
+		                  get_match_list_element(mchxt, mlb)->match_id : 0;
 #endif
 		for (size_t mle = mlb; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -212,52 +212,6 @@ static Clause * build_clause(Exp *e)
 	return c;
 }
 
-// #define DEBUG
-#ifdef DEBUG
-/* Misc printing functions, useful for debugging */
-
-static void print_Tconnector_list(Tconnector * e)
-{
-	for (;e != NULL; e=e->next) {
-		if (e->multi) printf("@");
-		printf("%s", e->condesc->string);
-		printf("%c", e->dir);
-		if (e->next != NULL) printf(" ");
-	}
-}
-
-GNUC_UNUSED static void print_clause_list(Clause * c)
-{
-	for (;c != NULL; c=c->next) {
-		printf("  Clause: ");
-		printf("(%4.2f, %4.2f) ", c->cost, c->maxcost);
-		print_Tconnector_list(c->c);
-		printf("\n");
-	}
-}
-
-static void print_connector_list(Connector * e)
-{
-	for (;e != NULL; e=e->next)
-	{
-		printf("%s", connector_string(e));
-		if (e->next != NULL) printf(" ");
-	}
-}
-
-GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
-{
-	for (;dj != NULL; dj=dj->next) {
-		printf("%10s: ", dj->word_string);
-		printf("(%f) ", dj->cost);
-		print_connector_list(dj->left);
-		printf(" <--> ");
-		print_connector_list(dj->right);
-		printf("\n");
-	}
-}
-#endif /* DEBUG */
-
 /**
  * Build a new list of connectors starting from the Tconnectors
  * in the list pointed to by e.  Keep only those whose strings whose
@@ -322,6 +276,49 @@ Disjunct * build_disjuncts_for_exp(Exp* exp, const char *word,
 }
 
 #ifdef DEBUG
+/* Misc printing functions, useful for debugging */
+
+static void print_Tconnector_list(Tconnector * e)
+{
+	for (;e != NULL; e=e->next) {
+		if (e->multi) printf("@");
+		printf("%s", e->condesc->string);
+		printf("%c", e->dir);
+		if (e->next != NULL) printf(" ");
+	}
+}
+
+GNUC_UNUSED static void print_clause_list(Clause * c)
+{
+	for (;c != NULL; c=c->next) {
+		printf("  Clause: ");
+		printf("(%4.2f, %4.2f) ", c->cost, c->maxcost);
+		print_Tconnector_list(c->c);
+		printf("\n");
+	}
+}
+
+static void print_connector_list(Connector * e)
+{
+	for (;e != NULL; e=e->next)
+	{
+		printf("%s", connector_string(e));
+		if (e->next != NULL) printf(" ");
+	}
+}
+
+GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
+{
+	for (;dj != NULL; dj=dj->next) {
+		printf("%10s: ", dj->word_string);
+		printf("(%f) ", dj->cost);
+		print_connector_list(dj->left);
+		printf(" <--> ");
+		print_connector_list(dj->right);
+		printf("\n");
+	}
+}
+
 /* There is a much better print_expression elsewhere
  * This one is for low-level debug. */
 GNUC_UNUSED void prt_exp(Exp *e, int i)
@@ -388,4 +385,4 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 		printf("con=%s dir=%c multi=%d\n", e->u.condesc->string, e->dir, e->multi);
 	}
 }
-#endif
+#endif /* DEBUG */


### PR DESCRIPTION
This change restores the repeatability of the displayed linkages
(in order to make linkage debugging easier).

My recent change of the hash function to use (uintptr_t)e->desc)
(connector descriptor pointer) causes non-deterministic linkage list
(every time different linkages are listed) when the number of linkages
to produce is smaller than found in the parse, even when
repeatable_rand=true. Even in the regular case, linkages with the same
metrics may be displayed in different order.

This happens when the OS uses "randomize addresses". What is hushed in
each bucket then depends on the addresses. This changes the order of
the disjunct list when it is reconstructed at the end of
eliminate_duplicate_disjuncts().

---> Solve this by using only non-address features of connectors.

In the same occasion, use a much better hash function, as the original
one (from version 4) was rather poor:
        for (e = d->left ; e != NULL; e = e->next) {
                i += string_hash(e->string);
        }
As many disjuncts have same connectors but in different order, it
hashes all of them to the same bucket, and absolutely most of
the disjunct_equal() calls fail.

---> Solve this by making the hash function connector-order sensitive.
The constant 5 and 7 were chosen to give the least number of collisions.

