### PR TITLE
Use long E_list chains

### DIFF
--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -182,25 +182,24 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	}
 	else
 	{
-		if (el->e->type == n->type)
+		do
 		{
-			print_expression_parens(e, el->e, false);
-		}
-		else
-		{
-			print_expression_parens(e, el->e, true);
-		}
-		if (el->next != NULL)
-		{
-			// dyn_strcat(e, "\nERROR! Unexpected list!\n");
-			/* The SAT parser just naively joins all X_node expressions
-			 * using "or", and this check used to give an error due to that,
-			 * preventing a convenient debugging.
-			 * Just accept it (but mark it with '!'). */
-			if (n->type == AND_type) dyn_strcat(e, " &! ");
-			if (n->type == OR_type) dyn_strcat(e, " or! ");
-			print_expression_parens(e, el->next->e, true);
-		}
+			if (el->e->type == n->type)
+			{
+				print_expression_parens(e, el->e, false);
+			}
+			else
+			{
+				print_expression_parens(e, el->e, true);
+			}
+
+			el = el->next;
+			if (el != NULL)
+			{
+				if (n->type == AND_type) dyn_strcat(e, " & ");
+				if (n->type == OR_type) dyn_strcat(e, " or ");
+			}
+		} while (el != NULL);
 	}
 
 	for (i=0; i<icost; i++) dyn_strcat(e, "]");

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1216,11 +1216,6 @@ static Exp * expression(Dictionary dict)
  */
 static Exp * make_expression(Dictionary dict)
 {
-	return restricted_expression(dict, true, true);
-}
-
-static Exp * restricted_expression(Dictionary dict, int and_ok, int or_ok)
-{
 	Exp *nl = NULL;
 	Exp *e_head = NULL;
 	E_list *el_tail = NULL; /* last part of the expression */


### PR DESCRIPTION
- Read terms in the same level iteratively.
- Put each level in a single E_list.
- Mixing OR and AND on same level is handled as an error, not a warning.
- Change the expression printing to correctly print long E_list chains.

As a result, reading dictionaries and handling expressions are faster.
With this change, some more functions can be replaced by a faster iterative version with a small stack usage (currently such iterative versions need a large stack too), and other can be changed not to use stack for E_list's, reducing the total needed stack.