### PR TITLE
Swig-related changes

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -24,6 +24,10 @@
 %mutable;
 %rename("%s") "";                    /* Grab everything for the rest of file. */
 
+// Set a default newfree typemap.
+%typemap(newfree) char * {
+   free($1);
+}
 
 const char * linkgrammar_get_version(void);
 const char * linkgrammar_get_configuration(void);

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -130,7 +130,7 @@ int  sentence_link_cost(Sentence sent, int i);
 %newobject linkage_print_diagram;
 %newobject linkage_print_postscript;
 %newobject linkage_print_constituent_tree;
-
+%newobject linkage_print_disjuncts;
 
 Linkage linkage_create(int index, Sentence sent, Parse_Options opts);
 void linkage_delete(Linkage linkage);

--- a/configure.ac
+++ b/configure.ac
@@ -834,6 +834,9 @@ fi
 if test -n "$swig_required"; then
 	AX_PKG_SWIG(2.0.0,, [AC_MSG_ERROR(['swig' is required to create bindings for: $swig_required])])
 	AX_SWIG_ENABLE_CXX
+	SWIGfound="$SWIG"
+else
+	SWIGfound=no
 fi
 AM_CONDITIONAL(HAVE_SWIG, test -n "$SWIG")
 


### PR DESCRIPTION
- configure.ac: Restore "swig" in configuration settings summary
  (value disappeared due to a previous change.)

- SWIG: Fix a crash in get_data_dir()
  Without a newfree typemap, "operator delete" is used instead of free()...
  I found it due to a crash.

- SWIG: Add apparently forgotten %newobject linkage_print_disjuncts