### PR TITLE
Fixes to PR #846 (the initial trailing connectors hashing implementation)

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -149,7 +149,7 @@ with a backslash.)
 This, along with "diff", "grep" etc., can be used in order to validate
 that a change didn't cause undesired effects. Special care should be taken
 if sentences with more than 1024 linkages are to be verified too (use a
-larger `-limit=N` and -test=auto-next-linkage:M`, when N>>M).
+larger `-limit=N` and `-test=auto-next-linkage:M`, when N>>M).
 
 Note that this technique is not very effective if the order to the
 linkages got changed (or if SAT-parser linkages need to be compared to the

--- a/debug/README.md
+++ b/debug/README.md
@@ -169,7 +169,13 @@ For more examples of how to use the wordgraph-display, see
 [link-grammar/tokenize/README.md](/link-grammar/tokenize/README.md#word-graph-display)
 and [msvc/README.md](/msvc/README.md).
 
-5) -test=<values> for SAT parser debugging:
+5) Test the "trailing connector" hashing for short sentences too (e.g. for
+all sentences with more than 10 tokens):
+`link-parser test=len_trailing_hash:10`
+Or optionally (in order to see relevant debug messages from `preparation.c`):
+`link-parser test=len_trailing_hash:10 -v=5 -debug=preparation.c`
+
+6) -test=<values> for SAT parser debugging:
 linkage-disconnected - Display also solutions which don't have a full linkage.
 sat-stats - Display the number of PP-violations and disconected linkages.
 no-pp_pruning_1 - Disable a partial CONTAINS_NONE_RULES pruning

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -176,7 +176,12 @@ static void set_connector_hash(Sentence sent)
 	/* FIXME: For short sentences, setting the optimized connector hashing
 	 * has a slight overhead. If this overhead is improved, maybe this
 	 * limit can be set lower. */
-	if (sent->length < 36)
+	size_t min_sent_len_trailing_hash = 36;
+	const char *len_trailing_hash = test_enabled("len_trailing_hash");
+	if (NULL != len_trailing_hash)
+		min_sent_len_trailing_hash = atoi(len_trailing_hash+1);
+
+	if (sent->length < min_sent_len_trailing_hash)
 	{
 		int id = WORD_OFFSET;
 		for (size_t w = 0; w < sent->length; w++)
@@ -196,6 +201,8 @@ static void set_connector_hash(Sentence sent)
 	}
 	else
 	{
+		lgdebug(D_PREP, "Debug: Using trailing hash (Sentence length %zu)\n",
+		    sent->length);
 #define CONSEP '&'      /* Connector string separator in the suffix sequence .*/
 #define WORDENC_ADD 'A'
 #define MAX_LINK_NAME_LENGTH 10 // XXX Use a global definition.

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -279,7 +279,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	size_t i;
 
 	build_sentence_disjuncts(sent, opts->disjunct_cost, opts);
-	if (verbosity_level(5))
+	if (verbosity_level(D_PREP))
 	{
 		prt_error("Debug: After expanding expressions into disjuncts:\n");
 		print_disjunct_counts(sent);
@@ -296,7 +296,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 	print_time(opts, "Eliminated duplicate disjuncts");
 
-	if (verbosity_level(5))
+	if (verbosity_level(D_PREP))
 	{
 		prt_error("Debug: After expression pruning and duplicate elimination:\n");
 		print_disjunct_counts(sent);

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -14,7 +14,7 @@
 #include "api-structures.h"
 #include "prepare/build-disjuncts.h"
 #include "connectors.h"
-#include "dict-common/dict-common.h" // For Dictionary_s
+#include "dict-common/dict-common.h"    // Dictionary_s
 #include "disjunct-utils.h"
 #include "externs.h"
 #include "preparation.h"
@@ -24,9 +24,9 @@
 #include "string-set.h"
 #include "string-id.h"
 #include "utilities.h"
-#include "tokenize/word-structures.h" // for Word_struct
+#include "tokenize/word-structures.h"   // Word_struct
 
-#define D_PREP 5 // Debug level for this module
+#define D_PREP 5 // Debug level for this module.
 
 /**
  * Set c->nearest_word to the nearest word that this connector could
@@ -183,11 +183,11 @@ static void set_connector_hash(Sentence sent)
 			{
 				for (Connector *c = d->left; NULL != c; c = c->next)
 				{
-						c->suffix_id = id++;
+					c->suffix_id = id++;
 				}
 				for (Connector *c = d->right; NULL != c; c = c->next)
 				{
-						c->suffix_id = id++;
+					c->suffix_id = id++;
 				}
 			}
 		}
@@ -200,13 +200,14 @@ static void set_connector_hash(Sentence sent)
 		char cstr[MAX_LINK_NAME_LENGTH * 20];
 
 		String_id *ssid = string_id_create();
+		/* Debug stats. */
 		int lcnum = 0;
 		int rcnum = 0;
 
 		for (size_t w = 0; w < sent->length; w++)
 		{
 			//printf("WORD %zu\n", w);
-			cstr[0] = (char)(w +1); /* Avoid '\0' by adding 1. */
+			cstr[0] = (char)(w + 1); /* Avoid '\0' by adding 1. */
 			const int wpreflen = 1;
 
 			for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
@@ -217,7 +218,7 @@ static void set_connector_hash(Sentence sent)
 				l = wpreflen;
 				for (Connector *c = d->left; NULL != c; c = c->next)
 				{
-					lcnum++; /* stat */
+					lcnum++;
 					if (c->multi) cstr[l++] = '@'; /* May have different linkages. */
 					l += lg_strlcpy(cstr+l, connector_string(c), sizeof(cstr)-l);
 					cstr[l++] = CONSEP;
@@ -239,7 +240,7 @@ static void set_connector_hash(Sentence sent)
 				l = wpreflen;
 				for (Connector *c = d->right; NULL != c; c = c->next)
 				{
-					rcnum++; /* stat */
+					rcnum++;
 					l += lg_strlcpy(cstr+l, connector_string(c), sizeof(cstr)-l);
 					cstr[l++] = CONSEP;
 				}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -128,6 +128,19 @@ static void print_connector_list(const char *s, const char *t, Connector * e)
 }
 #endif
 
+#define ITOA_BASE 64
+static char* itoa_compact(char* buffer, int num)
+{
+	 do {
+		*buffer++ = '0' + num % ITOA_BASE;
+		num /= ITOA_BASE;
+	 } while (num > 0);
+
+	*buffer = '\0';
+
+	return buffer;
+}
+
 /**
  * Set a unique identifier per connector, to be used in the memoizing
  * table of the classic parser.

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -250,6 +250,7 @@ static void set_connector_hash(Sentence sent)
 				for (Connector *c = d->right; NULL != c; c = c->next)
 				{
 					rcnum++;
+					if (c->multi) cstr[l++] = '@'; /* May have different linkages. */
 					l += lg_strlcpy(cstr+l, connector_string(c), sizeof(cstr)-l);
 					cstr[l++] = CONSEP;
 				}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -242,7 +242,7 @@ static void set_connector_hash(Sentence sent)
 					s++; /* Skip word number encoding or CONSEP. */
 					int id = string_id_add(s, ssid) + WORD_OFFSET;
 					c->suffix_id = id;
-					//printf("ID %d pref=%s\n", id, s);
+					//printf("ID %d trail=%s\n", id, s);
 					s = memchr(s, CONSEP, sizeof(cstr));
 				}
 
@@ -264,7 +264,7 @@ static void set_connector_hash(Sentence sent)
 					s++; /* Skip word number encoding or CONSEP. */
 					int id = string_id_add(s, ssid) + WORD_OFFSET;
 					c->suffix_id = id;
-					//printf("ID %d pref=%s\n", id, s);
+					//printf("ID %d trail=%s\n", id, s);
 					s = memchr(s, CONSEP, sizeof(cstr));
 				}
 			}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -167,6 +167,8 @@ static void print_connector_list(const char *s, const char *t, Connector * e)
  * connector sequence (since disjunct duplicates has been discarded), and
  * hence they don't need the use of the string_id mechanism - just an
  * incremented suffix_id is enough. This can save some overhead here.
+ * Update: Tested, but for some (yet unknown) reason it increases the
+ * hashing overhead by tens of percents.
  */
 #define WORD_OFFSET 256 /* Reserved for null connectors. */
 static void set_connector_hash(Sentence sent)

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -272,8 +272,8 @@ static void set_connector_hash(Sentence sent)
 		if (verbosity_level(D_PREP))
 		{
 			int maxid = string_id_add("MAXID", ssid) - 1;
-			prt_error("Debug: lcnum %d rcnum %d suffix_id %d\n",
-			          lcnum, rcnum, maxid);
+			prt_error("Debug: suffix_id %d, %d (%d+,%d-) connectors\n",
+			          maxid, lcnum+rcnum, rcnum, lcnum);
 		}
 
 		string_id_delete(ssid);

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -121,7 +121,7 @@ static void print_connector_list(const char *s, const char *t, Connector * e)
 	printf("%s %s: ", s, t);
 	for (;e != NULL; e=e->next)
 	{
-		printf("%s", connector_string(e));
+		printf("%s%s", e->multi?"@":"", connector_string(e));
 		if (e->next != NULL) printf(" ");
 	}
 	printf("\n");

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -138,12 +138,15 @@ struct Gword_struct
 
 	/* For debug and inspiration. */
 	const char *label;   /* Debug label - code locations of tokenization */
-	size_t node_num;     /* For differentiating words with identical subwords,
-	                        and for indicating the order in which word splits
-                           have been done. Shown in the Wordgraph display and in
-                           debug messages. Not used otherwise. Could have been
-                           used for hier_position instead of pointers in order
-                           to optimize its generation and comparison. */
+	size_t node_num;     /* A sequential number, assigned in the order in
+	                        which word splits are done. Shown in the
+	                        Wordgraph display and in debug messages for
+	                        easier differentiating words with identical
+	                        subwords, and for indicating their split order.
+	                        Also used in set_connector_hash().  Could have
+	                        been used for hier_position instead of pointers
+	                        in order to optimize its generation and
+	                        comparison. */
 
 	/* Tokenizer state */
 	Tokenizing_step tokenizing_step;


### PR DESCRIPTION
I fixed 3 bugs in the initial implementation:
1. The word number encoding should have been prepended to each trailing sequence and not only the to full sequence.
2. Identical trailing connectors sequences of disjuncts that are derived from different alternatives, should have different suffix_id (the number that is used for hashing). This is because each may have different number of linkages.
3. "multi" connectors check was not done for "right" connectors. It didn't affect anything. (However, not making this check for the "left" connectors", which is already done, causes  a crash on many sentences).

This PR includes prepending the Gword number of each disjunct to the connector strings so different alternatives will get different suffix_is's. This fixes both (2) and (1). It fixes (1) because the Gword number is prepended to each connector string, and different words cannot share the same Gwords.

Fixing (2) doesn't add much overhead, since alternative tokens with identical trailing connector are apparently not common. But fixing (1) adds about 0-15% overhead for long sentences (they are still very much faster than originally...).

I'm not sure why these two bugs didn't reveal themselves as wrong linkages or even crashes.
With and without this fix, the "trailing connectors hashing " code produces exactly the same linkages as the  original code (tested by producing up to 250K linkages per sentence for each batch, sorting them to get a "canonical order") and comparing the first 25K ones). I think this may be because the hash table is still sized as originally but now it has much less entries, and also the word numbers are still used in the hash function (in order a to add more entropy) so the chances are low that two bad pairs will get hashed to the same bucket. I have some more related speedup ideas to try so I hope that the answer to this question will become clearer when I get to it more deeply.

A related addition is `-test=len_trailing_hash:SENTLEN` when `SENTLEN` is the minimum sentence length to use the "trailing connectors hash" method. The default is, as before, 36.
This makes it easier to validate that shorter sentences work fine too and give the same result, and that longer sentences give the same result with and without this method.

More fixes in this PR:
- Fix/update formatting / comments / debug messages.
- Consolidate the left/right loops.

