### PR TITLE
Trailing connector hash - bug fix: It should be unique per disjunct cost

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -171,9 +171,9 @@ and [msvc/README.md](/msvc/README.md).
 
 5) Test the "trailing connector" hashing for short sentences too (e.g. for
 all sentences with more than 10 tokens):
-`link-parser test=len_trailing_hash:10`
+`link-parser test=len-trailing-hash:10`
 Or optionally (in order to see relevant debug messages from `preparation.c`):
-`link-parser test=len_trailing_hash:10 -v=5 -debug=preparation.c`
+`link-parser test=len-trailing-hash:10 -v=5 -debug=preparation.c`
 
 6) -test=<values> for SAT parser debugging:
 linkage-disconnected - Display also solutions which don't have a full linkage.

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -197,7 +197,7 @@ static void set_connector_hash(Sentence sent)
 	 * has a slight overhead. If this overhead is improved, maybe this
 	 * limit can be set lower. */
 	size_t min_sent_len_trailing_hash = 36;
-	const char *len_trailing_hash = test_enabled("len_trailing_hash");
+	const char *len_trailing_hash = test_enabled("len-trailing-hash");
 	if (NULL != len_trailing_hash)
 		min_sent_len_trailing_hash = atoi(len_trailing_hash+1);
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -226,9 +226,10 @@ static void set_connector_hash(Sentence sent)
 		lgdebug(D_PREP, "Debug: Using trailing hash (Sentence length %zu)\n",
 		    sent->length);
 #define CONSEP '&'      /* Connector string separator in the suffix sequence .*/
-#define MAX_LINK_NAME_LENGTH 10 // XXX Use a global definition.
+#define MAX_LINK_NAME_LEN 10 // XXX Use a global definition.
 #define MAX_GWORD_ENCODING 16 /* Up to 64^15 ... */
-		char cstr[(MAX_LINK_NAME_LENGTH + MAX_GWORD_ENCODING) * 20];
+#define MAX_COST_LEN 10 /* Up to 9999.9999f. */
+		char cstr[(MAX_LINK_NAME_LEN + MAX_GWORD_ENCODING + MAX_COST_LEN) * 20];
 
 		String_id *ssid = string_id_create();
 		int cnum[2] = { 0 }; /* Connector counts stats for debug. */
@@ -255,6 +256,24 @@ static void set_connector_hash(Sentence sent)
 					l += lg_strlcpy(gword_nums+l, gword_num, sizeof(gword_nums)-l);
 					cstr[l++] = ',';
 				}
+
+				if (d->cost != 0)
+				{
+					char costbuffer[MAX_COST_LEN];
+					int n;
+					/* The cost string includes a dot, so it cannot be confused
+					 * with anything that itoa_compact() may generate. */
+					n = snprintf(costbuffer, sizeof(costbuffer), "%.4f,", d->cost);
+					if ((n < 0) || (n >= MAX_COST_LEN))
+					{
+						prt_error("Warning: set_connector_hash(): "
+						          "Token %s with cost %.4f: snprintf()==%d\n",
+						          d->word_string, d->cost, n);
+					}
+					l += lg_strlcpy(gword_nums+l, gword_num, sizeof(gword_nums)-l);
+					//printf("w=%zu, token=%s: COST %s\n", w, d->word_string, costbuffer);
+				}
+
 				if (l > (int)sizeof(gword_nums)-2)
 				{
 					/* Overflow. Never observed, maybe cannot happen. Tag it with


### PR DESCRIPTION
Bogus linkages (having wrong costs) have been observed due to this problem after another fix (that will be sent soon). 

An example sentence that has trailing connector sequences (on the same word) with different costs is:
`The fact that he smiled at me gives me hope`

In this PR also:
- Update some comments.
- Change`-test=len_trailing_hash` to use dashes like other test strings.

FIXME: A constant 20 is used in `set_connector_hash()` for max. connectors per disjuncts. In `lisjuncts.c ` a constant 20 is used for max. number of links per word. Maybe use a common symbolic definition (need to find a name for it).