### PR TITLE
 corpus-failures.batch: Remove duplicate sentences

### DIFF
--- a/data/en/corpus-failures.batch
+++ b/data/en/corpus-failures.batch
@@ -245,7 +245,6 @@ Suffocated and uninspired by their hometown, Shake shook themselves up, hopped o
 Before the hoist came to a halt, the Twins were up and out of it, hopping lightly ashore and closing in on the woman, one either side of her. 
 I hopped on a bus to King's Cross and then took a tube round to Leicester Square, missing out Covent Garden station as the lifts were out of action again. 
 But we can say nothing to these things you know Jackson, we must jog on and be content with the jingling of the bells, only d -- it, I hate a dust, and kicking up a dust, and being confined in harness while others ride in the waggon, under cover, stretching their legs in the straw at ease, and gazing at green trees and blue skies without half my Taste. 
-Got you my beauty, he gasped His triumph was shortlived With a massive burst of energy the fish broke free of his grasp and leapt six feet in the air. 
 And when she tried to interest him in niente acqua, he laughed as he limped round his shelves serving several customers at once and, shrugging his high shoulders, said,  Non c' pioggia, non c' acqua. 
 Cornucopia : rabbits, hunched and private, loping slowly about the lawn in the moonlight; a green frog, gleaming and sparkling in the dewy sunlit grass as it wiggled along some compelling migratory path; squirrels -- quick flashes of ginger and grey in the treetops, a sudden glimpse of bright beady eyes; a mythical fox -- dusky shadow and sinister snowprints. 
 On each side were stalls heaped with fruit, vegetables, fish and other staples, behind which strapping black-shawled women bawled produce and price, oblivious of the packs of snarling dogs and ragged children lunging in and out between them for whatever scraps they could scavenge. 
@@ -296,7 +295,6 @@ I looked through her bright red glasses into her light grey eyes and said, Well,
 Guruji seems very much at home in these surroundings. 
 He smelt very strongly of  well, Marcus. 
 'E likes to know what everythin' smells like so's he knows who to say hello to and who not. 
-He didn't want to contemplate what he smelt like. 
 I'm sorry, she said suddenly, eyes open again, I stink of some horrible aftershave. 
 The cheese stunk like that. 
 (12) So then the farmer asked his cat (13) to scratch the dog (14) so the dog would bark loudly (15) and thereby frighten the donkey into the shed 
@@ -395,7 +393,6 @@ The aunt (actually great-aunt) who had known him from his appearance was Sarah, 
 And don't forget, I was by then dominated by my aunt to such an extent that I wouldn't have dared. 
 Mr and Mrs Jonesy apologised to Dad for their son's behaviour and promised that he would get what's comin' to'im when we get'ome. 
 And ask them how they'd answer their children's inevitable questions, such as why don't I have a daddy like the other kids at school ? 
-In the drawing-room itself, Sargent's portraits of the Hon Mrs Frederick E. Guest, all whipped cream lace and cabbage roses, with a Japanese spaniel under her arm, and Mrs Henry Phipps, holding her infant grandson Winston in her lap, survey an appropriately Edith Wharton roomscape of Chinese porcelain parrots on eighteenth-century brackets, Boucher crayons, and banks of strange and beautiful orchids : Mrs Guest's pride. 
 In the drawing-room itself, Sargent's portraits of the Hon Mrs Frederick E. Guest, all whipped cream lace and cabbage roses, with a Japanese spaniel under her arm, and Mrs Henry Phipps, holding her infant grandson Winston in her lap, survey an appropriately Edith Wharton roomscape of Chinese porcelain parrots on eighteenth-century brackets, Boucher crayons, and banks of strange and beautiful orchids : Mrs Guest's pride. 
 Not for her granddaughter, but for Kate. 
 Ah yes, the hysterical Penelope, niece of the late William Coombes. 
@@ -584,7 +581,6 @@ The celebration of each child's birthday in school can involve other ideas than 
 The inhabitants of the closes and the tenements had headed for the high ground, leaving the trams and turmoil behind for the mist, the heather, and a good brew-up in the but and ben. 
 She did not reflect that only a few weeks ago she would have thought it impossible that she could have lived the life of a servant, let alone bear eating and drinking in the den in which Rose and her ma lived, but she did know one thing -- she would never take her comfortable life for granted again. 
 With so many ways to build a kitchen, it helps if you have clear idea of what you want. 
-Like someone sleepwalking, she entered the lift, Bye, she said huskily, and as the lift sailed upwards she wasn't conscious of thinking of anything. 
 However, during training, decisions such as when to leave the lift and start to get back to the field are too often taken by the instructor. 
 There was nearly a chance when he got locked in a lift at the Horseguards Hotel the other day, but the prospect of being out of the front line for a few hours was more than he could bear. 
 A few minutes later, feeling decidedly the worse for wear after the last Armagnac had been downed, Mark moved unsteadily into the lift with his voluptuous mate. 
@@ -600,7 +596,6 @@ The side wings were raised to the height of the main block in 1769 by I. J. Pall
 Cary established himself in business c.1783 at 188 Strand in London, subsequently trading at Johnson's Court, Fleet Street (c.1782), 181 Strand (from c.1791), and 86 St James's Street (from January 1820, when fire destroyed his workshop and his brother William's adjacent premises). 
 Methinks I am to be your chaperon -- which means, I suppose, that I am to see that you conduct yourself properly and are accompanied suitably whenever you leave these apartments. 
 They are also rigorously colour-coded, so that when the Wife (Helen Mirren) walks into the lavatory from the dining-room, the camera keeping pace with her all the while, she is miraculously redressed in identical tacky Jean-Paul Gaultier clobber, but now in white and not red. 
-Everywhere you look, little shards of glass glistening in the lamplight. 
 Annual exhibition to coincide with the street fair in September. 
 Ahead of her glittered the tracks of Frere's previous solitary excursion. 
 She looked away a moment, noticing how the fire's light flickered in the window pane; how it cast a mottled, ever-changing pattern against the narrow opening. 
@@ -679,7 +674,6 @@ It is true that Edward V's one and only regnal year began on the day the previou
 Chinese medicine regards tonic and adjustive remedies as the most important (the kings) of all medicines while curative drugs are the least important (the servants). 
 Characteristics of the patient when well that are still present when ill are not actually a part of the picture of the acute illness and are therefore not important when selecting a remedy for the acute disease. 
 This not the early 1980s, when new members entered the party to the left; old members exited to the right; and Labour voters deserted. 
-This not the early 1980s, when new members entered the party to the left; old members exited to the right; and Labour voters deserted. 
 Aromatherapy (massage with fragrant essential oils) is not only sybaritic experience but can ease tension, improve circulation and release accumulated tensions. 
 When stenosis is the cause of severe symptoms, the prognosis without valve replacement is worse than that of many cancers, with a three year mortality around 75% Balloon valvoplasty offers only short term palliation. 
 It is, however, not easy to backstitch the neckband through the open loops because of the loops which are part of the construction of the yarn. 
@@ -732,7 +726,6 @@ Vine fruits -- that is, currants, sultanas and raisins -- are full of invert sug
 Chemically, these vegetable oils are much more like saturated animal fats than good quality sunflower or corn oil which are high in the healthier polyunsaturates. 
 Based on beer and widely used for preserving and pickling, malt vinegar is also available as a strong, colourless, distilled vinegar which is particularly useful for preserving foods that have to last a long time. 
 Instructions were given on what foods to eat (fresh fruits, salads, raw vegetables, carrot juice, nuts, seeds, whole grain products, tubers, flax seed oil, extra virgin olive oil) what foods to avoid (alcohol, caffeine, foods containing refined sugar, corn syrup, refined and / or hydrogenated oil, refined flour, dairy, eggs, and all meat) and how to prepare freshly extracted carrot juice with the supplied Champion juicer (Plastaket Mfg.
-Instructions were given on what foods to eat (fresh fruits, salads, raw vegetables, carrot juice, nuts, seeds, whole grain products, tubers, flax seed oil, extra virgin olive oil) what foods to avoid (alcohol, caffeine, foods containing refined sugar, corn syrup, refined and / or hydrogenated oil, refined flour, dairy, eggs, and all meat) and how to prepare freshly extracted carrot juice with the supplied Champion juicer (Plastaket Mfg.
 Piper auritum leaf juice is applied topically to remove ticks and head lice in El Salvador and Ecuador respectively [92]. In Guatemala, Panama and Columbia the juice of crushed leaves of Piper species or the decoction of roots are drunk or used in baths for snakebites or rubbed onto the body as a snake repellent [63 95 139]. In Eastern Nicaragua and Jamaica Piper hispidum is used in remedies for colds, fever, stomach aches and for aches and pains [116 53]. In Trinidad, Puerto Rico and other Caribbean countries Piper amalgo leaf infusions are used as ritual baths or baths to perfume the body [52 16].
 The company's 1996 shipment of unpasteurized apple juice led to an E. coli outbreak that killed a 16 - month - old girl and sickened at least 66 other people.
 ' Other loanwords which have acquired changed meanings include chitra axis deer,' from citra spotted'; hathi gray,' from hathi elephant'; pukka genuine, reliable, good,' from pakka cooked, ripe, mature'; puttee soldier's legging,' from patti bandage'; pyke civilian at whose expense a soldier is treated,' from payik messenger'; and toddy type of hot drink,' from tari palmyra palm juice.
@@ -743,7 +736,6 @@ yeah i i've gotten to where i won't even buy juices anymore because i'm afraid o
 KAMIKAZE BLEEDING BRAIN 1 ounce vodka Fill a shot glass with half 1 ounce Triple Sec peppermint schnapps, Few drops Rose's Lime half Irish cream liqueur, Juice and add a few drops of Glass : rocks glass, with grenadine.
 well yeah but it it's like it's just chicken it it's as much as you want you know torn up and and rice and cream of chicken soup and some mayonnaise and lemon juice
 because certainly they're not using it for juices and stuff i mean they use the junk for that it makes me wonder gosh if they're using junk for that what are we getting here
-what are we yeah yeah hat's in the juice this is what i would put in juice
 because you can you can put it on top of the stove and do this and and there's so much broth and juice in there that it has to uh soak up into the rice all day long in order for it to uh uh to come out fluffy and and nice
 yeah we we have a real nice cafeteria we can go to that anytime during the day and it's always it is always nice to go down there and get a coffee or a tea or a juice
 oh yeah they look terrible here i look at those thing i say i wouldn't buy them not even to squeeze for orange juice uh
@@ -783,7 +775,6 @@ Became a literary outcast after referring in his memoirs to Gustave's epilepsy.
 Great new cover treatment for this family saga of struggling siblings in the aftermath of the First World War. 
 Many of his verses, for example Ecclesiastical Sketches, Sonnets upon the Punishment of Death (in favour of capital punishment), several sonnets on Railways (both for -- in general; and against -- in the Lake District), and one on Illustrated Books and Newspapers (against !) might well find their present day equivalent in irate letters to national or local newspapers, or in an Any Questions discussion. 
 In the sonnets on the Rival Poet, for instance, whether the first or second person dominates, the technique of praising the other poet while denigrating oneself is clearly ironic, as J. W. Lever's discussion has shown. 
-A nice gimmick; but read this trilogy immediately after an in depth study of quantum theory and you find that it represents possibly the most scientific of all science fiction novels. 
 Pamper him with a shave, facial, massage, pedicure, manicure and more ! 
 The Random House general book division will be divided into two operating groups, allowing editors to see their authors' books through from hardback to paperback publication (or to choose which they find most appropriate). 
 And the great lays -- you can learn them, meantime. 
@@ -881,7 +872,6 @@ Not only is this a thoroughly terrific experience, but The Bad Seeds give it the
 I decided to go the house a few gardens away where a few pitiful meows brings some food from the woman. 
 It was extremely upsetting and the generously exposed support of the Honourable the Colonel Alexander Augustus Hope, M. P., when they went to the site of Allan Bank was very warmly appreciated. 
 The second and more troubling event has left me -- the self-styled, experienced, capable, worldly-wise individual -- in a moral dilemma with no idea how I should respond. 
-No doubt they excelled at things in which indolent societies specialize; no doubt their basketwork became rococo, their erotic skills more gymnastical, their use of crushed leaves to induce stupefying trances increasingly efficient. 
 All in all, then, a pioneering collection of very worthwhile and stimulating music, ideal for guess-the-composer quizzes. 
 To tell the truth, it's pretty scary. 
 Because everything that's in our lives and is displeasing to God can surely be put into the chair of judgement, ad the power turn on and they're gone.
@@ -900,7 +890,6 @@ However, a new, earlier and potentially far more troublesome deadline will arise
 Perhaps some of the most encouraging experimental results started with the work carried out in Switzerland by W. Pelikan and G. Unger, and published in English in 1965. 
 They came into my hands in a rather distressing, but all too familiar, way. 
 It's very distressing. 
-The more that de Man can encourage the illusion of unmediated congress between reader and text, the less obliged he is to formulate potentially alienating propositions of his own. 
 The recorder Nicholas Jarman jailed him for a further 3 and a half years for what he described as a terrible act with the most appalling consequences. 
 You agreed that my consent was necessary, she reminded him, sudden appalling agitation making her breathless. 
 This seems a bewildering tangle of dates, but as a rule the traveller would take note only of the month and the day. 
@@ -1043,7 +1032,6 @@ However, I shall not be parting with Shelley either, whose touching sincerity an
 Playtex Secrets cotton-rich full briefs, with a reinforced tummy panel, are a cross between briefs and a girdle, sizes s, m, l, xl, 19.99. 
 They too were suffering from exhaustion after recent events, and had less energy to carry Charles; their main concern was just to keep themselves going. 
 Victoria said, You are recovered from your exhaustion, Shelley ? 
-E gives people a heightened sense of well-being, she says, but when people go to nightclubs they can't actually dance all night, so they take amphetamines to overcome tiredness. 
 Competition for a female or other sex object may not produce the same hierarchy as that for food, simply because a sexually aroused animal, say, is not necessarily a hungry one. 
 Were the technicians indifferent to what they were recording or did they sometimes become aroused too, and if so, were there rules against them joining in ? 
  That director chap came and a couple of the actors  the leading ones. 
@@ -1053,7 +1041,6 @@ Indeed, never was I anywhere so idyllically drowsy.
 It is more likely the Goblin will be smashed apart -- which although sad is considered a good way to go for a Goblin and infinitely better than being eaten by a peckish troll. 
 He or she can feel a very real, very deep sense of nausea at the intrusion, and often find that they can no longer regard their house as home. 
 Even in the 1930s the anti-Semitism of literary figures like Hilaire Belloc and G. K. Chesterton co-existed uneasily with their revulsion at the racial policies of the new Germany. 
-God, what an accursed night ! mumbled Mr Beckenham, and, sipping his liquor, he looked over the makeshift meal with revulsion. 
 There was, as yet, no significant revulsion amongst the general public towards the use of nuclear weapons to save manpower. 
 T was to stop you becoming completely distraught, but I was afraid to look at you, afraid to come to you that night in case I saw fear or revulsion in your eyes. 
 Had pier alone, Carrie knew, than when she was with them, and although she didn't really mind this, it made her feel lonely this particular day. 
@@ -1093,7 +1080,6 @@ Guinness Flight (071-522 2109) pioneered the concept of managed currency funds i
 I had always understood that quantum chemical ab initio calculations for molecules using gaussian orbitals were pioneered by S. F. Boys at Cambridge, but there is no reference to his work in Martin's article. 
 He was the man who first coined the term Dinosauria, from the Greek word deinos (terrible) and sauros (lizard or perhaps reptile).
 Sometimes elite is used only as a synonym for leaders. 
-The equivalence between queen and female monarch, and kitten and young cat, for instance, establishes queen as a hyponym of monarch, and kitten as a hyponym of cat. 
 The equivalence between queen and female monarch, and kitten and young cat, for instance, establishes queen as a hyponym of monarch, and kitten as a hyponym of cat. 
 The one with Bill Dean aka Harry Cross on the cover
 Two words which collocate (may occur together) in your own language may not collocate in the target language. 
@@ -1181,7 +1167,6 @@ Even if the final goal is a paper, as it is with a DTP system, it is important h
 (x) To do all such other things as may be deemed incidental or conducive to the attainment of the Company's objects or any of them.
 The feel good factor may only be jolted when you come to a Y junction and curse that thick rear side panel, obstructing the over-the-shoulder rear three-quarter view.
 As if he had X-ray eyes he could visualise the metal cylinder concealed within the bag, the pointed bomb with its tail fins reclining at an angle of forty-five degrees.
-The feel good factor may only be jolted when you come to a Y junction and curse that thick rear side panel, obstructing the over-the-shoulder rear three-quarter view.
 A handful of Muslim Generals had been assassinated by the radicals -- he himself, a captain then, had narrowly escaped such a fate when a gang with knives and spears had broken into his home. 
 As discussed earlier (p. 31), it is likely that unemployment can contribute to attempted suicide by precipitating or exacerbating domestic, social, and financial problems. 
 JERRY Seinfeld has found a new passion in life - daily foot massages from a gal who's a dead ringer for his ex, Shoshana Lonstein.
@@ -1194,7 +1179,6 @@ He must have managed to purloin a copy of the house key from somewhere and was o
 And even as I did I was astounded at myself. 
 The tiger that was nearest to him, and which he could see most easily, seemed so bored that he did the same thing day after day, hour after hour. 
 His girlfriend, a dealer too, would give him a bored hard look, if she happened to be around. 
-The animal seemed to take a perverse delight in terrorizing him. 
 So I got very, very depressed about it all and I just said to the officers, Put me in my cell and leave me alone. 
 Don't be such a nincompoop, Madeleine retorted, apparently not in the least disconcerted. 
 Thank you, thank you ! she cried, quite ecstatic that he'd unbent. 
@@ -1252,8 +1236,6 @@ The Rev C Malpass gave a short address, which he always bases on the story of Ch
 Alex Tate, 34-year-old ship's cook, was told by Judge Alan Simpson that the assault merited a short prison sentence but that it should not interfere with his work. 
 Grilled Dover sole (not buttery), be assertive about any plain grilled white fish, tell the waiter that you do not want it served swimming with butter. 
 And I remember talking to my husband about that in the car ride home, as well, because we're both teachers and I was -- when I hear things like that, I immediately think of my students, and I was thinking about the diverse group of students that I have in my classroom, who all have different religious viewpoints, and how difficult that would be to tell one student that, you know, we can't express your belief, but we can express that person's belief in the classroom.
-And I remember talking to my husband about that in the car ride home, as well, because we're both teachers and I was -- when I hear things like that, I immediately think of my students, and I was thinking about the diverse group of students that I have in my classroom, who all have different religious viewpoints, and how difficult that would be to tell one student that, you know, we can't express your belief, but we can express that person's belief in the classroom.
-], who runs Robbie Vinson's Night Line and refers to himself in the third person, is often very unpleasant indeed, and some of the conversations cited in the article (especially one in which a caller was told that if he didn't like Britain he should get out) smack strongly of his acerbic, dyspeptic, often rude manner.
 Oh, thousands of people, Piers informed lazily. 
 Better not, advised Meredith. 
 Only the game, assures Nicholas. 
@@ -1287,7 +1269,6 @@ Her attention was distracted by a clatter of hoofs as a rider on a grey came up 
 In fact, he seems on occasion to recreate the clatter of an entire wrecking yard, and it sounds terribly tough on the instrument itself 
 When she too heard the clatter of the galloping horse far below she went to the window, but there was no longer anything to see and only the sound of the nursemaids chattering. 
 Is that Anya's doing, I wonder, as the clatter of kitchen chairs announces an imminent scene shift, or is it mine ? 
-She came crawling across the pitch-black floor, the scuff of her knees completely muffled by the clatter of raindrops. 
 He was if anything more irritated by the quiet drumming of the electric typewriter than by the clatter of the old mechanical one. 
 I introduced her, she took two steps, and there was an almighty clatter. 
 The oilbird's click lasts for about a hundredth of a second and is not a single sound but a burst of pulses, each only about a thousandth of a second long. 
@@ -1304,7 +1285,6 @@ As he looked at her, preparing to bargain all over again, there was a splat ! of
 Ka-prap ! went Kaptan, imitating the snarl of the M-16 and spinning sideways to the carpet. 
 A muffled thump from below, somewhere at the foot of the stairs. 
 Father Wilfred Knox, a nice fellow but with a horrible mirthless titter. 
-With a shrill yelp she nipped him in the hind leg and he shot away in alarm. 
 He let out a yelp. 
 Far-carrying voice a loud, clear, vibrant, fluty string of double notes; also a single repeated musical yelp. 
 ANGRY, frustrated and disillusioned Arsenal fans yesterday borrowed a line from pools winner Viv Nicholson and urged manager George Graham to spend, spend, spend. 
@@ -1317,7 +1297,6 @@ And depending whether it's a rectangular plot or whether it isn't or not or if i
 Two legs good or four wheels bad or does it depend who's in the driving seat, after all who ever heard of a road sow.
 11.6 (a) Two-mesh circuit analysed with the aid of Laplace transformation in the text and (b) the solutions for I 2 and V as a function of time for certain network parameters.
 Efforts by Alexander I's reforming minister, Speransky, to make promotion dependent upon examinations were frustrated by opposition from officials.
-No matter how much Norse manure you splatter on to them, they've a habit of coming up smelling of roses. 
 European Colloquy on Gypsies in the Locality 
 It's not so much the snow; more the salt that gets strewn around. 
 Where one such lift is used the dock and load would be balanced by a suspended weight but two such lifts would generally be arranged to work simultaneously in opposite directions so as to balance each other. 
@@ -1378,7 +1357,6 @@ Now he's overboard for France, and spells his name with a c instead of a k.
 Consonants in possible trisyllabic words -- for example, can the child pronounce the l in elephant or the m in umbrella ?
 But let us look at the weather's influence on ferreting.
 yeah i didn't know anyone that that i can recall that went that which is uh now i've met some i've met some after the fact you know people that i worked with and stuff that had been several actually that i worked with that had been but i didn't know i no one that i grew up with
-yeah i didn't know anyone that that i can recall that went that which is uh now i've met some i've met some after the fact you know people that i worked with and stuff that had been several actually that i worked with that had been but i didn't know i no one that i grew up with
 and um the the how i met him was through uh the aerobics class that he used to teach
 because like uh i'm really glad that i'm in like uh the classes uh like honors classes and so it's like what's really good about that is that you meet people who really are interested in in talking about things and discussing world issues and
 we're we're in pretty good agreement actually on it it would be an interesting it would be even more interesting you you to to meet some of these people who are at the other end of the spectrum that's opposite
@@ -1414,7 +1392,6 @@ Even the Pentagon don't know or won't divulge what type of plane it was.
 It must be confessed that it is really difficult to pinpoint the precise locations of these ancient workings, which, at that time may have been little else than shallow holes on the outcrops.
 If by that you mean am I going to the police station to confess, then no. 
 The prosecution relied on the circumstances of the shooting, an alleged confession by the defendant to the husband of the deceased, and previous threats to kill the deceased made by the defendant as testified to by the deceased's husband and sister. 
-Judith had once confided that she too had an uncertain grasp of the past, though she'd been drunk at the time, and had denied it vehemently when he'd raised the subject again.
 There are 2,000 Italian-born people living in the North-East, according to Durham University lecturer Hugh Shankland, and many thousands more who are second, third and fourth generation Italians.
 We believe that WFS are unable to clearly define on their terms, the absolute necessity of Feminism (and even less so) of its purported relationship to socialism.
 The law of nullity covers not only cases where the purported marriage was void, but also those where the marriage, though initially valid, is voidable, and thus may be set aside.
@@ -1513,10 +1490,8 @@ Partly in the course of his business, partly out of a personal interest, Julian 
 The Paris court must consider whether it is entitled or competent to act on a decision taken in a foreign country such a long time ago.
 Any result of war, invasion, act of foreign enemy, hostilities (whether war be declared or not), civil war, rebellion, revolution, insurrection or usurped power.
 The impact of a foreign competitor in the company's home market.
-In principle these recorders are not so very different from a normal domestic tape recorder, but they too are installed in the tail end of the aircraft and are heavily protected from crash damage.
 Make sure you agree from the start on whether babysitting is part of her job, and if so how often.
 I very much agree with my hon. Friend.
-The law of nullity covers not only cases where the purported marriage was void, but also those where the marriage, though initially valid, is voidable, and thus may be set aside.
 Godfrey J. answered the question by concluding that the Board of Review were incorrect in law in holding that the relevant profits did not arise in or derive from Hong Kong.
 The population, which was estimated at 36 million in 1990 consist of people from a wide range of different nationalities (by origin).
 Borland International Inc president and chief executive Philippe Kahn says the company will report profit for the fourth quarter to March 31, and adds that he is comfortable with analysts' estimates of profits of about $0.10 a share : Borland's target is to be profitable every quarter in the coming fiscal 1994 -- Paradox for Windows is doing great and is on a winning track and Quattro Pro is now picking up.
@@ -1588,7 +1563,6 @@ This function returns the appropriate root of that quadratic, if it is a genuine
 There is no doubt but that, if Mrs. Steed's signature had been forged or if the non est factum plea had been made good, the case would have fallen squarely within paragraph (g). 
 If n is negative the pseudo random sequence generator is set to a number based on n and n is returned. 
 However, the Pacific-North American plate boundary has undergone significant changes over the past few million years with the subduction of part of the East Pacific Rise spreading ridge and the evolution of a predominantly transform margin.
-A few times, the marchers halt for photo-calls.
 We perform -- Yes, confirmed Vicky, we are players, and she made as if to sweep on majestically.
 For instance, which of us has not prolonged an atmosphere of hostility by keeping the coals smouldering within ?
 Eugenicists advocated measures to restrain the mentally, and less determinedly the physically, weak from reproducing (by placing them in institutions, or, more radically, by sterilization).
@@ -1738,10 +1712,8 @@ you know because apparently people i i read somewhere that you can replace your 
 and he used to tease us about he would he was gon na clean his shotgun when out on the front porch when we were gon na go out on dates or
 Having first transformed yourself (Rule 1) into `a creature unlike any other -- radiant, confident, fashionable, mysterious, elusive, quiet, and, if necessary, nose-jobbed -- don't talk to a man first (2) or too much (3), don't go Dutch (4) or sleep with him on the first date (14), don't call him and rarely return his calls (5), always end phone calls (6) and dates (11) first, and never accept a Saturday night date after Wednesday (7).
 so that i would have something warm enough and i didn't need anything i mean it just happened to be the week that i was there it was just really nice and pleasant so
-so um it was a little bit because however it was a real warm winter so even even into like November and December i was still wearing the short sleeve dresses course i'm always hot when i'm pregnant too so i didn't really need warm clothes
 They involve Dada nose-thumbing, Expressionist brio, an American appreciation of pure funk, a flneur's eye for chance and juxtaposition in the streets, a sensualist's feeling for the most outr kinds of texture, and a scopophiliac's unquenchable thirst for images, all kinds, right now, from industrial logos to comic strips to postage stamps to Velzquez's Rokeby Venus. (He also, incidentally, has quite an ear, capable of doing more with a one - word title -- Rebus, Currency, Interview, Barge, Express -- than most writers.)
 and i try to uh you know try something else you know something with a little more vegetables or something but yeah i was the same way but we haven't really eaten Chinese that much since we've been in uh Texas it's funny
-Piper auritum leaf juice is applied topically to remove ticks and head lice in El Salvador and Ecuador respectively [92]. In Guatemala, Panama and Columbia the juice of crushed leaves of Piper species or the decoction of roots are drunk or used in baths for snakebites or rubbed onto the body as a snake repellent [63 95 139]. In Eastern Nicaragua and Jamaica Piper hispidum is used in remedies for colds, fever, stomach aches and for aches and pains [116 53]. In Trinidad, Puerto Rico and other Caribbean countries Piper amalgo leaf infusions are used as ritual baths or baths to perfume the body [52 16].
 The Mosetene Indians in Bolivia use the crushed Renealmia alpinia plant mixed with water and rub this preparation over the dog's body to improve its hunting ability [108]. In Trinidad a leaf poultice or bath or root decoction is used on swellings, sprains, sores, wounds and for stomach pains and malnutrition [52 54 65]. The purple - red juice from the
 i had i had a dog one time and uh he chased after a after a skunk and got sprayed so we had to uh we had to give him a tomato tomato juice bath
 uh-huh i mean it's good because they they try new things you know but it's like


### PR DESCRIPTION
The file remains in DOS format and extra blank after many sentences, since I though it may be a good idea to keep one such batch file. But if it is better I can remove them.