### PR TITLE
Add URLs at link-parser's help text

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,16 @@
-AC_INIT([link-grammar],[5.5.1],[link-grammar@googlegroups.com])
+# This file is processed by the Windows build system using confvar.bat. It
+# assumes AC_INIT is the first command, with no blank lines before it and with
+# a blank line after it. If this things are changed, change confvar.bat
+# accordingly.
+# Don't end the URLs with a slash even if it appears in the official address,
+# because we may append a component. Also, they cannot include "!".
+AC_INIT([link-grammar],[5.5.1],[https://github.com/opencog/link-grammar],,
+		  [https://www.abisource.com/projects/link-grammar])
+
+DISCUSSION_GROUP=https://groups.google.com/d/forum/link-grammar
+AC_SUBST(DISCUSSION_GROUP)
+OVERVIEW=https://en.wikipedia.org/wiki/Link_grammar
+AC_SUBST(OVERVIEW)
 
 dnl Set release number
 dnl This is derived from "Versioning" chapter of info libtool documentation.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -656,10 +656,6 @@ int sentence_parse(Sentence sent, Parse_Options opts)
  * Definitions for linkgrammar_get_configuration().
  */
 
-/* __VA_ARGS__ must be used because arguments may contain commas. */
-#define lg_xstr(...) lg_str(__VA_ARGS__)
-#define lg_str(...) #__VA_ARGS__
-
 #ifdef __STDC_VERSION__
 #define LG_S1 "__STDC_VERSION__=" lg_xstr(__STDC_VERSION__)
 #else

--- a/link-grammar/link-features.h.in
+++ b/link-grammar/link-features.h.in
@@ -43,4 +43,12 @@
 #define LG_CFLAGS "CFLAGS=" lg_str(@CFLAGS@)
 #define LG_DEFS lg_str(@LG_DEFS@)
 
+#define DISCUSSION_GROUP "@DISCUSSION_GROUP@"
+#define OVERVIEW "@OVERVIEW@"
+/* Must appear here to support Windows. */
+#undef PACKAGE_BUGREPORT
+#define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+#undef PACKAGE_URL
+#define PACKAGE_URL "@PACKAGE_URL@"
+
 #endif

--- a/link-grammar/link-features.h.in
+++ b/link-grammar/link-features.h.in
@@ -34,6 +34,10 @@
 
 #define LINK_VERSION_STRING "@LINK_MAJOR_VERSION@.@LINK_MINOR_VERSION@.@LINK_MICRO_VERSION@"
 
+/* __VA_ARGS__ must be used because arguments may contain commas. */
+#define lg_xstr(...) lg_str(__VA_ARGS__)
+#define lg_str(...) #__VA_ARGS__
+
 #define LG_HOST_OS lg_str(@HOST_OS@)
 #define LG_CPPFLAGS "CPPFLAGS=" lg_str(@CPPFLAGS@)
 #define LG_CFLAGS "CFLAGS=" lg_str(@CFLAGS@)

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -545,6 +545,25 @@ static void display_help(const Switch *sp, Command_Options *copts)
 	}
 }
 
+#define URL_LINE "%-20s %s\n"
+void print_url_info(void)
+{
+	printf("\n");
+#ifdef OVERVIEW
+	printf(URL_LINE, "Overview:", OVERVIEW);
+#endif /* OVERVIEW */
+#ifdef PACKAGE_URL
+	printf(URL_LINE, "Home page:", PACKAGE_URL);
+	printf(URL_LINE, "Documentation:", PACKAGE_URL"/dict/");
+#endif /* PACKAGE_URL */
+#ifdef DISCUSSION_GROUP
+	printf(URL_LINE, "Discussion group:", DISCUSSION_GROUP);
+#endif /* DISCUSSION_GROUP */
+#ifdef PACKAGE_BUGREPORT
+	printf(URL_LINE, "Report bugs to:" , PACKAGE_BUGREPORT"/issues");
+#endif /* PACKAGE_BUGREPORT */
+}
+
 static int help_cmd(const Switch *uc, int n)
 {
 	printf("Special commands always begin with \"!\".  Command and variable names\n");
@@ -565,6 +584,8 @@ static int help_cmd(const Switch *uc, int n)
 	printf("\n");
 	printf(" !<var>          Toggle the specified Boolean variable.\n");
 	printf(" !<var>=<val>    Assign that value to that variable.\n");
+
+	print_url_info();
 
 	return 'c';
 }

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -73,5 +73,7 @@ int issue_special_command(const char*, Command_Options*, Dictionary);
 Command_Options* command_options_create(void);
 void command_options_delete(Command_Options*);
 void display_1line_help(const Switch *, bool);
+void print_url_info(void);
+
 
 #define UNDOC "\1" /* undocumented command */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -636,14 +636,12 @@ int main(int argc, char * argv[])
 
 	save_default_opts(copts); /* Options so far are the defaults */
 
-	i = 1;
 	if ((argc > 1) && (argv[1][0] != '-')) {
 		/* the dictionary is the first argument if it doesn't begin with "-" */
 		language = argv[1];
-		i++;
 	}
 
-	for (; i<argc; i++)
+	for (i = 1; i<argc; i++)
 	{
 		if (strcmp("--help", argv[i]) == 0)
 		{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -512,6 +512,7 @@ static void print_usage(FILE *out, char *str, Command_Options *copts, int exit_v
 	fprintf(out, "\nSpecial commands are:\n");
 	if (stdout != out) divert_stdio(stdout, out);
 	issue_special_command("var", copts, NULL);
+	if (out == stdout) print_url_info(); /* don't print it for errors */
 	exit(exit_value);
 }
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -650,7 +650,7 @@ int main(int argc, char * argv[])
 			print_usage(stdout, argv[0], copts, 0);
 		}
 
-		if (argv[i][0] == '-' && strcmp("--version", argv[i]) == 0)
+		if (strcmp("--version", argv[i]) == 0)
 		{
 			printf("Version: %s\n", linkgrammar_get_version());
 			printf("%s\n", linkgrammar_get_configuration());

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -573,7 +573,7 @@ int main(int argc, char * argv[])
 	FILE            *input_fh = stdin;
 	Dictionary      dict;
 	const char     *language = NULL;
-	int             num_linkages, i;
+	int             num_linkages;
 	Label           label = NO_LABEL;
 	Command_Options *copts;
 	Parse_Options   opts;
@@ -641,7 +641,7 @@ int main(int argc, char * argv[])
 		language = argv[1];
 	}
 
-	for (i = 1; i<argc; i++)
+	for (int i = 1; i < argc; i++)
 	{
 		if (strcmp("--help", argv[i]) == 0)
 		{
@@ -657,7 +657,7 @@ int main(int argc, char * argv[])
 	}
 
 	/* Process command line variable-setting commands (only). */
-	for (i = 1; i < argc; i++)
+	for (int i = 1; i < argc; i++)
 	{
 		if (argv[i][0] == '-')
 		{
@@ -692,7 +692,7 @@ int main(int argc, char * argv[])
 	}
 
 	/* Process the command line '!' commands */
-	for (i = 1; i<argc; i++)
+	for (int i = 1; i < argc; i++)
 	{
 		if ((argv[i][0] == '-') && (argv[i][1] == '!'))
 		{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -503,11 +503,36 @@ static void restore_stdio(FILE *from, int origfd)
 }
 #endif
 
-static void print_usage(FILE *out, char *str, Command_Options *copts, int exit_value)
+/**
+ * Find the basename of the given file name.
+ * The last component that starts with '\\' or '\'
+ * (whichever is last) is returned.
+ * On POSIX systems it can be confused if the program name
+ * contains '\\' characters, but we don't care.
+ */
+static const char *fbasename(const char *fpath)
 {
+	const char *progf, *progb;
+
+	if ((NULL == fpath) || ('\0' == fpath[0])) return "(null)";
+
+	progf = strrchr(fpath, '/');
+	if (NULL == progf)
+		progb = strrchr(fpath, '\\');
+	else
+		progb = strchr(progf, '\\');
+
+	if (NULL != progb) return progb + 1;
+	if (NULL == progf) return fpath;
+	return progf + 1;
+}
+
+static void print_usage(FILE *out, char *argv0, Command_Options *copts, int exit_value)
+{
+
 	fprintf(out, "Usage: %s [language|dictionary location]\n"
 			 "                   [-<special \"!\" command>]\n"
-			 "                   [--version]\n", str);
+			 "                   [--version]\n", fbasename(argv0));
 
 	fprintf(out, "\nSpecial commands are:\n");
 	if (stdout != out) divert_stdio(stdout, out);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -643,13 +643,13 @@ int main(int argc, char * argv[])
 		i++;
 	}
 
-	if ((i < argc) && strcmp("--help", argv[i]) == 0)
-	{
-		print_usage(stdout, argv[0], copts, 0);
-	}
-
 	for (; i<argc; i++)
 	{
+		if (strcmp("--help", argv[i]) == 0)
+		{
+			print_usage(stdout, argv[0], copts, 0);
+		}
+
 		if (argv[i][0] == '-' && strcmp("--version", argv[i]) == 0)
 		{
 			printf("Version: %s\n", linkgrammar_get_version());


### PR DESCRIPTION
Per issue #838.

Add the following printout to -`-help` and `!help`:
``` text
Overview:            https://en.wikipedia.org/wiki/Link_grammar
Home page:           https://www.abisource.com/projects/link-grammar/
Documentation:       https://www.abisource.com/projects/link-grammar/dict/
Discussion group:    https://groups.google.com/d/forum/link-grammar
Report bugs to:      https://github.com/opencog/link-grammar/issues
```

The URLs are defined at the start of `configure.ac`. They are extracted from there also by the Windows build. The usual URL for the discussion group contains `!`, which is not preserved when extracted by Windows (a fix is welcome - it seems complex). Hence I used an alternative URL.

Also, as mentioned in issue #838:
In the usage message use the basename of the program instead of its full path.
BTW, in the same occasion of touching this code, I simplified some of it.
