### PR TITLE
extract-links.c (+lisjuncts.c) fixes

### DIFF
--- a/link-grammar/linkage/freeli.c
+++ b/link-grammar/linkage/freeli.c
@@ -22,18 +22,7 @@ void free_linkage(Linkage linkage)
 	exfree(linkage->chosen_disjuncts, linkage->num_words * sizeof(Disjunct *));
 	free(linkage->link_array);
 
-	/* Q: Why isn't this in a string set ?? A: Because there is no
-	 * string-set handy when we compute this. */
-	if (linkage->disjunct_list_str)
-	{
-		size_t j;
-		for (j=0; j<linkage->num_words; j++)
-		{
-			if (linkage->disjunct_list_str[j])
-				free(linkage->disjunct_list_str[j]);
-		}
-		free(linkage->disjunct_list_str);
-	}
+	free(linkage->disjunct_list_str);
 #ifdef USE_CORPUS
 	lg_sense_delete(linkage);
 #endif

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -62,7 +62,7 @@ struct Linkage_s
 
 	Disjunct **     chosen_disjuncts; /* Disjuncts used, one per word */
 	size_t          cdsz;         /* Alloc'ed length of chosen_disjuncts */
-	char **         disjunct_list_str; /* Stringified version of above */
+	const char **   disjunct_list_str; /* Stringified version of above */
 #ifdef USE_CORPUS
 	Sense **        sense_list;   /* Word senses, inferred from disjuncts */
 #endif

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -24,6 +24,11 @@
 #include "lisjuncts.h"
 #include "string-set.h"
 
+#ifdef DEBUG
+#include "print/print-util.h"
+static void assert_same_disjunct(Linkage, WordIdx, const char *);
+#endif /* DEBUG */
+
 /* Links are *always* less than 10 chars long . For now. The estimate
  * below is somewhat dangerous .... could be  fixed. */
 #define MAX_LINK_NAME_LENGTH 10
@@ -99,6 +104,32 @@ void lg_compute_disjunct_strings(Linkage lkg)
 		if ((len > 0) && (djstr[len-1] == ' ')) len--;
 		djstr[len++] = '\0';
 
+#ifdef DEBUG
+		assert_same_disjunct(lkg, w, djstr);
+#endif
+
 		lkg->disjunct_list_str[w] = strdup(djstr);
 	}
 }
+
+#ifdef DEBUG
+static void assert_same_disjunct(Linkage lkg, WordIdx w, const char *djstr)
+{
+	char *cs;
+	if (lkg->chosen_disjuncts[w])
+	{
+		cs = print_one_disjunct(lkg->chosen_disjuncts[w]);
+		char *cs_lastchar = &cs[strlen(cs)-1];
+		if (*cs_lastchar == ' ') *cs_lastchar = '\0';
+	}
+	else
+		cs = (char *)"";
+
+	assert(strcmp(cs, djstr) == 0,
+			 "Word %zu: Inconsistent disjunct string %s (link_array %s)",
+	       w, cs, djstr);
+
+	if (lkg->chosen_disjuncts[w])
+		free(cs);
+}
+#endif /* DEBUG */

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -43,7 +43,7 @@
  * compute_chosen_disjuncts()).
  *
  * In order that multi-connectors will not be extracted several times
- * for each disjunct (if they connect to multiple words) their address
+ * for each disjunct (if they connect to multiple words) their suffix_id
  * is checked for duplication.
  */
 void lg_compute_disjunct_strings(Linkage lkg)
@@ -61,7 +61,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 
 		for (int dir = 0; dir < 2; dir++)
 		{
-			Connector *last_ms = NULL; /* last multi-connector */
+			int last_multi_suffix_id = 0; /* last multi-connector */
 
 			for (LinkIdx i = lkg->num_links-1; i < lkg->num_links; i--)
 			{
@@ -81,8 +81,8 @@ void lg_compute_disjunct_strings(Linkage lkg)
 
 				if (c->multi)
 				{
-					if (last_ms == c) continue; /* already included */
-					last_ms = c;
+					if (last_multi_suffix_id == c->suffix_id) continue; /* already included */
+					last_multi_suffix_id = c->suffix_id;
 					djstr[len++] = '@';
 				}
 				len += lg_strlcpy(djstr+len, connector_string(c), sizeof(djstr)-len);

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -68,7 +68,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 		{
 			int last_multi_suffix_id = 0; /* last multi-connector */
 
-			for (LinkIdx i = lkg->num_links-1; i < lkg->num_links; i--)
+			for (LinkIdx i = lkg->num_links-1; i != (WordIdx)-1; i--)
 			{
 				Link *lnk = &lkg->link_array[i];
 				Connector *c;

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -57,7 +57,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 	size_t nwords = lkg->num_words;
 
 	if (lkg->disjunct_list_str) return;
-	lkg->disjunct_list_str = (char **) malloc(nwords * sizeof(char *));
+	lkg->disjunct_list_str = malloc(nwords * sizeof(char *));
 	memset(lkg->disjunct_list_str, 0, nwords * sizeof(char *));
 
 	for (WordIdx w = 0; w < nwords; w++)
@@ -108,7 +108,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 		assert_same_disjunct(lkg, w, djstr);
 #endif
 
-		lkg->disjunct_list_str[w] = strdup(djstr);
+		lkg->disjunct_list_str[w] = string_set_add(djstr, lkg->sent->string_set);
 	}
 }
 

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -96,6 +96,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 				djstr[len++] = ' ';
 			}
 		}
+		if ((len > 0) && (djstr[len-1] == ' ')) len--;
 		djstr[len++] = '\0';
 
 		lkg->disjunct_list_str[w] = strdup(djstr);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -11,15 +11,15 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include <limits.h>  /* For UINT_MAX */
+#include <limits.h>                     // INT_MAX
 
 #include "connectors.h"
 #include "count.h"
-#include "disjunct-utils.h" // for Disjunct
+#include "disjunct-utils.h"             // Disjunct
 #include "extract-links.h"
-#include "utilities.h"                // for Windows rand_r()
+#include "utilities.h"                  // Windows rand_r()
 #include "linkage/linkage.h"
-#include "tokenize/word-structures.h" // for Word_Struct
+#include "tokenize/word-structures.h"   // Word_Struct
 
 //#define RECOUNT
 
@@ -39,7 +39,7 @@ struct Parse_choice_struct
 {
 	Parse_choice * next;
 	Parse_set * set[2];
-	Link        link[2];   /* the lc fields of these is NULL if there is no link used */
+	Link        link[2]; /* the lc fields of these is NULL if there is no link used */
 	Disjunct    *md;     /* the chosen disjunct for the middle word */
 };
 
@@ -66,7 +66,7 @@ struct Parse_set_struct
 typedef struct Pset_bucket_struct Pset_bucket;
 struct Pset_bucket_struct
 {
-	Parse_set         set;
+	Parse_set set;
 	Pset_bucket *next;
 };
 

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -65,7 +65,7 @@ static inline void pop_match_list(fast_matcher_t *ctxt, size_t match_list_last)
 }
 
 /**
- * Return true iff there is no match list (not even en empty one).
+ * Return true iff there is no match-list (not even en empty one).
  */
 static inline bool is_no_match_list(fast_matcher_t *ctxt, size_t match_list_start)
 {
@@ -73,7 +73,7 @@ static inline bool is_no_match_list(fast_matcher_t *ctxt, size_t match_list_star
 }
 
 /**
- * Return true iff there is no match list (not even en empty one).
+ * Return Get the match-list current position.
  */
 static inline size_t get_match_list_position(fast_matcher_t *ctxt)
 {

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -79,4 +79,12 @@ static inline size_t get_match_list_position(fast_matcher_t *ctxt)
 {
 	return ctxt->match_list_end;
 }
+
+/**
+ * Return the match-list at a given position.
+ */
+static inline Disjunct **get_match_list(fast_matcher_t *ctxt, size_t pos)
+{
+	return &ctxt->match_list[pos];
+}
 #endif


### PR DESCRIPTION
Bug fixes:
- Fix disjunct connectors (see the discussion at PR #868).
- Fix extra multi-connectors in disjunct stringifying.

Efficiency:
- Keep only the middle disjunct (~1% speedup on the fix-long batch).

Output:
- lg_compute_disjunct_strings(): Discard blank at end of string.
  This affects the output of `!disjunct`.

DEBUG:
- Validate that  link_array exactly matches all the disjuncts (done on `!disjunct`).

**New:**
- extract-links.c: Implement sort_match_list()
For testing it, use:
`link-parser -test=sort-match-list`

For some reason it doesn't find the lowest cost linkage (**please check**).
Test sentence:
`And yet [...] and dine alone [...]`
(i.e. without `quite`, which prevents its parsing with 0 nulls)
When sorting the match lists, it gives a higher cost. For some reason the length metric is then much lower, and also the valid P.P. linkages density is much higher. The `Built parse set` step CPU time is about the same.