### PR TITLE
SQL dict: Install demo-sql

### DIFF
--- a/data/demo-sql/Makefile.am
+++ b/data/demo-sql/Makefile.am
@@ -6,9 +6,8 @@ DICTS=                           \
       4.0.knowledge              \
       4.0.regex
 
-# Do NOT install the demo at this time ...
-# dictdir=$(pkgdatadir)/demo-sql
-# dict_DATA = $(DICTS)
+dictdir=$(pkgdatadir)/demo-sql
+dict_DATA = $(DICTS)
 
 EXTRA_DIST = $(DICTS)            \
       corpus-basic.batch


### PR DESCRIPTION
Now that the SQL dict support is supposed to fully work, it is most the time to actually install it.