### PR TITLE
Expression pruning speedup

### DIFF
--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -194,6 +194,17 @@ X_node * catenate_X_nodes(X_node *d1, X_node *d2)
 	return d1;
 }
 
+#ifdef DEBUG
+static void print_x_node(X_node *x)
+{
+	if (x == NULL) printf("NULL X_node\n");
+	for (; x != NULL; x = x->next)
+	{
+		printf("%p: exp=%p next=%p\n", x, x->exp, x->next);
+	}
+}
+#endif
+
 /* ======================================================== */
 /* More connector utilities ... */
 

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -122,6 +122,38 @@ static void free_connector_table(exprune_context *ctxt)
 	ctxt->ct_size = 0;
 }
 
+/**
+ * This hash function only looks at the leading upper case letters of
+ * the connector string, and the label fields.  This ensures that if two
+ * strings match (formally), then they must hash to the same place.
+ */
+static inline unsigned int hash_S(condesc_t * c)
+{
+	return c->uc_num;
+}
+
+/**
+ * Returns TRUE if c can match anything in the set S (err. the connector table ct).
+ */
+static inline bool matches_S(connector_table **ct, int w, condesc_t * c)
+{
+	connector_table *e;
+
+	for (e = ct[hash_S(c)]; e != NULL; e = e->next)
+	{
+		if (e->farthest_word <= 0)
+		{
+			if (w < -e->farthest_word) continue;
+		}
+		else
+		{
+			if (w > e->farthest_word) continue;
+		}
+		if (easy_match_desc(e->condesc, c)) return true;
+	}
+	return false;
+}
+
 /* ================================================================= */
 /**
  * Here is expression pruning.  This is done even before the expressions
@@ -232,38 +264,6 @@ static Exp* purge_Exp(Exp *e)
 	}
 */
 	return e;
-}
-
-/**
- * This hash function only looks at the leading upper case letters of
- * the connector string, and the label fields.  This ensures that if two
- * strings match (formally), then they must hash to the same place.
- */
-static inline unsigned int hash_S(condesc_t * c)
-{
-	return c->uc_num;
-}
-
-/**
- * Returns TRUE if c can match anything in the set S (err. the connector table ct).
- */
-static inline bool matches_S(connector_table **ct, int w, condesc_t * c)
-{
-	connector_table *e;
-
-	for (e = ct[hash_S(c)]; e != NULL; e = e->next)
-	{
-		if (e->farthest_word <= 0)
-		{
-			if (w < -e->farthest_word) continue;
-		}
-		else
-		{
-			if (w > e->farthest_word) continue;
-		}
-		if (easy_match_desc(e->condesc, c)) return true;
-	}
-	return false;
 }
 
 static void zero_connector_table(exprune_context *ctxt)

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -278,37 +278,6 @@ static void zero_connector_table(exprune_context *ctxt)
 }
 
 /**
- * Mark as dead all of the dir-pointing connectors
- * in e that are not matched by anything in the current set.
- * Returns the number of connectors so marked.
- */
-static int mark_dead_connectors(connector_table **ct, int w, Exp * e, char dir)
-{
-	int count;
-	count = 0;
-	if (e->type == CONNECTOR_type)
-	{
-		if (e->dir == dir)
-		{
-			if (!matches_S(ct, w, e->u.condesc))
-			{
-				e->u.condesc = NULL;
-				count++;
-			}
-		}
-	}
-	else
-	{
-		E_list *l;
-		for (l = e->u.l; l != NULL; l = l->next)
-		{
-			count += mark_dead_connectors(ct, w, l->e, dir);
-		}
-	}
-	return count;
-}
-
-/**
  * This function puts connector c into the connector table
  * if one like it isn't already there.
  */


### PR DESCRIPTION
2.7%    en/corpus-basic.batch
2.6%    den/corpus-fixes.batch
1.7%    ru/corpus-basic.batch
Based on 32 (8*4) runs.
The language learning has a similar speedup.
The speedup here for long sentences is negligible.

The main speedup is for directly purging dead connectors without marking them first.

I also tried the following changes, but they (surprisingly) didn't yield any speedups:
- Consolidate the `insert_connectors()` loop with the r->l / l->r pass loops (maybe the loop doesn't fit then in the instruction cache?).
- Change `insert_connectors()` not to recurse on connectors.
- Implement a simple totally iterative `insert_connectors()` with a small stack.