### PR TITLE
SWIG interface file major revision

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Version 5.5.2 (XXX 2018)
  * Remove the experimental Viterbi code.
  * Revise the SAT parser cost model to align it with the classic parser.
  * Implement a strict check on connector name.
+ * Major revision of the SWIG interface file; Wrap all the library functions.
 
 Version 5.5.1 (27 July 2018)
  * Fix broken Java bindings build.

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -40,7 +40,8 @@ class ParseOptions(object):
                  spell_guess=False,
                  use_sat=False,
                  max_parse_time=-1,
-                 disjunct_cost=2.7):
+                 disjunct_cost=2.7,
+                 repeatable_rand=True,):
 
         self._obj = clg.parse_options_create()
         self.verbosity = verbosity
@@ -55,13 +56,14 @@ class ParseOptions(object):
         self.use_sat = use_sat
         self.max_parse_time = max_parse_time
         self.disjunct_cost = disjunct_cost
+        self.repeatable_rand = repeatable_rand
 
     # Allow only the attribute names listed below.
     def __setattr__(self, name, value):
         if not hasattr(self, name) and name != "_obj":
             # TypeError for consistency. It maybe should have been NameError.
             raise TypeError('Unknown parse option "{}".'.format(name))
-        super(self.__class__, self).__setattr__(name, value)
+        super(ParseOptions, self).__setattr__(name, value)
 
     def __del__(self):
         if hasattr(self, '_obj'):
@@ -273,6 +275,22 @@ class ParseOptions(object):
         if not isinstance(value, bool):
             raise TypeError("all_short_connectors must be set to a bool")
         clg.parse_options_set_all_short_connectors(self._obj, 1 if value else 0)
+
+    @property
+    def repeatable_rand(self):
+        """
+        If set to True, then a repeatable random sequence will be used, whenever
+        a random number is required.  The parser almost never uses random
+        numbers; currently they are only used in one place: to sample a subset
+        of linkages, if there are more parses than linkage_limit.
+        """
+        return clg.parse_options_get_repeatable_rand(self._obj) == 1
+
+    @repeatable_rand.setter
+    def repeatable_rand(self, value):
+        if not isinstance(value, bool):
+            raise TypeError("repeatable_rand must be set to a bool")
+        clg.parse_options_set_repeatable_rand(self._obj, 1 if value else 0)
 
 
 class LG_Error(Exception):

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -18,85 +18,7 @@
 #define bool int
 #endif /* bool */
 
-const char * linkgrammar_get_version(void);
-const char * linkgrammar_get_configuration(void);
-const char * linkgrammar_get_dict_version(Dictionary dict);
-const char * linkgrammar_get_dict_locale(Dictionary dict);
-
-/**********************************************************************
-*
-* Functions to manipulate Dictionaries
-*
-***********************************************************************/
-
-Dictionary dictionary_create_lang(const char * lang);
-Dictionary dictionary_create_default_lang(void);
-const char * dictionary_get_lang(Dictionary dict);
-
-void dictionary_delete(Dictionary dict);
-void dictionary_set_data_dir(const char * path);
 %newobject dictionary_get_data_dir;
-char * dictionary_get_data_dir(void);
-
-/**********************************************************************
-*
-* Functions to manipulate Parse Options
-*
-***********************************************************************/
-
-Parse_Options parse_options_create(void);
-int parse_options_delete(Parse_Options opts);
-void parse_options_set_verbosity(Parse_Options opts, int verbosity);
-int  parse_options_get_verbosity(Parse_Options opts);
-void parse_options_set_linkage_limit(Parse_Options opts, int linkage_limit);
-int  parse_options_get_linkage_limit(Parse_Options opts);
-void parse_options_set_disjunct_cost(Parse_Options opts, double disjunct_cost);
-double parse_options_get_disjunct_cost(Parse_Options opts);
-void parse_options_set_min_null_count(Parse_Options opts, int null_count);
-int  parse_options_get_min_null_count(Parse_Options opts);
-void parse_options_set_max_null_count(Parse_Options opts, int null_count);
-int  parse_options_get_max_null_count(Parse_Options opts);
-void parse_options_set_islands_ok(Parse_Options opts, int islands_ok);
-int  parse_options_get_islands_ok(Parse_Options opts);
-void parse_options_set_short_length(Parse_Options opts, int short_length);
-int  parse_options_get_short_length(Parse_Options opts);
-void parse_options_set_max_memory(Parse_Options  opts, int mem);
-int  parse_options_get_max_memory(Parse_Options opts);
-void parse_options_set_max_parse_time(Parse_Options  opts, int secs);
-int  parse_options_get_max_parse_time(Parse_Options opts);
-void parse_options_set_cost_model_type(Parse_Options opts, Cost_Model_type cm);
-Cost_Model_type  parse_options_get_cost_model_type(Parse_Options opts);
-int  parse_options_timer_expired(Parse_Options opts);
-int  parse_options_memory_exhausted(Parse_Options opts);
-int  parse_options_resources_exhausted(Parse_Options opts);
-void parse_options_set_display_morphology(Parse_Options opts, int val);
-int  parse_options_get_display_morphology(Parse_Options opts);
-void parse_options_set_spell_guess(Parse_Options opts, int val);
-int  parse_options_get_spell_guess(Parse_Options opts);
-void parse_options_set_all_short_connectors(Parse_Options opts, int val);
-int  parse_options_get_all_short_connectors(Parse_Options opts);
-void parse_options_reset_resources(Parse_Options opts);
-void parse_options_set_use_sat_parser(Parse_Options opts, bool val);
-int parse_options_get_use_sat_parser(Parse_Options opts);
-
-/**********************************************************************
-*
-* Functions to manipulate Sentences
-*
-***********************************************************************/
-
-Sentence sentence_create(const char *input_string, Dictionary dict);
-void sentence_delete(Sentence sent);
-int  sentence_split(Sentence sent, Parse_Options opts);
-int  sentence_parse(Sentence sent, Parse_Options opts);
-int  sentence_length(Sentence sent);
-int  sentence_null_count(Sentence sent);
-int  sentence_num_linkages_found(Sentence sent);
-int  sentence_num_valid_linkages(Sentence sent);
-int  sentence_num_linkages_post_processed(Sentence sent);
-int  sentence_num_violations(Sentence sent, int i);
-double sentence_disjunct_cost(Sentence sent, int i);
-int  sentence_link_cost(Sentence sent, int i);
 
 /**********************************************************************
 *
@@ -120,9 +42,6 @@ int  sentence_link_cost(Sentence sent, int i);
 %newobject linkage_print_postscript;
 %newobject linkage_print_constituent_tree;
 %newobject linkage_print_disjuncts;
-
-Linkage linkage_create(int index, Sentence sent, Parse_Options opts);
-void linkage_delete(Linkage linkage);
 
 %typemap(newfree) char * {
    linkage_free_diagram($1);
@@ -163,40 +82,15 @@ char * linkage_print_pp_msgs(Linkage linkage);
 %typemap(newfree) char * {
    free($1);
 }
-int linkage_get_num_words(Linkage linkage);
-int linkage_get_num_links(Linkage linkage);
-int linkage_get_link_lword(Linkage linkage, int index);
-int linkage_get_link_rword(Linkage linkage, int index);
-int linkage_get_link_length(Linkage linkage, int index);
-const char * linkage_get_link_label(Linkage linkage, int index);
-const char * linkage_get_link_llabel(Linkage linkage, int index);
-const char * linkage_get_link_rlabel(Linkage linkage, int index);
-int linkage_get_link_num_domains(Linkage linkage, int index);
-const char ** linkage_get_link_domain_names(Linkage linkage, int index);
-const char ** linkage_get_words(Linkage linkage);
-//const char *  linkage_get_disjunct(Linkage linkage, int w);
-const char *  linkage_get_word(Linkage linkage, int w);
-int linkage_get_word_byte_start(Linkage linkage, int index);
-int linkage_get_word_byte_end(Linkage linkage, int index);
-int linkage_get_word_char_start(Linkage linkage, int index);
-int linkage_get_word_char_end(Linkage linkage, int index);
-
-int linkage_unused_word_cost(Linkage linkage);
-double linkage_disjunct_cost(Linkage linkage);
-int linkage_link_cost(Linkage linkage);
-double linkage_corpus_cost(Linkage linkage);
-const char * linkage_get_violation_name(Linkage linkage);
 
 /* Error-handling facility calls. */
 %rename(_lg_error_formatmsg) lg_error_formatmsg;
 %newobject lg_error_formatmsg;
-char * lg_error_formatmsg(lg_errinfo *lge);
-int lg_error_clearall(void);
 %rename(_prt_error) prt_error;
 /* For security, the first argument should always contain a single "%s"
  * (e.g. "%s\n"), and the second one should always be a C string. */
 int prt_error(const char *, const char *);
-bool lg_error_flush(void);
+
 /*
  * void *lg_error_set_handler_data(void *);
  * A wrapper to this function is complex and is not implemented here.  However,

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -127,17 +127,17 @@ void linkage_delete(Linkage linkage);
 %typemap(newfree) char * {
    linkage_free_diagram($1);
 }
-char * linkage_print_diagram(Linkage linkage, bool display_walls, size_t screen_width);
+char * linkage_print_diagram(const Linkage linkage, bool display_walls, size_t screen_width);
 
 %typemap(newfree) char * {
    linkage_free_postscript($1);
 }
-char * linkage_print_postscript(Linkage linkage, bool display_walls, bool print_ps_header);
+char * linkage_print_postscript(const Linkage linkage, bool display_walls, bool print_ps_header);
 
 %typemap(newfree) char * {
    linkage_free_links_and_domains($1);
 }
-char * linkage_print_links_and_domains(Linkage linkage);
+char * linkage_print_links_and_domains(const Linkage linkage);
 
 %typemap(newfree) char * {
    linkage_free_senses($1);

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -13,21 +13,10 @@
 
 %nodefaultdtor lg_errinfo;
 
-/* Grab non-function definitions so we do not need to repeat them here. */
-%rename("$ignore", %$isfunction) "";
 #define link_public_api(x) x
 #ifndef bool                         /* Prevent syntax errors if no bool. */
 #define bool int
 #endif /* bool */
-%immutable;                          /* Future-proof for const definitions. */
-%include ../link-grammar/link-includes.h
-%mutable;
-%rename("%s") "";                    /* Grab everything for the rest of file. */
-
-// Set a default newfree typemap.
-%typemap(newfree) char * {
-   free($1);
-}
 
 const char * linkgrammar_get_version(void);
 const char * linkgrammar_get_configuration(void);
@@ -216,6 +205,14 @@ bool lg_error_flush(void);
  * languages can free the memory of the callback data.
  */
 
+// Set a default newfree typemap.
+%typemap(newfree) char * {
+   free($1);
+}
+
+%immutable;                          /* Future-proof for const definitions. */
+%include ../link-grammar/link-includes.h
+%mutable;
 
 #ifdef SWIGPYTHON
 %extend lg_errinfo

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -92,12 +92,12 @@ char * linkage_print_pp_msgs(Linkage linkage);
 int prt_error(const char *, const char *);
 
 /*
- * void *lg_error_set_handler_data(void *);
  * A wrapper to this function is complex and is not implemented here.  However,
  * such a wrapper may not be needed anyway since this function is provided
  * mainly for the low-level implementation of the error callback, so bound
  * languages can free the memory of the callback data.
  */
+%ignore lg_error_set_handler_data;
 
 // Set a default newfree typemap.
 %typemap(newfree) char * {

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -46,37 +46,37 @@
 %typemap(newfree) char * {
    linkage_free_diagram($1);
 }
-char * linkage_print_diagram(const Linkage linkage, bool display_walls, size_t screen_width);
+%rename("%s") linkage_print_diagram;
 
 %typemap(newfree) char * {
    linkage_free_postscript($1);
 }
-char * linkage_print_postscript(const Linkage linkage, bool display_walls, bool print_ps_header);
+%rename("%s")  linkage_print_postscript;
 
 %typemap(newfree) char * {
    linkage_free_links_and_domains($1);
 }
-char * linkage_print_links_and_domains(const Linkage linkage);
+%rename("%s")  linkage_print_links_and_domains;
 
 %typemap(newfree) char * {
    linkage_free_senses($1);
 }
-char * linkage_print_senses(Linkage linkage);
+%rename("%s")  linkage_print_senses;
 
 %typemap(newfree) char * {
    linkage_free_constituent_tree_str($1);
 }
-char * linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle mode);
+%rename("%s")  linkage_print_constituent_tree;
 
 %typemap(newfree) char * {
    linkage_free_disjuncts($1);
 }
-char * linkage_print_disjuncts(const Linkage linkage);
+%rename("%s")  linkage_print_disjuncts;
 
 %typemap(newfree) char * {
    linkage_free_pp_msgs($1);
 }
-char * linkage_print_pp_msgs(Linkage linkage);
+%rename("%s")  linkage_print_pp_msgs;
 
 // Reset to default.
 %typemap(newfree) char * {

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -36,38 +36,38 @@
 * newobject'd to avoid memory leaks
 *
 ***********************************************************************/
-%newobject linkage_print_senses;
-%newobject linkage_print_links_and_domains;
-%newobject linkage_print_diagram;
-%newobject linkage_print_postscript;
-%newobject linkage_print_constituent_tree;
-%newobject linkage_print_disjuncts;
 
+%newobject linkage_print_diagram;
 %typemap(newfree) char * {
    linkage_free_diagram($1);
 }
 %rename("%s") linkage_print_diagram;
 
+%newobject linkage_print_postscript;
 %typemap(newfree) char * {
    linkage_free_postscript($1);
 }
 %rename("%s")  linkage_print_postscript;
 
+%newobject linkage_print_links_and_domains;
 %typemap(newfree) char * {
    linkage_free_links_and_domains($1);
 }
 %rename("%s")  linkage_print_links_and_domains;
 
+%newobject linkage_print_senses;
 %typemap(newfree) char * {
    linkage_free_senses($1);
 }
 %rename("%s")  linkage_print_senses;
 
+%newobject linkage_print_constituent_tree;
 %typemap(newfree) char * {
    linkage_free_constituent_tree_str($1);
 }
 %rename("%s")  linkage_print_constituent_tree;
 
+%newobject linkage_print_disjuncts;
 %typemap(newfree) char * {
    linkage_free_disjuncts($1);
 }


### PR DESCRIPTION
The original design of the SWIG interface file is to list the declarations of all the functions to which language bindings are desired. This means that we need to add functions from time to time, for example to address #825 or to add the recent `sentence_wordgraph_display().` Moreover - declarations may become incorrect over time (it actually happened with many functions, see the list of affected functions in the commit messages).

So I introduced these changes in the interface definition:
1. Wrap all functions by default in the default way, and only list functions that need special handling. 
2. Use function names only instead of function declarations - this way there are no declarations that can get out of date.

For the Python bindings of `parse_options_*_repeatable_rand()` I still needed to update `linkgrammar.py`.  But see the notes below.

After these changes, I tested Python on Linux, Windows and macOS, and  all the tests pass.
On Linux I validated there are no memory leaks in the test, and that the demo programs run fine. I also validated on Linux that the Perl bindings can still be produced without errors (I have never tried to run them and I guess they need some updates).

This is a major interface file rewrite so it would be a good idea if someone could use the library with this patch on existing complex LG Python programs to validate that all is OK.

**Notes**:
1. With this patch, if parse-options are added before `linkgrammar.py` is updated, it is possible to directly use the corresponding C functions (since all the functions are then wrapped by default).
2. In principle it is possible to redesign the Python `ParseOption()` interface to automatically redirect each option to the corresponding `parse_options_*()` function.