### PR TITLE
Speed up build-disjuncts

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -14,6 +14,10 @@
 <dictionary-version-number>: V5v5v2+;
 <dictionary-locale>: EN4us+;
 
+t1: Wd- & A+ & ([()] or [[[()]]]) & C+;
+t2: A- or () or [()];
+t3: C-;
+
  % _ORGANIZATION OF THE DICTIONARY_
  %
  % I. NOUNS

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -207,13 +207,15 @@ void pool_reuse(Pool_desc *mp)
 	mp->ring = mp->chain;
 	mp->alloc_next = mp->ring;
 	mp->curr_elements = 0;
+#ifdef POOL_FREE
+	mp->free_list = NULL;
+#endif // POOL_FREE
 }
 
 #ifdef POOL_FREE
 /**
- * Free elements. They are added to a free list that is used by
- * pool_alloc() before it allocates from memory blocks.
- * XXX Unchecked.
+ * Allow to reuse individual elements. They are added to a free list that is
+ * used by pool_alloc() before it allocates from memory blocks.
  */
 void pool_free(Pool_desc *mp, void *e)
 {

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -81,7 +81,9 @@ Pool_desc *pool_new(const char *func, const char *name,
 	mp->alloc_next = NULL;
 	mp->chain = NULL;
 	mp->ring = NULL;
+#ifdef POOL_FREE
 	mp->free_list = NULL;
+#endif // POOL_FREE
 	mp->curr_elements = 0;
 	mp->num_elements = num_elements;
 

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -133,6 +133,8 @@ void pool_delete(Pool_desc *mp)
  */
 void *pool_alloc(Pool_desc *mp)
 {
+	mp->curr_elements++; /* For stats. */
+
 #ifdef POOL_FREE
 	if (NULL != mp->free_list)
 	{
@@ -142,8 +144,6 @@ void *pool_alloc(Pool_desc *mp)
 		return alloc_next;
 	}
 #endif // POOL_FREE
-
-	mp->curr_elements++; /* For stats. */
 
 	if ((NULL == mp->alloc_next) || (mp->alloc_next == mp->ring + mp->data_size))
 	{
@@ -204,6 +204,7 @@ void pool_reuse(Pool_desc *mp)
 	        mp->curr_elements, mp->name, mp->func);
 	mp->ring = mp->chain;
 	mp->alloc_next = mp->ring;
+	mp->curr_elements = 0;
 }
 
 #ifdef POOL_FREE
@@ -216,6 +217,7 @@ void pool_free(Pool_desc *mp, void *e)
 {
 	assert(mp->element_size >= FLDSIZE_NEXT);
 	if (NULL == e) return;
+	mp->curr_elements--;
 
 	char *next = mp->free_list;
 	mp->free_list = e;
@@ -270,12 +272,14 @@ void pool_reuse(Pool_desc *mp)
 	}
 
 	mp->chain = NULL;
+	mp->curr_elements = 0;
 }
 
 #ifdef POOL_FREE
 void pool_free(Pool_desc *mp, void *e)
 {
 	free(e);
+	mp->curr_elements--;
 }
 #endif // POOL_FREE
 #endif // POOL_ALLOCATOR

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -75,7 +75,9 @@ Pool_desc *pool_new(const char *func, const char *name,
 	}
 
 	mp->zero_out = zero_out;
+#ifdef POOL_EXACT
 	mp->exact = exact;
+#endif /* POOL_EXACT */
 	mp->alloc_next = NULL;
 	mp->chain = NULL;
 	mp->ring = NULL;
@@ -145,9 +147,11 @@ void *pool_alloc(Pool_desc *mp)
 
 	if ((NULL == mp->alloc_next) || (mp->alloc_next == mp->ring + mp->data_size))
 	{
+#ifdef POOL_EXACT
 		assert(!mp->exact || (NULL == mp->alloc_next),
 				 "Too many elements %zu>%zu (pool '%s' created in %s())",
 				 mp->curr_elements, mp->num_elements, mp->name, mp->func);
+#endif /* POOL_EXACT */
 
 		/* No current block or current block exhausted - obtain another one. */
 		char *prev = mp->ring; /* Remember current block for possible chaining. */
@@ -231,9 +235,11 @@ void pool_free(Pool_desc *mp, void *e)
 void *pool_alloc(Pool_desc *mp)
 {
 	mp->curr_elements++;
+#ifdef POOL_EXACT
 	assert(!mp->exact || mp->curr_elements <= mp->num_elements,
 	       "Too many elements (%zu>%zu) (pool '%s' created in %s())",
 	       mp->curr_elements, mp->num_elements, mp->name, mp->func);
+#endif /* POOL_EXACT */
 
 	/* Allocate a new element and chain it. */
 	char *next = mp->chain;

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -200,7 +200,7 @@ void *pool_alloc(Pool_desc *mp)
  */
 void pool_reuse(Pool_desc *mp)
 {
-	lgdebug(+D_MEMPOOL, "Used %zu elements (pool '%s' created in %s())\n",
+	lgdebug(+D_MEMPOOL, "Reuse %zu elements (pool '%s' created in %s())\n",
 	        mp->curr_elements, mp->name, mp->func);
 	mp->ring = mp->chain;
 	mp->alloc_next = mp->ring;
@@ -260,7 +260,7 @@ void *pool_alloc(Pool_desc *mp)
 void pool_reuse(Pool_desc *mp)
 {
 	if (NULL == mp) return;
-	lgdebug(+D_MEMPOOL, "Used %zu elements (pool '%s' created in %s())\n",
+	lgdebug(+D_MEMPOOL, "Reuse %zu elements (pool '%s' created in %s())\n",
 	        mp->curr_elements, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -68,4 +68,27 @@ struct  Pool_desc_s
 	bool exact;                 // Abort if more than num_elements are needed.
 #endif /* POOL_EXACT */
 };
+
+// Macros for our memory-pool usage debugging.
+// https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning
+#if !defined(__has_feature)
+#define __has_feature(x) 0
+#endif
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#include <sanitizer/asan_interface.h>
+#define ASAN_POISON_MEMORY_REGION(addr, size) \
+	__asan_poison_memory_region((addr), (size))
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+	__asan_unpoison_memory_region((addr), (size))
+#define ASAN_ADDRESS_IS_POISONED(addr) \
+	__asan_address_is_poisoned(addr)
+#else
+#define ASAN_POISON_MEMORY_REGION(addr, size) \
+	((void)(addr), (void)(size))
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+	((void)(addr), (void)(size))
+#define ASAN_ADDRESS_IS_POISONED(addr) \
+	((void)(addr), false)
+#endif // __SANITIZE_ADDRESS__
+
 #endif // _MEMORY_POOL_H

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -27,7 +27,9 @@ Pool_desc *pool_new(const char *, const char *, size_t, size_t, bool, bool, bool
 void *pool_alloc(Pool_desc *) GNUC_MALLOC;
 void pool_reuse(Pool_desc *);
 void pool_delete(Pool_desc *);
+#ifdef POOL_FREE
 void pool_free(Pool_desc *, void *e);
+#endif // POOL_FREE
 
 /* Pool allocator debug facility:
  * If configured with "CFLAGS=-DPOOL_ALLOCATOR=0", a fake pool allocator
@@ -48,7 +50,9 @@ struct  Pool_desc_s
 	char *chain;                // Allocated blocks. */
 	char *ring;                 // Current area for allocation.
 	char *alloc_next;           // Next element to be allocated.
+#ifdef POOL_FREE
 	char *free_list;            // Allocations that got freed.
+#endif // POOL_FREE
 	size_t block_size;          // Block size for pool extension.
 	size_t data_size;           // Size of data inside block_size.
 	size_t alignment;           // Alignment of element allocation.

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -18,6 +18,7 @@
 #define D_MEMPOOL (D_SPEC+4)
 #define MIN_ALIGNMENT sizeof(void *)    // Minimum element alignment.
 #define MAX_ALIGNMENT 64                // Maximum element alignment.
+/*#define POOL_EXACT // Not used for now and hence left undefined. */
 
 typedef struct Pool_desc_s Pool_desc;
 
@@ -63,6 +64,8 @@ struct  Pool_desc_s
 
 	/* Flags that are used by pool_alloc(). */
 	bool zero_out;              // Zero out allocated elements.
+#ifdef POOL_EXACT
 	bool exact;                 // Abort if more than num_elements are needed.
+#endif /* POOL_EXACT */
 };
 #endif // _MEMORY_POOL_H

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -18,6 +18,7 @@
 #define D_MEMPOOL (D_SPEC+4)
 #define MIN_ALIGNMENT sizeof(void *)    // Minimum element alignment.
 #define MAX_ALIGNMENT 64                // Maximum element alignment.
+//#define POOL_FREE                       // Allow to reuse individual elements.
 /*#define POOL_EXACT // Not used for now and hence left undefined. */
 
 typedef struct Pool_desc_s Pool_desc;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -105,21 +105,29 @@ static Connector * reverse(Connector *e)
  */
 static Tconnector * catenate(Tconnector * e1, Tconnector * e2)
 {
-	Tconnector * e, * head;
-	head = NULL;
-	for (;e1 != NULL; e1 = e1->next) {
-		e = (Tconnector *) xalloc(sizeof(Tconnector));
-		*e = *e1;
-		e->next = head;
-		head = e;
+	Tconnector head;
+	Tconnector *preve = &head;
+	Tconnector *newe = &head;
+
+	for (;e1 != NULL; e1 = e1->next)
+	{
+		newe = (Tconnector *) xalloc(sizeof(Tconnector));
+		*newe = *e1;
+
+		preve->next = newe;
+		preve = newe;
 	}
-	for (;e2 != NULL; e2 = e2->next) {
-		e = (Tconnector *) xalloc(sizeof(Tconnector));
-		*e = *e2;
-		e->next = head;
-		head = e;
+	for (;e2 != NULL; e2 = e2->next)
+	{
+		newe = (Tconnector *) xalloc(sizeof(Tconnector));
+		*newe = *e2;
+
+		preve->next = newe;
+		preve = newe;
 	}
-	return Treverse(head);
+
+	newe->next = NULL;
+	return head.next;
 }
 
 /**

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -13,7 +13,6 @@
 
 /* stuff for transforming a dictionary entry into a disjunct list */
 
-#include <math.h>
 #include "build-disjuncts.h"
 #include "connectors.h"
 //#include "dict-common/print-dict.h"      // for print_expression

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -16,7 +16,7 @@
 #include <math.h>
 #include "build-disjuncts.h"
 #include "connectors.h"
-//#include "dict-common/dict-api.h"        // for print_expression
+//#include "dict-common/print-dict.h"      // for print_expression
 #include "dict-common/dict-structures.h"   // for Exp_struct
 #include "disjunct-utils.h"
 #include "utilities.h"

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -39,6 +39,12 @@ struct clause_struct
 	Tconnector * c;
 };
 
+#ifdef DEBUG
+static void print_Tconnector_list(Tconnector * e);
+static void print_clause_list(Clause * c);
+static void print_connector_list(Connector * e);
+#endif
+
 static void free_Tconnectors(Tconnector *e)
 {
 	Tconnector * n;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -52,27 +52,29 @@ static void print_clause_list(Clause * c);
 static void print_connector_list(Connector * e);
 #endif
 
-static void free_Tconnectors(Tconnector *e)
+#if BUILD_DISJUNCTS_FREE_INETERMEDIATE_MEMOEY /* Undefined - CPU overhead. */
+static void free_Tconnectors(Tconnector *e, Pool_desc *mp)
 {
 	Tconnector * n;
 	for(;e != NULL; e=n)
 	{
 		n = e->next;
-		xfree((char *)e, sizeof(Tconnector));
+		pool_free(mp, e);
 	}
 }
 
-static void free_clause_list(Clause *c)
+static void free_clause_list(Clause *c, clause_context *ct)
 {
 	Clause *c1;
 	while (c != NULL)
 	{
 		c1 = c->next;
-		free_Tconnectors(c->c);
-		xfree((char *)c, sizeof(Clause));
+		free_Tconnectors(c->c, ct->Tconnector_pool);
+		pool_free(ct->Clause_pool, c);
 		c = c1;
 	}
 }
+#endif
 
 #if 0 /* old stuff */
 /**
@@ -188,8 +190,10 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 					c_head = c;
 				}
 			}
-			//free_clause_list(c1);
-			//free_clause_list(c2);
+#if BUILD_DISJUNCTS_FREE_INETERMEDIATE_MEMOEY /* Undefined - CPU overhead. */
+			free_clause_list(c1, ct);
+			free_clause_list(c2, ct);
+#endif
 			c1 = c_head;
 		}
 		c = c1;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -187,16 +187,26 @@ static Clause * build_clause(Exp *e, double cost_cutoff)
 	}
 	else if (e->type == OR_type)
 	{
+		c = build_clause(e->u.l->e, cost_cutoff);
 		/* we'll catenate the lists of clauses */
-		c = NULL;
-		for (e_list = e->u.l; e_list != NULL; e_list = e_list->next)
+		for (e_list = e->u.l->next; e_list != NULL; e_list = e_list->next)
 		{
 			c1 = build_clause(e_list->e, cost_cutoff);
-			while(c1 != NULL) {
-				c3 = c1->next;
-				c1->next = c;
+			if (c1 == NULL) continue;
+			if (c == NULL)
+			{
 				c = c1;
-				c1 = c3;
+			}
+			else
+			{
+				for (c2 = c; ; c2 = c2->next)
+				{
+					if (NULL == c2->next)
+					{
+						c2->next = c1;
+						break;
+					}
+				}
 			}
 		}
 	}

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -67,6 +67,7 @@ static void free_clause_list(Clause *c)
 	}
 }
 
+#if 0 /* old stuff */
 /**
  * reverse the order of the list e.  destructive
  */
@@ -98,6 +99,7 @@ static Connector * reverse(Connector *e)
 	}
 	return head;
 }
+#endif
 
 /**
  * Builds a new list of connectors that is the catenation of e1 with e2.

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -15,8 +15,8 @@
 
 #include "build-disjuncts.h"
 #include "connectors.h"
-//#include "dict-common/print-dict.h"      // for print_expression
-#include "dict-common/dict-structures.h"   // for Exp_struct
+//#include "dict-common/print-dict.h"      // print_expression()
+#include "dict-common/dict-structures.h"   // Exp_struct()
 #include "disjunct-utils.h"
 #include "utilities.h"
 

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -169,7 +169,7 @@ static Clause * build_clause(Exp *e, double cost_cutoff)
 				for (c4 = c2; c4 != NULL; c4 = c4->next)
 				{
 					double maxcost = MAX(c3->maxcost,c4->maxcost);
-					if (maxcost > cost_cutoff) continue;
+					if (maxcost + e->cost > cost_cutoff) continue;
 
 					c = (Clause *) xalloc(sizeof (Clause));
 					c->cost = c3->cost + c4->cost;
@@ -224,6 +224,9 @@ static Clause * build_clause(Exp *e, double cost_cutoff)
 		 * had it right!?
 		 */
 		c1->maxcost += e->cost;
+		/* Note: The above computation is used as a saving shortcut in
+		 * build_clause(). If it is changed here, it needs to be changed
+		 * there too. */
 	}
 	return c;
 }


### PR DESCRIPTION
This patch is for a major speedup of the disjunct building out of expressions.

The ideas behind the changes are:
1. Cost cutoff pruning while building the clauses. This is a major saving.
2.  Improved Tconnector list traversing.
3.  Not trying to concatenate empty lists (it's much overhead to traverse a list only to append a NULL).
4. Avoid reversing lists altogether. The new list traversing/build algos build them in the needed order.
5. Extract both types of connectors (+ and -) at once.
6. Use memory pools.
7. Don't free intermediate memory until the end.

In addition this patch includes slight memory-pool changes:
1. Ifdef out the yet unused POOL_EXACT feature.
2. Actually check the POOL_FREE feature (but it is left ifdef'ed out).
3. Add ASAN checks for POOL_FREE and fake-pools (fake-pools is a debug feature).
TBD: Add ASAN checks to the whole memory-pool system.

I validated the correctness of the change by producing all the linkages for en/corpus-fixes.batch (except for the "The problem is" sentences, which overflows). They are completely identical.

The speedup of building the disjuncts is > 50% and may be way over 80% for long sentences.
For example, check the long sentence at the end of `ru` corpus:
```
# BEFORE
$ link-parser ru -v=2
...
linkparser> как и ожидалось, он заявил, что дсб не поддержит вотум недоверия правительству, предложенный левой  изза отказа от проекта
...
++++ Built disjuncts                         0.41 seconds
...

# AFTER
++++ Built disjuncts                         0.07 seconds
```
