### PR TITLE
Fix disabling 4.0.*knowledge to be backward compatible

### DIFF
--- a/data/ru/4.0.constituent-knowledge
+++ b/data/ru/4.0.constituent-knowledge
@@ -1,2 +1,3 @@
-DISABLE
+;DISABLE
 ; This file intentionally disabled.
+STARTING_LINK_TYPE_TABLE:

--- a/data/ru/4.0.knowledge
+++ b/data/ru/4.0.knowledge
@@ -1,3 +1,4 @@
-DISABLE
+;DISABLE
 ; Post-processing knowledge file
 ; This file intentionally disabled.
+STARTING_LINK_TYPE_TABLE:

--- a/link-grammar/post-process/pp_knowledge.c
+++ b/link-grammar/post-process/pp_knowledge.c
@@ -397,14 +397,14 @@ pp_knowledge *pp_knowledge_open(const char *path)
     return NULL;
   }
 
-  /* Ignore the file if it starts with "DISABLE". */
+  /* Ignore the file if it starts with ";DISABLE". */
   char buf[16];
   if ((NULL == fgets(buf, sizeof(buf), f)) && ferror(f))
   {
       prt_error("Error: File %s: Read error\n", path);
       return NULL;
   }
-  if (0 == strncmp("DISABLE", buf, sizeof("DISABLE")-1))
+  if (0 == strncmp(";DISABLE", buf, sizeof(";DISABLE")-1))
   {
     if (verbosity_level(D_PPK))
       prt_error("Warning: File %s disabled\n", path);


### PR DESCRIPTION
Fix it in a way that will not generate errors by older libraries.
(Original PR: #836.)