### PR TITLE
 Implement memory pools for disjuncts and connectors

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -123,6 +123,8 @@ struct Sentence_s
 	Pool_desc * E_list_pool;
 	Pool_desc * Exp_pool;
 	Pool_desc * X_node_pool;
+	Pool_desc * Disjunct_pool;
+	Pool_desc * Connector_pool;
 
 	/* Trailing connector encoding stuff (suffix_id), used for speeding up
 	 * parsing (the classic one for now) of long sentences. */

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -56,9 +56,15 @@ set_connector_length_limit(Connector *c, Parse_Options opts)
 		c->length_limit = length_limit;
 }
 
-Connector * connector_new(const condesc_t *desc, Parse_Options opts)
+Connector * connector_new(Pool_desc *connector_pool, const condesc_t *desc,
+                          Parse_Options opts)
 {
-	Connector *c = (Connector *) xalloc(sizeof(Connector));
+	Connector *c;
+
+	if (NULL == connector_pool) /* For the SAT-parser, until fixed. */
+		c = xalloc(sizeof(Connector));
+	else
+		c = pool_alloc(connector_pool);
 
 	c->desc = desc;
 	c->nearest_word = 0;

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -152,7 +152,7 @@ static inline int connector_uc_num(const Connector * c)
 
 
 /* Connector utilities ... */
-Connector * connector_new(const condesc_t *, Parse_Options);
+Connector * connector_new(Pool_desc *, const condesc_t *, Parse_Options);
 void set_connector_length_limit(Connector *, Parse_Options);
 void free_connectors(Connector *);
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -48,7 +48,6 @@ Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct *);
 char * print_one_disjunct(Disjunct *);
 void word_record_in_disjunct(const Gword *, Disjunct *);
-Disjunct * disjuncts_dup(Disjunct *origd);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
@@ -57,4 +56,16 @@ void pack_sentence(Sentence, bool);
 void print_connector_list(Connector *);
 void print_disjunct_list(Disjunct *);
 void print_all_disjuncts(Sentence);
+
+/* Save and restore sentence disjuncts */
+typedef struct
+{
+	Pool_desc *Disjunct_pool;
+	Pool_desc *Connector_pool;
+	Disjunct **disjuncts;
+} Disjuncts_desc_t;
+
+void save_disjuncts(Sentence, Disjuncts_desc_t *);
+void restore_disjuncts(Sentence, Disjuncts_desc_t *);
+void free_saved_disjuncts(Disjuncts_desc_t *ddesc);
 #endif /* _LINK_GRAMMAR_DISJUNCT_UTILS_H_ */

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -63,7 +63,6 @@ static void setup_connectors(Sentence sent)
 			    (set_dist_fields(d->right, w, 1) >= (int) sent->length))
 			{
 				d->next = NULL;
-				free_disjuncts(d);
 			}
 			else
 			{
@@ -103,12 +102,20 @@ static void build_sentence_disjuncts(Sentence sent, double cost_cutoff,
 	Disjunct * d;
 	X_node * x;
 	size_t w;
+
+	sent->Disjunct_pool = pool_new(__func__, "Disjunct",
+	                   /*num_elements*/2048, sizeof(Disjunct),
+	                   /*zero_out*/false, /*align*/false, /*exact*/false);
+	sent->Connector_pool = pool_new(__func__, "Connector",
+	                   /*num_elements*/8192, sizeof(Connector),
+	                   /*zero_out*/false, /*align*/false, /*exact*/false);
+
 	for (w = 0; w < sent->length; w++)
 	{
 		d = NULL;
 		for (x = sent->word[w].x; x != NULL; x = x->next)
 		{
-			Disjunct *dx = build_disjuncts_for_exp(x->exp, x->string, cost_cutoff, opts);
+			Disjunct *dx = build_disjuncts_for_exp(sent, x->exp, x->string, cost_cutoff, opts);
 			word_record_in_disjunct(x->word, dx);
 			d = catenate_disjuncts(dx, d);
 		}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -536,7 +536,6 @@ static int power_prune(Sentence sent, Parse_Options opts)
 {
 	power_table *pt;
 	prune_context pc;
-	Disjunct *free_later = NULL;
 	Connector *c;
 	int N_deleted = 0;
 	int total_deleted = 0;
@@ -570,8 +569,6 @@ static int power_prune(Sentence sent, Parse_Options opts)
 
 					/* discard the current disjunct */
 					*dd = d->next; /* NEXT - set current disjunct to the next one */
-					d->next = free_later;
-					free_later = d;
 				}
 				else
 				{
@@ -608,8 +605,6 @@ static int power_prune(Sentence sent, Parse_Options opts)
 
 					/* Discard the current disjunct. */
 					*dd = d->next; /* NEXT - set current disjunct to the next one */
-					d->next = free_later;
-					free_later = d;
 				}
 				else
 				{
@@ -627,7 +622,6 @@ static int power_prune(Sentence sent, Parse_Options opts)
 		if (pc.N_changed == 0) break;
 		pc.N_changed = N_deleted = 0;
 	}
-	free_disjuncts(free_later);
 	power_table_delete(pt);
 
 	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc.power_cost);
@@ -889,9 +883,6 @@ static void delete_unmarked_disjuncts(Sentence sent)
 			if (d->marked) {
 				d->next = d_head;
 				d_head = d;
-			} else {
-				d->next = NULL;
-				free_disjuncts(d);
 			}
 		}
 		sent->word[w].d = d_head;

--- a/link-grammar/prepare/build-disjuncts.h
+++ b/link-grammar/prepare/build-disjuncts.h
@@ -17,7 +17,7 @@
 #include "api-types.h"
 #include "link-includes.h"
 
-Disjunct * build_disjuncts_for_exp(Exp*, const char*, double cost_cutoff, Parse_Options opts);
+Disjunct * build_disjuncts_for_exp(Sentence sent, Exp*, const char*, double cost_cutoff, Parse_Options opts);
 
 #ifdef DEBUG
 void prt_exp(Exp *, int);

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1823,8 +1823,8 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 
     // Allocate memory for the connectors, because they should persist
     // beyond the lifetime of the sat-solver data structures.
-    clink.lc = connector_new(NULL, NULL);
-    clink.rc = connector_new(NULL, NULL);
+    clink.lc = connector_new(NULL, NULL, NULL);
+    clink.rc = connector_new(NULL, NULL, NULL);
 
     *clink.lc = lpc->connector;
     *clink.rc = rpc->connector;
@@ -1888,7 +1888,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 #else
     cost_cutoff = 1000.0;
 #endif // LIMIT_TOTAL_LINKAGE_COST
-    d = build_disjuncts_for_exp(de, xnode_word[wi]->string, cost_cutoff, _opts);
+    d = build_disjuncts_for_exp(NULL, de, xnode_word[wi]->string, cost_cutoff, _opts);
     free_Exp(de);
 
     if (d == NULL)


### PR DESCRIPTION
A significant speedup results.
The `en` basic/fixes corpus benchmarks show nearly 15% speedup and the `ru` corpus shows about 10% speedup.  For the fix-long corpus there is less speedup (~4%).

This implementation is a fast change for enabling me to finish the fast `power_prune()` implementation
(that also gives a significant speedup). While making last code reviews I decided that its memory management is over-complex because the new code uses memory pools for disjuncts/connectors, but the old code doesn't do that so it needs to consider that and the code has become complex and unmanageable (even though it works with no leaks). After this PR I will be able to simplify things considerably.