### PR TITLE
Fix  read dict cost when ther is no locale_t + add/change tests

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -322,6 +322,8 @@ class DBasicParsingTestCase(unittest.TestCase):
         linkage = self.parse_sent("This is a silly sentence.")[0]
         self.assertEqual([len(l) for l in linkage.links()], [6,2,1,1,3,2,1,1,1])
 
+    # The following test is using the locale "tr_TR.UTF-8".
+    # It is skipped if it is not installed in the system.
     def test_dictionary_locale_definition(self):
         if is_python2(): # Locale stuff seems to be broken
             raise unittest.SkipTest("Test not supported with Python2")
@@ -332,7 +334,11 @@ class DBasicParsingTestCase(unittest.TestCase):
         #print('toupper hij:', 'hij'.upper())
 
         tr_locale = 'tr_TR.UTF-8' if os.name != 'nt' else 'Turkish'
-        locale.setlocale(locale.LC_CTYPE, tr_locale)
+        try:
+            locale.setlocale(locale.LC_CTYPE, tr_locale)
+        except locale.Error as e:
+            raise unittest.SkipTest("Locale {}: {}".format(tr_locale, e))
+
         #print('Turkish locale:', locale.setlocale(locale.LC_CTYPE, None))
 
         # python2: prints HiJ (lowercase small i in the middle)

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1035,7 +1035,7 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
 
         # Lines starting with "-" contain a Parse Option
         elif line[0] == '-':
-            exec('popt.' + line[1:], None, locals())
+                exec('popt.' + line[1:]) in {}, locals()
 
         elif line[0] in '%\r\n':
             pass

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -154,6 +154,11 @@ dictionary_six_str(const char * lang,
 	}
 
 	/* Read dictionary from the input string. */
+
+	/* Make sure "." is used in string conversion to floating point.
+	 * FIXME: Use a locale-agnostic conversion function. */
+	setlocale(LC_NUMERIC, "C");
+
 	dict->input = input;
 	dict->pin = dict->input;
 	if (!read_dictionary(dict))

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -658,6 +658,7 @@ char * get_default_locale(void)
 	return safe_strdup(locale);
 }
 
+#ifdef HAVE_LOCALE_T
 static locale_t get_C_LC_NUMERIC(void)
 {
 	static locale_t locobj;
@@ -672,6 +673,7 @@ static locale_t get_C_LC_NUMERIC(void)
 
 	return locobj;
 }
+#endif /* HAVE_LOCALE_T */
 
 bool strtodC(const char *s, double *r)
 {
@@ -680,12 +682,7 @@ bool strtodC(const char *s, double *r)
 #ifdef HAVE_LOCALE_T
 	double val = strtod_l(s, &err, get_C_LC_NUMERIC());
 #else
-	static bool is_lc_numeric_c;
-	if (!is_lc_numeric_c)
-	{
-		is_lc_numeric_c = true;
-		setlocal(LC_NUMERIC, "C");
-	}
+	/* dictionary_setup_locale() invokes setlocale(LC_NUMERIC, "C") */
 	double val = strtod(s, &err);
 #endif /* HAVE_LOCALE_T */
 

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -659,6 +659,8 @@ char * get_default_locale(void)
 }
 
 #ifdef HAVE_LOCALE_T
+static void free_C_LC_NUMERIC(void);
+
 static locale_t get_C_LC_NUMERIC(void)
 {
 	static locale_t locobj;
@@ -671,7 +673,14 @@ static locale_t get_C_LC_NUMERIC(void)
 	locobj = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
 #endif /* _WIN32 */
 
+	atexit(free_C_LC_NUMERIC);
+
 	return locobj;
+}
+
+static void free_C_LC_NUMERIC(void)
+{
+	freelocale(get_C_LC_NUMERIC());
 }
 #endif /* HAVE_LOCALE_T */
 


### PR DESCRIPTION
1. Locale-related tests:
-- Fix converting dict cost to float in case no locale_t:
On MinGW there is still no locale_t (this is the only system that I have access to with no locale_t, on MSVC/Linux/BSD/OSX there is locale_t). In that case my recent fix 01f3044bcba9631311de407598872eb19475f321 is buggy.
-- Add dict cost reading with a comma-separator LC_NUMERIC.
-- Move the per-dict locale test to its own class.
So if it fails, the test teardown will restore the previous locale.
Also skip it if no tr locale (may be better than a test failure).

2. Test creating dictionary using various dictionary directory paths:
-- Test opening dictionary by relative/absolute paths.
It validates success and also that the dictionary language is set properly.
This also validate the recent directory-separator handling change.

The tests run successfully on Linux, MinGW64, MSVC 15, and newest macOS (using Homebrew libtr and python). On Cygwin the regex `\w` test fails - I will send a patch soon.

