### PR TITLE
count.c: Fix a bug with initial words that have no left disjuncts

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -375,7 +375,8 @@ static Count_bin do_count(
 	{
 		int nopt_words = num_optional_words(ctxt, lw, rw);
 
-		if ((null_count == 0) || (!ctxt->islands_ok && (lw != -1)) )
+		if ((null_count == 0) ||
+		    (!ctxt->islands_ok && (lw != -1) && (ctxt->sent->word[lw].d != NULL)))
 		{
 			/* The null_count of skipping n words is just n.
 			 * In case the unparsable range contains optional words, we
@@ -409,6 +410,7 @@ static Count_bin do_count(
 		for (int opt = 0; opt <= !!ctxt->sent->word[w].optional; opt++)
 		{
 			null_count += opt;
+
 			for (Disjunct *d = ctxt->sent->word[w].d; d != NULL; d = d->next)
 			{
 				if (d->left == NULL)
@@ -417,6 +419,7 @@ static Count_bin do_count(
 						do_count(ctxt, w, rw, d->right, NULL, null_count-1));
 				}
 			}
+
 			hist_accumv(&t->count, 0.0,
 				do_count(ctxt, w, rw, NULL, NULL, null_count-1));
 		}

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -418,7 +418,8 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 		Parse_set* dummy;
 		Disjunct* dis;
 
-		if (!pex->islands_ok && (lw != -1)) return &xt->set;
+		if (!pex->islands_ok && (lw != -1) && (pex->words[lw].d != NULL))
+			return &xt->set;
 		if (null_count == 0) return &xt->set;
 
 		RECOUNT({xt->set.recount = 0;})


### PR DESCRIPTION
Problem reported by Scott Guthery at
https://groups.google.com/d/msg/link-grammar/ynDNXmih5xk/4rm6sFRpHQAJ
See the commit message for a how to test this bug.

I tested this solution, but as always - I cannot prove its correctness.

There seem to be no sentences in the basic/fixes `en` corpus that has been affected by this problem.
However, 3 sentences in the `lt` corpus have been affected  (null `LEFT-WALL`):
Old:
`LEFT-WALL [ji] [eina] [į] [mokyklą] [.]`
With this PR:
```
                 +---LI--+
                 |  +-DG-+
                 |  |    |
LEFT-WALL [ji] eina į mokyklą [.]
```
Old:
`LEFT-WALL [Brolis] [eina] [į] [mokyklą] [.]`
With this PR:
```
                     +---LI--+
                     |  +-DG-+
                     |  |    |
LEFT-WALL [Brolis] eina į mokyklą [.]
```
Old:
`LEFT-WALL [medinis] [irklas] [buvo] [baltas] [.]
With this PR:
```
             +-------DVvv----->+
             |       +LLPIRMIas+
             |       |         |
LEFT-WALL medinis irkl.=    =as.pvv [buvo] [baltas] [.]
```

The `tr` corpus is also badly affected by this problem. Now I understand why its dict author used there `island-ok=1`

I also checked at the CMU site.
The problems seem not to exist in LG version 2.1, since it has this comment:
`    /* the following allows the possibility of a null link used on the leftmost word */`
However, LG version 4.1 contains this exact problem.
