### PR TITLE
SAT cleanup and speedup

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -171,6 +171,11 @@ For more examples of how to use the wordgraph display, see
 [link-grammar/README.md](/link-grammar/README.md)
 and [msvc/README.md](/msvc/README.md).
 
+5) -test=<values> for SAT parser debugging:
+linkage-disconnected - Display also solutions which don't have a full linkage.
+sat-stats - Display the number of PP-violations and disconected linkages.
+no-pp_pruning_1 - Disable a partial CONTAINS_NONE_RULES pruning
+
 Debugging and STDIO streams
 ---------------------------
 Messages at severity Info and higher (i.e. also Warning, Error and

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -319,7 +319,7 @@ static void clean_table(unsigned int size, C_list ** t)
  * Return true iff they may become adjacent (i.e. all the words
  * between them are optional).
  */
-static bool optional_gap_collapse(Sentence sent, int w1, int w2)
+bool optional_gap_collapse(Sentence sent, int w1, int w2)
 {
 	for (int w = w1+1; w < w2; w++)
 		if (!sent->word[w].optional) return false;

--- a/link-grammar/parse/prune.h
+++ b/link-grammar/parse/prune.h
@@ -17,5 +17,6 @@
 
 int        power_prune(Sentence, Parse_Options);
 void       pp_and_power_prune(Sentence, Parse_Options);
+bool       optional_gap_collapse(Sentence, int, int);
 
 #endif /* _PRUNE_H */

--- a/link-grammar/sat-solver/clock.hpp
+++ b/link-grammar/sat-solver/clock.hpp
@@ -2,8 +2,8 @@
 #define __CLOCK_H__
 
 /**
-*   Time measurment functions
-*/
+ *   Time measurement functions
+ */
 
 #include <iostream>
 #include <ctime>
@@ -15,19 +15,17 @@ public:
 	Clock() {
 		reset();
 	}
-	
+
 	void reset()
 	{
 		start = clock();
 	}
 
-public:	
+public:
 	double elapsed()
 	{
 		clock_t stop = clock();
 		return ((double)stop-(double)start)/CLOCKS_PER_SEC;
-	
 	}
 };
-
 #endif

--- a/link-grammar/sat-solver/clock.hpp
+++ b/link-grammar/sat-solver/clock.hpp
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <ctime>
 
+#include "error.h"
+
 class Clock {
 private:
 	clock_t  start;
@@ -26,6 +28,14 @@ public:
 	{
 		clock_t stop = clock();
 		return ((double)stop-(double)start)/CLOCKS_PER_SEC;
+	}
+
+	void print_time(int verbosity_opt, const char *s)
+	{
+		if (verbosity_opt >= D_USER_TIMES)
+		{
+			printf("++++ %-36s %7.2f seconds\n", s, elapsed());
+		}
 	}
 };
 #endif

--- a/link-grammar/sat-solver/guiding.hpp
+++ b/link-grammar/sat-solver/guiding.hpp
@@ -91,11 +91,6 @@ public:
     setParameters(var, isDecision, 0.0, 0.0);
   }
 
-#if 0
-  /* thin_link variables */
-  virtual void setThinLinkParameters (int var, int wi, int wj) = 0;
-#endif
-
   /* Pass SAT search parameters to the MiniSAT solver */
   void passParametersToSolver(Solver* solver) {
     for (size_t v = 0; v < _parameters.size(); v++) {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -243,9 +243,14 @@ void SATEncoder::build_word_tags()
   name[0] = 'w';
 
   for (size_t w = 0; w < _sent->length; w++) {
-    // sprintf(name, "w%zu", w);
-    fast_sprintf(name+1, w);
-    _word_tags.push_back(WordTag(w, name, _variables, _sent, _opts));
+    fast_sprintf(name+1, (int)w);
+    // The SAT word variables are set to be equal to the word numbers.
+    Var var = _variables->string(name);
+    assert((Var)w == var);
+  }
+
+  for (size_t w = 0; w < _sent->length; w++) {
+    _word_tags.push_back(WordTag(w, _variables, _sent, _opts));
     int dfs_position = 0;
 
     if (_sent->word[w].x == NULL) continue;
@@ -260,6 +265,7 @@ void SATEncoder::build_word_tags()
     cout << endl;
 #endif
 
+    fast_sprintf(name+1, (int)w);
     bool leading_right = true;
     bool leading_left = true;
     std::vector<int> eps_right, eps_left;

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1284,10 +1284,10 @@ void SATEncoder::power_prune()
     }
   }
 
-  /*
+#if 0
   // on two adjacent words, a pair of connectors can be used only if
   // they're the deepest ones on their disjuncts
-  for (int wl = 0; wl < _sent->length - 2; wl++) {
+  for (size_t wl = 0; wl < _sent->length - 2; wl++) {
     const std::vector<PositionConnector>& rc = _word_tags[wl].get_right_connectors();
     std::vector<PositionConnector>::const_iterator rci;
     for (rci = rc.begin(); rci != rc.end(); rci++) {
@@ -1298,28 +1298,30 @@ void SATEncoder::power_prune()
       for (std::vector<PositionConnector*>::const_iterator lci = matches.begin(); lci != matches.end(); lci++) {
         if (!(*lci)->leading_left || (*lci)->word != wl + 1)
           continue;
-        int link = _variables->link(wl, rci->position, rci->connector.string,
-                                    (*lci)->word, (*lci)->position, (*lci)->connector.string);
-        std::vector<int> clause(2);
-        clause[0] = -link;
+        int link = _variables->link(wl, rci->position, rci->connector.desc->string, rci->exp,
+                                    (*lci)->word, (*lci)->position, (*lci)->connector.desc->string, (*lci)->exp);
+        vec<Lit> clause(2);
+        clause.push(~Lit(link));
 
         for (std::vector<int>::const_iterator i = rci->eps_right.begin(); i != rci->eps_right.end(); i++) {
-          clause[1] = *i;
+          clause.push(Lit(*i));
         }
 
         for (std::vector<int>::const_iterator i = (*lci)->eps_left.begin(); i != (*lci)->eps_left.end(); i++) {
-          clause[1] = *i;
+          clause.push(Lit(*i));
         }
 
         add_clause(clause);
       }
     }
   }
+#endif
 
 
+#if 0
   // Two deep connectors cannot match (deep means notlast)
   std::vector<std::vector<PositionConnector*> > certainly_deep_left(_sent->length), certainly_deep_right(_sent->length);
-  for (int w = 0; w < _sent->length; w++) {
+  for (size_t w = 0; w < _sent->length - 2; w++) {
     if (_sent->word[w].x == NULL)
       continue;
 
@@ -1335,7 +1337,7 @@ void SATEncoder::power_prune()
       free_alternatives(exp);
   }
 
-  for (int w = 0; w < _sent->length; w++) {
+  for (size_t w = 0; w < _sent->length; w++) {
     std::vector<PositionConnector*>::const_iterator i;
     for (i = certainly_deep_right[w].begin(); i != certainly_deep_right[w].end(); i++) {
       const std::vector<PositionConnector*>& matches = (*i)->matches;
@@ -1343,13 +1345,13 @@ void SATEncoder::power_prune()
       for (j = matches.begin(); j != matches.end(); j++) {
         if (std::find(certainly_deep_left[(*j)->word].begin(), certainly_deep_left[(*j)->word].end(),
                       *j) != certainly_deep_left[(*j)->word].end()) {
-          generate_literal(-_variables->link((*i)->word, (*i)->position, (*i)->connector.string,
-                                             (*j)->word, (*j)->position, (*j)->connector.string));
+          generate_literal(~Lit(_variables->link((*i)->word, (*i)->position, (*i)->connector.desc->string, (*i)->exp,
+                                             (*j)->word, (*j)->position, (*j)->connector.desc->string, (*j)->exp)));
         }
       }
     }
   }
-  */
+#endif
 }
 
 /*--------------------------------------------------------------------------*

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -375,7 +375,7 @@ void SATEncoder::generate_satisfaction_for_expression(int w, int& dfs_position, 
         if (total_cost > _cost_cutoff) {
           generate_literal(~Lit(_variables->string_cost(var, e->cost)));
         }
-      } else if (e->u.l != NULL && e->u.l->next == NULL) {
+      } else if (e->u.l->next == NULL) {
         /* unary and - skip */
         generate_satisfaction_for_expression(w, dfs_position, e->u.l->e, var, total_cost);
       } else {
@@ -423,7 +423,7 @@ void SATEncoder::generate_satisfaction_for_expression(int w, int& dfs_position, 
         /* zeroary or */
         cerr << "Zeroary OR" << endl;
         exit(EXIT_FAILURE);
-      } else if (e->u.l != NULL && e->u.l->next == NULL) {
+      } else if (e->u.l->next == NULL) {
         /* unary or */
         generate_satisfaction_for_expression(w, dfs_position, e->u.l->e, var, total_cost);
       } else {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1091,8 +1091,6 @@ void SATEncoder::generate_planarity_conditions()
       }
     }
   }
-
-  //  generate_linked_min_max_planarity();
 }
 
 /*--------------------------------------------------------------------------*
@@ -1654,88 +1652,6 @@ void SATEncoderConjunctionFreeSentences::generate_linked_definitions()
   }
   DEBUG_print("------- end linked definitions");
 }
-
-#if 0
-void SATEncoder::generate_linked_min_max_planarity()
-{
-  DEBUG_print("---- linked_max");
-  for (size_t w1 = 0; w1 < _sent->length; w1++) {
-    for (size_t w2 = 0; w2 < _sent->length; w2++) {
-      Lit lhs = Lit(_variables->linked_max(w1, w2));
-      vec<Lit> rhs;
-      if (w2 < _sent->length - 1) {
-        rhs.push(Lit(_variables->linked_max(w1, w2 + 1)));
-        if (w1 != w2 + 1 && _linked_possible(std::min(w1, w2+1), std::max(w1, w2+1)))
-          rhs.push(~Lit(_variables->linked(std::min(w1, w2+1), std::max(w1, w2+1))));
-      }
-      generate_classical_and_definition(lhs, rhs);
-    }
-  }
-  DEBUG_print("---- end linked_max");
-
-
-  DEBUG_print("---- linked_min");
-  for (size_t w1 = 0; w1 < _sent->length; w1++) {
-    for (size_t w2 = 0; w2 < _sent->length; w2++) {
-      Lit lhs = Lit(_variables->linked_min(w1, w2));
-      vec<Lit> rhs;
-      if (w2 > 0) {
-        rhs.push(Lit(_variables->linked_min(w1, w2 - 1)));
-        if (w1 != w2-1 && _linked_possible(std::min(w1, w2 - 1), std::max(w1, w2 - 1)))
-          rhs.push(~Lit(_variables->linked(std::min(w1, w2 - 1), std::max(w1, w2 - 1))));
-      }
-      generate_classical_and_definition(lhs, rhs);
-    }
-  }
-  DEBUG_print("---- end linked_min");
-
-
-  vec<Lit> clause;
-  for (size_t wi = 3; wi < _sent->length; wi++) {
-    for (size_t wj = 1; wj < wi - 1; wj++) {
-      for (size_t wl = wj + 1; wl < wi; wl++) {
-        clause.growTo(3);
-        clause[0] = ~Lit(_variables->linked_min(wi, wj));
-        clause[1] = ~Lit(_variables->linked_max(wi, wl - 1));
-        clause[2] = Lit(_variables->linked_min(wl, wj));
-        add_clause(clause);
-      }
-    }
-  }
-
-  DEBUG_print("------------");
-
-  for (size_t wi = 0; wi < _sent->length - 1; wi++) {
-    for (size_t wj = wi + 1; wj < _sent->length - 1; wj++) {
-      for (size_t wl = wi+1; wl < wj; wl++) {
-        clause.growTo(3);
-        clause[0] = ~Lit(_variables->linked_max(wi, wj));
-        clause[1] = ~Lit(_variables->linked_min(wi, wl + 1));
-        clause[2] = Lit(_variables->linked_max(wl, wj));
-        add_clause(clause);
-      }
-    }
-  }
-
-  DEBUG_print("------------");
-  clause.clear();
-  for (size_t wi = 1; wi < _sent->length; wi++) {
-    for (size_t wj = wi + 2; wj < _sent->length - 1; wj++) {
-      for (size_t wl = wi + 1; wl < wj; wl++) {
-        clause.growTo(2);
-        clause[0] = ~Lit(_variables->linked_min(wi, wj));
-        clause[1] = Lit(_variables->linked_min(wl, wi));
-        add_clause(clause);
-
-        clause.growTo(2);
-        clause[0] = ~Lit(_variables->linked_max(wj, wi));
-        clause[1] = Lit(_variables->linked_max(wl, wj));
-        add_clause(clause);
-      }
-    }
-  }
-}
-#endif
 
 Exp* SATEncoderConjunctionFreeSentences::PositionConnector2exp(const PositionConnector* pc)
 {

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -208,23 +208,24 @@ void SATEncoder::generate_equivalence_definition(Lit l1, Lit l2) {
 void SATEncoder::encode() {
     Clock clock;
     generate_satisfaction_conditions();
-    DEBUG_print(clock.elapsed());
+    clock.print_time(verbosity, "Generated satisfaction conditions");
     generate_linked_definitions();
-    DEBUG_print(clock.elapsed());
+    clock.print_time(verbosity, "Generated linked definitions");
     generate_planarity_conditions();
-    DEBUG_print(clock.elapsed());
+    clock.print_time(verbosity, "Generated planarity conditions");
 
 #ifdef _CONNECTIVITY_
     generate_connectivity();
-    DEBUG_print(clock.elapsed());
+    clock.print_time(verbosity, "Generated connectivity");
 #endif
 
     generate_encoding_specific_clauses();
-    DEBUG_print(clock.elapsed());
+    //clock.print_time(verbosity, "Generated encoding specific clauses");
 
     pp_prune();
+    clock.print_time(verbosity, "PP pruned");
     power_prune();
-    DEBUG_print(clock.elapsed());
+    clock.print_time(verbosity, "Power pruned");
 
     _variables->setVariableParameters(_solver);
 }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1438,6 +1438,7 @@ void SATEncoder::pp_prune()
     DEBUG_print("---end pp_pruning--");
   }
 
+  if (test_enabled("no-pp_pruning_1")) return; // For result comparison.
   /* Additional PP pruning.
    * Since the SAT parser defines constrains on links, it is possible
    * to encode all the postprocessing rules, in order to prune all the

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1260,8 +1260,8 @@ void SATEncoder::power_prune()
         if (!(*lci)->leading_left || (*lci)->connector.multi || (*lci)->word <= wl + 2)
           continue;
 
-        //        printf("LR: .%d. .%d. %s\n", wl, rci->position, rci->connector.string);
-        //        printf("LL: .%d. .%d. %s\n", (*lci)->word, (*lci)->position, (*lci)->connector.string);
+        //        printf("LR: .%zu. .%d. %s\n", wl, rci->position, rci->connector.desc->string);
+        //        printf("LL: .%zu. .%d. %s\n", (*lci)->word, (*lci)->position, (*lci)->connector.desc->string);
 
         vec<Lit> clause;
         for (std::vector<int>::const_iterator i = rci->eps_right.begin(); i != rci->eps_right.end(); i++) {

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -296,7 +296,26 @@ protected:
 public:
   // Sentence that is being parsed.
   Sentence _sent;
-};
+
+  /**
+   * Statistics.
+   */
+
+  // Counters of main bottlenecks.
+  int _num_pp_violations = 0;    // PP failures
+  int _num_lkg_disconnected = 0; // A disconnected linkage
+
+  // Print stats on solutions that have a performance impact.
+  void print_stats(void)
+  {
+    if (verbosity_level(D_USER_TIMES) || test_enabled("sat-stats"))
+    {
+      prt_error("Info: %d pp_violations, %d disconnected linkages.\n",
+                _num_pp_violations,_num_lkg_disconnected);
+    }
+  }
+}
+;
 
 
 /*******************************************************************************

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -176,34 +176,6 @@ public:
     return var;
   }
 
-  // If guiding params are unknown, they are set do default
-  int linked_max(int wi, int wj) {
-    int var;
-    if (!get_linked_max_variable(wi, wj, var)) {
-#ifdef _VARS
-      var_defs_stream << "linked_max_" << wi << "_" << wj << "\t" << var << endl;
-#endif
-      _guiding->setLinkedMinMaxParameters(var, wi, wj);
-    }
-    assert(var != -1, "Var == -1");
-    return var;
-  }
-
-#if 0
-  // If guiding params are unknown, they are set do default
-  int linked_min(int wi, int wj) {
-    int var;
-    if (!get_linked_min_variable(wi, wj, var)) {
-#ifdef _VARS
-      var_defs_stream << "linked_min_" << wi << "_" << wj << "\t" << var << endl;
-#endif
-      _guiding->setLinkedMinMaxParameters(var, wi, wj);
-    }
-    assert(var != -1, "Var == -1");
-    return var;
-  }
-#endif
-
   /*
    *                  link(wi, pi, wj, pj)
    * Variables that specify that a direct link has been established
@@ -446,12 +418,6 @@ private:
     _linked_variables[var] = new LinkedVar(i, j);
     _linked_variables_indices.push_back(var);
   }
-
-  // What is the number of the linked_min(i, j) variable?
-  Matrix<int> _linked_min_variable_map;
-
-  // What is the number of the linked_max(i, j) variable?
-  Matrix<int> _linked_max_variable_map;
 
   /*
    *   Information about the link_cw(w, wj, pj) variables

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -71,9 +71,6 @@ public:
   Variables(Sentence sent)
     : _link_variable_map(sent->length)
     ,_linked_variable_map(sent->length, -1)
-    ,_linked_min_variable_map(sent->length, -1)
-    ,_linked_max_variable_map(sent->length, -1)
-    ,_thin_link_variable_map(sent->length, -1)
     ,_link_cw_variable_map(sent->length)
     ,_guiding(new CostDistanceGuiding(sent))
     ,_var(0)
@@ -244,27 +241,6 @@ public:
     assert(var != -1, "Var == -1");
     return var;
   }
-
-#if 0
-  /*
-   *             thin_link(wi, wj)
-   * Variables that specify that two words are linked by a thin link
-   */
-
-  // If guiding params are unknown, they are set do default
-  int thin_link(int wi, int wj) {
-    assert(wi < wj, "Variables: thin link should be ordered");
-    int var;
-    if (!get_thin_link_variable(wi, wj, var)) {
-#ifdef _VARS
-      var_defs_stream << "thin_link_" << wi << "_" << wj << "\t" << var << endl;
-#endif
-      _guiding->setThinLinkParameters(var, wi, wj);
-    }
-    assert(var != -1, "Var == -1");
-    return var;
-  }
-#endif
 
   /*
    *                   link_cw(wi, wj, pj)
@@ -478,12 +454,6 @@ private:
   Matrix<int> _linked_max_variable_map;
 
   /*
-   * Information about the thin_link(i, j) variables
-   */
-  // What is the number of the thin_link(i, j) variable?
-  MatrixUpperTriangle<int> _thin_link_variable_map;
-
-  /*
    *   Information about the link_cw(w, wj, pj) variables
    */
   // What is the number of the link_cw(wi, wj, pj) variable?
@@ -581,18 +551,6 @@ private:
 
   bool get_linked_variable(int i, int j, int& var) {
     return get_2int_variable(i, j, var, _linked_variable_map);
-  }
-
-  bool get_linked_min_variable(int i, int j, int& var) {
-    return get_2int_variable(i, j, var, _linked_min_variable_map);
-  }
-
-  bool get_linked_max_variable(int i, int j, int& var) {
-    return get_2int_variable(i, j, var, _linked_max_variable_map);
-  }
-
-  bool get_thin_link_variable(int i, int j, int& var) {
-    return get_2int_variable(i, j, var, _thin_link_variable_map);
   }
 
   bool get_link_cw_variable(int i, int j, int pj, int& var) {

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -74,9 +74,6 @@ public:
     ,_linked_min_variable_map(sent->length, -1)
     ,_linked_max_variable_map(sent->length, -1)
     ,_thin_link_variable_map(sent->length, -1)
-#if 0
-      ,_link_top_cw_variable_map(sent->length)
-#endif
     ,_link_cw_variable_map(sent->length)
     ,_guiding(new CostDistanceGuiding(sent))
     ,_var(0)
@@ -293,34 +290,6 @@ public:
     return var;
   }
 
-
-  /*
-   *                 link_top_cw(wi, wj, pj)
-   * Variables that specify that a connective word has been directly
-   * linked to a connector
-   */
-
-#if 0
-  // If guiding params for this variable are not set earlier, they are
-  // now set to default
-  int link_top_cw(int wi, int wj, int pj, const char* cj) {
-    int var;
-    if (!get_link_top_cw_variable(wi, wj, pj, var)) {
-      add_link_top_cw_variable(wi, wj, pj, cj, var);
-      _guiding->setLinkTopCWParameters(var, wi, wj, cj);
-#ifdef _VARS
-      var_defs_stream << "link_top_cw_"
-                      << "(" << wj << "_" << pj << "_" << cj  << ")_"
-                      << wi
-                      << "\t" << var << endl;
-#endif
-    }
-    assert(var != -1, "Var == -1");
-    return var;
-  }
-#endif
-
-
 #ifdef _CONNECTIVITY_
   /* The following variables are deprecated */
 
@@ -414,37 +383,6 @@ public:
   const LinkedVar* linked_variable(int var) const {
     return _linked_variables[var];
   }
-
-
-
-  /*
-   *           link_top_cw((wi, pi), wj)
-   */
-
-#if 0
-  // Returns indices of all link_top_cw variables
-  const std::vector<int>& link_top_cw_variables() const {
-    return _link_top_cw_variables_indices;
-  }
-
-  // Additional info about the link_top_cw(wi, wj, pj) variable
-  struct LinkTopCWVar {
-    LinkTopCWVar(const std::string& _name, int _tw, int _cw, const char* _c)
-      : name(_name), connector_word(_cw), top_word(_tw), connector(_c) {
-    }
-
-    std::string name;
-    int connector_word;
-    int top_word;
-    char* label;
-    const char* connector;
-  };
-
-  // Returns additional info about the given link_top_cw variable
-  const LinkTopCWVar* link_top_cw_variable(int var) const {
-    return _link_top_cw_variables[var];
-  }
-#endif
 
   /* Pass SAT search parameters to the MiniSAT solver */
   void setVariableParameters(Solver* solver) {
@@ -544,46 +482,6 @@ private:
    */
   // What is the number of the thin_link(i, j) variable?
   MatrixUpperTriangle<int> _thin_link_variable_map;
-
-#if 0
-  /*
-   * Information about the link_top_cw(w, wj, pj) variables
-   */
-
-  // What is the number of the link_top_cw(wi, wj, pj) variable?
-  Matrix< std::map<int, int> > _link_top_cw_variable_map;
-
-  // What are the numbers of all link_top_cw(wi, wj, pj) variables?
-  std::vector<int>  _link_top_cw_variables_indices;
-
-  // Additional info about the link_top_cw(wi, wj, pj) variable with the given number
-  std::vector<LinkTopCWVar*> _link_top_cw_variables;
-#endif
-
-#if 0
-  // Set this additional info
-  void add_link_top_cw_variable(int i, int j, int pj, const char* cj, size_t var) {
-    char name[MAX_VARIABLE_NAME];
-    char* s = name;
-    *s++ = 'l';    *s++ = 'i';     *s++ = 'n';     *s++ = 'k'; *s++ = '_'; *s++ = 't'; *s++ = 'o'; *s++ = 'p';
-    *s++ = '_';
-    s = fast_sprintf(s, i);
-    *s++ = '_'; *s++ = '(';
-    s = fast_sprintf(s, j);
-    *s++ = '_';
-    s = fast_sprintf(s, pj);
-    *s++ = '_';
-    s = fast_sprintf(s, cj);
-    *s++ = ')';
-    *s = '\0';
-
-    if (var >= _link_top_cw_variables.size()) {
-      _link_top_cw_variables.resize(var + 1, 0);
-    }
-    _link_top_cw_variables[var] = new LinkTopCWVar(name, i, j, cj);
-    _link_top_cw_variables_indices.push_back(var);
-  }
-#endif
 
   /*
    *   Information about the link_cw(w, wj, pj) variables
@@ -700,13 +598,6 @@ private:
   bool get_link_cw_variable(int i, int j, int pj, int& var) {
     return get_3int_variable(i, j, pj, var, _link_cw_variable_map);
   }
-
-#if 0
-  bool get_link_top_cw_variable(int i, int j, int pj, int& var) {
-    return get_3int_variable(i, j, pj, var, _link_top_cw_variable_map);
-  }
-#endif
-
 
 #ifdef _CONNECTIVITY_
   bool get_lcon_variable(int i, int j, int k, int& var) {

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -82,14 +82,12 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
           insert_connectors(l->e, dfs_position, leading_right, leading_left,
                 eps_right, eps_left, new_var, false, cost, parent_exp, word_xnode);
 
-#ifdef POWER_PRUNE_CONNECTORS
           if (leading_right) {
             eps_right.push_back(_variables->epsilon(new_var, '+'));
           }
           if (leading_left) {
             eps_left.push_back(_variables->epsilon(new_var, '-'));
           }
-#endif
         }
       }
   } else if (exp->type == OR_type) {

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -58,7 +58,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
     if (exp->u.l == NULL) {
       /* zeroary and */
     } else
-      if (exp->u.l != NULL && exp->u.l->next == NULL) {
+      if (exp->u.l->next == NULL) {
         /* unary and - skip */
         insert_connectors(exp->u.l->e, dfs_position, leading_right,
              leading_left, eps_right, eps_left, var, root, cost, parent_exp, word_xnode);

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -110,13 +110,9 @@ private:
   }
 
 public:
-  WordTag(int word, const char* name, Variables* variables, Sentence sent, Parse_Options opts)
+  WordTag(int word, Variables* variables, Sentence sent, Parse_Options opts)
     : _word(word), _variables(variables), _sent(sent), _opts(opts) {
     _match_possible.resize(_sent->length);
-
-    // The SAT word variables are set to be equal to the word numbers.
-    Var var = _variables->string(name);
-    assert(word == var);
 
     verbosity = opts->verbosity;
     debug = opts->debug;


### PR DESCRIPTION
Main changes:

Speed:
- Add/fix debug printouts related to to parse speed. Including:
 -- Print  step times on -verbosity=2 similarly to what is done in the classic parser.
 -- Add -test<values> (and document in debug/README.md).
- Remove a redundant comparison in expression handling.
- Fix and re-enable the main code in the main power_prune() code. It got broken (and hence disabled)
when I added the optional-word fix (to replace the use of empty-words). Note that the purpose of the power pruning code is only to add restrictions in order to speed up the SAT-solving.
- Add a partial CONTAINS_NONE_RULES  pruning to reduce the number of postprocessing failures. This is a proof-of-concept that demonstrates that encoding postprocessing rules may have a significant speed-up effect.

Cleanup:
- Remove dead code.
- Ensure word variables are equal to word numbers (to allow code changes, as in this PR).
- Fix typo/whitespace.
- Port unused code to minisat 2.2 (in case it will be needed).

TODO:
- Add much more hashing - for various expression aspects. Among other things, currently the pruning code  has much encoding overhead due to the need of rescanning a large amount of data.
- Add more postprocessing pruning.
- **New idea**: Prevent duplicate linkages due to duplicate disjuncts.
Motivation: The classic-parser works with disjuncts, and thus duplicate ones can be eliminated. This saves parsing overhead and also prevents duplicate results. However, the SAT-parser works "directly" on expressions and thus is not able to prevent duplicate disjuncts. Because duplicate results is exponential to the number of different disjuncts that have duplicates and to the number of duplicates, a very large amount of duplicates may happen (a low percentage of distinct results). This has overhead implications in case several results are needed (they may be needed because the SAT-parser is not effectively able now to provide the best results first).
The idea is to prohibit further solutions with the exact same links after each solution (instead of the current prohibition of only the same exact solution).