### PR TITLE
Russian speedup (35%) and more

### DIFF
--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -93,6 +93,7 @@ struct Dictionary_s
 	/* Affixes are used during the tokenization stage. */
 	Dictionary      affix_table;
 	Afdict_class *  afdict_class;
+	bool pre_suf_class_exists;         /* True iff PRE or SUF exists */
 
 	/* Random morphology generator */
 	struct anysplit_params * anysplit;

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -581,6 +581,10 @@ bool afdict_init(Dictionary dict)
 			char last_entry[MAX_WORD+1] = "";
 			get_dict_affixes(dict, dict->root, ac->string[0][0], last_entry);
 		}
+		else
+		{
+			afdict->pre_suf_class_exists = true;
+		}
 	}
 	else
 	{

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -118,12 +118,7 @@ dictionary_six_str(const char * lang,
 	lgdebug(D_USER_FILES, "Debug: Language: %s\n", dict->lang);
 	dict->name = string_set_add(dict_name, dict->string_set);
 
-	/*
-	 * A special setup per dictionary type. The check here assumes the affix
-	 * dictionary name contains "affix". FIXME: For not using this
-	 * assumption, the dictionary creating stuff needs a rearrangement.
-	 */
-	if (0 == strstr(dict->name, "affix"))
+	if (NULL != affix_name)
 	{
 		/* To disable spell-checking, just set the checker to NULL */
 		dict->spell_checker = spellcheck_create(dict->lang);

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -801,16 +801,19 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				if (MT_PUNC == morpheme_type) /* It's a terminal token */
 					tokenization_done(sent, subword);
 
-				if (last_split)
+				if (!sent->dict->affix_table->pre_suf_class_exists && last_split)
 				{
-#if 0
-					/* XXX the new Turkish experimental dictionary depend on
-					 * specifying compound suffixes which are not in the dict file,
-					 * in the SUF affix class. This allows them to split farther.
+					/* XXX The "tr" and "kz" dictionaries depend on specifying
+					 * compound suffixes which are not in the dict file, in the
+					 * SUF affix class. This allows them to split farther.
 					 * However, there is a need to detail all the supported
 					 * combinations of compound suffixes.
 					 * FIXME: There is a need for a real multi affix splitter.
-					 * (last_split will get optimized out by the compiler.) */
+					 *
+					 * This way of allowing suffixes to split further is very
+					 * much not * efficient, as suffixes need to be reexamined.
+					 * To solve that, pre_suf_class_exists indicates whether
+					 * SUF and/or PRE are used in the affix file.*/
 
 					/* This is a stem, or an affix which is marked by INFIX_MARK.
 					 * Hence it must be a dict word - regex/spell are not done
@@ -818,7 +821,6 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 					 * Save resources by marking it accordingly. */
 					subword->status |= WS_INDICT;
 					subword->tokenizing_step = TS_DONE;
-#endif
 				}
 				word_label(sent, subword, "+", label);
 


### PR DESCRIPTION
- Re-enable the code that prevents "recursive" morpheme splits.
I disabled it once when I realized that it is not compatible for the then new `tr` dict.
It didn't so badly affected Russian then because the parsing time dominated then.
Now the parsing-related time when running the basic corpus batch is unbelievable small (in the order of 10%) and most of the CPU is taken by the dict read, tokenizing and malloc().

- dictionary_six_str(): Replace the strange check for the affix file name.
I named my git branch directory `affix_suf` and wondered why I get horrible errors when running the tests... I then recalled the "temporary" hack I once did. I have never got to rewrite the dictionary file handling, but for some time it is higher in my list due to the need to read dictionaries from strings.