### PR TITLE
Misc. "cleanups"

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -171,9 +171,9 @@ and [msvc/README.md](/msvc/README.md).
 
 5) Test the "trailing connector" hashing for short sentences too (e.g. for
 all sentences with more than 10 tokens):
-`link-parser test=len_trailing_hash:10`
+`link-parser test=len-trailing-hash:10`
 Or optionally (in order to see relevant debug messages from `preparation.c`):
-`link-parser test=len_trailing_hash:10 -v=5 -debug=preparation.c`
+`link-parser test=len-trailing-hash:10 -v=5 -debug=preparation.c`
 
 6) -test=<values> for SAT parser debugging:
 linkage-disconnected - Display also solutions which don't have a full linkage.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -442,7 +442,6 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 	sent->dict = dict;
 	sent->string_set = string_set_create();
 	sent->rand_state = global_rand_state;
-	sent->disjuncts_connectors_memblock = NULL;
 
 	sent->postprocessor = post_process_new(dict->base_knowledge);
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -454,8 +454,6 @@ bool sort_condesc_by_uc_constring(Dictionary dict)
 	{
 		condesc_t **condesc = &sdesc[n];
 
-//#define DEBUG_UC_HASH_CHANGE
-#ifndef DEBUG_UC_HASH_CHANGE /* Use a shortcut - not needed for correctness. */
 		if (condesc[0]->uc_length != condesc[-1]->uc_length)
 
 		{
@@ -463,7 +461,6 @@ bool sort_condesc_by_uc_constring(Dictionary dict)
 			uc_num++;
 		}
 		else
-#endif
 		{
 			const char *uc1 = &condesc[0]->string[condesc[0]->uc_start];
 			const char *uc2 = &condesc[-1]->string[condesc[-1]->uc_start];

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -349,12 +349,8 @@ static bool link_advance(Dictionary dict)
 				return true;
 			}
 			if (c[0] == 0x0) {
-				if (i == 0) {
-					dict->token[0] = '\0';
-					return true;
-				}
-				dict->token[i] = '\0';
-				dict->already_got_it = '\0';
+				if (i != 0) dict->already_got_it = '\0';
+				dict->token[0] = '\0';
 				return true;
 			}
 			if (lg_isspace(c[0])) {

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -197,7 +197,6 @@ static Match_node **get_match_table_entry(unsigned int size, Match_node **t,
 			 * unused hash bucket.
 			 */
 			h = (h + 1) & (size-1);
-			if (NULL == t[h]) break;
 			if (h == s) return NULL;
 		}
 	}
@@ -207,7 +206,6 @@ static Match_node **get_match_table_entry(unsigned int size, Match_node **t,
 		{
 			if (con_uc_eq(t[h]->d->left, c)) break;
 			h = (h + 1) & (size-1);
-			if (NULL == t[h]) break;
 			if (h == s) return NULL;
 		}
 	}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -195,7 +195,7 @@ static void set_connector_hash(Sentence sent)
 	 * has a slight overhead. If this overhead is improved, maybe this
 	 * limit can be set lower. */
 	size_t min_sent_len_trailing_hash = 36;
-	const char *len_trailing_hash = test_enabled("len_trailing_hash");
+	const char *len_trailing_hash = test_enabled("len-trailing-hash");
 	if (NULL != len_trailing_hash)
 		min_sent_len_trailing_hash = atoi(len_trailing_hash+1);
 

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -1163,7 +1163,7 @@ void post_process_lkgs(Sentence sent, Parse_Options opts)
 
 			post_process_scan_linkage(pp, lkg);
 
-			if ((49 == in%50) && resources_exhausted(opts->resources)) break;
+			if ((63 == in%64) && resources_exhausted(opts->resources)) break;
 		}
 	}
 
@@ -1190,7 +1190,7 @@ void post_process_lkgs(Sentence sent, Parse_Options opts)
 		N_linkages_post_processed++;
 
 		linkage_score(lkg, opts);
-		if ((9 == in%10) && resources_exhausted(opts->resources)) break;
+		if ((15 == in%16) && resources_exhausted(opts->resources)) break;
 	}
 
 	/* If the timer expired, then we never finished post-processing.

--- a/link-grammar/string-id.c
+++ b/link-grammar/string-id.c
@@ -70,7 +70,7 @@ String_id *string_id_create(void)
 }
 
 /**
- * lookup the given string in the table.  Return a pointer
+ * lookup the given string in the table.  Return an index
  * to the place it is, or the place where it should be.
  */
 static unsigned int find_place(const char * str, String_id *ss)

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -92,7 +92,7 @@ String_set * string_set_create(void)
 }
 
 /**
- * lookup the given string in the table.  Return a pointer
+ * lookup the given string in the table.  Return an index
  * to the place it is, or the place where it should be.
  */
 static unsigned int find_place(const char * str, String_set *ss)

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -530,8 +530,8 @@ static void wordgraph_unlink_xtmpfile(void)
 
 /**
  * Display the word-graph in the indicated mode.
- * This is for debug. It is not reentrant due to the static pid and the
- * possibly created fixed filenames.
+ * This is for debug and inspiration. It is not reentrant due to the
+ * static pid and the possibly created fixed filenames.
  * When Using X11, a "dot -Txlib" program is launched on the graph
  * description file.  The xlib driver refreshes the graph when the file is
  * changed, displaying additional sentences in the same window.  The viewer

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -662,7 +662,7 @@ int main(int argc, char * argv[])
 	save_default_opts(copts); /* Options so far are the defaults */
 
 	if ((argc > 1) && (argv[1][0] != '-')) {
-		/* the dictionary is the first argument if it doesn't begin with "-" */
+		/* The dictionary is the first argument if it doesn't begin with "-" */
 		language = argv[1];
 	}
 


### PR DESCRIPTION
- Simplify code.
- Remove unusable ifdef's and the corresponding incorrect comment.
- Change len_trailing_hash to len-trailing-hash for consistency with other test names.
- Fix comments.
- Use power-of-2 divisors.
