### PR TITLE
 Fix crash in classic_parse(): Fix condition for freeing the jet table

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1045,6 +1045,9 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 	size_t jet_table_entries[2] = {0};
 	Connector ***jet_table = js->table;
 
+	assert(!rebuild || (js->table[0] && js->csid[0]), "jet rebuild with no info");
+	assert(rebuild || (!js->table[0] && !js->csid[0]), "jet !rebuild with info");
+
 	if (!rebuild)
 		jet_sharing_init(sent);
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -306,8 +306,8 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			/* Currently the jet-sharing is for power_prune() only.
 			 * For testing using it during do_count(), move it to be
 			 * after do_parse() below. */
-			if ((nl > 0) || !is_null_count_0) /* If not needed for rebuild. */
-				free_jet_sharing(sent);
+			if ((0 < nl) || (0 == max_null_count) )
+				free_jet_sharing(sent); /* Not needed for rebuild. */
 #if 0 // See below
 			bool real_suffix_ids =
 #endif


### PR DESCRIPTION
Most probably this is the problem of issue #907.
PR #906 has another bug, but I couldn't cause a crash even with UBSAN/ASAN enabled (I will send a fix too).
