### PR TITLE
pp_prune speed imprtovment

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1010,18 +1010,19 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			{
 				if (!d->marked) continue;
 				deleteme = false;
-				for (dir = 0; dir < 2; dir++)
+				for (i = 0; i < knowledge->n_contains_one_rules; i++)
 				{
-					Connector *c;
-					for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
-					{
-						for (i = 0; i < knowledge->n_contains_one_rules; i++)
-						{
-							pp_rule* rule = &knowledge->contains_one_rules[i]; /* the ith rule */
-							const char * selector = rule->selector;  /* selector string for this rule */
-							pp_linkset * link_set = rule->link_set;  /* the set of criterion links */
+					pp_rule* rule = &knowledge->contains_one_rules[i]; /* the ith rule */
+					const char * selector = rule->selector;  /* selector string for this rule */
+					pp_linkset * link_set = rule->link_set;  /* the set of criterion links */
 
-							if (rule->selector_has_wildcard) continue;  /* If it has a * forget it */
+					if (rule->selector_has_wildcard) continue;  /* If it has a * forget it */
+
+					for (dir = 0; dir < 2; dir++)
+					{
+						Connector *c;
+						for (c = ((dir) ? (d->left) : (d->right)); c != NULL; c = c->next)
+						{
 
 							if (!post_process_match(selector, connector_string(c))) continue;
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1021,7 +1021,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 							const char * selector = rule->selector;  /* selector string for this rule */
 							pp_linkset * link_set = rule->link_set;  /* the set of criterion links */
 
-							if (strchr(selector, '*') != NULL) continue;  /* If it has a * forget it */
+							if (rule->selector_has_wildcard) continue;  /* If it has a * forget it */
 
 							if (!post_process_match(selector, connector_string(c))) continue;
 

--- a/link-grammar/post-process/pp-structures.h
+++ b/link-grammar/post-process/pp-structures.h
@@ -119,6 +119,7 @@ typedef struct pp_rule_s
 	/* Holds a single post-processing rule. Since rules come in many
 	   flavors, not all fields of the following are always relevant  */
 	const char *selector; /* name of link to which rule applies      */
+	bool selector_has_wildcard; /* selector contains '*' */
 	pp_linkset *link_set; /* handle to set of links relevant to rule */
 	int   link_set_size;  /* size of this set                        */
 	int   domain;         /* type of domain to which rule applies    */

--- a/link-grammar/post-process/pp_knowledge.c
+++ b/link-grammar/post-process/pp_knowledge.c
@@ -307,6 +307,7 @@ static bool read_contains_rules(pp_knowledge *k, const char *label,
       }
 
       (*rules)[r].selector = string_set_add(tokens[0], k->string_set);
+      (*rules)[r].selector_has_wildcard = (strchr(tokens[0], '*') != NULL);
 
       /* read link set */
       tokens = pp_lexer_get_next_group_of_tokens_of_label(k->lt, &n_tokens);


### PR DESCRIPTION
1. Cache whether the selector has a `*`.
2. First loop over rules.

The speed improvement for `corpus-fixes.batch` is about 1% (may need many runs to see such a small improvement), but it can be clearly seen per sentence when running the current and patched versions with `verbosity=2`.