### PR TITLE
 mk_parse_set() speedup

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -434,10 +434,9 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 	RECOUNT({xt->set.recount = 0;})
 	for (w = start_word; w < end_word; w++)
 	{
-		size_t mlb, mle;
-		mle = mlb = form_match_list(mchxt, w, le, lw, re, rw);
+		size_t mlb = form_match_list(mchxt, w, le, lw, re, rw);
 		// if (mlist) mlist = sort_matchlist(mlist);
-		for (; get_match_list_element(mchxt, mle) != NULL; mle++)
+		for (size_t mle = mlb; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{
 			unsigned int lnull_count, rnull_count;
 			Disjunct *d = get_match_list_element(mchxt, mle);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -443,6 +443,7 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 			Disjunct *d = get_match_list_element(mchxt, mle);
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
+			bool ls_exists = false;
 
 			for (lnull_count = 0; lnull_count <= null_count; lnull_count++)
 			{
@@ -477,9 +478,13 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 						ls[3] = mk_parse_set(words, mchxt, ctxt,
 						              ld, d, lw, w, le, d->left,
 						              lnull_count, pex, islands_ok);
+
+					ls_exists =
+						ls[0] != NULL || ls[1] != NULL || ls[2] != NULL || ls[3] != NULL;
 				}
 
-				if (Rmatch)
+
+				if (Rmatch && (ls_exists || le == NULL))
 				{
 					rs[0] = mk_parse_set(words, mchxt, ctxt,
 					                 d, rd, w, rw, d->right->next, re->next,
@@ -516,7 +521,7 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 					}
 				}
 
-				if (ls[0] != NULL || ls[1] != NULL || ls[2] != NULL || ls[3] != NULL)
+				if (ls_exists)
 				{
 					/* Evaluate using the left match, but not the right */
 					Parse_set* rset = mk_parse_set(words, mchxt, ctxt,

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -438,20 +438,19 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 		// if (mlist) mlist = sort_matchlist(mlist);
 		for (size_t mle = mlb; get_match_list_element(mchxt, mle) != NULL; mle++)
 		{
-			unsigned int lnull_count, rnull_count;
 			Disjunct *d = get_match_list_element(mchxt, mle);
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
 			bool ls_exists = false;
 
-			for (lnull_count = 0; lnull_count <= null_count; lnull_count++)
+			for (unsigned int lnull_count = 0; lnull_count <= null_count; lnull_count++)
 			{
 				int i, j;
 				Parse_set *ls[4], *rs[4];
 
 				/* Here, lnull_count and rnull_count are the null_counts
 				 * we're assigning to those parts respectively. */
-				rnull_count = null_count - lnull_count;
+				unsigned int rnull_count = null_count - lnull_count;
 
 				/* Now, we determine if (based on table only) we can see that
 				   the current range is not parsable. */

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -542,7 +542,7 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 						}
 					}
 				}
-				if ((le == NULL) && (rs[0] != NULL ||
+				else if ((le == NULL) && (rs[0] != NULL ||
 				     rs[1] != NULL || rs[2] != NULL || rs[3] != NULL))
 				{
 					/* Evaluate using the right match, but not the left */

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -68,6 +68,7 @@ struct extractor_s
 	unsigned int   log2_x_table_size;
 	Pset_bucket ** x_table;  /* Hash table */
 	Parse_set *    parse_set;
+	Word           *words;
 	bool           islands_ok;
 
 	/* thread-safe random number state */
@@ -322,7 +323,7 @@ static Match_node* sort_matchlist(Match_node* mlist)
  * parse structures.
  */
 static
-Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
+Parse_set * mk_parse_set(fast_matcher_t *mchxt,
                  count_context_t * ctxt,
                  Disjunct *ld, Disjunct *rd, int lw, int rw,
                  Connector *le, Connector *re, unsigned int null_count,
@@ -375,14 +376,14 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 		RECOUNT({xt->set.recount = 0;})
 
 		w = lw + 1;
-		for (int opt = 0; opt <= !!words[w].optional; opt++)
+		for (int opt = 0; opt <= !!pex->words[w].optional; opt++)
 		{
 			null_count += opt;
-			for (dis = words[w].d; dis != NULL; dis = dis->next)
+			for (dis = pex->words[w].d; dis != NULL; dis = dis->next)
 			{
 				if (dis->left == NULL)
 				{
-					pset = mk_parse_set(words, mchxt, ctxt,
+					pset = mk_parse_set(mchxt, ctxt,
 											  dis, NULL, w, rw, dis->right, NULL,
 											  null_count-1, pex);
 					if (pset == NULL) continue;
@@ -393,7 +394,7 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 					RECOUNT({xt->set.recount += pset->recount;})
 				}
 			}
-			pset = mk_parse_set(words, mchxt, ctxt,
+			pset = mk_parse_set(mchxt, ctxt,
 									  NULL, NULL, w, rw, NULL, NULL,
 									  null_count-1, pex);
 			if (pset != NULL)
@@ -459,22 +460,22 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 				for (i=0; i<4; i++) { ls[i] = rs[i] = NULL; }
 				if (Lmatch)
 				{
-					ls[0] = mk_parse_set(words, mchxt, ctxt,
+					ls[0] = mk_parse_set(mchxt, ctxt,
 					             ld, d, lw, w, le->next, d->left->next,
 					             lnull_count, pex);
 
 					if (le->multi)
-						ls[1] = mk_parse_set(words, mchxt, ctxt,
+						ls[1] = mk_parse_set(mchxt, ctxt,
 						              ld, d, lw, w, le, d->left->next,
 						              lnull_count, pex);
 
 					if (d->left->multi)
-						ls[2] = mk_parse_set(words, mchxt, ctxt,
+						ls[2] = mk_parse_set(mchxt, ctxt,
 						              ld, d, lw, w, le->next, d->left,
 						              lnull_count, pex);
 
 					if (le->multi && d->left->multi)
-						ls[3] = mk_parse_set(words, mchxt, ctxt,
+						ls[3] = mk_parse_set(mchxt, ctxt,
 						              ld, d, lw, w, le, d->left,
 						              lnull_count, pex);
 
@@ -485,22 +486,22 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 
 				if (Rmatch && (ls_exists || le == NULL))
 				{
-					rs[0] = mk_parse_set(words, mchxt, ctxt,
+					rs[0] = mk_parse_set(mchxt, ctxt,
 					                 d, rd, w, rw, d->right->next, re->next,
 					                 rnull_count, pex);
 
 					if (d->right->multi)
-						rs[1] = mk_parse_set(words, mchxt, ctxt,
+						rs[1] = mk_parse_set(mchxt, ctxt,
 					                 d, rd, w, rw, d->right, re->next,
 						              rnull_count, pex);
 
 					if (re->multi)
-						rs[2] = mk_parse_set(words, mchxt, ctxt,
+						rs[2] = mk_parse_set(mchxt, ctxt,
 						              d, rd, w, rw, d->right->next, re,
 						              rnull_count, pex);
 
 					if (d->right->multi && re->multi)
-						rs[3] = mk_parse_set(words, mchxt, ctxt,
+						rs[3] = mk_parse_set(mchxt, ctxt,
 						              d, rd, w, rw, d->right, re,
 						              rnull_count, pex);
 				}
@@ -523,7 +524,7 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 				if (ls_exists)
 				{
 					/* Evaluate using the left match, but not the right */
-					Parse_set* rset = mk_parse_set(words, mchxt, ctxt,
+					Parse_set* rset = mk_parse_set(mchxt, ctxt,
 					                        d, rd, w, rw, d->right, re,
 					                        rnull_count, pex);
 					if (rset != NULL)
@@ -545,7 +546,7 @@ Parse_set * mk_parse_set(Word* words, fast_matcher_t *mchxt,
 				     rs[1] != NULL || rs[2] != NULL || rs[3] != NULL))
 				{
 					/* Evaluate using the right match, but not the left */
-					Parse_set* lset = mk_parse_set(words, mchxt, ctxt,
+					Parse_set* lset = mk_parse_set(mchxt, ctxt,
 					                        ld, d, lw, w, le, d->left,
 					                        lnull_count, pex);
 
@@ -625,10 +626,11 @@ bool build_parse_set(extractor_t* pex, Sentence sent,
                     count_context_t *ctxt,
                     unsigned int null_count, Parse_Options opts)
 {
+	pex->words = sent->word;
 	pex->islands_ok = opts->islands_ok;
 
 	pex->parse_set =
-		mk_parse_set(sent->word, mchxt, ctxt,
+		mk_parse_set(mchxt, ctxt,
 		             NULL, NULL, -1, sent->length, NULL, NULL, null_count+1,
 		             pex);
 


### PR DESCRIPTION
The main change here is:
- mk_parse_set(): Optimize Rmatch processing

In the profiling for fix-long. it speeds up `mk_parse_set()` by about 40% (from 13.9% to 7.9% of the total CPU).
Before this patch (legend at the end [**]):
`     242   1.8%  85.4%     1916  13.9% mk_parse_set`
After it:
`     146   1.2%  89.2%     1002   7.9%  mk_parse_set`


However, since it consists only a small part of total CPU time, the batch benchmarks show only small speedup (for some sentences the speed increase is big [*]):
``` text
 +0.2%    en/corpus-basic.batch
 +1.0%    en/corpus-fixes.batch
 +1.4%    ru/corpus-basic.batch
+26.8%    ../debug/prune/ex/en/bms.batch (In vivo studies...) [*]
 +4.3%    data/en/corpus-fix-long.batch
```

fix-long profiling after this PR (per file, only >0.1% are shown):
```
    6158  49.2%  49.2%     6162  49.2% link-grammar/parse/fast-match.c
    3137  25.0%  74.2%     9948  79.4% link-grammar/parse/count.c
    1223   9.8%  84.0%     1223   9.8% link-grammar/connectors.h
     694   5.5%  89.5%      994   7.9% link-grammar/parse/extract-links.c
     447   3.6%  93.1%     1093   8.7% link-grammar/parse/prune.c
     220   1.8%  94.8%      240   1.9% link-grammar/post-process/post-process.c
     115   0.9%  96.8%      115   0.9% link-grammar/parse/fast-match.h
     109   0.9%  97.7%      266   2.1% link-grammar/parse/preparation.c
      61   0.5%  98.2%       95   0.8% link-grammar/disjunct-utils.c
      43   0.3%  98.9%       58   0.5% link-grammar/string-id.c
      14   0.1%  99.2%       59   0.5% link-grammar/prepare/build-disjuncts.c
      14   0.1%  99.3%       45   0.4% link-grammar/utilities.h
       9   0.1%  99.4%       49   0.4% link-grammar/memory-pool.c
       7   0.1%  99.6%       55   0.4% link-grammar/utilities.c
```

So there is no much room for more speedup for long sentences (only maybe 20%) unless processing shortcuts will be found. The profiling for short sentences is totally different and there is more room there for speedup (>0.5% are shown):
``` text
     227  20.5%  44.5%      264  23.8% link-grammar/post-process/post-process.c
     131  11.8%  56.4%      294  26.6% link-grammar/parse/prune.c
      65   5.9%  62.2%      118  10.7% link-grammar/prepare/exprune.c
      51   4.6%  66.8%       51   4.6% link-grammar/connectors.h
      44   4.0%  70.8%       90   8.1% link-grammar/parse/count.c
      35   3.2%  74.0%      132  11.9% link-grammar/dict-common/dict-utils.c
      29   2.6%  76.6%       29   2.6% link-grammar/parse/fast-match.c
      27   2.4%  79.0%       53   4.8% link-grammar/disjunct-utils.c
      24   2.2%  81.2%      116  10.5% link-grammar/prepare/build-disjuncts.c
      21   1.9%  83.1%      160  14.5% link-grammar/parse/preparation.c
      20   1.8%  84.9%       28   2.5% link-grammar/parse/extract-links.c
      15   1.4%  86.3%       21   1.9% link-grammar/dict-file/read-dict.c
      11   1.0%  89.5%       15   1.4% link-grammar/post-process/pp_linkset.c
      10   0.9%  90.4%       45   4.1% link-grammar/connectors.c
      10   0.9%  91.3%       64   5.8% link-grammar/memory-pool.c
       8   0.7%  93.0%       40   3.6% link-grammar/utilities.h
       5   0.5%  94.5%      158  14.3% link-grammar/tokenize/tokenize.c
```
[**] Fields in the above:

1. Number of profiling samples in this function
2. Percentage of profiling samples in this function
3. Percentage of profiling samples in the functions printed so far
4. Number of profiling samples in this function and its callees
5. Percentage of profiling samples in this function and its callees
6. Name


