### PR TITLE
Prune speedup

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -212,7 +212,7 @@ static inline bool easy_match(const char * s, const char * t)
  * When this function is called, it is assumed that the upper-case
  * parts are equal, and thus do not need to be checked again.
  */
-static bool lc_easy_match(const condesc_t *c1, const condesc_t *c2)
+static inline bool lc_easy_match(const condesc_t *c1, const condesc_t *c2)
 {
 	return (((c1->lc_letters ^ c2->lc_letters) & c1->lc_mask & c2->lc_mask) ==
 	        (c1->lc_mask & c2->lc_mask & 1));

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -295,20 +295,19 @@ static power_table * power_table_new(Sentence sent)
  * who are obsolete.  The word fields of an obsolete one has been set to
  * BAD_WORD.
  */
-static void clean_table(unsigned int size, C_list ** t)
+static void clean_table(unsigned int size, C_list **t)
 {
-	unsigned int i;
-	C_list * m, * xm, * head;
-	for (i = 0; i < size; i++) {
-		head = NULL;
-		for (m = t[i]; m != NULL; m = xm) {
-			xm = m->next;
-			if (m->c->nearest_word != BAD_WORD) {
-				m->next = head;
-				head = m;
-			}
-		}
-		t[i] = head;
+	for (unsigned int i = 0; i < size; i++)
+	{
+		C_list **m = &t[i];
+
+		while (NULL != *m)
+		{
+			if ((*m)->c->nearest_word == BAD_WORD)
+				*m = (*m)->next;
+			else
+				m = &(*m)->next;
+		};
 	}
 }
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -627,7 +627,7 @@ right_connector_list_update(prune_context *pc, Connector *c,
 }
 
 /** The return value is the number of disjuncts deleted */
-int power_prune(Sentence sent, Parse_Options opts)
+static int power_prune(Sentence sent, Parse_Options opts)
 {
 	power_table *pt;
 	prune_context pc;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -659,9 +659,6 @@ int power_prune(Sentence sent, Parse_Options opts)
 					for (c=d->left;  c != NULL; c = c->next) c->nearest_word = BAD_WORD;
 					for (c=d->right; c != NULL; c = c->next) c->nearest_word = BAD_WORD;
 					N_deleted++;
-					total_deleted++;
-				}
-			}
 
 			clean_table(pt->r_table_size[w], pt->r_table[w]);
 			nd = NULL;
@@ -677,6 +674,8 @@ int power_prune(Sentence sent, Parse_Options opts)
 			}
 			sent->word[w].d = nd;
 		}
+
+		total_deleted += N_deleted;
 		lgdebug(D_PRUNE, "Debug: l->r pass changed %d and deleted %zu\n",
 		        pc.N_changed, N_deleted);
 
@@ -695,7 +694,6 @@ int power_prune(Sentence sent, Parse_Options opts)
 					for (c=d->right; c != NULL; c = c->next) c->nearest_word = BAD_WORD;
 					for (c=d->left;  c != NULL; c = c->next) c->nearest_word = BAD_WORD;
 					N_deleted++;
-					total_deleted++;
 				}
 			}
 			clean_table(pt->l_table_size[w], pt->l_table[w]);
@@ -713,6 +711,7 @@ int power_prune(Sentence sent, Parse_Options opts)
 			sent->word[w].d = nd;
 		}
 
+		total_deleted += N_deleted;
 		lgdebug(D_PRUNE, "Debug: r->l pass changed %d and deleted %zu\n",
 		        pc.N_changed, N_deleted);
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -449,6 +449,9 @@ static bool possible_connection(prune_context *pc,
 	int dist;
 	if (!easy_match_desc(lc->desc, rc->desc)) return false;
 
+#ifdef DEBUG
+	assert((lc->nearest_word != BAD_WORD) && (rc->nearest_word != BAD_WORD));
+#endif
 	if ((lc->nearest_word > rword) || (rc->nearest_word < lword)) return false;
 
 	dist = rword - lword;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -627,9 +627,10 @@ int power_prune(Sentence sent, Parse_Options opts)
 {
 	power_table *pt;
 	prune_context pc;
-	Disjunct *free_later;
+	Disjunct *free_later = NULL;
 	Connector *c;
-	size_t N_deleted, total_deleted;
+	size_t N_deleted = 0;
+	size_t total_deleted = 0;
 
 	pc.power_cost = 0;
 	pc.null_links = (opts->min_null_count > 0);
@@ -639,11 +640,6 @@ int power_prune(Sentence sent, Parse_Options opts)
 
 	pt = power_table_new(sent);
 	pc.pt = pt;
-
-	free_later = NULL;
-	N_deleted = 0;
-
-	total_deleted = 0;
 
 	while (1)
 	{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -213,7 +213,14 @@ static void put_into_power_table(C_list * m, unsigned int size, C_list ** t,
 }
 
 /**
- * Allocates and builds the initial power hash tables
+ * Allocates and builds the initial power hash tables.
+ * Each word has 2 tables - for its left and right connectors.
+ * In these tables, the connectors are hashed according to their
+ * uppercase part.
+ * In each hash slot, the shallow connectors appear first, so when
+ * matching deep connectors to the connectors in a slot, the
+ * match loop can stop when there are no more shallow connectors in that
+ * slot (since if both are deep there cannot be matched).
  */
 static power_table * power_table_new(Sentence sent)
 {

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -630,7 +630,6 @@ int power_prune(Sentence sent, Parse_Options opts)
 	Disjunct *free_later;
 	Connector *c;
 	size_t N_deleted, total_deleted;
-	size_t w;
 
 	pc.power_cost = 0;
 	pc.null_links = (opts->min_null_count > 0);
@@ -649,7 +648,7 @@ int power_prune(Sentence sent, Parse_Options opts)
 	while (1)
 	{
 		/* left-to-right pass */
-		for (w = 0; w < sent->length; w++)
+		for (WordIdx w = 0; w < sent->length; w++)
 		{
 			for (Disjunct **dd = &sent->word[w].d; *dd != NULL; /* See: NEXT */)
 			{
@@ -690,7 +689,7 @@ int power_prune(Sentence sent, Parse_Options opts)
 
 		pc.N_changed = N_deleted = 0;
 		/* right-to-left pass */
-		for (w = sent->length-1; w != (size_t) -1; w--)
+		for (WordIdx w = sent->length-1; w != (size_t) -1; w--)
 		{
 			for (Disjunct **dd = &sent->word[w].d; *dd != NULL; /* See: NEXT */)
 			{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -32,6 +32,7 @@
 
 #if defined(ALT_MUTUAL_CONSISTENCY) || defined(ALT_DISJUNCT_CONSISTENCY)
 #include <tokenize/tok-structures.h>
+#define OPTIMIZE_EN
 #endif /* ALT_MUTUAL_CONSISTENCY || ALT_DISJUNCT_CONSISTENCY */
 
 #define D_PRUNE 5
@@ -354,6 +355,16 @@ static bool alt_consistency(prune_context *pc,
 #ifdef ALT_MUTUAL_CONSISTENCY
 	/* Validate that rc and lc are from the same alternative.
 	 * Each of the loops is of one iteration most of the times. */
+
+#ifdef OPTIMIZE_EN
+	/* Try a shortcut first. */
+	if ((lc->originating_gword->o_gword->hier_depth == 0) ||
+	    (rc->originating_gword->o_gword->hier_depth == 0))
+	{
+			return true;
+	}
+#endif /* OPTIMIZE_EN */
+
 	for (const gword_set *ga = lc->originating_gword; NULL != ga; ga = ga->next) {
 		for (const gword_set *gb = rc->originating_gword; NULL != gb; gb = gb->next) {
 			if (in_same_alternative(ga->o_gword, gb->o_gword)) {

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -24,6 +24,7 @@
 #include "string-set.h"
 #include "tokenize/word-structures.h" // for Word_struct
 #include "tokenize/wordgraph.h"
+#include "utilities.h"                // strdupa()
 
 /* This code is not too effective and is costly for the current corpus
  * batches and also for ady/amy. So maybe it should be discarded. */
@@ -924,7 +925,7 @@ static bool rule_satisfiable(multiset_table *cmt, pp_linkset *ls)
 {
 	unsigned int hashval;
 	const char * t;
-	char name[20], *s;
+	char *name, *s;
 	pp_linkset_node *p;
 	int bad, n_subscripts;
 
@@ -933,9 +934,9 @@ static bool rule_satisfiable(multiset_table *cmt, pp_linkset *ls)
 		for (p = ls->hash_table[hashval]; p!=NULL; p=p->next)
 		{
 			/* ok, we've got our hands on one of the criterion links */
-			strncpy(name, p->str, sizeof(name)-1);
+			name = strdupa(p->str);
 			/* could actually use the string in place because we change it back */
-			name[sizeof(name)-1] = '\0';
+
 			/* now we want to see if we can satisfy this criterion link */
 			/* with a collection of the links in the cms table */
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -632,14 +632,13 @@ int power_prune(Sentence sent, Parse_Options opts)
 	size_t N_deleted = 0;
 	size_t total_deleted = 0;
 
+	pt = power_table_new(sent);
+
+	pc.pt = pt;
 	pc.power_cost = 0;
 	pc.null_links = (opts->min_null_count > 0);
 	pc.N_changed = 1;  /* forces it always to make at least two passes */
-
 	pc.sent = sent;
-
-	pt = power_table_new(sent);
-	pc.pt = pt;
 
 	while (1)
 	{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -31,6 +31,7 @@
 //#define ALT_DISJUNCT_CONSISTENCY
 
 #if defined(ALT_MUTUAL_CONSISTENCY) || defined(ALT_DISJUNCT_CONSISTENCY)
+#include <tokenize/tok-structures.h>
 #endif /* ALT_MUTUAL_CONSISTENCY || ALT_DISJUNCT_CONSISTENCY */
 
 #define D_PRUNE 5

--- a/link-grammar/parse/prune.h
+++ b/link-grammar/parse/prune.h
@@ -15,7 +15,6 @@
 
 #include "link-includes.h"
 
-int        power_prune(Sentence, Parse_Options);
 void       pp_and_power_prune(Sentence, Parse_Options);
 bool       optional_gap_collapse(Sentence, int, int);
 

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -452,8 +452,8 @@ void expression_prune(Sentence sent, Parse_Options opts)
 
 		DBG_EXPSIZES("l->r pass removed %d\n%s", N_deleted, e);
 
-		zero_connector_table(&ctxt);
 		if (N_deleted == 0) break;
+		zero_connector_table(&ctxt);
 
 		/* Right-to-left pass */
 		N_deleted = 0;


### PR DESCRIPTION
Corpus batch benchmarks (10x10 runs):
en basic: 2+%
en fixes: 3+%
ru: ~0.5%

Individual runs  of a small sample of very long sentences shows ~5% speed up.
Runs with `-verbosity=2` show a big power_prune() speedup. However, `power_prune()` currently takes only a small fraction of the total CPU, so the total saving is not as big.

The largest speedup is due to the shallow/deep connector ordering that allows an early termination of the loop in `*_table_search()` , that is implemented in the following commit:
prune.c: Matching shallow connectors: Stop earlier

Some other changes didn't show a noticeable save in their benchmarks, so they are not included here:
1. Using memory pools for `pp_prune()`.
2. Consolidating all the memory allocations and initializations in `power_table_new()`.
But now I may know better and can improve their implementation, so I may include them in a future PR.

Some other changes in this PR:
- Reformat touched code and localize some of its variables.
- Add some code for ALT_*_CONSISTENCY while pruning (still commented out, more changes are needed in order to make more efficient).
- Make `power_prune()` static.
- Define `lc_easy_match()` as inline (I guess it got inlined anyway).

(I also have major exprune.c changes with a greater speedup impact, to be sent soon.)

BTW, here is a `power_prune()` speedup idea for a future check:
Eliminate `bool shallow` in `struct c_list_s`, in order that it will be exactly half CPU cache line size.
- If we had Connector_struct in the expressions, it could be added there. It is not clear if using Connector_struct in expressions will worth their memory handling overhead, but they have other advantages that may offset this overhead.
-  Alternatively, the hashing can be done separately for shallow/deep connectors (with the expense of using some more memory), and this will save the "shallow" checks in `*_table_search()` loop.

