### PR TITLE
Regex-related fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -604,22 +604,84 @@ then
 fi
 
 # ====================================================================
-# Find a regex library that supports regexec().
-# Check in this order: libtre, libc, libregex.
+# Configure a regex library that supports UTF-8 and a POSIX interface.
+dnl AC_CHECK_HEADERS defines HAVE_FILENAME_H if found.
 
-AC_CHECK_HEADER([tre/regex.h], [AC_CHECK_LIB(tre, regexec, [REGEX_LIBS=-ltre])])
+AC_ARG_WITH([regexlib],
+	[AS_HELP_STRING([--with-regexlib=pcre2|tre|regex|c],
+	[Use the pecified regex library (default=first found)])],
+	[], with_regexlib=)
+
+lgregexlib=--with-regexlib="$with_regexlib"
+
+case $with_regexlib in
+	'')
+		break
+		;;
+	pcre2)
+		AC_CHECK_HEADERS([pcre2.h], ,
+		                 [AC_MSG_ERROR([$lgregexlib: pcre2.h not found])],
+							  [#define PCRE2_CODE_UNIT_WIDTH 8])
+		PKG_CHECK_MODULES([REGEX], [libpcre2-8])
+		;;
+	tre)
+		AC_CHECK_HEADERS([tre/regex.h], ,
+		                 [AC_MSG_ERROR([$lgregexlib: tre/regex.h not found])])
+		PKG_CHECK_MODULES([REGEX], [tre])
+		;;
+	regex)
+		AC_CHECK_HEADERS([regex.h], ,[AC_MSG_ERROR([No regex.h header found])])
+		AC_CHECK_LIB([regex], [regexec], [REGEX_LIBS=-lregex],
+		             [AC_MSG_ERROR([$lgregexlib: regexec() not found])])
+		;;
+	c)
+		AC_CHECK_HEADERS([regex.h], ,[AC_MSG_ERROR([No regex.h header found])])
+		AC_CHECK_FUNCS(regexec, [REGEX_LIBS=-lc],
+		               [AC_MSG_ERROR([$lgregexlib: regexec() not found])])
+		;;
+	*)
+		AC_MSG_ERROR([$lgregexlib: Library not configurable (see configure --help)])
+		;;
+esac
 
 if test -z "$REGEX_LIBS"; then
-	AC_CHECK_HEADER([regex.h], ,[AC_MSG_ERROR([No regex.h header found])])
-	AC_CHECK_FUNCS(regexec, ,
-					[AC_CHECK_LIB(regex, regexec, REGEX_LIBS=-lregex,
-	                             [AC_MSG_ERROR([No regex library found])])])
+	AC_MSG_NOTICE([Checking for REGEX implementation:])
+fi
+dnl Find the first regex library according to this order:
+dnl libpcre2-8, libtre, libregex, libc.
+
+if test -z "$REGEX_LIBS"; then
+	AC_CHECK_HEADER([pcre2.h],
+		[PKG_CHECK_MODULES([REGEX], [libpcre2-8],
+								 [AC_DEFINE([HAVE_PCRE2_H], 1)],
+								 [AC_MSG_RESULT([... missing libpcre2-8, continuing])])]
+							    , , [#define PCRE2_CODE_UNIT_WIDTH 8])
+
+fi
+if test -z "$REGEX_LIBS"; then
+	AC_CHECK_HEADER([tre/regex.h],
+		[PKG_CHECK_MODULES([REGEX], [tre],
+								 [AC_DEFINE([HAVE_TRE_REGEX_H], 1)],
+								 [AC_MSG_RESULT([... missing libtre, continuing])])])
+fi
+if test -z "$REGEX_LIBS"; then
+	AC_CHECK_HEADERS([regex.h],
+		[AC_CHECK_LIB([regex], [regex], [REGEX_LIBS=-lregex],
+		              [AC_MSG_RESULT([... libregex not found, continuing])]
+		              [AC_CHECK_FUNCS([regexec], [REGEX_LIBS=-lc])])],
+		[AC_MSG_ERROR([No regex.h header found])])
 fi
 
-if test "x$REGEX_LIBS" = "x-ltre"; then
-	AC_DEFINE(HAVE_TRE_TRE_H, 1)
+if test -n "$REGEX_LIBS"; then
+	AC_MSG_RESULT([... found REGEX implementation: $REGEX_LIBS])
+	test "x$REGEX_LIBS" = x-lc && REGEX_LIBS=
+	test -n "$REGEX_CFLAGS" && CFLAGS="$CFLAGS $REGEX_CFLAGS"
+else
+	AC_MSG_ERROR([No REGEX implementation found])
 fi
+
 AC_SUBST(REGEX_LIBS)
+AC_SUBST(REGEX_CFLAGS)
 
 # =====================================================================
 # Try to guess location of the jni.h file.

--- a/configure.ac
+++ b/configure.ac
@@ -1074,4 +1074,5 @@ $PACKAGE-$VERSION  build configuration settings
 	Viterbi algorithm parser:       ${enable_viterbi}
 	Corpus statistics database:     ${enable_corpus_stats}
 	RegEx tokenizer:                ${enable_regex_tokenizer}
+	Definitions:                    ${DEFS}
 "

--- a/configure.ac
+++ b/configure.ac
@@ -1048,6 +1048,8 @@ man/Makefile
 AC_OUTPUT
 
 # ====================================================================
+lglibs=`${ECHO} "$REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS $LIBS"|${SED} 's/  */ /g'`
+
 echo "
 $PACKAGE-$VERSION  build configuration settings
 
@@ -1075,4 +1077,5 @@ $PACKAGE-$VERSION  build configuration settings
 	Corpus statistics database:     ${enable_corpus_stats}
 	RegEx tokenizer:                ${enable_regex_tokenizer}
 	Definitions:                    ${DEFS}
+	Libraries:                      ${lglibs}
 "

--- a/configure.ac
+++ b/configure.ac
@@ -592,16 +592,16 @@ fi
 # ====================================================================
 
 # Tokenizing by RegEx
-AC_ARG_ENABLE( regex_tokenizer,
-  [  --enable-regex-tokenizer enable use of regex word splitter (experimental)],
-  [],
-  [enable_regex_tokenizer=no]
-)
-if test "x$enable_regex_tokenizer" = "xyes"
-then
-	AC_DEFINE(USE_REGEX_TOKENIZER, 1, [Define for compilation])
-	AX_PATH_LIB_PCRE
-fi
+#AC_ARG_ENABLE( regex_tokenizer,
+#  [  --enable-regex-tokenizer enable use of regex word splitter (experimental)],
+#  [],
+#  [enable_regex_tokenizer=no]
+#)
+#if test "x$enable_regex_tokenizer" = "xyes"
+#then
+#	AC_DEFINE(USE_REGEX_TOKENIZER, 1, [Define for compilation])
+#	AX_PATH_LIB_PCRE
+#fi
 
 # ====================================================================
 # Configure a regex library that supports UTF-8 and a POSIX interface.

--- a/data/en/4.0.regex
+++ b/data/en/4.0.regex
@@ -70,8 +70,8 @@
 <ALL-UPPER>: /^[A-Z]([A-Z])+$/
 
 % Greek letters with numbers
-<GREEK-LETTER-AND-NUMBER>: /^(alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega)\-?[0-9]+$/
-<PL-GREEK-LETTER-AND-NUMBER>: /^(alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega)s\-?[0-9]+$/
+<GREEK-LETTER-AND-NUMBER>: /^(alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega)-?[0-9]+$/
+<PL-GREEK-LETTER-AND-NUMBER>: /^(alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega)s-?[0-9]+$/
 
 % Some "safe" derived units. Simple units are in dictionary.
 % The idea here is for the regex to match something that is almost

--- a/data/en/4.0.regex
+++ b/data/en/4.0.regex
@@ -238,14 +238,16 @@
 % treated as a HYPHENATED-WORD (a generic adjective/noun), and
 % never a verb. To return to this ordering, move this regex just
 % after the CAPITALIZED-WORDS regex.
-% We also match on commas, dots, brackets: n-amino-3-azabicyclo[3.3.0]octane
-% []] means "match right-bracket"
+% We also match on commas, dots, brackets:
+% n-amino-3-azabicyclo[3.3.0]octane
+% 3'-Amino-2',3'-dideoxyguanosine
+% N-Phenylsulphonyl-N'-(3-azabicycloalkyl)
+% []...] means "match right-bracket"
 % Explicitly call out (5'|3') so that we don't all a generic match to 'll
-% But something is funky about this 5'-3' business since 2' also matches ???
 %  /^[[:alnum:]][][:alnum:],:.\[-]*-[][:alnum:],:.\[-]*[[:alnum:]]$/
 <HYPHENATED-WORDS>: !/--/
 <HYPHENATED-WORDS>:
-  /^[[:alnum:](5'|3')][][:alnum:](5'|3'),:.\(\)\[-]*-[][:alnum:],:.\(\)\[-]*[[:alnum:]]$/
+  /^([[:alnum:]]|5'|3'|2'|N')([][:alnum:],:.()[-]|5'|3'|2'|N')*-[][:alnum:],:.()[-]*[[:alnum:]]*$/
 
 % Emoticon checks must come *after* the above, so that the above take precedence.
 % See Wikipedia List_of_emoticons (also the References section).

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -45,6 +45,8 @@ MAINTAINERCLEANFILES = $(top_srcdir)/link-grammar/post-process/pp_lexer.c
 
 lib_LTLIBRARIES = liblink-grammar.la
 
+LINK_CFLAGS += ${REGEX_CFLAGS}
+
 EXTRA_liblink_grammar_la_DEPENDENCIES = $(srcdir)/link-grammar.def
 
 liblink_grammar_la_LDFLAGS = -version-info @VERSION_INFO@ \
@@ -53,6 +55,8 @@ liblink_grammar_la_LDFLAGS = -version-info @VERSION_INFO@ \
 	$(LINK_CFLAGS)
 
 liblink_grammar_la_LIBADD  =  ${REGEX_LIBS}
+
+liblink_grammar_la_LIBADD  +=  ${REGEX_LIBS}
 
 if HAVE_HUNSPELL
 liblink_grammar_la_LIBADD  +=  ${HUNSPELL_LIBS}
@@ -203,6 +207,7 @@ uninstall-hook:
 	-rmdir $(liblink_grammar_includedir)
 
 EXTRA_DIST=                         \
+	dict-common/pcre2posix.c         \
 	link-grammar.def                 \
 	README.md                        \
 	dict-sql/dict.sql                \

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -77,6 +77,7 @@ int compile_regexs(Regex_node *re, Dictionary dict)
 			if (rc)
 			{
 				prt_regerror("Failed to compile regex", re, rc);
+				re->re = NULL;
 				return rc;
 			}
 

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -10,13 +10,28 @@
 /*                                                                       */
 /*************************************************************************/
 
+/**
+ * Support for the regular-expression based token matching system
+ * using standard POSIX regex or PCRE2.
+ * (Cannot use pcre2posix.h at this time because pcre2posix <= 10.32
+ * don't have pcre2_regcomp() etc., and then regcomp() etc.
+ * may bind to libc., e.g. when the Python bindings are used.)
+ */
+
+/* The regex include definitions must be checked here in reverse order
+ * of their check in "configure.ac". */
+#if HAVE_REGEX_H
 /* On MS Windows, regex.h fails to pull in size_t, so work around this by
  * including <stddef.h> before <regex.h> (<sys/types.h> is not enough) */
 #include <stddef.h>
-#if HAVE_TRE_TRE_H
+#include <regex.h>
+#elif HAVE_PCRE2_H
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#elif HAVE_TRE_REGEX_H
 #include <tre/regex.h>
 #else
-#include <regex.h>
+#error No regex header file.
 #endif
 #include "api-structures.h"
 #include "error.h"          /* verbosity */
@@ -26,116 +41,136 @@
 #include "dict-common/regex-morph.h"
 #include "link-includes.h"
 
-
-/**
- * Support for the regular-expression based token matching system
- * using standard POSIX regex.
- */
+#if HAVE_PCRE2_H
+typedef struct {
+	pcre2_code *re_code;
+	pcre2_match_data* re_md;
+} regex_t;
+#endif
 
 /**
  * Notify an error message according to the error code.
  */
-static void prt_regerror(const char *msg, const Regex_node *re, int rc)
+#define ERRBUFFLEN 120
+static void prt_regerror(const char *msg, const Regex_node *re, int rc,
+                         int erroffset)
 {
-	const size_t errbuf_size = regerror(rc, re->re, NULL, 0);
-	char * const errbuf = malloc(errbuf_size);
+#if HAVE_PCRE2_H
+	PCRE2_UCHAR errbuf[ERRBUFFLEN];
+	pcre2_get_error_message(rc, errbuf, ERRBUFFLEN);
+#else
+	char errbuf[ERRBUFFLEN];
+	regerror(rc, re->re, errbuf, ERRBUFFLEN);
+#endif /* HAVE_PCRE2_H */
 
-	/*
-	prt_error("Error: Failed to compile regex '%s' (%s) at %d: %s\n",
-					re->pattern, re->name, erroroffset, error);
-	*/
-	regerror(rc, re->re, errbuf, errbuf_size);
-	prt_error("Error: %s: \"%s\" (%s): %s\n", msg, re->pattern, re->name, errbuf);
-	free(errbuf);
+	prt_error("Error: %s: \"%s\" (%s", msg, re->pattern, re->name);
+	if (-1 != erroffset) prt_error(" at %d", erroffset);
+	prt_error("): %s (%d)\n", errbuf, rc);
 }
 
 /**
- * Compiles all the given regexs. Returns 0 on success,
- * else an error code.
+ * Compile all the given regexs.
+ * Return 0 on success, else an error code.
  */
-int compile_regexs(Regex_node *re, Dictionary dict)
+int compile_regexs(Regex_node *rn, Dictionary dict)
 {
-	regex_t *preg;
-	int rc;
-
-	while (re != NULL)
+	while (rn != NULL)
 	{
-		/* If re->re non-null, assume compiled already. */
-		if(re->re == NULL)
+		/* If rn->re non-null, assume compiled already. */
+		if(rn->re == NULL)
 		{
-			/* Compile with default options (0) and default character
-			 * tables (NULL). */
-			/* re->re = pcre_compile(re->pattern, 0, &error, &erroroffset, NULL); */
-			preg = (regex_t *) malloc (sizeof(regex_t));
-			re->re = preg;
+			int rc;
+			regex_t *re = rn->re = malloc(sizeof(regex_t));
 
-			/* REG_ENHANCED is needed for OS X to support \w etc. */
+#if HAVE_PCRE2_H
+			PCRE2_SIZE erroffset;
+			re->re_code =
+				pcre2_compile((PCRE2_SPTR)rn->pattern, PCRE2_ZERO_TERMINATED,
+				              PCRE2_UTF|PCRE2_UCP, &rc, &erroffset, NULL);
+			if (NULL != re->re_code)
+			{
+				rc = 0;
+				re->re_md = pcre2_match_data_create(0, NULL);
+				if (NULL == re->re_md) return -1; /* Unhandled for now. */
+			}
+#else
+			const int erroffset = -1;
+
+			/* REG_ENHANCED is needed for macOS to support \w etc. */
 #ifndef REG_ENHANCED
 #define REG_ENHANCED 0
 #endif
-			rc = regcomp(preg, re->pattern, REG_NOSUB|REG_EXTENDED|REG_ENHANCED);
+			rc = regcomp(re, rn->pattern, REG_NOSUB|REG_EXTENDED|REG_ENHANCED);
+#endif
+
 			if (rc)
 			{
-				prt_regerror("Failed to compile regex", re, rc);
-				re->re = NULL;
+				prt_regerror("Failed to compile regex", rn, rc ,erroffset);
+				rn->re = NULL;
 				return rc;
 			}
 
 			/* Check that the regex name is defined in the dictionary. */
-			if ((NULL != dict) && !boolean_dictionary_lookup(dict, re->name))
+			if ((NULL != dict) && !boolean_dictionary_lookup(dict, rn->name))
 			{
 				/* TODO: better error handing. Maybe remove the regex? */
 				prt_error("Error: Regex name %s not found in dictionary!\n",
-				       re->name);
+				       rn->name);
 			}
 		}
-		re = re->next;
+		rn = rn->next;
 	}
 	return 0;
 }
 
 /**
- * Tries to match each regex in turn to word s.
- * On match, returns the name of the first matching regex.
- * If no match is found, returns NULL.
+ * Try to match each regex in turn to word s.
+ * On match, return the name of the first matching regex.
+ * If no match is found, return NULL.
  */
 #define D_MRE 6
-const char *match_regex(const Regex_node *re, const char *s)
+const char *match_regex(const Regex_node *rn, const char *s)
 {
-	int rc;
-	const char *nre_name;
-
-	while (re != NULL)
+	while (rn != NULL)
 	{
+		int rc;
+		bool nomatch;
+		bool match;
+		regex_t *re = rn->re;
+
 		/* Make sure the regex has been compiled. */
-		assert(re->re);
+		assert(re);
 
-#if 0
-		/* Try to match with no extra data (NULL), whole str
-		 * (0 to strlen(s)), and default options (second 0). */
-		int rc = pcre_exec(re->re, NULL, s, strlen(s), 0,
-		                   0, ovector, PCRE_OVEC_SIZE);
+#if HAVE_PCRE2_H
+		rc = pcre2_match(re->re_code, (PCRE2_SPTR)s,
+		                 PCRE2_ZERO_TERMINATED, /*startoffset*/0,
+		                 PCRE2_NO_UTF_CHECK, re->re_md, NULL);
+		match = (rc >= 0);
+		nomatch = (rc == PCRE2_ERROR_NOMATCH);
+#else
+		rc = regexec(rn->re, s, 0, NULL, /*eflags*/0);
+		match = (rc == 0);
+		nomatch = (rc == REG_NOMATCH);
 #endif
-
-		rc = regexec((regex_t*) re->re, s, 0, NULL, 0);
-		if (0 == rc)
+		if (match)
 		{
-			lgdebug(+D_MRE, "%s%s %s\n", &"!"[!re->neg], re->name, s);
-			if (!re->neg)
-				return re->name; /* Match found - return--no multiple matches. */
+			lgdebug(+D_MRE, "%s%s %s\n", &"!"[!rn->neg], rn->name, s);
+			if (!rn->neg)
+				return rn->name; /* Match found - return--no multiple matches. */
 
 			/* Negative match - skip this regex name. */
-			for (nre_name = re->name; re->next != NULL; re = re->next)
+			for (const char *nre_name = rn->name; rn->next != NULL; rn = rn->next)
 			{
-				if (strcmp(nre_name, re->next->name) != 0) break;
+				if (strcmp(nre_name, rn->next->name) != 0) break;
 			}
 		}
-		else if (rc != REG_NOMATCH)
+		else if (!nomatch)
 		{
 			/* We have an error. */
-			prt_regerror("Regex matching error", re, rc);
+			prt_regerror("Regex matching error", rn, rc, -1);
 		}
-		re = re->next;
+
+		rn = rn->next;
 	}
 	return NULL; /* No matches. */
 }
@@ -144,20 +179,27 @@ const char *match_regex(const Regex_node *re, const char *s)
 /**
  * Delete associated storage
  */
-void free_regexs(Regex_node *re)
+void free_regexs(Regex_node *rn)
 {
-	while (re != NULL)
+	while (rn != NULL)
 	{
-		Regex_node *next = re->next;
+		Regex_node *next = rn->next;
+		regex_t *re = rn->re;
 
 		/* Prevent a crash in regfree() in case of a regex compilation error. */
-		if (NULL != re->re)
-			regfree((regex_t *)re->re);
-
-		free(re->re);
-		free(re->name);
-		free(re->pattern);
+		if (NULL != re)
+		{
+#if HAVE_PCRE2_H
+			pcre2_match_data_free(re->re_md);
+			pcre2_code_free(re->re_code);
+#else
+			regfree(re);
+#endif
+		}
 		free(re);
-		re = next;
+		free(rn->name);
+		free(rn->pattern);
+		free(rn);
+		rn = next;
 	}
 }

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -141,7 +141,10 @@ int read_regex_file(Dictionary dict, const char *file_name)
 			}
 			prev = c;
 			c = fgetc(fp);
-			regex[i++] = c;
+			if ((c == '/') && (prev == '\\'))
+				regex[i-1] = '/'; /* \/ is undefined */
+			else
+				regex[i++] = c;
 		}
 		while ((c != '/' || prev == '\\') && (c != EOF));
 		regex[i-1] = '\0';

--- a/msvc/Local.props
+++ b/msvc/Local.props
@@ -17,7 +17,7 @@
   <PropertyGroup Condition=" '$(GNUREGEX)' != '' " />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HAVE_REGEX_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The main changes are adding the ability to use more regex packages.
This is done is two ways:
1.  By default, the first detected regex package is used, according to this order:
`libpcre2-8`, `libtre`, `libregex`, `libc`
`libpcre2` is the fastest.  Its use on **Cygwin** also fixes problem (1) from issue #437.  `libregex` is said to fix a problem in BSD POSIX regex in libc, which doesn't support `\w` (etc.) escapes. I didn't try to test that on a xBSD system, but at least libregex on MinGW64 passes the `\w` test.
Notes on the use of **pcre2**:
I first used `libpcre2posix` in order not to rewrite `regex-morph.c`. However, `regexec()` etc. got bound to the libc functions when using Python, with apparently no reasonable/portable way to fix that. I notified the author and a fix will appear in the next version (which may take years to propagate to the various distributions). So I had to rewrite `regex-morph.c` to directly use `libpcre2-8`. I tried JIT but didn't notice any speedup.
2.  A new `configure` argument: `--with-regexlib=pcre2|tre|regex|c`

I also tried to add an option for C++ regex. This try failed because C++ regex doesn't support UNICODE well enough. Due to this try I noted that escapes like `\-` and `\/` (and any other escape which doesn't modify the meaning of the escaped character) are claimed not to be defined. This may happen in principle in other POSIX-lookalike packages so I added fixes to eliminate such escapes.

In addition I fixed the amino-matching regex (contained original bugs, including a try to define alternations inside a character class).

In order to ease debug, I added the following in the setting summary of `configure`:
1. Display the used libraries (didn't try to do that in their real order of use, which depends on the makefiles).
2. Display DEFS (until then I mostly used `make V=1` when I needed to see then...).

Last thing, due to a possible `configure` argument confusion, for now I disabled the ability to configure the regex tokenizer demo (it should be fix to becomes a full tokenizer demo, or maybe be removed altogether).

This patch passes all the Python tests (using python3) on these up-to-date systems:
Fedora 27/28, MinGW64 and Cygwin (both on Windows 10), Windows 10  (w/o SAT and speller), macOS. (The other tests are not tested after this patch, but they passed on these systems in recent patches.)