### PR TITLE
SAT solver cost

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Version 5.5.2 (XXX 2018)
  * Major documentation update for building with Cygwin.
  * Revise the manpage.
  * Remove the experimental Viterbi code.
+ * Modify the SAT parser disjunct cost metric to be like in the classic parser.
 
 Version 5.5.1 (27 July 2018)
  * Fix broken Java bindings build.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -582,7 +582,6 @@ int sentence_link_cost(Sentence sent, LinkageIdx i)
 {
 	if (!sent) return 0;
 
-	/* The sat solver (currently) fails to fill in link_info */
 	if (!sent->lnkages) return 0;
 	if (sent->num_linkages_alloced <= i) return 0; /* bounds check */
 	return sent->lnkages[i].lifo.link_cost;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -573,7 +573,6 @@ double sentence_disjunct_cost(Sentence sent, LinkageIdx i)
 {
 	if (!sent) return 0.0;
 
-	/* The sat solver (currently) fails to fill in link_info */
 	if (!sent->lnkages) return 0.0;
 	if (sent->num_linkages_alloced <= i) return 0.0; /* bounds check */
 	return sent->lnkages[i].lifo.disjunct_cost;

--- a/link-grammar/linkage/score.c
+++ b/link-grammar/linkage/score.c
@@ -71,14 +71,7 @@ static double compute_disjunct_cost(Linkage lkg)
 void linkage_score(Linkage lkg, Parse_Options opts)
 {
 	lkg->lifo.unused_word_cost = unused_word_cost(lkg);
-	if (opts->use_sat_solver)
-	{
-		lkg->lifo.disjunct_cost = 0.0;
-	}
-	else
-	{
-		lkg->lifo.disjunct_cost = compute_disjunct_cost(lkg);
-	}
+	lkg->lifo.disjunct_cost = compute_disjunct_cost(lkg);
 	lkg->lifo.link_cost = compute_link_cost(lkg);
 	lkg->lifo.corpus_cost = -1.0;
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -416,6 +416,7 @@ void SATEncoder::generate_satisfaction_for_expression(int w, int& dfs_position, 
           *s++ = 'c';
           fast_sprintf(s, i);
 
+          /* if (i != 0) total_cost = 0; */ // This interferes with the cost cutoff
           generate_satisfaction_for_expression(w, dfs_position, l->e, new_var, total_cost);
         }
       }

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1862,13 +1862,16 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     if (xnode_word[wi] == NULL)
     {
       if (!_sent->word[wi].optional)
-        prt_error("Warning: Non-optional word %zu has no linkage\n", wi);
+      {
+        de = null_exp();
+        prt_error("Error: Internal error: Non-optional word %zu has no linkage\n", wi);
+      }
       continue;
     }
 
     if (de == NULL) {
       de = null_exp();
-      lgdebug(+0, "Warning: No expression for word %zu\n", wi);
+      prt_error("Error: Internal error: No expression for word %zu\n", wi);
     }
 
 #ifndef MAX_CONNECTOR_COST
@@ -1893,7 +1896,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 
   lkg->num_links = current_link;
 
-  DEBUG_print("Total: ." <<  lkg->num_links << "." << endl);
+  DEBUG_print("Total links: ." <<  lkg->num_links << "." << endl);
   return false;
 }
 #undef D_SEL

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -278,7 +278,7 @@ protected:
   virtual bool sat_extract_links(Linkage) = 0;
 
   // Create linkage from a propositional model
-  Linkage create_linkage();
+  bool create_linkage(Linkage);
 
   // Generate clause that prohibits the current model
   void generate_linkage_prohibiting();

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #include "utilities.h"
 }
 
-#define D_IC 6
+#define D_IC 8
 void WordTag::insert_connectors(Exp* exp, int& dfs_position,
                                 bool& leading_right, bool& leading_left,
                                 std::vector<int>& eps_right,
@@ -63,6 +63,12 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
   } else if (exp->type == AND_type) {
     if (exp->u.l == NULL) {
       /* zeroary and */
+      if (cost != 0)
+      {
+        lgdebug(+D_IC, "EmptyConnector var=%s(%d) cost %.2f pcost %.2f\n",
+                var, _variables->string(var), cost, parent_cost);
+        _empty_connectors.push_back(EmptyConnector(_variables->string(var),cost));
+      }
     } else
       if (exp->u.l->next == NULL) {
         /* unary and - skip */

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -22,10 +22,16 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
   double cost = parent_cost + exp->cost;
 
 #ifdef DEBUG
-  if (0 && verbosity_level(+D_IC)) { // Extreme debug
-    printf("Expression type %d for Word%d, var %s:\n", exp->type, _word, var);
-    printf("parent_exp: "); print_expression(parent_exp);
-    printf("exp: "); print_expression(exp);
+  if (0 && verbosity_level(+D_IC)) // Extreme debug
+  //if (_word == 2)
+  {
+    const char*type =
+      ((const char *[]) {"OR_type", "AND_type", "CONNECTOR_type"}) [exp->type-1];
+    printf("Expression type %s for Word%d, var %s:\n", type, _word, var);
+    //printf("parent_exp: "); print_expression(parent_exp);
+    printf("exp(%s) e=%.2f pc=%.2f ", word_xnode->string,exp->cost, parent_cost);
+    print_expression(exp);
+    if (exp->cost > 0 || root) prt_exp_mem(exp, 0);
   }
 #endif
 

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -44,7 +44,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _dir.push_back('+');
       _right_connectors.push_back(
            PositionConnector(parent_exp, exp, '+', _word, dfs_position,
-                             cost, leading_right, false,
+                             cost, parent_cost, leading_right, false,
                              eps_right, eps_left, word_xnode, _opts));
       leading_right = false;
       break;
@@ -53,7 +53,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       _dir.push_back('-');
       _left_connectors.push_back(
            PositionConnector(parent_exp, exp, '-', _word, dfs_position,
-                             cost, false, leading_left,
+                             cost, parent_cost, false, leading_left,
                              eps_right, eps_left, word_xnode, _opts));
       leading_left = false;
       break;
@@ -85,8 +85,9 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
           *s++ = 'c';
           fast_sprintf(s, i);
 
+          double and_cost = (i == 0) ? cost : 0;
           insert_connectors(l->e, dfs_position, leading_right, leading_left,
-                eps_right, eps_left, new_var, false, cost, parent_exp, word_xnode);
+                eps_right, eps_left, new_var, false, and_cost, parent_exp, word_xnode);
 
           if (leading_right) {
             eps_right.push_back(_variables->epsilon(new_var, '+'));

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -17,10 +17,10 @@ extern "C" {
 struct PositionConnector
 {
   PositionConnector(Exp* pe, Exp* e, char d, int w, int p,
-                    double pcst, bool lr, bool ll,
+                    double cst, double pcst, bool lr, bool ll,
                     const std::vector<int>& er, const std::vector<int>& el, const X_node *w_xnode, Parse_Options opts)
     : exp(pe), dir(d), word(w), position(p),
-      cost(e->cost), parent_cost(pcst),
+      cost(cst), parent_cost(pcst),
       leading_right(lr), leading_left(ll),
       eps_right(er), eps_left(el), word_xnode(w_xnode)
   {

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -84,6 +84,14 @@ struct PositionConnector
 
 };
 
+struct EmptyConnector {
+  EmptyConnector(int var, double cst)
+    : ec_var(var), ec_cost(cst)
+  {
+  }
+  int ec_var;
+  double ec_cost;
+};
 
 // XXX TODO: Hash connectors for faster matching
 
@@ -92,6 +100,7 @@ class WordTag
 private:
   std::vector<PositionConnector> _left_connectors;
   std::vector<PositionConnector> _right_connectors;
+  std::vector<EmptyConnector> _empty_connectors;
 
   std::vector<char> _dir;
   std::vector<int> _position;
@@ -131,6 +140,10 @@ public:
 
   const std::vector<PositionConnector>& get_right_connectors() const {
     return _right_connectors;
+  }
+
+  const std::vector<EmptyConnector>& get_empty_connectors() const {
+    return _empty_connectors;
   }
 
   PositionConnector* get(int dfs_position)

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -84,6 +84,11 @@ struct PositionConnector
 
 };
 
+/*
+ * Record the SAT variable and cost of costly-null expressions.
+ * Their cost is recovered (in sat_extract_links()) if
+ * they happen to reside on a participating disjunct.
+ */
 struct EmptyConnector {
   EmptyConnector(int var, double cst)
     : ec_var(var), ec_cost(cst)


### PR DESCRIPTION
Fix the SAT parser disjunct cost to take into account null expression cost. See (1) in this post in issue [#188](https://github.com/opencog/link-grammar/issues/188#issuecomment-143903475). (It seems I didn't open a new issue for that and instead continued the discussion in the same issue.)

Also fix the total cost per disjunct to be according to the calculation that is done in the classic parser, including the cost-cutoff calculation (see issue #783).

The result is that the reported costs (can be inspected with `!disjunct`) should now be identical to those reported by the classic parser. Note that because duplicate disjuncts are not discarded, and they may have different costs (in the classic parser only the one with the lowest cost is retained) the same parse can be shown multiple times, with different costs.

I had a difficulty to word the ChangeLog description.
I also used there "Modify" and not "fixed" because I am not convinced yet that the cost-cutoff calculation method that is currently used is "correct" (or "optimal").


I did comparison tests (SAT vs classic parsers) when I produce all the possible solutions for each input sentence.  The order of the parses is of course different, and also the SAT parser produces many duplicates. But by using md5 hashes of each parse I validated they they produce exactly the same parses. I didn't try to programmatically match the reported disjunct costs - I only inspected them manually and they seem identical (if you compare to the linkage with the lower total cost among the duplicates).

If you find different costs please tell me and I will try to investigate/fix that.

Some remaining problems (in addition to the open one from issue #188):
1. I suspect that the cost-guiding solution preference is currently broken (the intention is that the SAT solver will produce solutions with lower cost first.) I still don't know how to fix that.
2. The reported connector order (as displayed by `!disjuncts`) is not correct (so the original disjuncts cannot be correctly reconstructed and used). I know how to fix that.
3. Panic timeout is not implemented (will be fixed when fixing #785 is done).
4. "Robust parsing" (parsing with nulls) is not implemented. I started this work but still need to learn more some SAT related material in order to make an efficient implementation.
5. Improving the speed in various ways (there is very much room for that).