### PR TITLE
Fix for issue #800

### DIFF
--- a/bindings/python-examples/lg_testutils.py
+++ b/bindings/python-examples/lg_testutils.py
@@ -7,7 +7,7 @@ def add_eqcost_linkage_order(original_class):
     be in a deterministic order.
     Usage: lg_testutils.add_eqcost_linkage_order(Sentence)
     """
-    class eqcost_soretd_parse(original_class.sentence_parse):
+    class eqcost_sorted_parse(original_class.sentence_parse):
         """
         Sort equal-cost linkages according to the alphabetic order of their
         diagram string, on demand.  We need it because the order of linkages
@@ -73,6 +73,6 @@ def add_eqcost_linkage_order(original_class):
         # parse() has an optional single argument for parse options. If it is not given,
         # call original_parse() also without arguments in order to test it that way.
         linkages = self.original_parse() if parse_options is None else self.original_parse(parse_options)
-        return eqcost_soretd_parse(linkages)
+        return eqcost_sorted_parse(linkages)
 
     original_class.parse = parse

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -357,7 +357,7 @@ class DBasicParsingTestCase(unittest.TestCase):
                           "This should take more than one second to parse! " * 20,
                           ParseOptions(max_parse_time=1))
 
-# The tests here are are numbered since their order is important.
+# The tests here are numbered since their order is important.
 # They depend on the result and state of the previous ones as follows:
 # - set_handler() returned a value that depend on it previous invocation.
 # - A class variable "handler" to record its previous results.
@@ -833,7 +833,7 @@ class ZENConstituentsCase(unittest.TestCase):
     def tearDownClass(cls):
         del cls.d, cls.po
 
-    def test_a_constiuents_after_parse_list(self):
+    def test_a_constituents_after_parse_list(self):
         """
         Validate that the post-processing data of the first linkage is not
         getting clobbered by later linkages.
@@ -990,7 +990,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             self.assertTrue(linkage, "at {}:{}: Sentence has no linkages".format(testfile, lineno))
 
         # Generate the next linkage of the last input sentence
-        if line[0] == 'N' :
+        if line[0] == 'N':
             diagram = ""
             constituents = ""
             wordpos = ""
@@ -999,7 +999,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line
-        if line[0] == 'O' :
+        if line[0] == 'O':
             diagram += line[1:]
             if line[1] == '\n' and len(diagram) > 1:
                 self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
@@ -1070,7 +1070,7 @@ class divert_start(object):
 
     __del__ = divert_end
 
-# Decorate Sentence.parse with eqcost_soretd_parse.
+# Decorate Sentence.parse with eqcost_sorted_parse.
 lg_testutils.add_eqcost_linkage_order(Sentence)
 
 unittest.main()

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -762,7 +762,7 @@ class IWordPositionTestCase(unittest.TestCase):
         linkage_testfile(self, self.d_en, ParseOptions(), 'pos')
 
     def test_en_spell_word_positions(self):
-        po = ParseOptions(spell_guess=10)
+        po = ParseOptions(spell_guess=1)
         if po.spell_guess == 0:
             raise unittest.SkipTest("Library is not configured with spell guess")
         linkage_testfile(self, self.d_en, po, 'pos-spell')

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -954,6 +954,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
     wordpos = None
     sent = None
     lineno = 0
+    last_opcode = None
 
     def getwordpos(lkg):
         words_char = []
@@ -964,9 +965,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         return ' '.join(words_char) + '\n' + ' '.join(words_byte) + '\n'
 
     # Function code and file format sanity check
-    self.opcode_detected = 0
     def validate_opcode(opcode):
-        self.opcode_detected += 1
         if opcode != ord('O'):
             self.assertFalse(diagram, "at {}:{}: Unfinished diagram entry".format(testfile, lineno))
         if opcode != ord('C'):
@@ -978,7 +977,12 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         lineno += 1
         if not is_python2():
             line = line.decode('utf-8')
+
         validate_opcode(ord(line[0])) # Use ord() for python2/3 compatibility
+        prev_opcode = last_opcode
+        if line[0] in 'INOCP':
+            last_opcode = line[0]
+
         # Lines starting with I are the input sentences
         if line[0] == 'I':
             sent = line[1:].rstrip('\r\n') # Strip whitespace before RIGHT-WALL (for P)
@@ -990,7 +994,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             self.assertTrue(linkage, "at {}:{}: Sentence has no linkages".format(testfile, lineno))
 
         # Generate the next linkage of the last input sentence
-        if line[0] == 'N':
+        elif line[0] == 'N':
             diagram = ""
             constituents = ""
             wordpos = ""
@@ -999,7 +1003,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
 
         # Lines starting with O are the parse diagram
         # It ends with an empty line
-        if line[0] == 'O':
+        elif line[0] == 'O':
             diagram += line[1:]
             if line[1] == '\n' and len(diagram) > 1:
                 self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
@@ -1007,7 +1011,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
 
         # Lines starting with C are the constituent output (type 1)
         # It ends with an empty line
-        if line[0] == 'C':
+        elif line[0] == 'C':
             if line[1] == '\n' and len(constituents) > 1:
                 self.assertEqual(linkage.constituent_tree(), constituents, "at {}:{}".format(testfile, lineno))
                 constituents = None
@@ -1018,7 +1022,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         # The first P line contains character positions
         # The second P line contains byte positions
         # It ends with an empty line
-        if line[0] == 'P':
+        elif line[0] == 'P':
             if line[1] == '\n' and len(wordpos) > 1:
                 self.assertEqual(getwordpos(linkage), wordpos, "at {}:{}".format(testfile, lineno))
                 wordpos = None
@@ -1026,13 +1030,17 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
                 wordpos += line[1:]
 
         # Lines starting with "-" contain a Parse Option
-        if line[0] == '-':
+        elif line[0] == '-':
             exec('popt.' + line[1:], None, locals())
+
+        elif line[0] in '%\r\n':
+            pass
+        else:
+            self.fail('\nTest file "{}": Invalid opcode "{}" (ord={})'.format(testfile, line[0], ord(line[0])))
 
     parses.close()
 
-    validate_opcode('')
-    self.assertGreaterEqual(self.opcode_detected, 2, "Nothing has been done for " + testfile)
+    self.assertIn(last_opcode , 'OCP', "Missing result comparison in " + testfile)
 
 def warning(*msg):
     progname = os.path.basename(sys.argv[0])


### PR DESCRIPTION
Fix issue #800.

Reason of the problem:
The check passes with "hunspell" but not "aspell", because "aspell" generates a spell guess which changes the order of the linkages.

Fixed (for now, at least) by reducing the number of allowed spell corrections from 10 to 1.

EDIT: In the same occasion fix typos and improve the opcode check.

---
This is not a general fix, as the problem may theoretical reappear here and in other tests.

I initially made a more general fix, but omitted it due to its added complexity and because the current fix is simpler. (I will keep it around in case it will ever be needed for something.)
In this fix, a regex optional argument to the "N" (generate next linkage) opcode is used in order to obtain the next matching linkage (tested again a concatenation of the linkage words).
In the case of this check, which is intended to check the position of word spell splits (marked with `[&]`),  the check definition would be:
```
Ithe seasand lakes are hot
N /&/
P ...
P ...
P
N /&/
```
(Part of this omitted fix was to make the first "N" a no-op and only use its argument.)
