### PR TITLE
Windows fixes

### DIFF
--- a/bindings/java-jni/jni-client.c
+++ b/bindings/java-jni/jni-client.c
@@ -6,7 +6,9 @@
  */
 
 #include <jni.h>
+#ifndef _WIN32
 #include <langinfo.h>
+#endif // _WIN32
 #include <locale.h>
 #include <stdio.h>
 #include <string.h>
@@ -107,7 +109,8 @@ static void global_init(JNIEnv *env)
 	dict_is_init = true;
 #endif /* HAVE_STDATOMIC_H */
 
-	const char *codeset, *dict_version;
+#ifndef _WIN32
+	const char *codeset;
 
 	/* Get the locale from the environment...
 	 * perhaps we should someday get it from the dictionary ??
@@ -124,12 +127,13 @@ static void global_init(JNIEnv *env)
 			codeset);
 		setlocale(LC_CTYPE, "en_US.UTF-8");
 	}
+#endif // _WIN32
 
 	dict = dictionary_create_lang(in_language);
 	if (!dict) throwException(env, "Error: unable to open dictionary");
 	else do_test();
 
-	dict_version = linkgrammar_get_dict_version(dict);
+	const char *dict_version = linkgrammar_get_dict_version(dict);
 	prt_error("Info: JNI: dictionary language '%s' version %s\n",
 		in_language, dict_version);
 }

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -64,9 +64,12 @@ _clinkgrammar_la_CPPFLAGS =       \
 # symlink to it of an unversioned name (at least up and including libtool
 # 2.4.6).  This is bad for Python modules, as they must have an identifier
 # name.
+# On MinGW, Python DLLs end with ".pyd". But Cygwin needs them with ".dll".
 if OS_WIN32
 AVOID_VERSION = -avoid-version
+if !OS_CYGWIN
 PYMODULE_EXT = -shrext .pyd
+endif
 endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -60,16 +60,17 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
-# On Cygwin and MinGW, a DLL with version is named name-major.dll with no
+# On Cygwin and MinGW, a DLL with version is named name-major.EXT with no
 # symlink to it of an unversioned name (at least up and including libtool
 # 2.4.6).  This is bad for Python modules, as they must have an identifier
 # name.
 if OS_WIN32
 AVOID_VERSION = -avoid-version
+PYMODULE_EXT = -shrext .pyd
 endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \
-    $(PYTHON2_LDFLAGS) -module -no-undefined
+    $(PYTHON2_LDFLAGS) -module -no-undefined $(PYMODULE_EXT)
 _clinkgrammar_la_LIBADD =                         \
     $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON2_LIBS)
 

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -75,9 +75,12 @@ _clinkgrammar_la_CPPFLAGS =       \
 # symlink to it of an unversioned name (at least up and including libtool
 # 2.4.6).  This is bad for Python modules, as they must have an identifier
 # name.
+# On MinGW, Python DLLs end with ".pyd". But Cygwin needs them with ".dll".
 if OS_WIN32
 AVOID_VERSION = -avoid-version
+if !OS_CYGWIN
 PYMODULE_EXT = -shrext .pyd
+endif
 endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -71,16 +71,17 @@ _clinkgrammar_la_CPPFLAGS =       \
    -I$(top_srcdir)                \
    -I$(top_builddir)
 
-# On Cygwin and MinGW, a DLL with version is named name-major.dll with no
+# On Cygwin and MinGW, a DLL with version is named name-major.EXT with no
 # symlink to it of an unversioned name (at least up and including libtool
 # 2.4.6).  This is bad for Python modules, as they must have an identifier
 # name.
 if OS_WIN32
 AVOID_VERSION = -avoid-version
+PYMODULE_EXT = -shrext .pyd
 endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \
-    $(PYTHON3_LDFLAGS) -module -no-undefined
+    $(PYTHON2_LDFLAGS) -module -no-undefined $(PYMODULE_EXT)
 _clinkgrammar_la_LIBADD =                         \
     $(top_builddir)/link-grammar/liblink-grammar.la $(PYTHON3_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,18 @@ esac
 AC_MSG_RESULT([$native_win32])
 AM_CONDITIONAL(OS_WIN32, test "x$native_win32" = "xyes")
 
+AC_MSG_CHECKING([for Cygwin])
+case "$host_os" in
+  *cygwin*)
+    cygwin=yes
+    ;;
+  *)
+    cygwin=no
+    ;;
+esac
+AC_MSG_RESULT([$cygwin])
+AM_CONDITIONAL(OS_CYGWIN, test "x$cygwin" = "xyes")
+
 AC_MSG_CHECKING([for 64-bit Apple OSX])
 case "$host_os" in
   darwin*)

--- a/configure.ac
+++ b/configure.ac
@@ -454,8 +454,20 @@ AC_ARG_ENABLE([hunspell], [AS_HELP_STRING([--disable-hunspell],
 
 AM_CONDITIONAL(WITH_HUNSPELL, test x${do_hunspell} = xyes)
 
+case "$host_os$host_cpu" in
+	*mingw*64)
+		default_hunspell_dictdir=/mingw64/share/myspell/dicts
+		;;
+	*mingw*32)
+		# Not checked
+		default_hunspell_dictdir=/mingw32/share/myspell/dicts
+		;;
+	*)
+		default_hunspell_dictdir=/usr/share/myspell/dicts
+		;;
+esac
 AC_ARG_WITH([hunspell-dictdir], [AS_HELP_STRING([--with-hunspell-dictdir=DIR],
-	[Use DIR to find HunSpell files (default=/usr/share/myspell/dicts])],
+	[Use DIR to find HunSpell files (default=$default_hunspell_dictdir])],
 	[], with_hunspell_dictdir=)
 
 # ====================================================================
@@ -480,9 +492,23 @@ if test x"$do_hunspell" = xyes; then
 		AC_SUBST(HUNSPELL_CFLAGS)
 
 		# Now, look for the dictionaries.
-		HunSpellDictDir=/usr/share/myspell/dicts
+		HunSpellDictDir=$default_hunspell_dictdir
 		if test -n "$with_hunspell_dictdir"; then
 			HunSpellDictDir=$with_hunspell_dictdir
+		fi
+
+		if test "$native_win32" = yes; then
+			# Convert to native format with forward slashes
+			# (allow spaces in DIR when using --with-hunspell-dictdir="DIR").
+			case $HunSpellDictDir in
+				*\ *)
+					file_format=dos
+					;;
+				*)
+					file_format=windows
+					;;
+			esac
+			HunSpellDictDir=`cygpath --$file_format --mixed "$HunSpellDictDir"`
 		fi
 
 		if ! test -d "$HunSpellDictDir" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -975,6 +975,7 @@ echo "
 $PACKAGE-$VERSION  build configuration settings
 
 	prefix:                         ${prefix}
+	datadir:                        $(eval "echo ${datadir}")
 	C compiler:                     ${CC} ${CPPFLAGS} ${CFLAGS}
 	C++ compiler:                   ${CXX} ${CPPFLAGS} ${CXXFLAGS}
 	Regex library:                  ${REGEX_LIBS}

--- a/configure.ac
+++ b/configure.ac
@@ -117,8 +117,7 @@ CXXFLAGS="${CXXFLAGS} -O3 -Wall"
 # GNU, but do NOT turn on POSIX.
 #
 if test x${native_win32} = xyes; then
-	SPAWNV_WORKAROUND=-D_spawnv=spawnv # Fix MSYS2 wrapper compilation problem
-	CFLAGS="-std=c11 -D_BSD_SOURCE -D_SVID_SOURCE -D_GNU_SOURCE -D_ISOC11_SOURCE ${CFLAGS} ${SPAWNV_WORKAROUND}"
+	CFLAGS="-std=c11 -D_BSD_SOURCE -D_SVID_SOURCE -D_GNU_SOURCE -D_ISOC11_SOURCE ${CFLAGS}"
 	CXXFLAGS="-std=c++11 ${CXXFLAGS}"
 	# We need the shlwapi for PathRemoveFileSpecA().
 	LDFLAGS="${LDFLAGS} -lshlwapi"

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -27,7 +27,14 @@ install-libtool-import-lib:
 uninstall-libtool-import-lib:
 endif
 
-DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir)\" -DCC=\"$(CC)\"
+if OS_WIN32
+   fileformat = $(if $(filter 1,$(words [$(pkgdatadir)])),windows,dos) # dos if whitespace
+   pkgdatadir_realpath := $(shell cygpath --${fileformat} --mixed "$(pkgdatadir)")
+else
+   pkgdatadir_realpath := $(pkgdatadir)
+endif
+
+DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir_realpath)\" -DCC=\"$(CC)\"
 
 # $(top_builddir) to pick up autogened link-grammar/link-features.h
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) $(WARN_CFLAGS) \

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -245,8 +245,8 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 
 	if ((unsigned long)(s-lc_string) > (CHAR_BIT*sizeof(lc_value)/LC_BITS))
 	{
-		prt_error("Error: Lower-case part '%s' is too long (%ld)\n",
-					 lc_string, s-lc_string);
+		prt_error("Error: Lower-case part '%s' is too long (%d)\n",
+					 lc_string, (int)(s-lc_string));
 		return false;
 	}
 

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -30,33 +30,33 @@
 #ifdef _WIN32
 int callGetLocaleInfoEx(LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, int cchData)
 {
-    int rc = -1;
+	int rc = -1;
 
-    // Normal call
-    int (WINAPI * pfnGetLocaleInfoEx)(LPCWSTR, LCTYPE, LPWSTR, int);
-    *(FARPROC*)&pfnGetLocaleInfoEx = GetProcAddress(GetModuleHandleA("Kernel32" ), "GetLocaleInfoEx" );
-    if (pfnGetLocaleInfoEx)
-    {
-        rc = pfnGetLocaleInfoEx(lpLocaleName, LCType, lpLCData, cchData);
-    }
-    else
-    {
-        // Workaround for missing GetLocaleInfoEx
-        HMODULE module = LoadLibraryA("Mlang");
-        HRESULT (WINAPI * pfnRfc1766ToLcidW)(LCID*, LPCWSTR);
-        *(FARPROC*)&pfnRfc1766ToLcidW = GetProcAddress(module, "Rfc1766ToLcidW" );
-        if  (pfnRfc1766ToLcidW)
-        {
-             LCID lcid;
-             if (SUCCEEDED(pfnRfc1766ToLcidW(&lcid, lpLocaleName)))
-             {
-                rc = GetLocaleInfoW(lcid, LCType, lpLCData, cchData);
-             }
-        }
-        FreeLibrary(module);
-    }
+	// Normal call
+	int (WINAPI * pfnGetLocaleInfoEx)(LPCWSTR, LCTYPE, LPWSTR, int);
+	*(FARPROC*)&pfnGetLocaleInfoEx = GetProcAddress(GetModuleHandleA("Kernel32" ), "GetLocaleInfoEx" );
+	if (pfnGetLocaleInfoEx)
+	{
+		rc = pfnGetLocaleInfoEx(lpLocaleName, LCType, lpLCData, cchData);
+	}
+	else
+	{
+		// Workaround for missing GetLocaleInfoEx
+		HMODULE module = LoadLibraryA("Mlang");
+		HRESULT (WINAPI * pfnRfc1766ToLcidW)(LCID*, LPCWSTR);
+		*(FARPROC*)&pfnRfc1766ToLcidW = GetProcAddress(module, "Rfc1766ToLcidW" );
+		if (pfnRfc1766ToLcidW)
+		{
+			 LCID lcid;
+			 if (SUCCEEDED(pfnRfc1766ToLcidW(&lcid, lpLocaleName)))
+			 {
+				rc = GetLocaleInfoW(lcid, LCType, lpLCData, cchData);
+			 }
+		}
+		FreeLibrary(module);
+	}
 
-    return rc;
+	return rc;
 }
 #endif //_WIN32
 

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -27,7 +27,7 @@
 /* ======================================================================= */
 
 // WindowsXP workaround - missing GetLocaleInfoEx
-#ifdef _WIN32
+#if _WINVER == 0x501 // XP
 int callGetLocaleInfoEx(LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, int cchData)
 {
 	int rc = -1;
@@ -47,7 +47,7 @@ int callGetLocaleInfoEx(LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, in
 		*(FARPROC*)&pfnRfc1766ToLcidW = GetProcAddress(module, "Rfc1766ToLcidW" );
 		if (pfnRfc1766ToLcidW)
 		{
-			 LCID lcid;
+			 LCID lcidlink-parser/parser-utilities.c;
 			 if (SUCCEEDED(pfnRfc1766ToLcidW(&lcid, lpLocaleName)))
 			 {
 				rc = GetLocaleInfoW(lcid, LCType, lpLCData, cchData);
@@ -58,7 +58,9 @@ int callGetLocaleInfoEx(LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, in
 
 	return rc;
 }
-#endif //_WIN32
+#else
+#define callGetLocaleInfoEx GetLocaleInfoEx
+#endif // _WINVER == 0x501
 
 /* ======================================================================= */
 

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -38,7 +38,7 @@
 #endif /*_WIN32 */
 
 #define IS_DIR_SEPARATOR(ch) (DIR_SEPARATOR[0] == (ch))
-#if !defined(DICTIONARY_DIR) || defined(__MINGW32__)
+#if !defined(DICTIONARY_DIR)
 	#define DEFAULTPATH NULL
 #else
 	#define DEFAULTPATH DICTIONARY_DIR

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -47,6 +47,23 @@
 #define MAX_PATH_NAME 200     /* file names (including paths)
                                  should not be longer than this */
 
+/**
+ * Find the location of the last directory separator (Windows/POSIX).
+ * Return NULL if none found.
+ * It doesn't modify its argument, but const is not used because
+ * it is to be called also with non-const argument.
+ */
+char *find_last_dir_separator(char *path)
+{
+	char *dirsep = NULL;
+	size_t pathlen = strlen(path);
+
+	for (size_t p = pathlen; p > 0; p--)
+		if (('/' == path[p]) || ('\\' == path[p])) return &path[p];
+
+	return dirsep;
+}
+
 char * join_path(const char * prefix, const char * suffix)
 {
 	char * path;
@@ -61,7 +78,7 @@ char * join_path(const char * prefix, const char * suffix)
 	 * only if the prefix isn't already terminated by a path sep.
 	 */
 	prel = strlen(path);
-	if (0 < prel && path[prel-1] != DIR_SEPARATOR[0])
+	if (0 < prel && (path[prel-1] != '/') && (path[prel-1] != '\\'))
 	{
 		path[prel] = DIR_SEPARATOR[0];
 		path[prel+1] = '\0';
@@ -354,10 +371,11 @@ void * object_open(const char *filename,
 			prt_error("Info: Dictionary found at %s\n", pfnd);
 		for (size_t i = 0; i < 2; i++)
 		{
-			char *root = strrchr(pfnd, DIR_SEPARATOR[0]);
+			char *root = find_last_dir_separator(pfnd);
 			if (NULL != root) *root = '\0';
 		}
 		path_found = pfnd;
+		lgdebug(D_USER_FILES, "Debug: Using dictionary path \"%s\"\n", path_found);
 	}
 
 	free(data_dir);

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -80,7 +80,7 @@ char * join_path(const char * prefix, const char * suffix)
 	prel = strlen(path);
 	if (0 < prel && (path[prel-1] != '/') && (path[prel-1] != '\\'))
 	{
-		path[prel] = DIR_SEPARATOR[0];
+		path[prel] = '/';
 		path[prel+1] = '\0';
 	}
 	strcat(path, suffix);
@@ -339,9 +339,9 @@ void * object_open(const char *filename,
 		{
 			path_found,
 			".",
-			"." DIR_SEPARATOR "data",
+			"./data",
 			"..",
-			".." DIR_SEPARATOR "data",
+			"../data",
 			data_dir,
 			dictionary_dir,
 		};

--- a/link-grammar/dict-common/file-utils.h
+++ b/link-grammar/dict-common/file-utils.h
@@ -25,5 +25,6 @@ void * object_open(const char *filename,
 
 bool file_exists(const char * dict_name);
 char * get_file_contents(const char *filename);
+char *find_last_dir_separator(char *path);
 
 #endif /* _DICT_FILE_UTILITIES_H_ */

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -112,7 +112,7 @@ dictionary_six_str(const char * lang,
 
 	/* Language and file-name stuff */
 	dict->string_set = string_set_create();
-	t = strrchr (lang, '/');
+	t = find_last_dir_separator((char *)lang);
 	t = (NULL == t) ? lang : t+1;
 	dict->lang = string_set_add(t, dict->string_set);
 	lgdebug(D_USER_FILES, "Debug: Language: %s\n", dict->lang);

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -218,7 +218,16 @@ static void default_error_handler(lg_errinfo *lge, void *data)
 	}
 
 	char *msgtext = lg_error_formatmsg(lge);
+
+	/* On MINGW64, fprintf() somehow doesn't follow fd redirection in Python
+	 * (see divert_start() in tests.py), but there is no such a problem with
+	 * fputs(). */
+#if 0
 	fprintf(outfile, "%s", msgtext);
+#else
+	fputs(msgtext, outfile);
+#endif
+
 	free(msgtext);
 
 	fflush(outfile); /* Also stderr, in case some OS does some strange thing */

--- a/link-grammar/tokenize/spellcheck-hun.c
+++ b/link-grammar/tokenize/spellcheck-hun.c
@@ -12,8 +12,21 @@
 
 #ifdef HAVE_HUNSPELL
 
+#ifdef __MINGW32__
+#define LGPTHREAD(x) x
+#else
+#define LGPTHREAD(x)
+#endif // __MINGW32__
+
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef __MINGW32__
+#include <pthread.h>
+#define LGPTHREAD(x) x
+#else
+#define LGPTHREAD(x)
+#endif // __MINGW32__
+
 #include "link-includes.h"
 #include "spellcheck.h"
 
@@ -119,6 +132,8 @@ bool spellcheck_test(void * chk, const char * word)
 	return (bool) Hunspell_spell((Hunhandle *)chk, word);
 }
 
+LGPTHREAD(static pthread_mutex_t hunspell_lock = PTHREAD_MUTEX_INITIALIZER;)
+
 int spellcheck_suggest(void * chk, char ***sug, const char * word)
 {
 	if (NULL == chk)
@@ -127,7 +142,10 @@ int spellcheck_suggest(void * chk, char ***sug, const char * word)
 		return 0;
 	}
 
-	return Hunspell_suggest((Hunhandle *)chk, sug, word);
+	LGPTHREAD(pthread_mutex_lock(&hunspell_lock);)
+	int rc = Hunspell_suggest((Hunhandle *)chk, sug, word);
+	LGPTHREAD(pthread_mutex_unlock(&hunspell_lock);)
+	return rc;
 }
 
 void spellcheck_free_suggest(void *chk, char **sug, int size)

--- a/link-grammar/tokenize/spellcheck-hun.c
+++ b/link-grammar/tokenize/spellcheck-hun.c
@@ -10,12 +10,12 @@
 /*                                                                       */
 /*************************************************************************/
 
+#ifdef HAVE_HUNSPELL
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "link-includes.h"
 #include "spellcheck.h"
-
-#ifdef HAVE_HUNSPELL
 
 #ifndef HUNSPELL_DICT_DIR
 #define HUNSPELL_DICT_DIR (char *)0

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -429,6 +429,7 @@ static void wordgraph_show_cancel(void)
  */
 static bool x_popen(const char *cmd, const char *wgds)
 {
+	lgdebug(+3, "Invoking: %s\n", cmd);
 	FILE *const cmdf = popen(cmd, "w");
 	bool rc = true;
 
@@ -439,9 +440,9 @@ static bool x_popen(const char *cmd, const char *wgds)
 	}
 	else
 	{
-		if (fprintf(cmdf, "%s", wgds) == -1)
+		if (fputs(wgds, cmdf) == EOF) /* see default_error_handler() */
 		{
-			prt_error("Error: print to display command: %s\n", strerror(errno));
+			prt_error("Error: x_popen(): fputs() error: %s\n", strerror(errno));
 			rc = false;
 		}
 		if (pclose(cmdf) == -1)

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -588,10 +588,10 @@ bool sentence_display_wordgraph(Sentence sent, const char *modestr)
 		}
 		else
 		{
-			if (fprintf(gvf, "%s", wgds) == -1)
+			if (fputs(wgds, gvf) == EOF)
 			{
 				gvf_error = true;
-				prt_error("Error: %s(): print to %s failed: %s\n",
+				prt_error("Error: %s(): fputs() to %s failed: %s\n",
 							 __func__, gvf_name, strerror(errno));
 			}
 			if (fclose(gvf) == EOF)

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -447,7 +447,7 @@ static bool x_popen(const char *cmd, const char *wgds)
 		}
 		if (pclose(cmdf) == -1)
 		{
-			prt_error("Error: pclose of display command: %s\n", strerror(errno));
+			prt_error("Error: x_popen(): pclose() error: %s\n", strerror(errno));
 			rc = false;
 		}
 	}
@@ -583,7 +583,7 @@ bool sentence_display_wordgraph(Sentence sent, const char *modestr)
 		gvf = fopen(gvf_name, "w");
 		if (NULL == gvf)
 		{
-			prt_error("Error: %s(): open %s failed: %s\n",
+			prt_error("Error: %s(): fopen() of %s failed: %s\n",
 						 __func__, gvf_name, strerror(errno));
 			gvf_error = true;
 		}
@@ -598,7 +598,7 @@ bool sentence_display_wordgraph(Sentence sent, const char *modestr)
 			if (fclose(gvf) == EOF)
 			{
 				gvf_error = true;
-				prt_error("Error: %s(): close %s failed: %s\n",
+				prt_error("Error: %s(): fclose() of %s failed: %s\n",
 							  __func__, gvf_name, strerror(errno));
 			}
 		}

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -130,6 +130,7 @@ typedef SSIZE_T ssize_t;
 #define iswspace_l  _iswspace_l
 #define towlower_l  _towlower_l
 #define towupper_l  _towupper_l
+#define strtod_l    _strtod_l
 #define freelocale _free_locale
 #endif /* HAVE_LOCALE_T */
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -103,6 +103,7 @@ void *alloca (size_t);
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif
+#undef rand_r  /* Avoid (a bad) definition on MinGW */
 int rand_r(unsigned int *);
 #ifndef __MINGW32__
 /* No strtok_s in XP/2003 and their strtok_r is incompatible.

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -50,7 +50,7 @@ static wchar_t * prompt(EditLine *el)
  * @param is_help \p input is the argument of an !help command.
  * @return 3 types of values:
  *  <code>""</code> There are no completions.
- *  <code>NULL</code> Choices help have been printed.
+ *  <code>NULL</code> Input not supported, or choices help has been printed.
  *  A NUL-terminated byte string (to be used as a completion).
  */
 static char *complete_command(const wchar_t *input, size_t len, bool is_help)
@@ -75,7 +75,7 @@ static char *complete_command(const wchar_t *input, size_t len, bool is_help)
 	char *astr = malloc(len+1);
 	for (size_t i = 0; i < len; i++)
 	{
-		if (input[i] < 0 || input[i] > 127)
+		if (input[i] <= 0 || input[i] > 127)
 		{
 			free(astr);
 			return NULL; /* unsupported input */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -601,6 +601,10 @@ int main(int argc, char * argv[])
 		prt_error("Fatal error: Unable to parse command line\n");
 		exit(-1);
 	}
+
+#ifdef _MSC_VER
+	_set_printf_count_output(1); /* enable %n support for display_1line_help()*/
+#endif /* _MSC_VER */
 #endif /* _WIN32 */
 
 #if LATER

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -92,10 +92,6 @@ static char * get_terminal_line(char *input_string, FILE *in, FILE *out)
 	const char *prompt = (0 == verbosity)? "" : "linkparser> ";
 
 #ifdef HAVE_EDITLINE
-	#ifdef _WIN32
-		#error __FILE__ ": Cannot use HAVE_EDITLINE "
-		                "(the console already has line editing and history)."
-	#endif /* _WIN32 */
 	pline = lg_readline(prompt);
 #else
 	fprintf(out, "%s", prompt);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -605,6 +605,8 @@ int main(int argc, char * argv[])
 #ifdef _MSC_VER
 	_set_printf_count_output(1); /* enable %n support for display_1line_help()*/
 #endif /* _MSC_VER */
+
+	win32_set_utf8_output();
 #endif /* _WIN32 */
 
 #if LATER
@@ -674,10 +676,6 @@ int main(int argc, char * argv[])
 			print_usage(stderr, argv[0], -1);
 		}
 	}
-
-#ifdef _WIN32
-	win32_set_utf8_output();
-#endif /* _WIN32 */
 
 	if (language && *language)
 	{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -597,6 +597,14 @@ int main(int argc, char * argv[])
 	const char *ostype = getenv("OSTYPE");
 	if ((NULL != ostype) && (0 == strcmp(ostype, "cygwin")))
 		running_under_cygwin = true;
+
+	/* argv encoding is in the current locale. */
+	argv = argv2utf8(argc);
+	if (NULL == argv)
+	{
+		prt_error("Fatal error: Unable to parse command line\n");
+		exit(-1);
+	}
 #endif /* _WIN32 */
 
 #if LATER

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -31,6 +31,7 @@ typedef SSIZE_T ssize_t;
 
 char *get_console_line(void);
 void win32_set_utf8_output(void);
+char **argv2utf8(int);
 int lg_isatty(int);
 #define isatty lg_isatty
 #endif /* _WIN32 */

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -93,10 +93,12 @@ LEFT-WALL this.p is.v a  test.n
 
 Test results
 ------------
-All the `tests.py` tests pass, along with all the tests in the `tests`
-directory (including the `multi-java` test) and `make installcheck`.
+All the `tests.py` tests pass, and also `make installcheck` is fine.
+From the tests in the `tests/`directory, the `multi-thread` test fails due to segfault
+at the hunspell library (a fix for that is being investigated). Regretfully, using
+Aspell for now is not an option, as it is not available yet for MinGW.
 
-Here is how to run the `java-multi` test directly:<br>
+BTW, here is how to run the `java-multi` test directly:<br>
 `cd tests; make TEST_LOGS=multi-java check-TESTS`
 
 Running

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -68,11 +68,6 @@ In MINGW64, the default install prefix is `/mingw64` which is mapped to
 will be found at `C:\msys64\mingw64\bin` and the dictionary files at
 `C:\msys64\mingw64\share\link-grammar`.
 
-In case you would like to build with hunspell, invoke `configure` as follows:<br>
-```
-configure --with-hunspell-dictdir=`cygpath -m /mingw64/share/myspell/dicts`
-```
-
 
 Python bindings
 ---------------

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -45,6 +45,8 @@ mingw-w64-x86_64-libtre-git<br>
 mingw-w64-x86_64-gettext<br>
 mingw-w64-x86_64-hunspell, mingw-w64-x86_64-hunspell-en (optional)<br>
 zlib-devel (optional - for the SAT parser)<br>
+mingw-w64-x86_64-python2<br>
+mingw-w64-x86_64-python3<br>
 
 Java bindings
 -------------

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -71,39 +71,25 @@ will be found at `C:\msys64\mingw64\bin` and the dictionary files at
 
 Python bindings
 ---------------
-The bindings for Python2 (package `python2 2.7.13-1` for MSYS) work fine.<br>
+The bindings for Python2 (2.7.15) and Python3 (3.7.0) work fine.<br>
 All the tests pass (when configured with `hunspell` and the SAT parser).
 
-Here is a way to work with it from Windows:
+Here is a way to work with python3 from Windows:
 ```
-C:\>cd msys64\mingw64\bin
-C:\msys64\mingw64\bin>C:\msys64\usr\bin\python2.exe
-Python 2.7.13 (default, Feb 14 2017, 14:46:01)
-[GCC 6.3.0] on msys
+C:\>cd \msys64\mingw64\bin
+C:\msys64\mingw64\bin>.\python3
+Python 3.7.0 (default, Jul 14 2018, 09:27:14)  [GCC 7.3.0 64 bit (AMD64)] on win32
 Type "help", "copyright", "credits" or "license" for more information.
->>> import sys
->>> sys.path.insert(0, 'C:\msys64\mingw64\lib\python2.7\site-packages')
->>> import linkgrammar
+>>> from linkgrammar import *
+>>> print(Sentence("This is a test",Dictionary(),ParseOptions()).parse().next().diagram())
+
+    +----->WV----->+---Ost--+
+    +-->Wd---+-Ss*b+  +Ds**c+
+    |        |     |  |     |
+LEFT-WALL this.p is.v a  test.n
+
 >>>
 ```
-(Alternatively, you can add `C:\>cd msys64\mingw64;C:\msys64\usr\bin` to the PATH
-and set `PYTHONPATH=C:\msys64\mingw64\lib\python2.7\site-packages`).
-
-However the bindings for the MINGW64 Python2 and Python3 don't work. For the MINGW64 version
-`mingw-w64-x86_64-python3-3.6.4-2` (and similarly for mingw-w64-x86_64-python2-2.7.14-5`)
-it even doesn't compile due to problems in its `pyconfig.h`:
-```
-/mingw64/include/python3.6m/pyconfig.h:1546:15: error: two or more data types in declaration specifiers
- #define uid_t int
-/mingw64/include/python3.6m/pyport.h:705:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
- #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
-```
-
-The binding for the MSYS Python3 (named just `python`) compile, but
-importing `link-grammar` causes the infamous problem of
-`Fatal Python error: PyThreadState_Get: no current thread`.
-(This version also insists that the _clinkparser module name will end with
-`.pyd` and not `dll`.)
 
 Test results
 ------------

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -30,6 +30,8 @@ First install `mingw-w64-x86_64-toolchain`. Also install the rest of the
 prerequisite tools from the list in the main
 [README](/README.md#building-from-the-github-repository).
 
+NOTE: You must also install **mingw-w64-x86_64-pkg-config** .
+
 You may find that the system is extremely slow. In that case, consult the
 Web for how to make tweaks that considerably speed it up. In addition, to
 avoid I/O trashing, don't use a too high `make` parallelism (maybe even

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -15,7 +15,7 @@ A note for new MSYS2 users
 --------------------------
 Download and install MinGW/MSYS2 from http://msys2.org.
 
-MSYS2 uses the `pacman`package management. If you are not familiar
+MSYS2 uses the `pacman` package management. If you are not familiar
 with it, consult the
 [Pacman Rosetta](https://wiki.archlinux.org/index.php/Pacman/Rosetta).
 
@@ -56,9 +56,9 @@ Then build and install link-grammar with
 
      mkdir build
      cd build
-	 ../configure
-	 make
-	 make install
+     ../configure
+     make
+     make install
 
 In MINGW64, the default install prefix is `/mingw64` which is mapped to
 `C:\msys64\mingw64`, so after 'make install', the libraries and executable
@@ -66,7 +66,9 @@ will be found at `C:\msys64\mingw64\bin` and the dictionary files at
 `C:\msys64\mingw64\share\link-grammar`.
 
 In case you would like to build with hunspell, invoke `configure` as follows:<br>
-`--with-hunspell-dictdir=`cygpath -m /mingw64/share/myspell/dicts`
+```
+configure --with-hunspell-dictdir=`cygpath -m /mingw64/share/myspell/dicts`
+```
 
 
 Python bindings
@@ -110,7 +112,7 @@ Test results
 All the `tests.py` tests pass, along with all the tests in the `tests`
 directory (including the `multi-java` test) and `make installcheck`.
 
-Here is how to run the `java-multi` directly:<br>
+Here is how to run the `java-multi` test directly:<br>
 `cd tests; make TEST_LOGS=multi-java check-TESTS`
 
 Running

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -44,7 +44,6 @@ mingw-w64-x86_64-sqlite3<br>
 mingw-w64-x86_64-libtre-git<br>
 mingw-w64-x86_64-gettext<br>
 mingw-w64-x86_64-hunspell, mingw-w64-x86_64-hunspell-en (optional)<br>
-libedit-devel (optional but recommended)<br>
 zlib-devel (optional - for the SAT parser)<br>
 
 Java bindings

--- a/mingw/README-MSYS2.md
+++ b/mingw/README-MSYS2.md
@@ -104,5 +104,7 @@ BTW, here is how to run the `java-multi` test directly:<br>
 Running
 -------
 On MINGW64, just invoke `link-parser`.<br>
-In Windows, put `C:\msys64\mingw64\bin` in your PATH (or cd to it), then invoke `link-parser`.
+In Windows, put `C:\msys64\mingw64\bin` in your PATH (or `cd` to it), then invoke `link-parser`.
+On both MINGW64 and Windows console, you can invoke `mingw/link-parser.bat`, which also
+sets PATH for the `dot` and `PhotoViewer` commands (needed for the wordgraph display feature).
 For more details see [RUNNING the program](/README.md#running-the-program).

--- a/mingw/link-parser.bat
+++ b/mingw/link-parser.bat
@@ -1,0 +1,17 @@
+%= A link-parser.exe wrapper for MinGW64 =%
+%- This wraper can be invoked from MINGW64 or from a the Windows console. =%
+@echo off
+setlocal
+if defined ProgramW6432 set ProgramFiles=%ProgramW6432%
+
+REM Prepend the MinGW64 binary path
+set "PATH=C:\msys64\mingw64\bin;%PATH%"
+
+REM For USE_WORDGRAPH_DISPLAY
+REM Path for "dot.exe"
+REM set "PATH=C:\cygwin64\bin;%PATH%"
+set "PATH=%ProgramFiles(x86)%\Graphviz2.38\bin;%PATH%"
+REM Path for "PhotoViewer.dll"
+set "PATH=%ProgramFiles%\Windows Photo Viewer;%PATH%"
+
+%debug_cmd% link-parser.exe %*

--- a/msvc/LGlib-features.props
+++ b/msvc/LGlib-features.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
+    <PKGDATADIR>"..\\data"</PKGDATADIR>
     <DEFS>USE_WORDGRAPH_DISPLAY;</DEFS>
   </PropertyGroup>
   <PropertyGroup>
@@ -9,10 +10,13 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>$(DEFS);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(DEFS);DICTIONARY_DIR=$(PKGDATADIR);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <BuildMacro Include="PKGDATADIR">
+      <Value>$(PKGDATADIR)</Value>
+    </BuildMacro>
     <BuildMacro Include="DEFS">
       <Value>$(DEFS)</Value>
       <EnvironmentVariable>true</EnvironmentVariable>

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -292,8 +292,8 @@ Samba), and still be able to use the custom build steps in the Project files,
 there is a need to "convince" Windows it is a local filesystem.  Else you will
 get "UNC path are not supported." on the batch runs, with bad results. This
 method will also allow the `link-parser.bat` file to run.  (For other solutions
-see tackoverflow.com/questions/9013941). You will need to find out by yourself
-if this makes a security or another problem in your case.
+see https:/stackoverflow.com/questions/9013941). You will need to find out by
+yourself if this makes a security or another problem in your case.
 
 Here is what worked for me:<br>
 Suppose you use `host:/usr/local/src` remotely as share `src`:

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -7,7 +7,7 @@ This directory contains project files for building Link Grammar with the
 Microsoft Visual Studio 2017 IDE (MSVC15). They were created and tested with
 the Community Edition of that product.
 
-**!!!WARNING!!!**
+**!!!WARNING!!!**<br>
 In the examples below, "console-prompt>" at start of line means the console
 prompt.  Don't type it because the result could be destructive!
 
@@ -171,7 +171,7 @@ console-prompt>make-check [PYTHON_FLAG] PYTHON_OUTDIR [script.py] [ARGUMENTS]
 
 - PYTHON_FLAG: Optional flag for the Python program, e.g. `-vv` to debug
 imports.
-- PYTHON_OUTDIR: The directory to which the Python bindings got written.
+- PYTHON_OUTDIR: The directory to which the Python bindings got written.<br>
 For example, `x64\Release\Python3`.
 - script.py: Path leading to the script. If only a filename is specified
 (i.e. no `\` in the path) the specified script file is taken from the
@@ -263,11 +263,11 @@ For using the library independently of the build directory:
 
 1) If Python bindings were generated, copy the following modules to a
    directory `linkgrammar` in a fixed location: `linkgrammar.py`,
-   `clinkgrammar.py`, `__init__.py`, `_clinkgrammar.pyd`.
+   `clinkgrammar.py`, `__init__.py`, `_clinkgrammar.pyd`.<br>
    Set the PYTHONPATH environment variable to point to the said
    "linkgrammar" directory.
 
-2) Copy the link-grammar DLL to a fixed location.
+2) Copy the link-grammar DLL to a fixed location.<br>
    Add the DLL location permanently to PATH.
 
 3) Copy the `data` directory to the location of the DLL so it will get found.
@@ -295,13 +295,13 @@ method will also allow the `link-parser.bat` file to run.  (For other solutions
 see tackoverflow.com/questions/9013941). You will need to find out by yourself
 if this makes a security or another problem in your case.
 
-Here is what worked for me:
+Here is what worked for me:<br>
 Suppose you use `host:/usr/local/src` remotely as share `src`:
 ```
 mklink /J src-j \\host\src
 mklink /D src src-link
 ```
-The second one needs administrator privileges.
+The second one needs administrator privileges.<br>
 Then use the repository through `src`.
 
 Debugging hints

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -303,3 +303,19 @@ mklink /D src src-link
 ```
 The second one needs administrator privileges.
 Then use the repository through "src".
+
+Debugging hints
+--------------
+If, when starting the program under the debugger (by "Local Windows Debugger",
+"Debug->Start Debugging" (F5), etc.), `regex.dll` is not found, it can be
+added to the search `PATH` as follows:<br>
+Enter to LinkGrammarExe's Property Pages:<br>
+ `Solution Explorer->LinkGrammarExe->Properties`<br>
+Click on the writable location of:<br>
+ `Debugging->Environment`<br>
+Put there (LG_DLLPATH is defined in the `Local` Property pages):<br>
+`PATH=$(LG_DLLPATH)`<br>
+Make sure "Merge Environment" there is `Yes`.
+
+(The result is kept in `.user` Property Pages that are not part of the
+LG repository).

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -291,18 +291,18 @@ In order to use a link-grammar source repository from a network share (e.g. via
 Samba), and still be able to use the custom build steps in the Project files,
 there is a need to "convince" Windows it is a local filesystem.  Else you will
 get "UNC path are not supported." on the batch runs, with bad results. This
-method will also allow the "link-parser.bat" file to run.  (For other solutions
+method will also allow the `link-parser.bat` file to run.  (For other solutions
 see tackoverflow.com/questions/9013941). You will need to find out by yourself
 if this makes a security or another problem in your case.
 
 Here is what worked for me:
-Suppose you use host:/usr/local/src remotely as share "src":
+Suppose you use `host:/usr/local/src` remotely as share `src`:
 ```
 mklink /J src-j \\host\src
 mklink /D src src-link
 ```
 The second one needs administrator privileges.
-Then use the repository through "src".
+Then use the repository through `src`.
 
 Debugging hints
 --------------

--- a/msvc/make-check.py
+++ b/msvc/make-check.py
@@ -42,9 +42,9 @@ def read_props(vsfile):
     macdef_re = re.compile(r'<(\w+)>([^<]*)<')
     for line in vs_f:
         read_m = re.search(macdef_re, line)
-        if None == read_m:
+        if read_m is None:
             continue
-        if 2 != len(read_m.groups()):
+        if len(read_m.groups()) != 2:
             error('Bad line in "{}": {}'.format(vsfile, line))
         local_prop[read_m.group(1)] = read_m.group(2)
     if not local_prop:
@@ -57,20 +57,20 @@ def get_prop(prop, default=NODEFAULT):
     Resolve a macro definition.
     """
     prop_val = local_prop.get(prop, None)
-    if None == prop_val:
+    if prop_val is None:
         if default is NODEFAULT:
             error('Property "{}" not found in {}' .format(prop, local_prop_file))
         return default
 
     while True:
         prop_m = re.search(prop_re, prop_val)
-        if None == prop_m:
+        if prop_m is None:
             break
         prop_rep = prop_m.group(1)
         prop_repval = local_prop.get(prop_rep, None)
-        if None == prop_repval:
+        if prop_repval is None:
             prop_repval = os.getenv(prop_rep)
-            if None == prop_repval:
+            if prop_repval is None:
                 error('Property "{}" not found in "{}" and also not in the environment'. \
                       format(prop_rep, local_prop_file))
         prop_val = str.replace(prop_val, '$('+prop_rep+')', prop_repval)
@@ -89,7 +89,7 @@ if len(sys.argv) < 2:
     error('Missing argument')
 
 pyargs = ''
-if len(sys.argv[1]) > 0 and sys.argv[1][0] == '-':
+if sys.argv[1] and sys.argv[1][0] == '-':
     pyargs = sys.argv.pop(1)
 
 if len(sys.argv) < 2:

--- a/msvc/make-check.py
+++ b/msvc/make-check.py
@@ -25,7 +25,7 @@ import re
 local_prop_file = 'Local.props' # In this directory
 scriptdir = r'..\bindings\python-examples'
 pyscript = 'tests.py'
-os.environ["LINK_GRAMMAR_DATA"] = r'..' # "data" in the parent directory
+#os.environ["LINK_GRAMMAR_DATA"] = r'../data'
 
 def error(msg):
     if msg:

--- a/msvc/post-build.bat
+++ b/msvc/post-build.bat
@@ -30,7 +30,7 @@ echo %~f0: Info: Creating %lgcmd%.bat in %cd%
 	echo REM Copy it to a directory in your PATH and modify it if needed.
 	echo.
 
-	echo REM The following prepends LG_DDLPATH from msvc14\Local.props
+	echo REM The following prepends LG_DDLPATH from msvc\Local.props
 	echo set "PATH=%LG_DLLPATH%;%%PATH%%"
 	echo.
 	echo REM For USE_WORDGRAPH_DISPLAY


### PR DESCRIPTION
I'm trying to improve the Windows ports (MinGW, Cygwin and MSVC) so they will be in the same level as on Linux. This is a work in progress, but it has mostly be done.

The number of commits for that is now very big, and I also did many more general fixes in the way (that help with Windows too).
This big number of changes can make it hard to review, due to the volume and diversity.

So I will gather the commits mostly according to type (Windows, configure, tests, and more) and will start to send PRs.
(Beside of that, I have a huge number of backlog changes in many branches, some are incomplete, but some only need final touch, or merging due to code changes meanwhile.)

This is the first PR from the backlog.
Main changes:
- WIN32: Add #define for strtod_l()
  Fix compilation problem MSVC in the last PR (#805).
- MSVC: Call _set_printf_count_output(1) to enable using %n format
- Windows: Convert argv from the startup locale to UTF-8 (solve possible crahshs)
- Use fputs() instead of printf() - printf() on Windows sometimes has redirection problems maybe because problems related to POSIX functions
- Windows: jni-client.c: Disable langinfo.h and its usage
- Documentation fixes and updates
- Support DICTIONARY_DIR on MinGW and MSVC
- Fix configuring hunspell on MinGW
- MinGW: Solve hunspell crash on multi-threading
- MinGW: Avoid a (bad) macro definition of rand_r
- Fix compilation warnings
- Cygwin: Python bindings
- MinGW: Fix the problematic Python bindings

Still WIP (for future PRs):
- Windows wordgraph-display improvements.
- Optional use of pcre2 (motivated by a need for Cygwin, but it runs much faster on Linux too).
