### PR TITLE
Changes for -verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ directory in that order, directly or under a directory names `data`:
 If link-parser cannot find the desired dictionary, use verbosity
 level 3 to debug the problem; for example:
 ```
-link-parser ru -verbosity=3
+link-parser ru -verbosity=4
 ```
 
 Other locations can be specified on the command line; for example:

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -302,7 +302,7 @@ void dictionary_delete(Dictionary dict)
 {
 	if (!dict) return;
 
-	if (verbosity > 0) {
+	if (verbosity >= D_USER_INFO) {
 		prt_error("Info: Freeing dictionary %s\n", dict->name);
 	}
 

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -20,8 +20,8 @@
  * For now hard-coded numbers are still used instead of D_USER_BASIC/TIMES. */
 #define D_USER_BASIC 1   /* Basic verbosity level. */
 #define D_USER_TIMES 2   /* Display step times. */
-#define D_USER_FILES 3   /* Display data file search and locale setup. */
-// #define D_USER_X  4   /* Not in use yet. */
+#define D_USER_INFO  3   /* Display some Info messages. */
+#define D_USER_FILES 4   /* Display data file search and locale setup. */
 #define D_USER_MAX   4   /* Maximum user verbosity level. */
 #define D_DICT      10   /* Base of dictionary debug levels. */
 #define D_SPEC     100   /* Base of special stand-alone levels. */

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -349,6 +349,14 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		post_process_lkgs(sent, opts);
 
 		if (sent->num_valid_linkages > 0) break;
+		if (verbosity >= D_USER_INFO)
+		{
+			if (sent->num_linkages_post_processed > 0)
+				prt_error("Info: All linkages had P.P. violations.\n"
+				        "Consider to increase the linkage limit.\n"
+				        "At the command line, use !limit\n");
+		}
+
 		if ((0 == nl) && (0 < max_null_count) && verbosity > 0)
 			prt_error("No complete linkages found.\n");
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -328,18 +328,18 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		hist = do_parse(sent, mchxt, ctxt, sent->null_count, opts);
 		total = hist_total(&hist);
 
-		if (verbosity >= D_USER_INFO)
-		{
-			prt_error("Info: Total count with %zu null links: %lld\n",
-			        sent->null_count, total);
-		}
-
 		/* total is 64-bit, num_linkages_found is 32-bit. Clamp */
 		total = (total > INT_MAX) ? INT_MAX : total;
 		total = (total < 0) ? INT_MAX : total;
 
 		sent->num_linkages_found = (int) total;
 		print_time(opts, "Counted parses");
+
+		if (verbosity >= D_USER_INFO)
+		{
+			prt_error("Info: Total count with %zu null links: %lld\n",
+			        sent->null_count, total);
+		}
 
 		extractor_t * pex = extractor_new(sent->length, sent->rand_state);
 		bool ovfl = setup_linkages(sent, pex, mchxt, ctxt, opts);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -208,9 +208,12 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 	 * So just pretend that it's shorter than it is */
 	sent->num_linkages_alloced = sent->num_valid_linkages;
 
-	lgdebug(D_PARSE, "Info: sane_morphism(): %zu of %d linkages had "
-	        "invalid morphology construction\n", N_invalid_morphism,
-	        itry + (itry != maxtries));
+	if (verbosity >= D_USER_INFO)
+	{
+		prt_error("Info: sane_morphism(): %zu of %d linkages had "
+		        "invalid morphology construction\n", N_invalid_morphism,
+		        itry + (itry != maxtries));
+	}
 }
 
 static void sort_linkages(Sentence sent, Parse_Options opts)
@@ -325,8 +328,11 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		hist = do_parse(sent, mchxt, ctxt, sent->null_count, opts);
 		total = hist_total(&hist);
 
-		lgdebug(D_PARSE, "Info: Total count with %zu null links:   %lld\n",
-		        sent->null_count, total);
+		if (verbosity >= D_USER_INFO)
+		{
+			prt_error("Info: Total count with %zu null links: %lld\n",
+			        sent->null_count, total);
+		}
 
 		/* total is 64-bit, num_linkages_found is 32-bit. Clamp */
 		total = (total > INT_MAX) ? INT_MAX : total;

--- a/man/link-parser.1
+++ b/man/link-parser.1
@@ -459,7 +459,7 @@ The directory search order for these files is:
 argument is provided to \%\fBlink\-parser\fP on the command line.
 On windows it may be relative to the location of the \%link\-grammar library DLL;
 in that case the actual location is displayed as "System data directory" when
-\%\fBlink\-parser\fP is invoked with -verbosity=3.
+\%\fBlink\-parser\fP is invoked with -verbosity=4.
 
 .SH SEE ALSO
 .nh


### PR DESCRIPTION
While implementing some major changes I decided to do some minor ones.
Changes here:
- Add verbosity for (some) Info messages at level 3 (but maybe it should be 2, for not cluttering the output with timing). Move the previous one (file search messages) to 4. Others Info messages may be added later. 
- Add a message when all the linkages are with P.P. violations. This is tipical to a too low linkage limit.
- The most drastic change, I hope you will like it (else just remove it...):
Don't notify "Freeing dictionary" unless the verbosity is at least 3. Maybe the only usefulness of it is if your dict gets out of scope unintentionally in Python.