### PR TITLE
Windows - additions to PR#806

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,4 +55,5 @@ EXTRA_DIST =            \
 	mingw/README-Cygwin.md                 \
 	mingw/README-MSYS.md                   \
 	mingw/README-MSYS2.md                  \
+	mingw/link-parser.bat                  \
 	TODO

--- a/Makefile.am
+++ b/Makefile.am
@@ -56,4 +56,5 @@ EXTRA_DIST =            \
 	mingw/README-MSYS.md                   \
 	mingw/README-MSYS2.md                  \
 	mingw/link-parser.bat                  \
+	mingw/link-parser-cygwin.bat           \
 	TODO

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -733,6 +733,10 @@ class HEnglishLinkageTestCase(unittest.TestCase):
 class GSQLDictTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        if os.name == 'nt' and \
+                -1 == clg.linkgrammar_get_configuration().lower().find('mingw'):
+            raise unittest.SkipTest("No SQL dict support yet on the MSVC build")
+
         #clg.parse_options_set_verbosity(clg.parse_options_create(), 3)
         cls.d, cls.po = Dictionary(lang='demo-sql'), ParseOptions()
 

--- a/mingw/link-parser-cygwin.bat
+++ b/mingw/link-parser-cygwin.bat
@@ -1,0 +1,19 @@
+%= A link-parser.exe wrapper for Cygwin =%
+%= This wraper can be invoked from Cygwin or from a the Windows console. =%
+@echo off
+setlocal
+if defined ProgramW6432 set ProgramFiles=%ProgramW6432%
+
+
+REM Add the Cygwin binary path
+set "PATH=%PATH%;C:\cygwin64\bin;\cygwin64\usr\local\bin"
+
+REM For USE_WORDGRAPH_DISPLAY
+REM "dot.exe, if exists, is in C:\cygwin64\bin
+REM set "PATH=%ProgramFiles(x86)%\Graphviz2.38\bin;%PATH%"
+REM Path for "PhotoViewer.dll"
+set "PATH=%ProgramFiles%\Windows Photo Viewer;%PATH%"
+path
+which link-parser.exe
+
+%debug_cmd% link-parser.exe %*

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -263,7 +263,8 @@ For using the library independently of the build directory:
 
 1) If Python bindings were generated, copy the following modules to a
    directory `linkgrammar` in a fixed location: `linkgrammar.py`,
-   `clinkgrammar.py`, `__init__.py`, `_clinkgrammar.pyd`.<br>
+   `clinkgrammar.py`, `__init__.py`, `_clinkgrammar.pyd`.
+
    Set the PYTHONPATH environment variable to point to the said
    "linkgrammar" directory.
 
@@ -292,7 +293,7 @@ Samba), and still be able to use the custom build steps in the Project files,
 there is a need to "convince" Windows it is a local filesystem.  Else you will
 get "UNC path are not supported." on the batch runs, with bad results. This
 method will also allow the `link-parser.bat` file to run.  (For other solutions
-see https:/stackoverflow.com/questions/9013941). You will need to find out by
+see https://stackoverflow.com/questions/9013941). You will need to find out by
 yourself if this makes a security or another problem in your case.
 
 Here is what worked for me:<br>


### PR DESCRIPTION
- Fix problems from PR #806.

- Add invocation file for Cygwin.
  It is added in the `mingw` directory. Historically the Cygwin port uses MNinGW under Cygwin, but now it uses a pure Cygwin compilation environment. So maybe it will be better to create a separate directory `cygwin` in the sources toplevel.

- MSVC: Skip the demo-sql test (not compiled with SQLite)
  There is no way for now to find out if an SQLite dict cannot be opened due to SQLite problem or because the code was not compiled with SQLite support, so the test is skipped if Windows/MSVC is detected. This can be solved by adding "SQLite" (if supported) to the extended version string (I will try that).
