### PR TITLE
Share connectors

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -117,13 +117,17 @@ struct Sentence_s
 	const char *orig_sentence;  /* Copy of original sentence */
 	size_t length;              /* Number of words */
 	Word  *word;                /* Array of words after tokenization */
-	String_id *connector_suffix_id; /* Used for connector trailing sequence ID */
 	String_set *   string_set;  /* Used for assorted strings */
 	Pool_desc * fm_Match_node;  /* Fast-matcher Match_node memory pool */
 	Pool_desc * Table_connector_pool; /* Count memoizing memory pool */
 	Pool_desc * E_list_pool;
 	Pool_desc * Exp_pool;
 	Pool_desc * X_node_pool;
+
+	/* Trailing connector encoding stuff (suffix_id), used for speeding up
+	 * parsing (the classic one for now) of long sentences. */
+	String_id *connector_suffix_id; /* For connector trailing sequence IDs */
+	unsigned int num_suffix_id;
 
 	/* Wordgraph stuff. FIXME: create stand-alone struct for these. */
 	Gword *wordgraph;            /* Tokenization wordgraph */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -465,7 +465,7 @@ static Connector *pack_connectors_dup(Connector *origc, pack_context *pc)
 	Connector *prevc = &head;
 	Connector *newc = &head;
 	Connector *t;
-	Connector *lcblock = pc->cblock; /* Optimization. */
+	Connector *lcblock = pc->cblock; /* For convenience. */
 
 	for (t = origc; t != NULL;  t = t->next)
 	{
@@ -483,7 +483,7 @@ static Connector *pack_connectors_dup(Connector *origc, pack_context *pc)
 
 /**
  * Duplicate the given disjunct chain.
- * If the argument is NULL, return NULL.
+ * If the disjunct is NULL, return NULL.
  */
 static Disjunct *pack_disjuncts_dup(Disjunct *origd, pack_context *pc)
 {
@@ -491,17 +491,18 @@ static Disjunct *pack_disjuncts_dup(Disjunct *origd, pack_context *pc)
 	Disjunct *prevd = &head;
 	Disjunct *newd = &head;
 	Disjunct *t;
-	Disjunct *ldblock = pc->dblock; /* Optimization. */
+	Disjunct *ldblock = pc->dblock; /* For convenience. */
 
 	for (t = origd; t != NULL; t = t->next)
 	{
 		newd = ldblock++;
 		newd->word_string = t->word_string;
 		newd->cost = t->cost;
+		newd->originating_gword = t->originating_gword;
 
 		newd->left = pack_connectors_dup(t->left, pc);
 		newd->right = pack_connectors_dup(t->right, pc);
-		newd->originating_gword = t->originating_gword;
+
 		prevd->next = newd;
 		prevd = newd;
 	}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -224,58 +224,6 @@ Disjunct *disjuncts_dup(Disjunct *origd)
 	return head.next;
 }
 
-static Connector *pack_connectors_dup(Connector *origc, Connector **cblock)
-{
-	Connector head;
-	Connector *prevc = &head;
-	Connector *newc = &head;
-	Connector *t;
-	Connector *lcblock = *cblock; /* Optimization. */
-
-	for (t = origc; t != NULL;  t = t->next)
-	{
-		newc = lcblock++;
-		*newc = *t;
-
-		prevc->next = newc;
-		prevc = newc;
-	}
-	newc->next = NULL;
-
-	*cblock = lcblock;
-	return head.next;
-}
-
-/**
- * Duplicate the given disjunct chain.
- * If the argument is NULL, return NULL.
- */
-static Disjunct *pack_disjuncts_dup(Disjunct *origd, Disjunct **dblock, Connector **cblock)
-{
-	Disjunct head;
-	Disjunct *prevd = &head;
-	Disjunct *newd = &head;
-	Disjunct *t;
-	Disjunct *ldblock = *dblock; /* Optimization. */
-
-	for (t = origd; t != NULL; t = t->next)
-	{
-		newd = ldblock++;
-		newd->word_string = t->word_string;
-		newd->cost = t->cost;
-
-		newd->left = pack_connectors_dup(t->left, cblock);
-		newd->right = pack_connectors_dup(t->right, cblock);
-		newd->originating_gword = t->originating_gword;
-		prevd->next = newd;
-		prevd = newd;
-	}
-	newd->next = NULL;
-
-	*dblock = ldblock;
-	return head.next;
-}
-
 static disjunct_dup_table * disjunct_dup_table_new(size_t sz)
 {
 	size_t i;
@@ -504,6 +452,58 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 
 
 /* ================ Pack disjuncts and connectors ============== */
+static Connector *pack_connectors_dup(Connector *origc, Connector **cblock)
+{
+	Connector head;
+	Connector *prevc = &head;
+	Connector *newc = &head;
+	Connector *t;
+	Connector *lcblock = *cblock; /* Optimization. */
+
+	for (t = origc; t != NULL;  t = t->next)
+	{
+		newc = lcblock++;
+		*newc = *t;
+
+		prevc->next = newc;
+		prevc = newc;
+	}
+	newc->next = NULL;
+
+	*cblock = lcblock;
+	return head.next;
+}
+
+/**
+ * Duplicate the given disjunct chain.
+ * If the argument is NULL, return NULL.
+ */
+static Disjunct *pack_disjuncts_dup(Disjunct *origd, Disjunct **dblock, Connector **cblock)
+{
+	Disjunct head;
+	Disjunct *prevd = &head;
+	Disjunct *newd = &head;
+	Disjunct *t;
+	Disjunct *ldblock = *dblock; /* Optimization. */
+
+	for (t = origd; t != NULL; t = t->next)
+	{
+		newd = ldblock++;
+		newd->word_string = t->word_string;
+		newd->cost = t->cost;
+
+		newd->left = pack_connectors_dup(t->left, cblock);
+		newd->right = pack_connectors_dup(t->right, cblock);
+		newd->originating_gword = t->originating_gword;
+		prevd->next = newd;
+		prevd = newd;
+	}
+	newd->next = NULL;
+
+	*dblock = ldblock;
+	return head.next;
+}
+
 #define SHORTEST_SENTENCE_TO_PACK 9
 
 /**

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -452,6 +452,26 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 
 
 /* ================ Pack disjuncts and connectors ============== */
+GNUC_UNUSED static void print_connector_list(Connector * e)
+{
+	for (;e != NULL; e=e->next)
+	{
+		printf("%s<%d>(%d,%d)",
+		       connector_string(e), e->suffix_id, e->nearest_word, e->length_limit);
+		if (e->next != NULL) printf(" ");
+	}
+}
+GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
+{
+	for (;dj != NULL; dj=dj->next) {
+		printf("%10s: ", dj->word_string);
+		printf("(%f) ", dj->cost);
+		print_connector_list(dj->left);
+		printf(" <--> ");
+		print_connector_list(dj->right);
+		printf("\n");
+	}
+}
 
 typedef struct
 {
@@ -480,7 +500,6 @@ static Connector *pack_connectors_dup(Connector *origc, pack_context *pc)
 	pc->cblock = lcblock;
 	return head.next;
 }
-
 /**
  * Duplicate the given disjunct chain.
  * If the disjunct is NULL, return NULL.

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -52,6 +52,6 @@ Disjunct * disjuncts_dup(Disjunct *origd);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
-void pack_sentence(Sentence);
+void pack_sentence(Sentence, bool);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -52,6 +52,6 @@ Disjunct * disjuncts_dup(Disjunct *origd);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
-Disjunct *pack_disjuncts_dup(Disjunct *, Disjunct **, Connector **);
+void pack_sentence(Sentence);
 
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -227,66 +227,6 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
 	print_time(opts, "Sorted all linkages");
 }
 
-#define SHORTEST_SENTENCE_TO_PACK 9
-
-/**
- * Pack all disjunct and connectors into one big memory block.
- * This facilitate a better memory caching for long sentences
- * (a performance gain of a few percents).
- *
- * The current Connector struct size is 32 bit, and future ones may be
- * smaller, but still with a power-of-2 size.
- * The idea is to put an integral number of connectors in each cache line
- * (assumed to be >= Connector struct size, e.g. 64 bytes),
- * so one connector will not need 2 cache lines.
- *
- * The allocated memory includes 3 sections , in that order:
- * 1. A block for disjuncts, when it start is not aligned (the disjunct size
- * is currently 56 bytes and cannot be reduced much).
- * 2. A small alignment gap, that ends in a 64-byte boundary.
- * 3. A block of connectors, which is so aligned to 64-byte boundary.
- *
- * FIXME: 1. Find the "best" value for SHORTEST_SENTENCE_TO_PACK.
- * 2. Maybe this check should be done in too stages, the second one
- * will use number of disjunct and connector thresholds.
- */
-static void pack_sentence(Sentence sent)
-{
-	int dcnt = 0;
-	int ccnt = 0;
-
-	if (sent->length < SHORTEST_SENTENCE_TO_PACK) return;
-	for (size_t w = 0; w < sent->length; w++)
-	{
-		Disjunct *d;
-
-		for (d = sent->word[w].d; NULL != d; d = d->next)
-		{
-			dcnt++;
-			for (Connector *c = d->right; c!=NULL; c = c->next) ccnt++;
-			for (Connector *c = d->left; c != NULL; c = c->next) ccnt++;
-		}
-	}
-
-#define CONN_ALIGNMENT sizeof(Connector)
-	size_t dsize = dcnt * sizeof(Disjunct);
-	dsize = ALIGN(dsize, CONN_ALIGNMENT); /* Align connector block. */
-	size_t csize = ccnt * sizeof(Connector);
-	void *memblock = malloc(dsize + csize);
-	Disjunct *dblock = memblock;
-	Connector *cblock = (Connector *)((char *)memblock + dsize);
-	sent->disjuncts_connectors_memblock = memblock;
-
-	for (size_t i = 0; i < sent->length; i++)
-	{
-		Disjunct *word_disjuncts = sent->word[i].d;
-
-		sent->word[i].d = pack_disjuncts_dup(sent->word[i].d, &dblock, &cblock);
-		free_disjuncts(word_disjuncts);
-	}
-}
-
-
 /**
  * classic_parse() -- parse the given sentence.
  * Perform parsing, using the original link-grammar parsing algorithm

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -296,8 +296,8 @@ void classic_parse(Sentence sent, Parse_Options opts)
 				}
 			}
 			pp_and_power_prune(sent, opts);
-			pack_sentence(sent);
 			bool real_suffix_ids = set_connector_hash(sent);
+			pack_sentence(sent, real_suffix_ids);
 			if (is_null_count_0) opts->min_null_count = 0;
 			if (resources_exhausted(opts->resources)) break;
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -221,6 +221,7 @@ bool set_connector_hash(Sentence sent)
 			}
 		}
 
+		sent->num_suffix_id = id + 1;
 		return false;
 	}
 
@@ -284,16 +285,14 @@ bool set_connector_hash(Sentence sent)
 		}
 	}
 
-	if (verbosity_level(D_PREP))
-	{
-		/* Support incremental suffix_id generation (only one time is needed). */
-		const char *smaxid[] = { "MAXID", "MAXID1" };
+	/* Support incremental suffix_id generation (only one time is needed). */
+	const char *snumid[] = { "NUMID", "NUMID1" };
 
-		int t = string_id_lookup(smaxid[0], csid);
-		int maxid = string_id_add(smaxid[(int)(t > 0)], csid) + WORD_OFFSET-1;
-		prt_error("Debug: Using trailing hash (length %zu): suffix_id %d\n",
-					 sent->length, maxid);
-	}
+	int t = string_id_lookup(snumid[0], csid);
+	int numid = string_id_add(snumid[(int)(t > 0)], csid) + WORD_OFFSET;
+	lgdebug(D_PREP, "Debug: Using trailing hash (length %zu): suffix_id %d\n",
+	        sent->length, numid);
+	sent->num_suffix_id = numid;
 
 	return true;
 }


### PR DESCRIPTION
This modification shares connector memory, so for long sentences it takes only a small fraction of the original one. The idea is to speed up parsing by reducing CPU cache trashing.

What is shared is identical trailing connector sequences. The first connector in a sequence defines the sequence. It has to have the same `suffix_id`, and same `nearest_word` value. The rest of fields are supposed to be the same, but the `originating_gword` field is verified.

The same `suffix_id` requirement identify identical sequences due to the way it is created.
The same `nearest_word` requirement is supposed to guarantee that the rest of the corresponding connector pairs have identical `nearest_word` too. I say "supposed" because I couldn't think of a way it cannot be so, but as usual I don't have a proof. I added a verification in the code for that, and it has never been triggered.

The result is a speedup of about 15% for the "fix-long" corpus.
Only long sentence are significantly sped up, because for small sentences the connector memory space is much smaller than the CPU cache.

The sharing amount can be impressive. Here are the numbers for the `And yet [...]` sentence.
`echo 'And yet [...]' | link-parser -v=5 -ti=100 -debug=pack_sentence,prune.c`
Quoting from the output of the command above (the first set of lines is for null_count==0, the second one for null_count==1):
```
Total: 67830 disjuncts, 381889 (193458+/188431-) connectors
Trace: pack_sentence: Info: 361549 connectors shared

Total: 129603 disjuncts, 773943 (409562+/364381-) connectors
Trace: pack_sentence: Info: 743666 connectors shared
```
Note: My current implementation doesn't share connectors with different directions.
It also doesn't share non-trailing connectors.
The intention was to allow "patching" of connectors fields in do_count(), for tuning of distance fields on the fly. A test of this idea indicated a significant speedup. But doing that in the parsing stage has an overhead, so I try now to see if it can be done while pruning.



