### PR TITLE
string-id.c: Bug fix: Return the correct ID after the table grows

### DIFF
--- a/link-grammar/string-id.c
+++ b/link-grammar/string-id.c
@@ -131,12 +131,14 @@ int string_id_add(const char *source_string, String_id *ss)
 	ss->table[p].id = ss->count;
 	ss->count++;
 
+	int keep_id = ss->table[p].id;
+
 	/* We just added it to the table.  If the table got too big,
 	 * we grow it.  Too big is defined as being more than 3/8 full.
 	 * There's a huge boost from keeping this sparse. */
 	if ((8 * ss->count) > (3 * ss->size)) grow_table(ss);
 
-	return ss->table[p].id;
+	return keep_id;
 }
 
 int string_id_lookup(const char *source_string, String_id *ss)


### PR DESCRIPTION
This is a potentially severe bug, that may cause a bad or missing linkage.
The bug happens when the string-id table grows. The the affected trailing connector sequence usually gets ID=256 again (but may get another incorrect number).

This problem doesn't cause any missing or different linkage with the basic (all languages) and en//fixes batches, but during a WIP of memory sharing of common trailing sequences I encountered an unexpected problem that was caused by this bug.

**I propose to issue a new release soon**, maybe after a cleanup PR and a small simple speed improvement that I can cherry-pick from the said WIP.
