### PR TITLE
Cleanup ++

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -16,7 +16,7 @@
 #include "api-structures.h"
 #include "corpus/corpus.h"
 #include "dict-common/dict-utils.h"
-#include "disjunct-utils.h"  // for free_disjuncts
+#include "disjunct-utils.h"   // for free_sentence_disjuncts()
 #include "linkage/linkage.h"
 #include "memory-pool.h"
 #include "parse/histogram.h"  // for PARSE_NUM_OVERFLOW

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -63,6 +63,7 @@ Connector * connector_new(const condesc_t *desc, Parse_Options opts)
 	c->desc = desc;
 	c->nearest_word = 0;
 	c->multi = false;
+	c->suffix_id = 0;
 	c->originating_gword = NULL;
 	set_connector_length_limit(c, opts);
 	//assert(0 != c->length_limit, "Connector_new(): Zero length_limit");

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -447,7 +447,7 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 
 
 /* ================ Pack disjuncts and connectors ============== */
-GNUC_UNUSED static void print_connector_list(Connector * e)
+void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
@@ -456,7 +456,7 @@ GNUC_UNUSED static void print_connector_list(Connector * e)
 		if (e->next != NULL) printf(" ");
 	}
 }
-GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
+void print_disjunct_list(Disjunct * dj)
 {
 	for (;dj != NULL; dj=dj->next) {
 		printf("%10s: ", dj->word_string);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -451,21 +451,41 @@ void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
-		printf("%s<%d>(%d,%d)",
-		       connector_string(e), e->suffix_id, e->nearest_word, e->length_limit);
+		printf("%s%s", e->multi ? "@" : "", connector_string(e));
+		if (e->suffix_id)
+			printf("<%d>", e->suffix_id);
+		if ((0 != e->nearest_word) || (0 != e->length_limit))
+			printf("(%d,%d)", e->nearest_word, e->length_limit);
+
 		if (e->next != NULL) printf(" ");
 	}
 }
+
 void print_disjunct_list(Disjunct * dj)
 {
-	for (;dj != NULL; dj=dj->next) {
-		printf("%10s: ", dj->word_string);
-		printf("(%f) ", dj->cost);
+	int i = 0;
+	char word[MAX_WORD + 32];
+
+	for (;dj != NULL; dj=dj->next)
+	{
+		lg_strlcpy(word, dj->word_string, sizeof(word));
+		patch_subscript_mark(word);
+		printf("%16s: ", word);
+		printf("[%d](%4.2f) ", i++, dj->cost);
 		print_connector_list(dj->left);
 		printf(" <--> ");
 		print_connector_list(dj->right);
 		printf("\n");
 	}
+}
+
+void print_all_disjuncts(Sentence sent)
+{
+		for (WordIdx w = 0; w < sent->length; w++)
+		{
+			printf("Word %zu:\n", w);
+			print_disjunct_list(sent->word[w].d);
+		}
 }
 
 typedef struct

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -54,4 +54,6 @@ int right_connector_count(Disjunct *);
 
 void pack_sentence(Sentence, bool);
 
+void print_connector_list(Connector *);
+void print_disjunct_list(Disjunct *);
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -56,4 +56,5 @@ void pack_sentence(Sentence, bool);
 
 void print_connector_list(Connector *);
 void print_disjunct_list(Disjunct *);
+void print_all_disjuncts(Sentence);
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -462,6 +462,7 @@ left_connector_list_update(prune_context *pc, Connector *c,
 
 	if (c == NULL) return w;
 	n = left_connector_list_update(pc, c->next, w, false) - 1;
+	if (0 > n) return -1;
 	if (((int) c->nearest_word) < n) n = c->nearest_word;
 
 	/* lb is now the leftmost word we need to check */
@@ -505,6 +506,7 @@ right_connector_list_update(prune_context *pc, Connector *c,
 
 	if (c == NULL) return w;
 	n = right_connector_list_update(pc, c->next, w, false) + 1;
+	if (sent_length <= n) return sent_length;
 	if (c->nearest_word > n) n = c->nearest_word;
 
 	/* ub is now the rightmost word we need to check */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -586,7 +586,7 @@ static int power_prune(Sentence sent, Parse_Options opts)
 
 		pc.N_changed = N_deleted = 0;
 		/* right-to-left pass */
-		for (WordIdx w = sent->length-1; w != (size_t) -1; w--)
+		for (WordIdx w = sent->length-1; w != (WordIdx) -1; w--)
 		{
 			for (Disjunct **dd = &sent->word[w].d; *dd != NULL; /* See: NEXT */)
 			{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -191,11 +191,13 @@ static void power_table_delete(power_table *pt)
  * The disjunct d (whose left or right pointer points to c) is put
  * into the appropriate hash table
  */
-static void put_into_power_table(C_list * m, unsigned int size, C_list ** t,
+static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list ** t,
                                  Connector * c, bool shal)
 {
 	unsigned int h;
 	h = connector_uc_num(c) & (size-1);
+
+	C_list *m = pool_alloc(mp);
 	m->next = t[h];
 	t[h] = m;
 	m->c = c;
@@ -273,7 +275,7 @@ static power_table * power_table_new(Sentence sent)
 			{
 				for (c = c->next; c != NULL; c = c->next)
 				{
-					put_into_power_table(pool_alloc(mp), r_size, r_t, c, false);
+					put_into_power_table(mp, r_size, r_t, c, false);
 				}
 			}
 			c = d->left;
@@ -281,7 +283,7 @@ static power_table * power_table_new(Sentence sent)
 			{
 				for (c = c->next; c != NULL; c = c->next)
 				{
-					put_into_power_table(pool_alloc(mp), l_size, l_t, c, false);
+					put_into_power_table(mp, l_size, l_t, c, false);
 				}
 			}
 		}
@@ -294,12 +296,12 @@ static power_table * power_table_new(Sentence sent)
 			c = d->right;
 			if (c != NULL)
 			{
-				put_into_power_table(pool_alloc(mp), r_size, r_t, c, true);
+				put_into_power_table(mp, r_size, r_t, c, true);
 			}
 			c = d->left;
 			if (c != NULL)
 			{
-				put_into_power_table(pool_alloc(mp), l_size, l_t, c, true);
+				put_into_power_table(mp, l_size, l_t, c, true);
 			}
 		}
 	}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -536,8 +536,8 @@ static int power_prune(Sentence sent, Parse_Options opts)
 	prune_context pc;
 	Disjunct *free_later = NULL;
 	Connector *c;
-	size_t N_deleted = 0;
-	size_t total_deleted = 0;
+	int N_deleted = 0;
+	int total_deleted = 0;
 
 	pt = power_table_new(sent);
 
@@ -581,7 +581,7 @@ static int power_prune(Sentence sent, Parse_Options opts)
 		}
 
 		total_deleted += N_deleted;
-		lgdebug(D_PRUNE, "Debug: l->r pass changed %d and deleted %zu\n",
+		lgdebug(D_PRUNE, "Debug: l->r pass changed %d and deleted %d\n",
 		        pc.N_changed, N_deleted);
 
 		if (pc.N_changed == 0) break;
@@ -619,7 +619,7 @@ static int power_prune(Sentence sent, Parse_Options opts)
 		}
 
 		total_deleted += N_deleted;
-		lgdebug(D_PRUNE, "Debug: r->l pass changed %d and deleted %zu\n",
+		lgdebug(D_PRUNE, "Debug: r->l pass changed %d and deleted %d\n",
 		        pc.N_changed, N_deleted);
 
 		if (pc.N_changed == 0) break;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -47,7 +47,6 @@ typedef struct
 #ifdef DEBUG
 static void print_Tconnector_list(Tconnector * e);
 static void print_clause_list(Clause * c);
-static void print_connector_list(Connector * e);
 #endif
 
 #if BUILD_DISJUNCTS_FREE_INETERMEDIATE_MEMOEY /* Undefined - CPU overhead. */
@@ -331,27 +330,6 @@ GNUC_UNUSED static void print_clause_list(Clause * c)
 		printf("  Clause: ");
 		printf("(%4.2f, %4.2f) ", c->cost, c->maxcost);
 		print_Tconnector_list(c->c);
-		printf("\n");
-	}
-}
-
-static void print_connector_list(Connector * e)
-{
-	for (;e != NULL; e=e->next)
-	{
-		printf("%s", connector_string(e));
-		if (e->next != NULL) printf(" ");
-	}
-}
-
-GNUC_UNUSED static void print_disjunct_list(Disjunct * dj)
-{
-	for (;dj != NULL; dj=dj->next) {
-		printf("%10s: ", dj->word_string);
-		printf("(%f) ", dj->cost);
-		print_connector_list(dj->left);
-		printf(" <--> ");
-		print_connector_list(dj->right);
 		printf("\n");
 	}
 }


### PR DESCRIPTION
Before sending a rewrite of `power_prune()` (with a drastic efficiency improving, but still same pruning) which is in the final stages, I am sending some commits that I separated from it.
(Another preparation PR for stuff needed for the new `power_prune()` will hopefully follow in the next hours).

In this PR:
- Removing of the (unused) ALT-consistency code.
- Type changes.
- Printout functions that I used to copy/modify etc. to WIP branches. But it will be less tedious for development if they are always included.
- A very small efficiency improve in `*_connector_list_update()`.
-  Prepare `put_into_power_table()` for a future change.
- Fix a comment rot.
- Initialize `suffix_id` (for convenience, e.g. preventing garbage on debug printouts of connectors).