### PR TITLE
Fix memory management problem in PR #896

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -889,6 +889,13 @@ class ZENLangTestCase(unittest.TestCase):
         self.assertEqual(len(linkages), 2)
         self.assertEqual(linkages.next().unused_word_cost(), 1)
 
+    def test_1_step_parsing_with_long_sentence_with_nulls(self):
+        self.po = ParseOptions(min_null_count=0, max_null_count=999, short_length=1)
+
+        text = 12 * 'This is a the test '
+        sent = Sentence(text, self.d, self.po)
+        self.assertTrue(len(sent.parse()) > 0) # Just check no crashes or leaks
+
 class JADictionaryLocaleTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -695,6 +695,7 @@ void pack_sentence(Sentence sent, bool real_suffix_ids)
 
 	pool_delete(sent->Disjunct_pool);
 	pool_delete(sent->Connector_pool);
+	sent->Disjunct_pool = NULL;
 
 	if (do_share)
 	{
@@ -730,11 +731,9 @@ void save_disjuncts(Sentence sent, Disjuncts_desc_t *ddesc)
 
 void restore_disjuncts(Sentence sent, Disjuncts_desc_t *ddesc)
 {
-	pool_delete(sent->Disjunct_pool);
 	sent->Disjunct_pool = ddesc->Disjunct_pool;
 	ddesc->Disjunct_pool = NULL;
 
-	pool_delete(sent->Connector_pool);
 	sent->Connector_pool = ddesc->Connector_pool;
 	ddesc->Connector_pool = NULL;
 

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -96,11 +96,20 @@ Pool_desc *pool_new(const char *func, const char *name,
 /**
  * Delete the given memory pool.
  */
-void pool_delete(Pool_desc *mp)
+#undef pool_delete
+#ifndef DEBUG
+void pool_delete (Pool_desc *mp)
+#else
+void pool_delete (const char *func, Pool_desc *mp)
+#endif
 {
 	if (NULL == mp) return;
-	lgdebug(+D_MEMPOOL, "Used %zu elements (pool '%s' created in %s())\n",
-	        mp->curr_elements, mp->name, mp->func);
+	const char *from_func = "";
+#ifdef DEBUG /* Macro-added first argument. */
+	from_func = func;
+#endif
+	lgdebug(+D_MEMPOOL, "Used %zu elements (%s deleted pool '%s' created in %s())\n",
+	        mp->curr_elements, from_func, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */
 	char *c_next;

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -27,7 +27,12 @@ typedef struct Pool_desc_s Pool_desc;
 Pool_desc *pool_new(const char *, const char *, size_t, size_t, bool, bool, bool);
 void *pool_alloc(Pool_desc *) GNUC_MALLOC;
 void pool_reuse(Pool_desc *);
+#ifndef DEBUG
 void pool_delete(Pool_desc *);
+#else
+void pool_delete(const char *func, Pool_desc *);
+#define pool_delete(...) pool_delete (__func__, __VA_ARGS__)
+#endif
 #ifdef POOL_FREE
 void pool_free(Pool_desc *, void *e);
 #endif // POOL_FREE

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -290,6 +290,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 					/* We are parsing now with null_count>0, when previously we
 					 * parsed with null_count==0. Restore the save disjuncts. */
+					free_sentence_disjuncts(sent); /* They are to be replaced. */
 					restore_disjuncts(sent, &disjuncts_copy);
 				}
 			}


### PR DESCRIPTION
Regretfully the memory management problem in the previous PR has not been fully fixed.
This PR fixes it, and it also includes
1. Added DEBUG code to find the location of such problems (when -v=104 is used).
2. A test that triggers the problem and causes a crash in the unfixed version.