### PR TITLE
MSVC: Fix get_dictionary_dir() to use LG DLL address

### DIFF
--- a/msvc/LGlib-features.props
+++ b/msvc/LGlib-features.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <PKGDATADIR>"..\\data"</PKGDATADIR>
+    <PKGDATADIR>"..\\..\\..\\data"</PKGDATADIR>
     <DEFS>USE_WORDGRAPH_DISPLAY;</DEFS>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Recently a possibility of relative DICTIONARY_DIR has been re-added to the MSVC code. However, this code makes it relative to the location of the link-parser executable, but the user may use programs in other locations, that use the LG library.

This change makes DICTIONARY_DIR (if it is a relative path) relative to the location of the LG DLL.

---
BTW, maybe it will be better to also add environment variable for the dictionary data directory that will take precedence over  DICTIONARY_DIR. (I think that there once was such a variable but it was been removed long ago.)

Now it is possible to produce a zip-file distribution of Windows -10 MSVC-compiled code, that the user will be able to extract and use in any filesystem location.
(If we would like to also provide Python bindings, we will also need to include a binary distribution of python3 in this zip-file.)

**Question:**
Will it be a good idea to do that?

(Of course we should also recommend users to use LG on Linux if possible.
I guess that a Linux-distribution LG package will run just fine under  [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10).)

BTW, I think it may also be possible to make a zip-file distribution of Cygwin compilation result by including in a zip-file a selective portion of the Cygwin file system after install LG. But we will need the said environment variable, or maybe better, to conditionally compiled the code of this PR also on Cygwin.