### PR TITLE
Sat fixes

### DIFF
--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1876,7 +1876,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     }
 
     double cost_cutoff;
-#if LIMIT_TOTAL_LINKAGE_COST // Undefined - incompatible to the classic parser.
+#if LIMIT_TOTAL_LINKAGE_COST // Undefined - incompatible with the classic parser
     cost_cutoff = _opts->disjunct_cost;
 #else
     cost_cutoff = 1000.0;
@@ -1884,6 +1884,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     d = build_disjuncts_for_exp(de, xnode_word[wi]->string, cost_cutoff, _opts);
     free_Exp(de);
 
+#if LIMIT_TOTAL_LINKAGE_COST
     if (d == NULL)
     {
       lgdebug(+D_SEL, "Debug: Word %zu: Disjunct cost > cost_cutoff %.2f\n",
@@ -1893,6 +1894,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 #endif
       return false;
     }
+#endif // LIMIT_TOTAL_LINKAGE_COST
 
     word_record_in_disjunct(xnode_word[wi]->word, d);
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1439,6 +1439,10 @@ void SATEncoder::pp_prune()
     DEBUG_print("---end pp_pruning--");
   }
 
+  /* The following code has a bug that causes it to be too restrictive.
+   * Instead of fixing it, it is disabled here, as it is to be replaced
+   * soon by the pp-pruning code of the classic parser. */
+#if 0
   if (test_enabled("no-pp_pruning_1")) return; // For result comparison.
   /* Additional PP pruning.
    * Since the SAT parser defines constrains on links, it is possible
@@ -1521,6 +1525,7 @@ void SATEncoder::pp_prune()
       DEBUG_print("---end pp_pruning 1--");
     }
   }
+#endif // 0
 }
 
 /*--------------------------------------------------------------------------*

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -242,7 +242,7 @@ void SATEncoder::build_word_tags()
 
   for (size_t w = 0; w < _sent->length; w++) {
     fast_sprintf(name+1, (int)w);
-    // The SAT word variables are set to be equal to the word numbers.
+    // The SAT encoding word variables are set to be equal to the word numbers.
     Var var = _variables->string(name);
     assert((Var)w == var);
   }
@@ -1876,7 +1876,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     }
 
     double cost_cutoff;
-#if LIMIT_TOTAL_LINKAGE_COST // Undefined - incompatible with the classic parser
+#if LIMIT_TOTAL_LINKAGE_COST // Undefined - incompatible to the classic parser.
     cost_cutoff = _opts->disjunct_cost;
 #else
     cost_cutoff = 1000.0;
@@ -1884,7 +1884,6 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     d = build_disjuncts_for_exp(de, xnode_word[wi]->string, cost_cutoff, _opts);
     free_Exp(de);
 
-#if LIMIT_TOTAL_LINKAGE_COST
     if (d == NULL)
     {
       lgdebug(+D_SEL, "Debug: Word %zu: Disjunct cost > cost_cutoff %.2f\n",
@@ -1894,7 +1893,6 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 #endif
       return false;
     }
-#endif // LIMIT_TOTAL_LINKAGE_COST
 
     word_record_in_disjunct(xnode_word[wi]->word, d);
 

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -140,20 +140,9 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
         lgdebug(+D_IC, "Word%d: var: %s; exp%d=%p; X_node: %s\n",
                 _word, var, i, l, word_xnode ? word_xnode->word->subword : "NULL X_node");
         assert(word_xnode != NULL, "NULL X_node for var %s", new_var);
-        if (root && parent_exp == NULL && l->e != word_xnode->exp) {
-          E_list *we = NULL;
+        if ((NULL != word_xnode->next) && (l->e == word_xnode->next->exp))
+          word_xnode = word_xnode->next;
 
-          if (word_xnode->exp->type == OR_type) {
-            for (we = word_xnode->exp->u.l; we != NULL; we = we-> next) {
-              if (l->e == we->e)
-                break;
-            }
-          }
-          if (we == NULL && word_xnode->next != NULL) {
-            lgdebug(+D_IC, "Next word_xnode for word %d is needed\n", _word);
-            word_xnode = word_xnode->next;
-          }
-        }
         insert_connectors(l->e, dfs_position, lr, ll, er, el, new_var, false, cost, l->e, word_xnode);
 
         if (lr)


### PR DESCRIPTION
1. Bug fix: SAT parser:
-- Disable the extra pp-pruning code
2. Efficiency and readability:
-- insert_connectors(): Simplify finding the next X_node
3. Ifdef out unreachable code:
-- sat_extract_links(): Add #if LIMIT_TOTAL_LINKAGE_COST
4. Improve a comment.

