### PR TITLE
ChangeLog: Add the recent linkage repeatability fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Version 5.5.1 (XXX 2018)
  * English dict: Various misc fixes.
  * English dict: Various paraphrasing verbs
  * Bring the SQL-backed dict to production state.
+ * Restore the repeatability of the produced linkages.
 
 Version 5.5.0 (29 April 2018)
  * Fix accidental API breakage that impacts OpenCog.


### PR DESCRIPTION
It seems it is a good idea to add that to the ChangeLog, as it turned out this was not important only for me...

But note that the linkage order may still not be repeatable between versions.
---> This can be mostly be fixed by adding an option for a "canonical order" of linkages.
(An option is needed because this has an overhead.)

Currently, when I  need to compare linkages between versions (and I need to do this a lot) I use a perl script to sort the same-metric linkages in a consistent order. I could release these script (to be put in the `debug/` directory of the repository) but I hesitate to do so because it is very sensitive to the output format of `link-parser`. 
---> Maybe we can add an option to `link-parser` to produce output in JSON format, so there will be no need to fix output-processing scripts due to any minor change in its output format.