### PR TITLE
Fix setting chosen_disjuncts and printing disjuncts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Version 5.5.2 (XXX 2018)
  * Revise the SAT parser cost model to align it with the classic parser.
  * Implement a strict check on connector name.
  * Major revision of the SWIG interface file; wrap all the library functions.
+ * Fix linkage_get_disjunct_*() when parse-option display_morphology is true.
+ * Change library and python-bindings default for display_morphology to true.
 
 Version 5.5.1 (27 July 2018)
  * Fix broken Java bindings build.

--- a/bindings/python-examples/parses-lt.txt
+++ b/bindings/python-examples/parses-lt.txt
@@ -2,6 +2,7 @@
 % This file containes test sentences, and the expected parses, for the
 % current Lituanian dictionary.
 
+-display_morphology = False
 IAš skaitau knygą.
 O
 O    +------->T------>+--------Xp-------+

--- a/bindings/python-examples/parses-pos-he.txt
+++ b/bindings/python-examples/parses-pos-he.txt
@@ -1,5 +1,6 @@
 % For the file purpose and format see parses-pos-en.txt.
 
+-display_morphology = False
 Iהכלב רץ מהחצר
 PLEFT-WALL(0, 0) (0, 1) הכלב(0, 4) רץ(5, 7) (8, 9) (9, 10) מהחצר(8, 13)
 PLEFT-WALL(0, 0) (0, 2) הכלב(0, 8) רץ(9, 13) (14, 16) (16, 18) מהחצר(14, 24)

--- a/bindings/python-examples/parses-pos-ru.txt
+++ b/bindings/python-examples/parses-pos-ru.txt
@@ -1,5 +1,6 @@
 % For the file purpose and format see parses-pos-en.txt.
 
+-display_morphology = False
 Iэто тести
 PLEFT-WALL(0, 0) это.msi(0, 3) тести.nlmpi(4, 9) RIGHT-WALL(9, 9)
 PLEFT-WALL(0, 0) это.msi(0, 6) тести.nlmpi(7, 17) RIGHT-WALL(17, 17)

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -406,7 +406,8 @@ class DBasicParsingTestCase(unittest.TestCase):
     # If \w is supported, other \ shortcuts are hopefully supported too.
     def test_regex_class_shortcut_support(self):
         r"""Test that regexes support \w"""
-        linkage = self.parse_sent("This is a _regex_ive regex test")[0]
+        po = ParseOptions(display_morphology=False)
+        linkage = self.parse_sent("This is a _regex_ive regex test", po)[0]
         self.assertEqual(linkage.word(4), '_regex_ive[!].a')
 
     def test_timer_exhausted_exception(self):
@@ -610,7 +611,7 @@ class FSATsolverTestCase(unittest.TestCase):
 class HEnglishLinkageTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.d, cls.po = Dictionary(), ParseOptions(linkage_limit=300)
+        cls.d, cls.po = Dictionary(), ParseOptions(linkage_limit=300, display_morphology=False)
 
     @classmethod
     def tearDownClass(cls):
@@ -1026,16 +1027,19 @@ class ZRULangTestCase(unittest.TestCase):
         return list(Sentence(text, self.d, self.po).parse())
 
     def test_a_getting_num_of_words(self):
+        self.po.display_morphology = False
         #Words include punctuation and a 'LEFT-WALL' and 'RIGHT_WALL'
         self.assertEqual(self.parse_sent('это тести.')[0].num_of_words(), 5)
         self.assertEqual(self.parse_sent('вверху плыли редкие облачка.')[0].num_of_words(), 7)
 
     def test_b_getting_words(self):
+        self.po.display_morphology = False
         self.assertEqual(list(self.parse_sent('вверху плыли редкие облачка.')[0].words()),
             ['LEFT-WALL', 'вверху.e', 'плыли.vnndpp', 'редкие.api',
                 'облачка.ndnpi', '.', 'RIGHT-WALL'])
 
     def test_c_getting_links(self):
+        self.po.display_morphology = False
         sent = 'вверху плыли редкие облачка.'
         linkage = self.parse_sent(sent)[0]
         self.assertEqual(linkage.link(0),

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -36,7 +36,7 @@ class ParseOptions(object):
                  islands_ok=False,
                  short_length=16,
                  all_short_connectors=False,
-                 display_morphology=False,
+                 display_morphology=True,
                  spell_guess=False,
                  use_sat=False,
                  max_parse_time=-1,

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -144,7 +144,7 @@ Parse_Options parse_options_create(void)
 	po->repeatable_rand = true;
 	po->resources = resources_create();
 	po->use_cluster_disjuncts = false;
-	po->display_morphology = false;
+	po->display_morphology = true;
 
 	return po;
 }

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -258,24 +258,53 @@ void remove_empty_words(Linkage lkg)
  * This takes the Wordgraph path array and uses it to
  * compute the chosen_words array.  "I.xx" suffixes are eliminated.
  *
- * chosen_words
- *    A pointer to an array of pointers to strings.  These are the words to be
- *    displayed when printing the solution, the links, etc.  Computed as a
- *    function of chosen_disjuncts[] by compute_chosen_words().  This differs
- *    from sentence.word[].alternatives because it contains the subscripts.  It
- *    differs from chosen_disjunct[].string in that the idiom symbols have been
- *    removed.  Furthermore, several chosen_disjuncts[].string elements may be
- *    combined into one chosen_words[] element if opts->display_morphology==0 or
- *    that they where linkage null-words that are morphemes of the same original
- *    word (i.e. subwords of an unsplit_word which are marked as morphemes).
+ * Input:
  *
- * wg_path
+ * chosen_disjuncts[]
+ *   This is an array pointers to disjuncts, one for each word, that is
+ *   computed by extract_links().  It represents the chosen disjuncts
+ *   for the current linkage. It is used here to compute the chosen_words[].
+ *
+ *
+ * wg_path[]
  *    A pointer to a NULL-terminated array of pointers to Wordgraph words.
  *    It corresponds 1-1 to the chosen_disjuncts array in Linkage structure.
- *    A new one is constructed below to correspond 1-1 to chosen_words.
  *
  *    FIXME Sometimes the word strings are taken from chosen_disjuncts,
  *    and sometimes from wordgraph subwords.
+ *
+ * ---
+ *
+ * Output:
+ *
+ * chosen_words[]
+ *    A pointer to an array of pointers to strings.  These are the words
+ *    to be displayed when printing the solution, the links, etc.
+ *    Computed as a function of chosen_disjuncts[]. This differs from
+ *    sentence.word[].alternatives because it contains the subscripts.  It
+ *    differs from chosen_disjunct[].string in that the idiom symbols have
+ *    been removed.  Furthermore, several chosen_disjuncts[].string
+ *    elements may be combined into one chosen_words[] element if
+ *    opts->display_morphology==0 or that they where linkage null-words
+ *    that are morphemes of the same original word (i.e. subwords of an
+ *    unsplit_word which are marked as morphemes).
+ *
+ * wg_path_display[]
+ *    It is constructed to correspond 1-1 to chosen_words.
+ *
+ * chosen_disjuncts
+ *    Elements are discarded to match it to chosen_words, so functions like
+ *    linkage_get_disjunct_str(linkage, w) will be able to return info that is
+ *    attributed to chosen_words[w].
+ *
+ * link_array[]
+ *   This is an array of links.  These links define the current linkage.
+ *   It is computed by extract_links().  It is used by analyze_linkage().
+ *   It is indirectly modified here as follows:
+ *     1. To correspond to chosen_words[].
+ *     2. Morphology links are removed if opts->display_morphology==0.
+ *
+ * Note: For historical reasons there is some overlap between the results.
  */
 #define D_CCW 8
 void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -677,6 +677,7 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 	 * Note that if a word only has morphology links and is not combined with
 	 * another word, then it will get displayed with no links at all (e.g.
 	 * when explicitly specifying root and suffix for debug: root.= =suf */
+	Disjunct **cdj = linkage->chosen_disjuncts;
 	for (i=0, j=0; i<linkage->num_words; ++i)
 	{
 		if (chosen_words[i] &&
@@ -685,6 +686,11 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 			//const char *cwtmp = linkage->word[j];
 			linkage->word[j] = chosen_words[i];
 			//chosen_words[i] = cwtmp;
+
+			Disjunct *cdtmp = cdj[j];
+			cdj[j] = cdj[i];
+			cdj[i] = cdtmp; /* The SAT parser frees chosen_disjuncts elements. */
+
 			remap[i] = j;
 			j++;
 		}

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -682,9 +682,9 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 		if (chosen_words[i] &&
 		    (chosen_words[i][0] || (!HIDE_MORPHO || show_word[i])))
 		{
-			const char *cwtmp = linkage->word[j];
+			//const char *cwtmp = linkage->word[j];
 			linkage->word[j] = chosen_words[i];
-			chosen_words[i] = cwtmp;
+			//chosen_words[i] = cwtmp;
 			remap[i] = j;
 			j++;
 		}

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -29,47 +29,6 @@
 #define MAX_LINK_NAME_LENGTH 10
 
 /**
- * Print connector list to string.
- * This reverses the order of the connectors in the connector list,
- * so that the resulting list is in the same order as it would appear
- * in the dictionary. The character 'dir' is appended to each connector.
- */
-static char * reversed_conlist_str(Connector* c, char dir, char* buf, size_t sz)
-{
-	char* p;
-	size_t len = 0;
-
-	if (NULL == c) return buf;
-	p = reversed_conlist_str(c->next, dir, buf, sz);
-
-	sz -= (p-buf);
-
-	if (c->multi)
-		p[len++] = '@';
-
-	len += lg_strlcpy(p+len, connector_string(c), sz-len);
-	if (3 < sz-len)
-	{
-		p[len++] = dir;
-		p[len++] = ' ';
-		p[len] = 0x0;
-	}
-	return p+len;
-}
-
-/**
- * Print disjunct to string.  The resulting list is in the same order
- * as it would appear in the dictionary.
- */
-static void disjunct_str(Disjunct* dj, char* buf, size_t sz)
-{
-	char* p;
-	if (NULL == dj) { *buf = 0; return; }
-	p = reversed_conlist_str(dj->left, '-', buf, sz);
-	reversed_conlist_str(dj->right, '+', p, sz - (p-buf));
-}
-
-/**
  * lg_compute_disjunct_strings -- Given sentence, compute disjuncts.
  *
  * This routine will compute the string representation of the disjunct

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -78,6 +78,14 @@ static void disjunct_str(Disjunct* dj, char* buf, size_t sz)
  * statistics functions: this string, together with the subscripted
  * word, is used as a key to index the statistics information in the
  * database.
+ *
+ * The connectors are extracted from link_array (and not chosen_disjuncts)
+ * so the lexical links remain hidden when HIDE_MORPHO is true (see
+ * compute_chosen_disjuncts()).
+ *
+ * In order that multi-connectors will not be extracted several times
+ * for each disjunct (if they connect to multiple words) their address
+ * is checked for duplication.
  */
 void lg_compute_disjunct_strings(Linkage lkg)
 {

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -631,6 +631,7 @@ int main(int argc, char * argv[])
 	parse_options_set_max_null_count(opts, 0);
 	parse_options_set_short_length(opts, 16);
 	parse_options_set_islands_ok(opts, false);
+	parse_options_set_display_morphology(opts, false);
 
 	save_default_opts(copts); /* Options so far are the defaults */
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -510,7 +510,7 @@ static void print_usage(FILE *out, char *str, Command_Options *copts, int exit_v
 			 "                   [--version]\n", str);
 
 	fprintf(out, "\nSpecial commands are:\n");
-	divert_stdio(stdout, stderr);
+	if (stdout != out) divert_stdio(stdout, out);
 	issue_special_command("var", copts, NULL);
 	exit(exit_value);
 }

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -503,15 +503,13 @@ static void restore_stdio(FILE *from, int origfd)
 }
 #endif
 
-static void print_usage(FILE *out, char *str, int exit_value)
+static void print_usage(FILE *out, char *str, Command_Options *copts, int exit_value)
 {
-	Command_Options *copts;
 	fprintf(out, "Usage: %s [language|dictionary location]\n"
 			 "                   [-<special \"!\" command>]\n"
 			 "                   [--version]\n", str);
 
 	fprintf(out, "\nSpecial commands are:\n");
-	copts = command_options_create();
 	divert_stdio(stdout, stderr);
 	issue_special_command("var", copts, NULL);
 	exit(exit_value);
@@ -616,28 +614,6 @@ int main(int argc, char * argv[])
 	sigaction (SIGWINCH, &winch_act, NULL);
 #endif
 
-	i = 1;
-	if ((argc > 1) && (argv[1][0] != '-')) {
-		/* the dictionary is the first argument if it doesn't begin with "-" */
-		language = argv[1];
-		i++;
-	}
-
-	if ((i < argc) && strcmp("--help", argv[i]) == 0)
-	{
-		print_usage(stdout, argv[0], 0);
-	}
-
-	for (; i<argc; i++)
-	{
-		if (argv[i][0] == '-' && strcmp("--version", argv[i]) == 0)
-		{
-			printf("Version: %s\n", linkgrammar_get_version());
-			printf("%s\n", linkgrammar_get_configuration());
-			exit(0);
-		}
-	}
-
 	copts = command_options_create();
 	if (copts == NULL || copts->panic_opts == NULL)
 	{
@@ -658,6 +634,28 @@ int main(int argc, char * argv[])
 
 	save_default_opts(copts); /* Options so far are the defaults */
 
+	i = 1;
+	if ((argc > 1) && (argv[1][0] != '-')) {
+		/* the dictionary is the first argument if it doesn't begin with "-" */
+		language = argv[1];
+		i++;
+	}
+
+	if ((i < argc) && strcmp("--help", argv[i]) == 0)
+	{
+		print_usage(stdout, argv[0], copts, 0);
+	}
+
+	for (; i<argc; i++)
+	{
+		if (argv[i][0] == '-' && strcmp("--version", argv[i]) == 0)
+		{
+			printf("Version: %s\n", linkgrammar_get_version());
+			printf("%s\n", linkgrammar_get_configuration());
+			exit(0);
+		}
+	}
+
 	/* Process command line variable-setting commands (only). */
 	for (i = 1; i < argc; i++)
 	{
@@ -665,12 +663,12 @@ int main(int argc, char * argv[])
 		{
 			const char *var = argv[i] + ((argv[i][1] != '-') ? 1 : 2);
 			if ((var[0] != '!') && (0 > issue_special_command(var, copts, NULL)))
-				print_usage(stderr, argv[0], -1);
+				print_usage(stderr, argv[0], copts, -1);
 		}
 		else if (i != 1)
 		{
 			prt_error("Fatal error: Unknown argument '%s'.\n", argv[i]);
-			print_usage(stderr, argv[0], -1);
+			print_usage(stderr, argv[0], copts, -1);
 		}
 	}
 
@@ -699,7 +697,7 @@ int main(int argc, char * argv[])
 		if ((argv[i][0] == '-') && (argv[i][1] == '!'))
 		{
 			if (0 > issue_special_command(argv[i]+1, copts, dict))
-				print_usage(stderr, argv[0], -1);
+				print_usage(stderr, argv[0], copts, -1);
 		}
 	}
 


### PR DESCRIPTION
See issue #828.
The !disjuncts printout for 'ru' is generally bogus for **both** values if !morphology" (even for non-lexical links).

Repeat by (a sentence from ru/corpus-basic.batch);
```
link-grammar: Info: Dictionary found at ../ru/4.0.dict
link-grammar: Info: Dictionary version 5.3.15, locale ru_RU.UTF-8
link-grammar: Info: Library version link-grammar-5.5.1. Enter "!help" for help.
linkparser> Палец непроизвольно нажал спуск пистолета.
No complete linkages found.
Found 4 linkages (4 had no P.P. violations) at null count 2
	Linkage 1, cost vector = (UNUSED=2 DIS= 2.00 LEN=18)

    +-------------------------------------Xp------------------------------------+
    +-------------------Wd------------------+                                   |
    |          +------------MVIv------------+----SIm3----+------Mg-----+        |
    |          |                            |            |             |        |
LEFT-WALL палец.ndmsv [непроизвольно] нажал.vspdpms спуск.ndmsi пистолета.ndmsg .

            LEFT-WALL    0.000  W+ Xp+ 
          палец.ndmsv    0.000  LLAYE+ 
      [непроизвольно]    1.000  LLAYE- MVIv+ 
      пистолета.ndmsg    0.000  LLGLP+ 
                    .    0.000  LLGLP- MVI- Wd- SIm+ 
           RIGHT-WALL    0.000  SIm3- M+ 

Press RETURN for the next linkage.
linkparser> !morphology 
Display word morphology turned on.
linkparser> Палец непроизвольно нажал спуск пистолета.
No complete linkages found.
Found 4 linkages (4 had no P.P. violations) at null count 2
	Linkage 1, cost vector = (UNUSED=2 DIS= 2.00 LEN=18)

    +-------------------------------------------Xp------------------------------------------+
    +-----------------------Wd-----------------------+                                      |
    |               +--------------MVIv--------------+           +----------Mg---------+    |
    |       +-LLAYE-+                       +--LLGLP-+----SIm3---+           +--LLAAQ--+    |
    |       |       |                       |        |           |           |         |    |
LEFT-WALL пал.= =ец.ndmsv [непроизвольно] наж.= =ал.vspdpms спуск.ndmsi пистолет.= =а.ndmsg .

            LEFT-WALL    0.000  W+ Xp+ 
                пал.=    0.000  LLAYE+ 
            =ец.ndmsv    1.000  LLAYE- MVIv+ 
          =ал.vspdpms    0.000  LLGLP+ 
          спуск.ndmsi    0.000  LLGLP- MVI- Wd- SIm+ 
           пистолет.=    0.000  SIm3- M+ 
             =а.ndmsg    0.000  LLAAQ+ 
                    .    1.000  LLAAQ- Mg- 
           RIGHT-WALL    0.000  Xp- RW+ 
```

Fixes in this PR:

**Library + Python-bindings:**
- Bug fixes for updating chosen_disjuncts.
- Rewrite `lg_compute_disjunct_strings()` to use `link_array` instead of `chosen_disjuncts`. This way the lexical links automatically excluded.
- Add/change related comments.
- Just forget discarded words in chosen_words[] (efficiency).
- Change library and Python-bindings default for display_morphology to true; remove functions that are now not needed.
- Fix the Python test cases that assume morphology=0 is the default.

**link-parser:**
- Explicitly set as default morphology=0.
- Fix "link-parser --help" to print actual link-parser's defaults (so !morphology will be printed as needed, and also several other variables that previously displayed wrong values).
- In the same occasion, fix a bug of printing `--help` to stderr when the intention was to print it to stdout.

