### PR TITLE
do_count(): Avoid linkages loss due to overflow

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -641,8 +641,6 @@ static Count_bin do_count(
 					total = INT_MAX;
 #endif /* PERFORM_COUNT_HISTOGRAMMING */
 					t->count = total;
-					pop_match_list(mchxt, mlb);
-					return total;
 				}
 			}
 		}


### PR DESCRIPTION
While I was rewriting pp_prune() (with astonishing observations and results, BTW), I noted that I don't get any good linkage for this sentence from the fixes-long batch:
```
In 1608 he wrote a treatise of the Errors, False Gods, and Other Superstitions of the Indians of the Provinces of Huarochiri, Mama, and Chaclla, of which unfortunately only the first six chapters are known to exist and have been translated into English.
```
The number of linkages was the same - as -v=5 shows (the link-parser's result is the 24-bit truncated one).
However, all were with P.P. violations.

I first thought this may be a problem with the random sampling - if it is  not so random it may miss part of the solution space. However, inspecting the `list_random_links()` code convinced me it is indeed random (and I also found how to improve this code speed...). Printing the `Parse_set` structs showed that the expected linkages are just not there.

Neutralizing  the new `pp_prune()` code didn't help. But during the tests I found that the linkages (and especially no linkages) strongly depend on the order of the disjuncts on each word. For example, in the sentence quoted above when there are no good linkages, if one reverses the disjunct order on word 10 (a comma) all the missing linkages magically reappear! But if even one totally unrelated idiom is added to the dict (it adds a connector type that changes the order of pruning due to hashing effects - and hence the order of disjuncts ), they may be missed again... It seemed horribly and hopelessly strange.

But then I added a printout of the count due to processing of each disjunct on word 0.
It turns out the problem happens when the count overflows.
The following, added at 4.6.3, causes it:
``` c
    516                                         if (INT_MAX < total)
    517                                         {
    518                                                 total = INT_MAX;
    519                                                 t->count = total;
    520                                                 put_match_list(sent, m1);
    521                                                 return total;
```
When an overflow happens, it just aborts the disjunct scanning loop between the currently handled words, and hence the parse result of sentences with overflow strongly depend on the order of disjuncts . As a result, many/all of good linkages may miss from the solution space, especially if the overflow results in the start of the sentence processing (like what happens with this example sentence,
for which only few disjuncts on word 0 don't have a parsing path that leads to overflow).
Printout example from this sentence - **all** the good solutions are missing after the overflow:
```
w 0 0 count=0 hWc+ hWV+ RW+ 
w 0 1 count=0 hWd+ hWV+ RW+ 
w 0 2 count=0 hCPa+ 
w 0 3 count=0 hWo+ hWV+ RW+ 
w 0 4 count=0 hWp+ hWV+ RW+ 
w 0 5 count=0 hWc+ hWV+ Xx+ hWV+ 
w 0 6 count=0 hWd+ hWV+ Xx+ hWV+ 
w 0 7 count=0 hWp+ hWV+ Xx+ hWV+ 
w 0 8 count=0 hWa+ hCPi+ Xp+ 
w 0 9 count=0 hWd+ hCPi+ Xp+ 
w 0 10 count=0 hWp+ hCPCi+ Xp+ 
w 0 11 count=0 hWa+ hCPu+ Xp+ 
w 0 12 count=0 hWc+ hCPu+ Xp+ 
w 0 13 count=2147483647 hWd+ hCPu+ Xp+ 
w 0 14 count=2147483647 hWi+ hCPu+ Xp+ 
w 0 15 count=2147483647 hWp+ hCPu+ Xp+ 
```

Removing the loop termination code (lines 520-521 above) fixes everything.
Sentence batch "benchmarks":
1. No observed slowness on the `en` "basic"/"fixes" and `ru` "basic" batches.
2. About 3% slowness on the "fix-long" batch.
3. About 5% slowness on the "failures" batch (with **cost_max=2.7** instead of 2), but with slightly less errors (1567 instead of 1571). (The `cost_max=2` is maybe a remain from old times that needs an update.)

However, WIP speedups of several tens of percents may offset (2) and (3). Also, I think it is a **must** due to correctness, which is usually preferred over speed. Maybe part of the overflows can be mitigated by a more aggressive pp-pruning, because absolutely most of the linkages for long sentences contain P.P. violations. Also, may be an overflow optimization would help. (E.g. if the LHS overflows, maybe we only need to know if the RHS has any count without fully calculating it. But this of course will add overhead for sentences w/o overflow.)

BTW, even though this fix may prevent hiding the lower-metric solutions (or the only non-P.P. violation ones) it doesn't automatically give a better metric on the first result, because also more solutions with P.P. violations are produced, and the sampling is from the linkage_limit number of actually produced linkages. The new `pp_prune()` prunes more but I haven't checked it yet in this regard.


