### PR TITLE
Fix compilation issues

### DIFF
--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -234,7 +234,7 @@ size_t append_utf8_char(dyn_str * string, const char * mbs)
 	int n = nb;
 	if (n < 0) n = 1; // charlen is negative if its not a valid UTF-8
 
-	assert(n<10, "Multi-byte character is too long!");
+	assert((size_t)n<sizeof(buf), "Multi-byte character is too long!");
 	memcpy(buf, mbs, n);
 
 	// Whitepsace pad if its a bad value

--- a/link-grammar/print/print-util.c
+++ b/link-grammar/print/print-util.c
@@ -229,12 +229,13 @@ size_t append_utf8_char(dyn_str * string, const char * mbs)
 {
 	/* Copy exactly one multi-byte character to buf */
 	char buf[12];
+	assert('\0' != *mbs);
 	int nb = utf8_charlen(mbs);
 	int n = nb;
 	if (n < 0) n = 1; // charlen is negative if its not a valid UTF-8
 
 	assert(n<10, "Multi-byte character is too long!");
-	strncpy(buf, mbs, n);
+	memcpy(buf, mbs, n);
 
 	// Whitepsace pad if its a bad value
 	if (nb < 0) { buf[n] = ' '; n++; }

--- a/link-grammar/sat-solver/guiding.hpp
+++ b/link-grammar/sat-solver/guiding.hpp
@@ -2,7 +2,7 @@
 #define __GUIDING_HPP__
 
 #include <vector>
-#include <minisat/core/Solver.h>
+#include "minisat/core/Solver.h"
 #undef assert
 #include "util.hpp"
 

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -5,6 +5,8 @@
 #include <map>
 #include <set>
 
+#undef assert
+
 extern "C" {
 #include "connectors.h"
 #include "dict-common/dict-common.h"

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -5,6 +5,8 @@
 #include <map>
 #include <set>
 
+#include "variables.hpp"
+
 #undef assert
 #include "lg_assert.h"
 
@@ -14,8 +16,6 @@ extern "C" {
 #include "tokenize/tok-structures.h"    // gword_set
 #include "tokenize/wordgraph.h"         // in_same_alternative()
 };
-
-#include "variables.hpp"
 
 struct PositionConnector
 {

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -6,6 +6,7 @@
 #include <set>
 
 #undef assert
+#include "lg_assert.h"
 
 extern "C" {
 #include "connectors.h"

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -393,7 +393,7 @@ static FILE *open_help_file(int verbosity)
 	{
 		if (NULL != help_file)
 			continue; /* until get_next_locale() returns NULL */
-		strncpy(ll_pos, ll, HELPFILE_LANG_TEMPLATE_SIZE);
+		memcpy(ll_pos, ll, HELPFILE_LANG_TEMPLATE_SIZE);
 		help_file = linkgrammar_open_data_file(help_filename);
 	}
 


### PR DESCRIPTION
-    Fix warnings under GCC8:
     --open_help_file(): Avoid gcc8 warning -Wstringop-truncation on strncpy
     --append_utf8_char(): Avoid gcc8 warning -Wstringop-truncation on strncpy
- In the same occasion:
    --append_utf8_char(): Use sizeof instead of a constant

- Fix a warning on macOS:
   -- macOS: Avoid assert() redefinition warning
- In the same occasion:
   -- word-tag.hpp: Explicitly include assert.h
   -- word-tag.hpp: Reorder include for consistency

- Also:
  -- guiding.hpp: Fix include syntax for consistency
