### PR TITLE
Pruning "trivial" cross links

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -452,7 +452,7 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 
 
 /* ================ Pack disjuncts and connectors ============== */
-GNUC_UNUSED static void print_connector_list(Connector * e)
+GNUC_UNUSED void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
@@ -461,7 +461,7 @@ GNUC_UNUSED static void print_connector_list(Connector * e)
 		if (e->next != NULL) printf(" ");
 	}
 }
-GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
+GNUC_UNUSED void print_disjunct_list(Disjunct * dj)
 {
 	for (;dj != NULL; dj=dj->next) {
 		printf("%10s: ", dj->word_string);

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -54,4 +54,6 @@ int right_connector_count(Disjunct *);
 
 void pack_sentence(Sentence, bool);
 
+void print_connector_list(Connector *);
+void print_disjunct_list(Disjunct *);
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -47,7 +47,6 @@ typedef struct
 #ifdef DEBUG
 static void print_Tconnector_list(Tconnector * e);
 static void print_clause_list(Clause * c);
-static void print_connector_list(Connector * e);
 #endif
 
 #if BUILD_DISJUNCTS_FREE_INETERMEDIATE_MEMOEY /* Undefined - CPU overhead. */
@@ -331,27 +330,6 @@ GNUC_UNUSED static void print_clause_list(Clause * c)
 		printf("  Clause: ");
 		printf("(%4.2f, %4.2f) ", c->cost, c->maxcost);
 		print_Tconnector_list(c->c);
-		printf("\n");
-	}
-}
-
-static void print_connector_list(Connector * e)
-{
-	for (;e != NULL; e=e->next)
-	{
-		printf("%s", connector_string(e));
-		if (e->next != NULL) printf(" ");
-	}
-}
-
-GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
-{
-	for (;dj != NULL; dj=dj->next) {
-		printf("%10s: ", dj->word_string);
-		printf("(%f) ", dj->cost);
-		print_connector_list(dj->left);
-		printf(" <--> ");
-		print_connector_list(dj->right);
 		printf("\n");
 	}
 }


### PR DESCRIPTION
**EDIT**:
This PR is for reviewing and testing the idea. **There is no need to actually apply it**.
Meanwhile I improved it and also extended the idea.
I also found how to extend it to deep connectors using iteration, and enumerated the different checks that can be added to find disjuncts that would need cross-linking and thus could be deleted.
These are a "quality" deletions because such disjuncts cause a lot of dead-path recursive work in do_count() and add mostly useless stuff to the count hash table.
I also found several new kinds of pruning optimizations, and a new kind of do_count() optimization that may resemble the skipping aspect of the Boyer-Moor algo (in our case, skipping ranges that cannot have the candidate link in the final linkage).

---
Copied from my post at PR #883:

The idea is "trivial" so I thought it would do nothing. But I tried anyway and it works.
It turned out it is able to performs pruning, and surprisingly, a power_pruning after it has a significant result, and after that again the the "cross links pruning" still doing useful work... (so I have put them in a loop).
BTW, pp_prune after all of that does nothing most of the times.

I implemented a "proof of concept" that only uses the shallow connectors.
It is possible to use the deep connectors too for a better pruning, and I am thinking about how to add that.

When I use the "fix-long" corpus as a benchmark, the current speedup is ~18%. For the "failures" corpus it is ~16%. For "short" sentences it is ~1%, but it seems this can be increased by tuning to ~2%.

It works only for null_count==0 since I don't have any idea how to do in the general case of null_count>0...

