### PR TITLE
tests.py: Fix HEnglishLinkageTestCase

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -611,7 +611,7 @@ class FSATsolverTestCase(unittest.TestCase):
 class HEnglishLinkageTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.d, cls.po = Dictionary(), ParseOptions(linkage_limit=300, display_morphology=False)
+        cls.d, cls.po = Dictionary(), ParseOptions(linkage_limit=1000, display_morphology=False)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
The sentence:
`Scientists sometimes may repeat experiments or use groups.`
now gives:
`Found 424 linkages (256 had no P.P. violations)`
instead of previously:
`Found 88 linkages (88 had no P.P. violations)`

As a result of the increased number of linkages and the P.P. violations, the lowest score linkage is not found now among 300 linkages, **and the test fails**.

Fix it by a more pessimistic value.
