### PR TITLE
Fix EMOTICON regex for PCRE to match "◠‿◠" (in en/corpus-fixes.batch)

### DIFF
--- a/data/en/4.0.regex
+++ b/data/en/4.0.regex
@@ -266,7 +266,10 @@
 % EMOTICON: /^[[:punct:];BDOpTX0578Ｃ☆ಠ●＠◎～][[:punct:]<bcdDLmoOpPSTvX0358ಠっ○ 。゜✿☆＊レツ◕●≧∇≦□◇＠◎∩ω旦ヨ彡ミ‿◠￣ー～━-]+$/
 % EMOTICON: /^[!"#$%&'()*+,\-/:;<=>?@[\\\]^_`{|}~;BDOpTX0578Ｃ☆ಠ●＠◎～][!"#$%&'()*+,\-/:;<=>?@[\\\]^_`{|}~<bcdDLmoOpPSTvX0358ಠっ○ 。゜✿☆＊レツ◕●≧∇≦□◇＠◎∩ω旦ヨ彡ミ‿◠￣ー～━-]+$/
 <EMOTICON>: !/^"|[[:alnum:]]+"$/
-<EMOTICON>: /^[[:punct:];BＣ☆ಠ●＠◎～][-!"#$%&'()+,:;<=>?@[\\^_`{|}~<cdDLmoOpPSTvXಠっ○ 。゜✿☆＊レツ◕●≧∇≦□◇＠◎∩ω旦ヨ彡ミ‿◠￣ー～━-]+$/
+% "◠" is matched by [:punct:] using "libc" or "tre", but not using PCRE.
+% Hence it been added to the leading character subexpression. (Maybe
+% there are additional such characters.)
+<EMOTICON>: /^[[:punct:];BＣ☆ಠ●＠◎～◠][-!"#$%&'()+,:;<=>?@[\\^_`{|}~<cdDLmoOpPSTvXಠっ○ 。゜✿☆＊レツ◕●≧∇≦□◇＠◎∩ω旦ヨ彡ミ‿◠￣ー～━-]+$/
 
 % Part numbers should not match words with punctuation at their end.
 % Else sentences like "I saw him on January 21, 1990" have problems.


### PR DESCRIPTION
I fixed it only because `◠‿◠` appears in `corpus-fixes.batch`.
This problem appears only when using PCRE, as from some reason it doesn't classify `◠` as `[:punct:]` (interestingly, it does classify so ` ‿`).

I noted this when I compared linkages generated by an old library (using the current repository dict and corpuses) to the  current repository library. All were the same but this sentence.

I thought to add in this occasion more regexes, but I was not sure which of them, if any, is a good idea.
Here are some that can maybe added to the capitalized word dict entry/entries:
1. IWORD and PL-IWORD for iPhone/iPhones etc.
2. USER (@...).
3. URI (a simplified version like `^(http[s]|ftp|file)://|mailto:`).
(I also thought of HASHTAG, but it can be used "externally" to sentences and in such cases I don't know how it can be handled in the framework of LG. URI may also have this problem.)