### PR TITLE
read_dict.c line numbers + cleanup

### DIFF
--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1775,7 +1775,7 @@ static bool read_entry(Dictionary dict)
 			dict->pin = dict->input;
 
 			/* The line number and dict name are used for error reporting */
-			dict->line_number = 0;
+			dict->line_number = 1;
 			dict->name = dict_name;
 
 			/* Now read the thing in. */

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1768,7 +1768,9 @@ static bool read_entry(Dictionary dict)
 			instr = get_file_contents(dict_name + skip_slash);
 			if (NULL == instr)
 			{
-				prt_error("Error: Could not open subdictionary \"%s\"\n", dict_name);
+				prt_error("Error: While parsing dictionary \"%s\":\n"
+				          "\t Line %d: Could not open subdictionary \"%s\"\n",
+				          dict->name, dict->line_number-1, dict_name);
 				goto syntax_error;
 			}
 			dict->input = instr;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -949,7 +949,7 @@ static Exp * make_connector(Dictionary dict)
 	Dict_node *dn, *dn_head;
 	int i;
 
-	i = strlen(dict->token) - 1;  /* this must be +, - or * if a connector */
+	i = strlen(dict->token) - 1;  /* this must be +, - or $ if a connector */
 	if ((dict->token[i] != '+') &&
 	    (dict->token[i] != '-') &&
 	    (dict->token[i] != ANY_DIR))

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -18,7 +18,6 @@
 #include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
 #include "dict-common/file-utils.h"
 #include "dict-common/idiom.h"
-#include "dict-common/regex-morph.h"
 #include "error.h"
 #include "print/print.h"
 #include "externs.h"


### PR DESCRIPTION
- Use 1-based line numbers in dict messages.
- Improve subdictionary open error message.
- Cleanup.
