### PR TITLE
Add a strict connector name check

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Version 5.5.2 (XXX 2018)
  * Revise the manpage.
  * Remove the experimental Viterbi code.
  * Revise the SAT parser cost model to align it with the classic parser.
+ * Implement a strict check on connector name.
 
 Version 5.5.1 (27 July 2018)
  * Fix broken Java bindings build.

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ Version 5.5.2 (XXX 2018)
  * Major documentation update for building with Cygwin.
  * Revise the manpage.
  * Remove the experimental Viterbi code.
- * Modify the SAT parser disjunct cost metric to be like in the classic parser.
+ * Revise the SAT parser cost model to align it with the classic parser.
 
 Version 5.5.1 (27 July 2018)
  * Fix broken Java bindings build.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -403,8 +403,9 @@ static bool check_connector(Dictionary dict, const char * s)
 		return false;
 	}
 	if (*s == '@') s++;
-	if (!isupper((unsigned char)*s) && ('h' != *s) && ('d' != *s)) {
-		dict_error(dict, "The first letter of a connector must be h,d or uppercase.");
+	if (('h' == *s) || ('d' == *s)) s++;
+	if (!isupper((unsigned char)*s)) {
+		dict_error(dict, "Connectors must start with uppercase after an optional h or d.");
 		return false;
 	}
 	if ((*s == 'I') && (*(s+1) == 'D') && isupper((unsigned char)*(s+2))) {

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -412,10 +412,25 @@ static bool check_connector(Dictionary dict, const char * s)
 		dict_error(dict, "Connectors beginning with \"ID\" are forbidden");
 		return false;
 	}
+
+	bool connector_base = true;
+	s++; /* The first uppercase has been validated above. */
 	while (*(s+1)) {
 		if ((!isalnum((unsigned char)*s)) && (*s != WILD_TYPE)) {
 			dict_error(dict, "All letters of a connector must be ASCII alpha-numeric.");
 			return false;
+		}
+		if (isupper((unsigned char)*s))
+		{
+			if (!connector_base)
+			{
+				dict_error(dict, "Connector subscript contains uppercase.");
+				return false;
+			}
+		}
+		else
+		{
+			connector_base = false;
 		}
 		s++;
 	}

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -408,6 +408,7 @@ static bool check_connector(Dictionary dict, const char * s)
 		dict_error(dict, "Connectors must start with uppercase after an optional h or d.");
 		return false;
 	}
+	/* Note that IDx when x is a subscript is allowed (to allow e.g. ID4id+). */
 	if ((*s == 'I') && (*(s+1) == 'D') && isupper((unsigned char)*(s+2))) {
 		dict_error(dict, "Connectors beginning with \"ID\" are forbidden");
 		return false;


### PR DESCRIPTION
See issue #775.

I notified the lang-learning project and they promptly fixed their connectors names.
In addition, it turns out the current code doesn't actually check that a connector has any uppercase letter,
or even anything at all after an initial h/d, so `h+` and `habc+` are currently "valid".

(In the same occasion I incorporated you ChangeLog line from #820, since I like it more.)