### PR TITLE
Expression misc. fixes

### DIFF
--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -244,7 +244,7 @@ int delete_dictionary_words(Dictionary dict, const char * s)
 /**
  * The following two functions free the Exp s and the
  * E_lists of the dictionary.  Not to be confused with
- * free_E_list in word-utils.c.
+ * free_E_list in dict-utils.c.
  */
 static void free_Elist(E_list * l)
 {

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -40,8 +40,8 @@ typedef enum
  * The E_list and Exp structures defined below comprise the expression
  * trees that are stored in the dictionary.  The expression has a type
  * (OR_type, AND_type or CONNECTOR_type).  If it is not a terminal it
- * has a list (an E_list) of children. Else "string" is the connector,
- * and "dir" indicates its direction.
+ * has a list (an E_list) of children. Else "condesc" is the connector
+ * descriptor, when "dir" indicates the connector direction.
  */
 struct Exp_struct
 {

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -145,7 +145,8 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	for (i=0; i<icost; i++) dyn_strcat(e, "[");
 
 	/* look for optional, and print only that */
-	if ((n->type == OR_type) && el->e && el->e->cost == 0 && (NULL == el->e->u.l))
+	if ((n->type == OR_type) && el->e &&
+	    (el->e->type == AND_type) && el->e->cost == 0 && (NULL == el->e->u.l))
 	{
 		dyn_strcat(e, "{");
 		if (NULL == el->next) dyn_strcat(e, "error-no-next");

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -419,7 +419,9 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 	else
 	{
 		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s dir=%c multi=%d\n", e->u.condesc->string, e->dir, e->multi);
+		printf("con=%s dir=%c multi=%d\n",
+		       e->u.condesc ? e->u.condesc->string : "(condesc=(null))",
+		       e->dir, e->multi);
 	}
 }
 #endif /* DEBUG */


### PR DESCRIPTION
Bug fix:
- print_expression_parens(): Fix "optional" printing

Enhance debug print:
- prt_exp_mem(): Allow to print expressions with NULL condesc

Fix comment rot:
- Exp_struct: Update the comment - "condesc" instead of "string"
- free_Elist(): Fix comment rot