### PR TITLE
Python bindings: Avoid sentence_delete() stale memory reference

### DIFF
--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -21,6 +21,7 @@ Sentence has 1 unlinked word:
 
 from __future__ import print_function
 import sys
+from sys import stdin
 import re
 import argparse
 import readline
@@ -44,7 +45,9 @@ class Formatter(argparse.HelpFormatter):
 
 #-----------------------------------------------------------------------------#
 
-PROMPT = "sentence-check: "
+is_stdin_atty = sys.stdin.isatty()
+
+PROMPT = "sentence-check: " if is_stdin_atty else ""
 DISPLAY_GUESSES = True   # Display regex and POS guesses
 
 print ("Version:", clg.linkgrammar_get_version())
@@ -83,6 +86,9 @@ while True:
     sentence_text = get_input(PROMPT)
     if sentence_text.strip() == '':
         continue
+    if not is_stdin_atty:
+        print("\n" + sentence_text)
+
     sent = Sentence(str(sentence_text), lgdict, po)
     try:
         linkages = sent.parse()

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -49,6 +49,7 @@ is_stdin_atty = sys.stdin.isatty()
 
 PROMPT = "sentence-check: " if is_stdin_atty else ""
 DISPLAY_GUESSES = True   # Display regex and POS guesses
+BATCH_LABELS = '*: '
 
 print ("Version:", clg.linkgrammar_get_version())
 
@@ -84,6 +85,14 @@ po.display_morphology = arg.morphology
 # iter(): avoid python2 input buffering
 while True:
     sentence_text = get_input(PROMPT)
+
+    if not is_stdin_atty and sentence_text:
+        if sentence_text[0] == '%':
+            continue
+        if sentence_text[0] == '!': # ignore user-settings for now
+            continue
+        if sentence_text[0] in BATCH_LABELS:
+            sentence_text = sentence_text[1:]
     if sentence_text.strip() == '':
         continue
     if not is_stdin_atty:

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -147,13 +147,11 @@ while True:
             if arg.position:
                 words_char = []
                 words_byte = []
-                wi = 0
-                for w in words:
+                for wi, w in enumerate(words):
                     if is_python2():
-                        words[wi] = words[wi].decode('utf-8')
-                    words_char.append(words[wi] + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
-                    words_byte.append(words[wi] + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
-                    wi += 1
+                        w = w.decode('utf-8')
+                    words_char.append(w + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
+                    words_byte.append(w + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
 
                 print(u"{}: {}".format(result_no, ' '.join(words_char)))
                 print(u"{}: {}".format(result_no, ' '.join(words_byte)))

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -122,7 +122,8 @@ while True:
 
     if correction_found:
         print(" - with correction", end='')
-    print(".")
+    if null_count == 0:
+        print(".")
 
     guess_found = False
     if DISPLAY_GUESSES:

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -82,7 +82,6 @@ po.max_parse_time = 10   # actual parse timeout may be about twice bigger
 po.spell_guess = True if DISPLAY_GUESSES else False
 po.display_morphology = arg.morphology
 
-# iter(): avoid python2 input buffering
 while True:
     try:
         sentence_text = get_input(PROMPT)

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -84,7 +84,11 @@ po.display_morphology = arg.morphology
 
 # iter(): avoid python2 input buffering
 while True:
-    sentence_text = get_input(PROMPT)
+    try:
+        sentence_text = get_input(PROMPT)
+    except EOFError:
+        print("EOF")
+        exit(0)
 
     if not is_stdin_atty and sentence_text:
         if sentence_text[0] == '%':

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -45,6 +45,7 @@ class Formatter(argparse.HelpFormatter):
 
 #-----------------------------------------------------------------------------#
 
+PROMPT = "sentence-check: "
 DISPLAY_GUESSES = True   # Display regex and POS guesses
 
 print ("Version:", clg.linkgrammar_get_version())
@@ -80,8 +81,7 @@ po.display_morphology = arg.morphology
 
 # iter(): avoid python2 input buffering
 while True:
-    sentence_text = get_input("sentence-check: ")
-
+    sentence_text = get_input(PROMPT)
     if sentence_text.strip() == '':
         continue
     sent = Sentence(str(sentence_text), lgdict, po)
@@ -98,6 +98,13 @@ while True:
         print('Cannot parse the input sentence')
         continue
     null_count = sent.null_count()
+
+    if arg.position:
+        print(' ' * len(PROMPT), end='')
+        for p in range (0, len(sentence_text)):
+            print(p%10, end="")
+        print()
+
     if null_count == 0:
         print("Sentence parsed OK", end='')
 
@@ -128,11 +135,6 @@ while True:
 
     # Show results with unlinked words or guesses
     if arg.position or guess_found or correction_found or null_count != 0:
-        if arg.position:
-            for p in range (0, len(sentence_text)):
-                print(p%10, end="")
-            print()
-
         print('Sentence has {} unlinked word{}:'.format(
             null_count, nsuffix(null_count)))
         result_no = 0

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -107,9 +107,9 @@ while True:
     # search for correction suggestions
     for l in linkages:
         for word in l.words():
-                if word.find(r'.#') > 0:
-                    correction_found = True
-                    break;
+            if word.find(r'.#') > 0:
+                correction_found = True
+                break
         if correction_found:
             break
 

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -22,7 +22,6 @@ Sentence has 1 unlinked word:
 from __future__ import print_function
 import sys
 import re
-import itertools
 import argparse
 import readline
 

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -29,10 +29,10 @@ import readline
 from linkgrammar import (Sentence, ParseOptions, Dictionary,
                          LG_Error, LG_TimerExhausted, Clinkgrammar as clg)
 
-get_input = input
-# If this is Python 2, use raw_input()
-if sys.version_info[:2] <= (2, 7):
-    get_input = raw_input
+def is_python2():
+    return sys.version_info[:1] == (2,)
+
+get_input = raw_input if is_python2() else input
 
 def nsuffix(q):
     return '' if q == 1 else 's'
@@ -149,7 +149,7 @@ while True:
                 words_byte = []
                 wi = 0
                 for w in words:
-                    if sys.version_info < (3, 0):
+                    if is_python2():
                         words[wi] = words[wi].decode('utf-8')
                     words_char.append(words[wi] + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
                     words_byte.append(words[wi] + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -483,11 +483,13 @@ class Sentence(object):
     def __init__(self, text, lgdict, parse_options):
         # Keep all args passed into clg.* functions.
         self.text, self.dict, self.parse_options = text, lgdict, parse_options
+        clg._py_incref(self.dict) # The Sentence struct refers to the Dictionary struct
         self._obj = clg.sentence_create(self.text, self.dict._obj)
 
     def __del__(self):
         if hasattr(self, '_obj'):
             clg.sentence_delete(self._obj)
+            clg._py_decref(self.dict)
             del self._obj
 
     def split(self, parse_options=None):

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -380,5 +380,20 @@ void delete_lg_errinfo(lg_errinfo *lge) {
   free((void *)lge->text);
   free((void *)lge);
 }
+
+/**
+ * incref/decref a Python object.
+ * Currently used on the Dictionary object when a Sentence object is created/deleted,
+ * because the Sentence object includes a reference to the Dictionary structure.
+ */
+void _py_incref(PyObject *x)
+{
+  Py_INCREF(x);
+}
+
+void _py_decref(PyObject *x)
+{
+  Py_DECREF(x);
+}
 %}
 #endif /* SWIGPYTHON */

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -208,7 +208,7 @@ bool lg_error_flush(void);
  * void *lg_error_set_handler_data(void *);
  * A wrapper to this function is complex and is not implemented here.  However,
  * such a wrapper may not be needed anyway since this function is provided
- * mainly for the low-level implementation the error callback, so bound
+ * mainly for the low-level implementation of the error callback, so bound
  * languages can free the memory of the callback data.
  */
 


### PR DESCRIPTION
The main fix here is to avoid a possible stale memory reference in the library sentence_delete().
It may happen because the Sentence struct includes a reference to the Dictionary struct, which, due to
a recent change, is used in sentence_delete(). So the Dictionary struct should not be deleted before the Sentence struct.

However, the Python bindings doesn't know about that, and this actually happens on unhanded exceptions (including keyboard interrupts) when python3 is used. Theoretically it can happen in other situations.

Maybe a better fix could be to avoid this reference in sentence_delete() by copying dict->db_handle to the Sentence struct when it is created. (But this fix seems more general and future-proof as long as the Sentence struct contains a reference to the Dictionary struct).

Repeat by (when LG is compiled with ASAN):
python3 sentence-check.py
sentence-check: x
^C

The other fixes are in `sentence-check.py`:
- Python cosmetic fixes
- EOF check
- Work with batch files (to check word position correctness)
- Fix printout problems 