### PR TITLE
Cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -439,7 +439,7 @@ fi
 
 # Don't set the CPPFLAGS unless we can find the library too.
 # Which is insane, of course, except that some Apple OSX systems
-# appear to be borken... have header files but no libs ...
+# appear to be broken... have header files but no libs ...
 if test "x${SQLiteFound}" = "xyes"; then
 	AC_DEFINE(HAVE_SQLITE, 1, [Define for compilation])
 fi

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -23,7 +23,7 @@
 #define MAX_LINK_NAME_LENGTH 10
 
 /**
- * This returns a string that is the the GCD of the two given strings.
+ * This returns a string that is the GCD of the two given strings.
  * If the GCD is equal to one of them, a pointer to it is returned.
  * Otherwise a new string for the GCD is put in the string set.
  */

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -283,7 +283,7 @@ void remove_empty_words(Linkage lkg)
  *    Computed as a function of chosen_disjuncts[]. This differs from
  *    sentence.word[].alternatives because it contains the subscripts.  It
  *    differs from chosen_disjunct[].string in that the idiom symbols have
- *    been removed.  Furthermore, several chosen_disjuncts[].string
+ *    been removed.  Furthermore, several chosen_disjuncts[].word_string
  *    elements may be combined into one chosen_words[] element if
  *    opts->display_morphology==0 or that they where linkage null-words
  *    that are morphemes of the same original word (i.e. subwords of an

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -398,7 +398,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 	/* This entry must be updated before we return. */
 	xt = x_table_store(lw, rw, le, re, null_count, pex);
 
-	/* The count we previously computed; its non-zero. */
+	/* The count we previously computed; it's non-zero. */
 	xt->set.count = hist_total(count);
 
 #define NUM_PARSES 4

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -405,7 +405,7 @@ static bool do_match_with_cache(Connector *a, Connector *b, match_cache *c_con)
 	if (c_con->desc == connector_desc(a))
 	{
 		/* The match_cache desc field is initialized to NULL, and this is
-		 * enough because the connector desc filed cannot be NULL, as it
+		 * enough because the connector desc field cannot be NULL, as it
 		 * actually fetched a non-empty match list. */
 		PRAGMA_MAYBE_UNINITIALIZED
 		return c_con->match;

--- a/link-grammar/parse/histogram.h
+++ b/link-grammar/parse/histogram.h
@@ -12,15 +12,8 @@
 #ifndef _HISTOGRAM_H_
 #define _HISTOGRAM_H_
 
-#ifndef _MSC_VER
 typedef long long s64; /* signed 64-bit integer, even on 32-bit cpus */
 #define PARSE_NUM_OVERFLOW (1LL<<24)
-#else
-/* Microsoft Visual C Version 6 doesn't support long long. */
-typedef signed __int64 s64; /* signed 64-bit integer, even on 32-bit cpus */
-#define PARSE_NUM_OVERFLOW (((s64)1)<<24)
-#endif
-
 
 /*
  * Count Histogramming is currently not required for anything, and the

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -269,17 +269,26 @@ static const char *test_enabled(const char *feature, const char *test_name)
 
 	if ('\0' == feature[0]) return NULL;
 	size_t len = strlen(test_name);
-	char *buff = alloca(len + 2 + 1); /* leading comma + comma/colon + NUL */
+	char *buff = malloc(len + 2 + 1); /* leading comma + comma/colon + NUL */
+	const char *r = NULL;
 
 	buff[0] = ',';
 	strcpy(buff+1, test_name);
 	strcat(buff, ",");
 
-	if (NULL != strstr(feature, buff)) return ",";
-	buff[len+1] = ':'; /* check for "feature:param" */
-	if (NULL == strstr(feature, buff)) return NULL;
+	if (NULL != strstr(feature, buff))
+	{
+		r = ",";
+	}
+	else
+	{
+		buff[len+1] = ':'; /* check for "feature:param" */
+		if (NULL != strstr(feature, buff))
+			r = strstr(feature, buff) + len + 1;
+	}
 
-	return strstr(feature, buff) + len + 1;
+	free(buff);
+	return r;
 }
 
 /**

--- a/msvc/LinkGrammar.vcxproj
+++ b/msvc/LinkGrammar.vcxproj
@@ -280,6 +280,7 @@
     <ClInclude Include="..\link-grammar\print\print.h" />
     <ClInclude Include="..\link-grammar\print\wcwidth.h" />
     <ClInclude Include="..\link-grammar\resources.h" />
+    <ClInclude Include="..\link-grammar\string-id.h" />
     <ClInclude Include="..\link-grammar\string-set.h" />
     <ClInclude Include="..\link-grammar\tokenize\anysplit.h" />
     <ClInclude Include="..\link-grammar\tokenize\regex-tokenizer.h" />
@@ -333,6 +334,7 @@
     <ClCompile Include="..\link-grammar\print\print.c" />
     <ClCompile Include="..\link-grammar\print\wcwidth.c" />
     <ClCompile Include="..\link-grammar\resources.c" />
+    <ClCompile Include="..\link-grammar\string-id.c" />
     <ClCompile Include="..\link-grammar\string-set.c" />
     <ClCompile Include="..\link-grammar\tokenize\anysplit.c" />
     <ClCompile Include="..\link-grammar\tokenize\regex-tokenizer.c" />

--- a/msvc/LinkGrammar.vcxproj.filters
+++ b/msvc/LinkGrammar.vcxproj.filters
@@ -165,6 +165,9 @@
     <ClCompile Include="..\link-grammar\memory-pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\link-grammar\string-id.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\link-grammar\api-structures.h">
@@ -339,6 +342,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="link-grammar\link-features.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\string-id.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
- Remove old MSVC6 code.
- Fix typos/comment rot.
- Fix MSVC compilation:
 -- Add missing files.
 -- Replace alloca() by malloc().