### PR TITLE
Typo/formatting cleanup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Version 5.5.2 (XXX 2018)
  * Remove the experimental Viterbi code.
  * Revise the SAT parser cost model to align it with the classic parser.
  * Implement a strict check on connector name.
- * Major revision of the SWIG interface file; Wrap all the library functions.
+ * Major revision of the SWIG interface file; wrap all the library functions.
 
 Version 5.5.1 (27 July 2018)
  * Fix broken Java bindings build.

--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,7 @@ AC_CHECK_HEADERS([xlocale.h])
 # ====================================================================
 
 dnl For stdatomic.h -- missing in gcc-4.8 (Ubuntu Trusty 14.04)
-dnl Its used in the Jva bindings, to avoid an ugly server-init race.
+dnl Its used in the Java bindings, to avoid an ugly server-init race.
 AC_MSG_CHECKING(for stdatomic.h)
 AC_CHECK_HEADER([stdatomic.h],
 	[AC_DEFINE([HAVE_STDATOMIC_H], 1, [Define to 1 if stdatomic.h exists])],

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -64,7 +64,7 @@ is shown.
 [limit]
 The maximum number of linkages that are considered for post-processing.
 Up to this many linkages are generated; if there are fewer parses than
-thhis limit, then they will all be printed, in deterministic,
+this limit, then they will all be printed, in deterministic,
 cost-ranked order. If there are more parses than this limit, then a
 random subset will be printed. The !random option is used to control
 whether this sampling will use a repeatable (deterministic) random
@@ -95,7 +95,7 @@ Determines the maximum allowed length for certain connectors. The
 intended use is to speed up parsing by not considering very long links
 for most connectors, since they are rarely used in a correct parse.
 Setting this too low will prevent valid parses; setting this too high
-will slow the system, and occasionaly generate unlikely parses.
+will slow the system, and occasionally generate unlikely parses.
 The limit applies only to those connectors not exempted by the
 UNLIMITED-CONNECTORS dictionary entry.
 
@@ -103,7 +103,7 @@ UNLIMITED-CONNECTORS dictionary entry.
 Determines the approximate maximum time (in seconds) that parsing is
 allowed to take. If a parse is not found before this time, normal parsing
 is halted, and a "panic parse" mode is entered. During the panic parse,
-a looser, less restricitive set of parameters is used (primarily, a
+a looser, less restrictive set of parameters is used (primarily, a
 larger !cost-max), in an effort to find some, any parse.  Panic mode
 can be enabled and disabled with the !panic option.
 
@@ -119,7 +119,7 @@ possible number of null links.
 
 [panic]
 If enabled, then a "panic-mode" will be entered if a parse cannot be
-found within the time limit set by !timeout. Wehn in panic mode, various
+found within the time limit set by !timeout. When in panic mode, various
 parse options are loosened so a less accurate parse can be found quickly.
 
 [use-sat]
@@ -189,7 +189,7 @@ mode, the usual parse printing is suppressed; only errors are reported.
 In batch mode, a leading * in the first column can be used to indicate
 a non-grammatical sentence. If such a sentence parses, an error is
 printed. Conversely, an error is reported if no parses are found for
-a a valid sentence.
+a valid sentence.
 
 Batch testing is typically performed by piping a file to the parser;
 for example
@@ -197,7 +197,7 @@ for example
 or
    cat input-file | link-parser [dictionary name] [arguments]
 
-This flag is then usually placed at the begining of the input-file
+This flag is then usually placed at the beginning of the input-file
 (other options may be specified, as well). Setting the !echo flag
 can be useful, as it will echo the input sentence.
 
@@ -218,7 +218,7 @@ This mode is set to True when the standard input is not a terminal.
 [rand]
 If set to true, then a repeatable random sequence will be used, whenever
 a random number is required.  The parser almost never uses random
-numbers; currently they are ony used in one place: to sample a subset
+numbers; currently they are only used in one place: to sample a subset
 of linkages, if there are more parses than the linkage limit.
 See "!help limit" for info on the linkage limit.
 
@@ -248,7 +248,7 @@ in our GitHub repository https://github.com/opencog/link-grammar .
 [file]
 Read text from this file. The file is assumed to contain sentences
 and/or option settings.  It is typically used for reading in batch-mode
-files (see "!help batch") but can also be usefil in other scripting
+files (see "!help batch") but can also be useful in other scripting
 situations.
 
 [variables]

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -12197,7 +12197,7 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 
 % After a closing quote, the sentence may continue...
 % You were asking, "How might this work?" so I answered.
-% should thes be a <sent-start> ??? why not?
+% should these be a <sent-start> ??? why not?
 <post-quote>:
   QUc- & {<wo-wall> or <wi-wall> or CP+};
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -10128,7 +10128,7 @@ RIGHT-WALL: RW- or ({@Xca-} & [[Xc-]]);
 
 % After a closing quote, the sentence may continue...
 % You were asking, "How might this work?" so I answered.
-% should thes be a <sent-start> ??? why not?
+% should these be a <sent-start> ??? why not?
 <post-quote>:
   QUc- & {<wo-wall> or <wi-wall> or CP+};
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -45,7 +45,7 @@ void free_disjuncts(Disjunct *);
 void free_sentence_disjuncts(Sentence);
 unsigned int count_disjuncts(Disjunct *);
 Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
-Disjunct * eliminate_duplicate_disjuncts(Disjunct * );
+Disjunct * eliminate_duplicate_disjuncts(Disjunct *);
 char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
 Disjunct * disjuncts_dup(Disjunct *origd);

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -943,7 +943,7 @@ static int read_constituents_from_domains(con_context_t *ctxt, Linkage linkage,
 							err_ctxt ec = { linkage->sent };
 							err_msgc(&ec, lg_Warn,
 							      "Warning: the constituents aren't nested! "
-							      "Adjusting them. (%d, %d)", c, c2);
+							      "Adjusting them. (%d, %d)\n", c, c2);
 					  }
 					  ctxt->constituent[c].left = ctxt->constituent[c2].left;
 					}

--- a/link-grammar/post-process/pp-structures.h
+++ b/link-grammar/post-process/pp-structures.h
@@ -119,7 +119,7 @@ typedef struct pp_rule_s
 	/* Holds a single post-processing rule. Since rules come in many
 	   flavors, not all fields of the following are always relevant  */
 	const char *selector; /* name of link to which rule applies      */
-	bool selector_has_wildcard; /* selector contains '*' */
+	bool selector_has_wildcard;             /* selector contains '*' */
 	pp_linkset *link_set; /* handle to set of links relevant to rule */
 	int   link_set_size;  /* size of this set                        */
 	int   domain;         /* type of domain to which rule applies    */

--- a/link-grammar/sat-solver/variables.hpp
+++ b/link-grammar/sat-solver/variables.hpp
@@ -107,7 +107,7 @@ public:
         }
   }
 
-  // If guiding params are unknown, they are set do default
+  // If guiding params are unknown, they are set to default
   int string(const char* name)
   {
     int var;
@@ -137,7 +137,7 @@ public:
    * without making any connections of the given direction.
    */
 
-  // If guiding params are unknown, they are set do default
+  // If guiding params are unknown, they are set to default
   int epsilon(char* v, char dir) {
     char name[MAX_VARIABLE_NAME];
     dir = (dir == '+') ? 'r' : 'l';
@@ -161,7 +161,7 @@ public:
    * Variables that specify that two words are linked
    */
 
-  // If guiding params are unknown, they are set do default
+  // If guiding params are unknown, they are set to default
   int linked(int wi, int wj) {
     assert(wi < wj, "Variables: linked should be ordered");
     int var;
@@ -183,7 +183,7 @@ public:
    * cj of the word_j at position j
    */
 
-  // If guiding params are unknown, they are set do default
+  // If guiding params are unknown, they are set to default
   int link(int wi, int pi, const char* ci, Exp* ei,
            int wj, int pj, const char* cj, Exp* ej)
   {

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -69,7 +69,7 @@ typedef enum
 	/* Experimental - for display purposes.
 	 * MT_CONTR is now used in the tokenization step, see the comments there. */
 	MT_CONTR,              /* Contracted part of a contraction (e.g. y', 's) */
-	MT_PUNC,               /* Punctuation (yet unused) */
+	MT_PUNC,               /* Punctuation */
 	/* We are not going to have >63 types up to here. */
 	MT_STEM    = 1<<6,     /* Stem */
 	MT_PREFIX  = 1<<7,     /* Prefix */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1059,7 +1059,7 @@ static Gword *wordgraph_getqueue_word(Sentence sent)
 	Gword *w;
 
 	if (NULL == sent->word_queue) return NULL;
-	w = sent->word_queue->word;;
+	w = sent->word_queue->word;
 
 	return w;
 }

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -785,7 +785,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		{
 			char *err;
 			double val = strtod(y, &err);
-			if (('\0' == *y) ||('\0' != *err))
+			if (('\0' == *y) || ('\0' != *err))
 			{
 				prt_error("Error: Invalid value %s for variable \"%s\". Type \"!help\" or \"!variables\"\n", y, as[j].string);
 				return -1;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -560,7 +560,7 @@ fail:
 	/* printf("cols %i\n", ws.ws_col); */
 
 	/* Set the screen width only if the returned value seems
-	 * rational: its positive and not insanely tiny.
+	 * rational: it's positive and not insanely tiny.
 	 */
 	if ((10 < ws.ws_col) && (16123 > ws.ws_col))
 	{
@@ -755,7 +755,7 @@ int main(int argc, char * argv[])
 		if ('c' == command) continue; /* It was another command */
 		if (-1 == command) continue;  /* It was a bad command */
 
-		/* We have to handle the !file command inline; its too hairy
+		/* We have to handle the !file command inline; it's too hairy
 		 * otherwise ... */
 		if ('f' == command)
 		{

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -138,7 +138,7 @@ of Cygwin (in which case it included the "xlib" driver"), or separately from
 Both `PhotoViewer.dll` (if used) and `dot` must be in your PATH (if needed,
 you can customized that in a copy of `link-parser.bat`, as described above).
 
-BTW, when running and MSVC-compiled binary under Cygwin, don't exit
+BTW, when running an MSVC-compiled binary under Cygwin, don't exit
 link-parser by using `^Z` - the shell may get stuck because the program
 somehow may continue to run in the background.  Instead, exit using `!exit` .
 


### PR DESCRIPTION
Fix typos.
Fix whitespace/formatting.
Add a missing newline in a warning.
EDIT:
Fix a comment rot.