### PR TITLE
Convert dict cost to float with the C locale

### DIFF
--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1251,7 +1251,16 @@ static Exp * restricted_expression(Dictionary dict, int and_ok, int or_ok)
 		 */
 		if (is_number(dict->token))
 		{
-			nl->cost += atof(dict->token);
+			double cost;
+			if (strtodC(dict->token, &cost))
+			{
+				nl->cost += cost;
+			}
+			else
+			{
+				warning(dict, "Invalid cost (using 1.0)\n");
+				nl->cost += 1.0;
+			}
 			if (!link_advance(dict)) {
 				return NULL;
 			}

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -152,7 +152,12 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 	bs->exp = make_expression(bs->dict, argv[0]);
 
 	if (bs->exp)
-		bs->exp->cost = atof(argv[1]);
+		if (!strtodC(argv[1], &bs->exp->cost))
+		{
+			prt_error("Warning: Invalid cost \"%s\" in expression \"%s\" "
+			          "(using 1.0)\n", argv[1], argv[0]);
+			bs->exp->cost = 1.0;
+		}
 
 	return 0;
 }

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -493,6 +493,7 @@ size_t get_max_space_used(void);
 char * get_default_locale(void);
 void set_utf8_program_locale(void);
 bool try_locale(const char *);
+bool strtodC(const char *, double *);
 
 /**
  * Returns the smallest power of two that is at least i and at least 1


### PR DESCRIPTION
Fix issue #804 by ensuring LC_NUMERIC is from the C locale.
Use local locale setting in order to not mangle the global/thread locale.
Also warn if the number is malformed.

N.B.: While inspecting the dictionary locale code I found it is not thread-safe.
It didn't matter when I wrote it, but now that the dict read is supposed to be thread-safe - this should be fixed (added to my fixes list). Especially, the global program locale should not be changed even temporarily (this interferes with other possible threads and also with the UI of the program that uses the library).
