### PR TITLE
Misc. cleanups

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -12188,7 +12188,7 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 % For now, using ".x and ".y in the above definitions multiplies the number
 % of linkages by 2^(number of "). So it is separated below.
 
-% [[ZZZ-]]: link to "random" quotion marks that show up "for no reason".
+% [[ZZZ-]]: link to "random" quotation marks that show up "for no reason".
 % Cannot use a blanket W+ here to pick up all W connectors, because ... ??
 """: QUd- or <post-quote> or [[ZZZ-]];
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -10119,7 +10119,7 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 % For now, using ".x and ".y in the above definitions multiplies the number
 % of linkages by 2^(number of "). So it is separated below.
 
-% [[ZZZ-]]: link to "random" quotion marks that show up "for no reason".
+% [[ZZZ-]]: link to "random" quotation marks that show up "for no reason".
 % Cannot use a blanket W+ here to pick up all W connectors, because ... ??
 """: QUd- or <post-quote> or [[ZZZ-]];
 

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -205,7 +205,7 @@ EXTRA_DIST=                         \
 
 # Clean up generated file that Windows MSVC compilation leaves behind.
 clean-local:
-	rm -f $(top_builddir)/link-grammar/link-features.h
+	rm -f $(top_srcdir)/link-grammar/link-features.h
 
 # -----------------------------------------------------------
 install-data-local: install-libtool-import-lib

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -70,15 +70,15 @@ struct Parse_Options_s
 {
 	/* General options */
 	short verbosity;       /* Level of detail to give about the computation 0 */
-	char * debug;          /* comma-separated function names to debug "" */
-	char * test;           /* comma-separated features to test "" */
+	char * debug;          /* Comma-separated function names to debug "" */
+	char * test;           /* Comma-separated features to test "" */
 	Resources resources;   /* For deciding when to abort the parsing */
 
 	/* Options governing the tokenizer (sentence-splitter) */
-	short use_spell_guess;  /* Perform spell-guessing of unknown words. */
+	short use_spell_guess; /* Up to this many spell-guesses per unknown word 7 */
 
 	/* Choice of the parser to use */
-	bool use_sat_solver;   /* Use the Boolean SAT based parser */
+	bool use_sat_solver;   /* Use the Boolean SAT based parser FALSE */
 #if USE_VITERBI
 	bool use_viterbi;      /* Use the Viterbi decoder-based parser */
 #endif
@@ -92,18 +92,18 @@ struct Parse_Options_s
 	                          will be generated (default=FALSE) */
 	bool use_cluster_disjuncts; /* Attempt using a broader list of disjuncts */
 	size_t short_length;   /* Links that are limited in length can be
-	                          no longer than this.  Default = 6 */
+	                          no longer than this.  Default = 16 */
 	bool all_short;        /* If true, there can be no connectors that are exempt */
 	bool repeatable_rand;  /* Reset rand number gen after every parse. */
 
 	/* Options governing post-processing */
-	bool perform_pp_prune; /* Perform post-processing-based pruning */
-	size_t twopass_length; /* min sent length for two-pass post processing */
+	bool perform_pp_prune; /* Perform post-processing-based pruning TRUE */
+	size_t twopass_length; /* Min sent length for two-pass post processing */
 	Cost_Model cost_model; /* For sorting linkages after parsing. */
 
 	/* Options governing the generation of linkages. */
 	size_t linkage_limit;  /* The maximum number of linkages processed 100 */
-	bool display_morphology;/* if true, print morpho analysis of words */
+	bool display_morphology;/* If true, print morpho analysis of words FALSE */
 };
 
 typedef struct word_queue_s word_queue_t;

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -79,7 +79,9 @@ struct Parse_Options_s
 
 	/* Choice of the parser to use */
 	bool use_sat_solver;   /* Use the Boolean SAT based parser */
+#if USE_VITERBI
 	bool use_viterbi;      /* Use the Viterbi decoder-based parser */
+#endif
 
 	/* Options governing the parser internals operation */
 	double disjunct_cost;  /* Max disjunct cost to allow */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -119,7 +119,9 @@ Parse_Options parse_options_create(void)
 	po->max_null_count = 0;
 	po->islands_ok = false;
 	po->use_sat_solver = false;
+#if USE_VITERBI
 	po->use_viterbi = false;
+#endif
 	po->linkage_limit = 100;
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 	po->use_spell_guess = 7;
@@ -293,11 +295,17 @@ bool parse_options_get_use_sat_parser(Parse_Options opts) {
 }
 
 void parse_options_set_use_viterbi(Parse_Options opts, bool dummy) {
+#if USE_VITERBI
 	opts->use_viterbi = dummy;
+#endif
 }
 
 bool parse_options_get_use_viterbi(Parse_Options opts) {
+#if USE_VITERBI
 	return opts->use_viterbi;
+#else
+	return false;
+#endif
 }
 
 void parse_options_set_linkage_limit(Parse_Options opts, int dummy)

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -249,7 +249,7 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 		return false;
 	}
 
-	desc->lc_mask = (lc_mask << 1) + !!(desc->flags & CD_HEAD_DEPENDET);
+	desc->lc_mask = (lc_mask << 1) + !!(desc->flags & CD_HEAD_DEPENDENT);
 	desc->lc_letters = (lc_value << 1) + !!(desc->flags & CD_HEAD);
 
 	return true;
@@ -267,8 +267,8 @@ static bool calculate_connector_info(condesc_t * c)
 	s = c->string;
 	if (islower(*s)) s++; /* ignore head-dependent indicator */
 	if ((c->string[0] == 'h') || (c->string[0] == 'd'))
-		c->flags |= CD_HEAD_DEPENDET;
-	if ((c->flags & CD_HEAD_DEPENDET) && (c->string[0] == 'h'))
+		c->flags |= CD_HEAD_DEPENDENT;
+	if ((c->flags & CD_HEAD_DEPENDENT) && (c->string[0] == 'h'))
 		c->flags |= CD_HEAD;
 
 #if 0

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -70,7 +70,7 @@ Connector * connector_new(const condesc_t *desc, Parse_Options opts)
 }
 
 /* ======================================================== */
-/* UNLIMITED-CONNECTORS handling. */
+/* Connector length limit handling. */
 
 static size_t get_connectors_from_expression(condesc_t **conlist, const Exp *e)
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -40,7 +40,7 @@ typedef uint64_t lc_enc_t;
 
 typedef uint32_t connector_hash_t;
 
-#define CD_HEAD_DEPENDET     (1<<0) /* Has a leading 'h' or 'd'. */
+#define CD_HEAD_DEPENDENT    (1<<0) /* Has a leading 'h' or 'd'. */
 #define CD_HEAD              (1<<1) /* 0: dependent; 1: head; */
 #define CD_PERMANENT         (1<<2) /* For SQL dict: Do not clear (future). */
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -14,10 +14,10 @@
 #ifndef _LG_DICT_COMMON_H_
 #define  _LG_DICT_COMMON_H_
 
-#include "api-types.h" // for pp_knowledge
-#include "connectors.h" // for condest_t
+#include "api-types.h"                  // pp_knowledge
+#include "connectors.h"                 // ConTable
 #include "dict-structures.h"
-#include "utilities.h" // for locale_t
+#include "utilities.h"                  // locale_t
 
 #define EMPTY_CONNECTOR "ZZZ"
 #define UNLIMITED_CONNECTORS_WORD ("UNLIMITED-CONNECTORS")

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -161,7 +161,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	/* print left side of binary expr */
 	print_expression_parens(e, el->e, true);
 
-	/* get a funny "and optional" when its a named expression thing. */
+	/* get a funny "and optional" when it's a named expression thing. */
 	if ((n->type == AND_type) && (el->next == NULL))
 	{
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -530,7 +530,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		if (('\0' != affix_types[0]) &&
 		    (NULL == match_regex(afdict->regex_root, affix_types)))
 		{
-			/* Morpheme type combination is invalid */
+			/* Morpheme type combination is invalid. */
 			match_found = false;
 			/* Notify to stdout, so it will be shown along with the result.
 			 * XXX We should have a better way to notify. */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -443,7 +443,7 @@ static bool possible_connection(prune_context *pc,
 	 * at least one intervening connector (i.e. cannot have both
 	 * lc->next and rc->next being null).  But we only enforce this
 	 * when we think its still possible to have a complete parse,
-	 * i.e. before well allow null-linked words.
+	 * i.e. before we allow null-linked words.
 	 */
 	else
 	if (!pc->null_links &&
@@ -486,7 +486,7 @@ right_table_search(prune_context *pc, int w, Connector *c,
 
 /**
  * This returns TRUE if the right table of word w contains
- * a connector that can match to c.  shallows tells if c is shallow
+ * a connector that can match to c.  shallow tells if c is shallow
  */
 static bool
 left_table_search(prune_context *pc, int w, Connector *c,

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -39,7 +39,7 @@
  * By "column widths", it is meant the number of terminal columns
  * needed to display a glyph. Almost all indoeuropean glyphs are one
  * column wide. Almost all CJK glyphs (hanzi, kanji) are two columns
- * wide. These widths are NOT to be confuxed with UTF-8 byte size.
+ * wide. These widths are NOT to be confused with UTF-8 byte size.
  *
  * FIXME Long link names between more distant words may still not
  * fit the space between these words.
@@ -47,7 +47,7 @@
  * Return the number of bytes needed for the all the words, including
  * the space needed for the link names as described above.  Note that
  * this byte length might be less than the glyph width! e.g. the
- * ASCII chars in the rangel 01 to 1F usually print in two columns,
+ * ASCII chars in the range 01 to 1F usually print in two columns,
  * but require only one byte to encode.
  */
 static size_t
@@ -562,7 +562,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	// be less, or it might be more than the total number of
 	// bytes in the UTF-8 string! Which one depends on just how
 	// much garage there might be in the string. Note also that,
-	// in general, the glyphy of the last word will stick out past
+	// in general, the glyph of the last word will stick out past
 	// the num_cols here.
 	unsigned int num_cols = center[N_words_to_print-1]+1;
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -463,7 +463,7 @@ void SATEncoder::generate_satisfaction_for_expression(int w, int& dfs_position, 
 
 Exp* SATEncoder::join_alternatives(int w)
 {
-  // join all alternatives using and OR_type node
+  // join all alternatives using an OR_type node
   Exp* exp;
   E_list* or_list = NULL;;
   for (X_node* x = _sent->word[w].x; x != NULL; x = x->next) {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1866,13 +1866,10 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 /**
  * Main entry point into the SAT parser.
  * A note about panic mode:
- * The current version of Minisat we use doesn't support timeouts.
- * (Minisat >= 2.2 supports timeout.) In addition, currently parsing
- * with null words is not supported here.
+ * - The MiniSAT support for timeout is not yet used (FIXME).
+ * - Parsing with null links is not supported (FIXME).
  * So nothing particularly useful happens in a panic mode, and it is
  * left for the user to disable it.
- * Observation: Apparently the panic options somehow may cause an
- * immediate failure to find a solution (not checked why).
  */
 extern "C" int sat_parse(Sentence sent, Parse_Options  opts)
 {


### PR DESCRIPTION
Fix code and comment typos.
Update comments.

Add USE_VITERBI over use_viterbi - can the relevant parse_option calls be removed from link-grammar.def?:w
