### PR TITLE
Expression manipulation speedup

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -121,6 +121,9 @@ struct Sentence_s
 	String_set *   string_set;  /* Used for assorted strings */
 	Pool_desc * fm_Match_node;  /* Fast-matcher Match_node memory pool */
 	Pool_desc * Table_connector_pool; /* Count memoizing memory pool */
+	Pool_desc * E_list_pool;
+	Pool_desc * Exp_pool;
+	Pool_desc * X_node_pool;
 
 	/* Wordgraph stuff. FIXME: create stand-alone struct for these. */
 	Gword *wordgraph;            /* Tokenization wordgraph */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -145,7 +145,7 @@ struct Dictionary_s
 bool find_word_in_dict(const Dictionary dict, const char *);
 
 Exp * Exp_create(Exp_list *);
-void add_empty_word(Dictionary const, X_node *);
+void add_empty_word(Sentence, X_node *);
 void free_Exp_list(Exp_list *);
 
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -68,7 +68,7 @@ int size_of_expression(Exp * e)
 /**
  * Build a copy of the given expression (don't copy strings, of course)
  */
-static E_list *copy_E_list(E_list *l)
+static E_list *copy_E_list(E_list *l, Pool_desc* mp[])
 {
 
 	E_list el_head;
@@ -76,29 +76,29 @@ static E_list *copy_E_list(E_list *l)
 
 	for (; l != NULL; l = l->next)
 	{
-		E_list *nl = malloc(sizeof(E_list));
+		E_list *nl = pool_alloc(mp[0]);
 
-		nl->e = malloc(sizeof(Exp));
+		nl->e = pool_alloc(mp[1]);
 		*nl->e = *l->e;
 		el->next = nl;
 		el = nl;
 		if (l->e->type != CONNECTOR_type)
-			nl->e->u.l = copy_E_list(l->e->u.l);
+			nl->e->u.l = copy_E_list(l->e->u.l, mp);
 	}
 	el->next = NULL;
 
 	return el_head.next;
 }
 
-Exp *copy_Exp(Exp *e)
+Exp *copy_Exp(Exp *e, Pool_desc *E_list_pool, Pool_desc *Exp_pool)
 {
 	if (e == NULL) return NULL;
-	Exp *ne = malloc(sizeof(Exp));
+	Exp *ne = pool_alloc(Exp_pool);
 
 	*ne = *e;
 	if (CONNECTOR_type == e->type) return ne;
 
-	ne->u.l = copy_E_list(ne->u.l);
+	ne->u.l = copy_E_list(ne->u.l, (Pool_desc*[]){E_list_pool, Exp_pool});
 	return ne;
 }
 
@@ -176,18 +176,6 @@ static int exp_contains(Exp * super, Exp * sub)
 
 /* ======================================================== */
 /* X_node utilities ... */
-/**
- * frees the list of X_nodes pointed to by x, and all of the expressions
- */
-void free_X_nodes(X_node * x)
-{
-	X_node * y;
-	for (; x!= NULL; x = y) {
-		y = x->next;
-		free_Exp(x->exp);
-		free(x);
-	}
-}
 
 /**
  * Destructively catenates the two disjunct lists d1 followed by d2.

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -68,27 +68,38 @@ int size_of_expression(Exp * e)
 /**
  * Build a copy of the given expression (don't copy strings, of course)
  */
-static E_list * copy_E_list(E_list * l);
-Exp * copy_Exp(Exp * e)
+static E_list *copy_E_list(E_list *l)
 {
-	Exp * n;
-	if (e == NULL) return NULL;
-	n = malloc(sizeof(Exp));
-	*n = *e;
-	if (e->type != CONNECTOR_type) {
-		n->u.l = copy_E_list(e->u.l);
+
+	E_list el_head;
+	E_list *el = &el_head;
+
+	for (; l != NULL; l = l->next)
+	{
+		E_list *nl = malloc(sizeof(E_list));
+
+		nl->e = malloc(sizeof(Exp));
+		*nl->e = *l->e;
+		el->next = nl;
+		el = nl;
+		if (l->e->type != CONNECTOR_type)
+			nl->e->u.l = copy_E_list(l->e->u.l);
 	}
-	return n;
+	el->next = NULL;
+
+	return el_head.next;
 }
 
-static E_list * copy_E_list(E_list * l)
+Exp *copy_Exp(Exp *e)
 {
-	E_list * nl;
-	if (l == NULL) return NULL;
-	nl = malloc(sizeof(E_list));
-	nl->next = copy_E_list(l->next);
-	nl->e = copy_Exp(l->e);
-	return nl;
+	if (e == NULL) return NULL;
+	Exp *ne = malloc(sizeof(Exp));
+
+	*ne = *e;
+	if (CONNECTOR_type == e->type) return ne;
+
+	ne->u.l = copy_E_list(ne->u.l);
+	return ne;
 }
 
 /**

--- a/link-grammar/dict-common/dict-utils.h
+++ b/link-grammar/dict-common/dict-utils.h
@@ -20,12 +20,11 @@
 void free_Exp(Exp *);
 void free_E_list(E_list *);
 int  size_of_expression(Exp *);
-Exp * copy_Exp(Exp *);
+Exp * copy_Exp(Exp *, Pool_desc *, Pool_desc *);
 bool is_exp_like_empty_word(Dictionary dict, Exp *);
 
 /* X_node utilities ... */
 X_node *    catenate_X_nodes(X_node *, X_node *);
-void free_X_nodes(X_node *);
 
 /* Dictionary utilities ... */
 bool word_has_connector(Dict_node *, const char *, char);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -178,15 +178,18 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	el = el->next;
 	if (el == NULL)
 	{
-		dyn_strcat(e, "()");
+		if (n->type == OR_type)
+			dyn_strcat(e, "error-no-next");
+		else
+			dyn_strcat(e, "()");
 	}
 	else
 	{
 		do
 		{
 			if (el->e->type == n->type)
-			{
-				print_expression_parens(e, el->e, false);
+				{
+					print_expression_parens(e, el->e, false);
 			}
 			else
 			{

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 
+#include "api-structures.h"           // For Sentence_s (add_empty_word())
 #include "dict-common/dict-affix.h"   // For is_stem()
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
@@ -1017,17 +1018,53 @@ static Exp * make_connector(Dictionary dict)
 /* ======================================================================== */
 /* Empty-word handling. */
 
+/** Expression-creating function versions that use the Sentence
+ *  expression memory pools.
+ *  (See the description of the similar functions above.)
+ */
+static Exp *make_or_node_from_pool(Sentence sent, Exp *nl, Exp *nr)
+{
+	E_list *ell, *elr;
+	Exp* n;
+
+	n = pool_alloc(sent->Exp_pool);
+	n->type = OR_type;
+	n->cost = 0.0;
+
+	n->u.l = ell = (E_list *) pool_alloc(sent->E_list_pool);
+	ell->next = elr = (E_list *) pool_alloc(sent->E_list_pool);
+	elr->next = NULL;
+
+	ell->e = nl;
+	elr->e = nr;
+	return n;
+}
+
+static Exp *make_zeroary_node_from_pool(Sentence sent)
+{
+	Exp * n = pool_alloc(sent->Exp_pool);
+	n->type = AND_type;  /* these must be AND types */
+	n->cost = 0.0;
+	n->u.l = NULL;
+	return n;
+}
+
+static Exp *make_optional_node_from_pool(Sentence sent, Exp *e)
+{
+	return make_or_node_from_pool(sent, make_zeroary_node_from_pool(sent), e);
+}
+
 /** Insert ZZZ+ connectors.
  *  This function was mainly used to support using empty-words, a concept
  *  that has been eliminated. However, it is still used to support linking of
  *  quotes that don't get the QUc/QUd links.
  */
-void add_empty_word(Dictionary const dict, X_node *x)
+void add_empty_word(Sentence sent, X_node *x)
 {
 	Exp *zn, *an;
 	E_list *elist, *flist;
-	Exp_list eli = { NULL };
-	const char *ZZZ = string_set_add(EMPTY_CONNECTOR, dict->string_set);
+	const char *ZZZ = string_set_lookup(EMPTY_CONNECTOR, sent->dict->string_set);
+	/* This function is called only if ZZZ is in the dictionary. */
 
 	/* The left-wall already has ZZZ-. The right-wall will not arrive here. */
 	if (MT_WALL == x->word->morpheme_type) return;
@@ -1041,26 +1078,26 @@ void add_empty_word(Dictionary const dict, X_node *x)
 		//lgdebug(+0, "Processing '%s'\n", x->string);
 
 		/* zn points at {ZZZ+} */
-		zn = Exp_create(&eli);
+		zn = pool_alloc(sent->Exp_pool);
 		zn->dir = '+';
-		zn->u.condesc = condesc_add(&dict->contable, ZZZ);
+		zn->u.condesc = condesc_add(&sent->dict->contable, ZZZ);
 		zn->multi = false;
 		zn->type = CONNECTOR_type;
 		zn->cost = 0.0;
-		zn = make_optional_node(&eli, zn);
+		zn = make_optional_node_from_pool(sent, zn);
 
 		/* flist is plain-word-exp */
-		flist = (E_list *) malloc(sizeof(E_list));
+		flist = (E_list *) pool_alloc(sent->E_list_pool);
 		flist->next = NULL;
 		flist->e = x->exp;
 
 		/* elist is {ZZZ+} , (plain-word-exp) */
-		elist = (E_list *) malloc(sizeof(E_list));
+		elist = (E_list *) pool_alloc(sent->E_list_pool);
 		elist->next = flist;
 		elist->e = zn;
 
 		/* an will be {ZZZ+} & (plain-word-exp) */
-		an = Exp_create(&eli);
+		an = pool_alloc(sent->Exp_pool);
 		an->type = AND_type;
 		an->cost = 0.0;
 		an->u.l = elist;

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -169,7 +169,7 @@ static inline bool matches_S(connector_table **ct, int w, condesc_t * c)
  *
  * If an OR or AND type expression node has one child, we can replace it
  * by its child.  This, of course, is not really necessary, except for
- * performance(?).
+ * performance.
  */
 
 static Exp* purge_Exp(connector_table **, int, Exp *, char, int *);
@@ -245,20 +245,14 @@ static Exp* purge_Exp(connector_table **ct, int w, Exp *e, char dir, int *N_dele
 		}
 	}
 
-/* This code makes it kill off nodes that have just one child
-   (1) It's going to give an insignificant speed-up
-   (2) Costs have not been handled correctly here.
-   The code is excised for these reasons.
-*/
-/*
+	/* Unary node elimination (for a slight performance improvement). */
 	if ((e->u.l != NULL) && (e->u.l->next == NULL))
 	{
-		ne = e->u.l->e;
-		xfree((char *) e->u.l, sizeof(E_list));
-		xfree((char *) e, sizeof(Exp));
+		Exp *ne = e->u.l->e;
+		ne->cost += e->cost;
 		return ne;
 	}
-*/
+
 	return e;
 }
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3041,10 +3041,10 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w, const char
 	dn = dn_head;
 	while (dn != NULL)
 	{
-		y = (X_node *) xalloc(sizeof(X_node));
+		y = (X_node *) pool_alloc(sent->X_node_pool);
 		y->next = x;
 		x = y;
-		x->exp = copy_Exp(dn->exp);
+		x->exp = copy_Exp(dn->exp, sent->E_list_pool, sent->Exp_pool);
 		if (NULL == s)
 		{
 			x->string = dn->string;
@@ -3157,7 +3157,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	if ((wordpos != *ZZZ_added) && is_exp_like_empty_word(dict, we->exp))
 	{
 		lgdebug(D_DWE, " (has ZZZ-)");
-		add_empty_word(dict, sent->word[wordpos-1].x);
+		add_empty_word(sent, sent->word[wordpos-1].x);
 		*ZZZ_added = wordpos; /* Remember it for not doing it again */
 	}
 	lgdebug(D_DWE, "\n");


### PR DESCRIPTION
Total speedup -  20x(best of 5) benchmark:
~16%    en/corpus-basic.batch
~21%    data/en/corpus-fixes.batch
~30%    data/ru/corpus-basic.batch
 ~1%    data/ru/corpus-fix-long.batch

The main speedup is due to using memory pools for `E_list`, `Exp` and `X_node` (implementing "not to free anything at all until sentence_delete()" that was mentioned in PR #880).
2 other changes (in `copy_Exp()` and `purge_Exp()` yield a small but noticeable speedup.
Very long sentences are almost not affected by these changes because the parsing time dominants for them.

---
Some future speedup work (there is more, some of it already previously mentioned):
- There is still some room to improve the performance by adding more memory pools.
- About 1/3 of the CPU for short sentences is the post processing, and most of its time is taken by `post_process_match()`. Most probably improving this function will yield a big speedup.
- For long sentences `form_match_list()` takes about half of the time. It can be improved too.
Second to it is do_count(). I need to port old connector-table cache improvements and see if they help now.
-  For `ru/corpus-basic.batch`, about 1/3 of the time (of the total - which includes including dict read) is taken by suffix_split(), which can be vastly improved.  Reading its dict can be sped up by memory pools and other fixes.
