### PR TITLE
Classic parse

### DIFF
--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -78,6 +78,7 @@ except LG_Error:
 po = ParseOptions(verbosity=arg.verbosity)
 
 po.max_null_count = 999  # > allowed maximum number of words
+po.linkage_limit = 10000 # maximum number of linkages to generate
 po.max_parse_time = 10   # actual parse timeout may be about twice bigger
 po.spell_guess = True if DISPLAY_GUESSES else False
 po.display_morphology = arg.morphology

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -45,6 +45,7 @@
 #include "corpus/corpus.h"
 #include "memory-pool.h"
 #include "string-set.h"
+#include "string-id.h"
 
 typedef struct Cost_Model_s Cost_Model;
 struct Cost_Model_s
@@ -116,6 +117,7 @@ struct Sentence_s
 	const char *orig_sentence;  /* Copy of original sentence */
 	size_t length;              /* Number of words */
 	Word  *word;                /* Array of words after tokenization */
+	String_id *connector_suffix_id; /* Used for connector trailing sequence ID */
 	String_set *   string_set;  /* Used for assorted strings */
 	Pool_desc * fm_Match_node;  /* Fast-matcher Match_node memory pool */
 	Pool_desc * Table_connector_pool; /* Count memoizing memory pool */

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -44,6 +44,7 @@
 #include "api-types.h"
 #include "corpus/corpus.h"
 #include "memory-pool.h"
+#include "string-set.h"
 #include "utilities.h"
 
 typedef struct Cost_Model_s Cost_Model;

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -45,7 +45,6 @@
 #include "corpus/corpus.h"
 #include "memory-pool.h"
 #include "string-set.h"
-#include "utilities.h"
 
 typedef struct Cost_Model_s Cost_Model;
 struct Cost_Model_s

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -516,6 +516,7 @@ void sentence_delete(Sentence sent)
 	free_sentence_words(sent);
 	wordgraph_delete(sent);
 	string_set_delete(sent->string_set);
+	string_id_delete(sent->connector_suffix_id);
 	free_linkages(sent);
 	post_process_free(sent->postprocessor);
 	post_process_free(sent->constituent_pp);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -375,13 +375,13 @@ void classic_parse(Sentence sent, Parse_Options opts)
 				}
 			}
 			pp_and_power_prune(sent, opts);
+			pack_sentence(sent);
 			set_connector_hash(sent);
 			if (is_null_count_0) opts->min_null_count = 0;
 			if (resources_exhausted(opts->resources)) break;
 
 			free_count_context(ctxt, sent);
 			free_fast_matcher(sent, mchxt);
-			pack_sentence(sent);
 			ctxt = alloc_count_context(sent);
 			mchxt = alloc_fast_matcher(sent);
 			print_time(opts, "Initialized fast matcher");

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -425,9 +425,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		if ((0 == nl) && (0 < max_null_count) && verbosity > 0)
 			prt_error("No complete linkages found.\n");
 
-		/* If we are here, then no valid linkages were found.
-		 * If there was a parse overflow, give up now. */
-		if (PARSE_NUM_OVERFLOW < total) break;
 		//if (sent->num_linkages_found > 0 && nl>0) printf("NUM_LINKAGES_FOUND %d\n", sent->num_linkages_found);
 	}
 	sort_linkages(sent, opts);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -376,6 +376,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 				}
 			}
 			pp_and_power_prune(sent, opts);
+			set_connector_hash(sent);
 			if (is_null_count_0) opts->min_null_count = 0;
 			if (resources_exhausted(opts->resources)) break;
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -363,12 +363,11 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			{
 				pp_and_power_prune_done = true;
 				if (is_null_count_0)
+				{
 					opts->min_null_count = 1; /* Don't optimize for null_count==0. */
 
-				/* We are parsing now with null_count>0, when previously we
-				 * parsed with null_count==0. Restore the save disjuncts. */
-				if (NULL != disjuncts_copy)
-				{
+					/* We are parsing now with null_count>0, when previously we
+					 * parsed with null_count==0. Restore the save disjuncts. */
 					free_sentence_disjuncts(sent);
 					for (size_t i = 0; i < sent->length; i++)
 						sent->word[i].d = disjuncts_copy[i];

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -221,8 +221,6 @@ void set_connector_hash(Sentence sent)
 		return;
 	}
 
-	lgdebug(D_PREP, "Debug: Using trailing hash (Sentence length %zu)\n",
-		 sent->length);
 #define CONSEP '&'      /* Connector string separator in the suffix sequence .*/
 #define MAX_LINK_NAME_LENGTH 10 // XXX Use a global definition.
 #define MAX_GWORD_ENCODING 16 /* Up to 64^15 ... */
@@ -305,8 +303,8 @@ void set_connector_hash(Sentence sent)
 	if (verbosity_level(D_PREP))
 	{
 		int maxid = string_id_add("MAXID", csid) + WORD_OFFSET - 1;
-		prt_error("Debug: suffix_id %d, %d (%d+,%d-) connectors\n",
-					 maxid, cnum[1]+cnum[0], cnum[1], cnum[0]);
+		prt_error("Debug: Using trailing hash (len %zu): suffix_id %d, %d (%d+,%d-) connectors\n",
+					 sent->length, maxid, cnum[1]+cnum[0], cnum[1], cnum[0]);
 	}
 }
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -194,7 +194,7 @@ void set_connector_hash(Sentence sent)
 	/* FIXME: For short sentences, setting the optimized connector hashing
 	 * has a slight overhead. If this overhead is improved, maybe this
 	 * limit can be set lower. */
-	size_t min_sent_len_trailing_hash = 36;
+	size_t min_sent_len_trailing_hash = 31;
 	const char *len_trailing_hash = test_enabled("len-trailing-hash");
 	if (NULL != len_trailing_hash)
 		min_sent_len_trailing_hash = atoi(len_trailing_hash+1);

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -231,8 +231,6 @@ void set_connector_hash(Sentence sent)
 		sent->connector_suffix_id = string_id_create();
 	csid = sent->connector_suffix_id;
 
-	int cnum[2] = { 0 }; /* Connector counts stats for debug. */
-
 	for (size_t w = 0; w < sent->length; w++)
 	{
 		//printf("WORD %zu\n", w);
@@ -276,7 +274,6 @@ void set_connector_hash(Sentence sent)
 				l = 0;
 				for (Connector *c = first_c; NULL != c; c = c->next)
 				{
-					cnum[dir]++;
 					l += lg_strlcpy(cstr+l, gword_num, sizeof(cstr)-l);
 					cstr[l++] = ',';
 					if (c->multi) cstr[l++] = '@'; /* May have different linkages. */
@@ -303,8 +300,8 @@ void set_connector_hash(Sentence sent)
 	if (verbosity_level(D_PREP))
 	{
 		int maxid = string_id_add("MAXID", csid) + WORD_OFFSET - 1;
-		prt_error("Debug: Using trailing hash (len %zu): suffix_id %d, %d (%d+,%d-) connectors\n",
-					 sent->length, maxid, cnum[1]+cnum[0], cnum[1], cnum[0]);
+		prt_error("Debug: Using trailing hash (length %zu): suffix_id %d\n",
+					 sent->length, maxid);
 	}
 }
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -189,7 +189,7 @@ static char* itoa_compact(char* buffer, size_t num)
  * Prepending the gword numbers solve both of these requirements.
  */
 #define WORD_OFFSET 256 /* Reserved for null connectors. */
-void set_connector_hash(Sentence sent)
+bool set_connector_hash(Sentence sent)
 {
 	/* FIXME: For short sentences, setting the optimized connector hashing
 	 * has a slight overhead. If this overhead is improved, maybe this
@@ -218,7 +218,7 @@ void set_connector_hash(Sentence sent)
 			}
 		}
 
-		return;
+		return false;
 	}
 
 #define CONSEP '&'      /* Connector string separator in the suffix sequence .*/
@@ -303,6 +303,8 @@ void set_connector_hash(Sentence sent)
 		prt_error("Debug: Using trailing hash (length %zu): suffix_id %d\n",
 					 sent->length, maxid);
 	}
+
+	return true;
 }
 
 /**

--- a/link-grammar/parse/preparation.h
+++ b/link-grammar/parse/preparation.h
@@ -16,5 +16,5 @@
 #include "link-includes.h"
 
 void prepare_to_parse(Sentence, Parse_Options);
-void set_connector_hash(Sentence);
+bool set_connector_hash(Sentence);
 #endif /* _PREPARATION_H */

--- a/link-grammar/parse/preparation.h
+++ b/link-grammar/parse/preparation.h
@@ -16,4 +16,5 @@
 #include "link-includes.h"
 
 void prepare_to_parse(Sentence, Parse_Options);
+void set_connector_hash(Sentence);
 #endif /* _PREPARATION_H */

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -853,7 +853,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		return -1;
 	}
 
-	prt_error("Error: I can't interpret \"%s\" as a command.  Try \"!help\".\n", line);
+	prt_error("Error: I can't interpret \"%s\" as a command.  Try \"!help\" or \"!variables\".\n", line);
 	return -1;
 }
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -848,7 +848,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 	if (0 < count)
 	{
-		prt_error("Error: Variable \"%s\" requires a value.  Try \"!help\".\n", as[j].string);
+		prt_error("Error: Variable \"%s\" requires a value.  Try \"!help %s\".\n",
+		          as[j].string, as[j].string);
 		return -1;
 	}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -470,7 +470,7 @@ static void batch_process_some_linkages(Label label,
 	}
 	else
 	{
-		if (test_enabled(test, "batch_print_parse_statistics"))
+		if (test_enabled(test, "batch-print-parse-statistics"))
 		{
 			print_parse_statistics(sent, opts, copts);
 		}

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -908,10 +908,14 @@ int main(int argc, char * argv[])
 			sentence_display_wordgraph(sent, wg_display_flags);
 		}
 
+		bool one_step_parse = !copts->batch_mode && copts->allow_null &&
+		                    test_enabled(test, "one-step-parse");
+		int max_null_count = one_step_parse ? sentence_length(sent) : 0;
+
 		/* First parse with cost 0 or 1 and no null links */
 		// parse_options_set_disjunct_cost(opts, 2.7);
 		parse_options_set_min_null_count(opts, 0);
-		parse_options_set_max_null_count(opts, 0);
+		parse_options_set_max_null_count(opts, max_null_count);
 		parse_options_reset_resources(opts);
 
 		num_linkages = sentence_parse(sent, opts);
@@ -973,7 +977,7 @@ int main(int argc, char * argv[])
 		}
 
 		/* Now parse with null links */
-		if (num_linkages == 0 && !copts->batch_mode)
+		if (!one_step_parse && num_linkages == 0 && !copts->batch_mode)
 		{
 			if (verbosity > 0) fprintf(stdout, "No complete linkages found.\n");
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -255,6 +255,34 @@ static void print_parse_statistics(Sentence sent, Parse_Options opts,
 }
 
 /**
+ * Check whether the given feature is enabled. It is considered
+ * enabled if it is found in the comma delimited list of features.
+ * This list, if not empty, has a leading and a trailing commas.
+ * Return NULL if not enabled, else ",". If the feature appears
+ * as "feature:param", return a pointer to the ":".
+ *
+ * This function is similar to feature_enabled() of the library (which
+ * is not exported) besides not including filename matching.
+ */
+static const char *test_enabled(const char *feature, const char *test_name)
+{
+
+	if ('\0' == feature[0]) return NULL;
+	size_t len = strlen(test_name);
+	char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
+
+	buff[0] = ',';
+	strcpy(buff+1, test_name);
+	strcat(buff, ",");
+
+	if (NULL != strstr(feature, buff)) return ",";
+	buff[len+1] = ':'; /* check for "feature:param" */
+	if (NULL == strstr(feature, buff)) return NULL;
+
+	return strstr(feature, buff) + len + 1;
+}
+
+/**
  * Check for the auto-next-linkage test request (for LG code development).
  * It is given using the special command: test=auto-next-linkage[:display_max]
  * when :display_max is an optional indication of the maximum number of
@@ -265,12 +293,13 @@ static void print_parse_statistics(Sentence sent, Parse_Options opts,
  */
 static int auto_next_linkage_test(const char *test_opt)
 {
-	char auto_next_linkage_str[] = ",auto-next-linkage";
-	char *auto_next_linkage_pos = strstr(test_opt, auto_next_linkage_str);
-	int max_display;
+	const char *auto_next_linkage_pos =
+		test_enabled(test_opt, "auto-next-linkage");
+	int max_display = 0;
 
 	if (auto_next_linkage_pos == NULL) return 0;
-	max_display = atoi(auto_next_linkage_pos + sizeof(auto_next_linkage_str));
+	if (':' == auto_next_linkage_pos[0])
+		max_display = atoi(auto_next_linkage_pos + 1);
 	if (max_display != 0) return max_display;
 	return DISPLAY_MAX;
 }
@@ -441,7 +470,7 @@ static void batch_process_some_linkages(Label label,
 	}
 	else
 	{
-		if (strstr(test, ",batch_print_parse_statistics,"))
+		if (test_enabled(test, "batch_print_parse_statistics"))
 		{
 			print_parse_statistics(sent, opts, copts);
 		}
@@ -867,9 +896,8 @@ int main(int argc, char * argv[])
 				case 3:
 					{
 						/* Use esoteric flags from the test user variable. */
-						const char wg[] = ",wg:";
-						const char *s = strstr(test, wg);
-						if (NULL != s) wg_display_flags = s+4;
+						const char *s = test_enabled(test, "wg");
+						if ((NULL != s) && (':' == s[0])) wg_display_flags = s;
 					}
 					break;
 				default:

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -1027,7 +1027,7 @@ int main(int argc, char * argv[])
 			}
 		}
 
-		/* print_total_time(opts); */
+		if (verbosity > 1) parse_options_print_total_time(opts);
 
 		const char *rc = "";
 		if (copts->batch_mode)

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -908,12 +908,14 @@ int main(int argc, char * argv[])
 			sentence_display_wordgraph(sent, wg_display_flags);
 		}
 
+		/* First parse with the default disjunct_cost as set by the library
+		 * (currently 2.7). Usually parse here with no null links.
+		 * However, if "-test=one-step-parse" is used and we are said to
+		 * parse with null links, allow parsing here with null links too. */
 		bool one_step_parse = !copts->batch_mode && copts->allow_null &&
 		                    test_enabled(test, "one-step-parse");
 		int max_null_count = one_step_parse ? sentence_length(sent) : 0;
 
-		/* First parse with cost 0 or 1 and no null links */
-		// parse_options_set_disjunct_cost(opts, 2.7);
 		parse_options_set_min_null_count(opts, 0);
 		parse_options_set_max_null_count(opts, max_null_count);
 		parse_options_reset_resources(opts);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -861,7 +861,7 @@ int main(int argc, char * argv[])
 			printf("%s\n", input_string);
 		}
 
-		if (copts->batch_mode)
+		if (copts->batch_mode || auto_next_linkage_test(test))
 		{
 			label = strip_off_label(input_string);
 		}

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -15,7 +15,7 @@
 
 #include "../link-grammar/link-includes.h"
 
-#define MAX_INPUT 1024
+#define MAX_INPUT 2048
 
 #ifdef _WIN32
 #ifndef __MINGW32__


### PR DESCRIPTION
**Classic-parser**:
- On one-step-parse, share the count connector table of the null_count==0 step with the null_count>0 step.
  This is done by defining the suffix_id's incrementally in 2 steps.
- Don't stop on linkage overflow (see issue #869).
- Redesign the suffix_id assignment algo to be more efficient (~+2% on the en/ru basic batches, ~+4% on the fixes batch).
- Improve debug messages.

**link-parser main changes**:
- Allow one-step parsing tests using `-test=one-step-parse`. It can be later changed to be the default.
- Print parse time on verbosity > 1 (verbosity=2 is the designed way to time messages only.)
- Improve help messages.
- Increase MAX_INPUT to 2048

BTW, I have an additional PR to send (cleanup + typo fixes) for version 3.6.0.
I also have some more speed fixes but if desired I can keep them for version 3.6.1.