### PR TITLE
Fast pp_prune()

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -951,13 +951,15 @@ static bool match_in_cms_table(multiset_table *cmt, const char *pp_link,
 	return false;
 }
 
-static Cms *lookup_in_cms_table(multiset_table *cmt, const char *pp_link)
+/* FIXME? There is some code duplication here and in insert_in_cms_table()
+ * but it seems cumbersome to fix it. */
+static Cms *lookup_in_cms_table(multiset_table *cmt, Connector *c)
 {
-	unsigned int h = cms_hash(pp_link);
+	unsigned int h = cms_hash(connector_string(c));
 
 	for (Cms *cms = cmt->cms_table[h]; cms != NULL; cms = cms->next)
 	{
-		if (string_set_cmp(pp_link, connector_string(cms->c))) return cms;
+		if (c->desc == cms->c->desc) return cms;
 	}
 
 	return NULL;
@@ -1050,7 +1052,7 @@ static bool mark_bad_connectors(multiset_table *cmt, Connector *c)
 	if (c->nearest_word == BAD_WORD)
 		return true; /* Already marked (mainly by jet sharing). */
 
-	Cms *cms = lookup_in_cms_table(cmt, connector_string(c));
+	Cms *cms = lookup_in_cms_table(cmt, c);
 	if (cms->c->nearest_word == BAD_WORD)
 	{
 		c->nearest_word = BAD_WORD;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1118,14 +1118,16 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 				{
 					if (c->nearest_word == BAD_WORD)
 					{
+						/* Already marked w/BAD_WORD, mainly through jet sharing. */
 						D_deleted++;
-						continue; /* Already marked, mainly through jet sharing */
+						break; /* no need to further check the same jet */
 					}
 					Cms *cms = lookup_in_cms_table(cmt, connector_string(c));
 					if (cms->c->nearest_word == BAD_WORD)
 					{
 						c->nearest_word = BAD_WORD;
 						D_deleted++;
+						break;
 					}
 				}
 			}
@@ -1133,7 +1135,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 		}
 	}
 
-	lgdebug(+D_PRUNE, "Deleted %d disjuncts (%d connector names)\n",
+	lgdebug(+D_PRUNE, "Deleted %d (%d connector names)\n",
 	        D_deleted, Cname_deleted);
 
 	cms_table_delete(cmt);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1142,16 +1142,6 @@ void pp_and_power_prune(Sentence sent, Parse_Options opts)
 		power_prune(sent, opts, &pt);
 
 	power_table_delete(&pt);
-	return;
 
-	// Not reached. We can actually gain a few percent of
-	// performance be skipping the loop below. Mostly, it just
-	// does a lot of work, and pretty much finds nothing.
-	// And so we skip it.
-#ifdef ONLY_IF_YOU_THINK_THIS_IS_WORTH_IT
-	for (;;) {
-		if (pp_prune(sent, opts) == 0) break;
-		if (power_prune(sent, opts) == 0) break;
-	}
-#endif
+	return;
 }

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1138,7 +1138,8 @@ void pp_and_power_prune(Sentence sent, Parse_Options opts)
 	power_table_init(sent, &pt);
 
 	power_prune(sent, opts, &pt);
-	pp_prune(sent, opts);
+	if (pp_prune(sent, opts) > 0)
+		power_prune(sent, opts, &pt);
 
 	power_table_delete(&pt);
 	return;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -847,14 +847,9 @@ static int power_prune(Sentence sent, Parse_Options opts, power_table *pt)
 
 static multiset_table * cms_table_new(void)
 {
-	multiset_table *mt;
-	int i;
+	multiset_table *mt = (multiset_table *) xalloc(sizeof(multiset_table));
+	memset(mt, 0, sizeof(multiset_table));
 
-	mt = (multiset_table *) xalloc(sizeof(multiset_table));
-
-	for (i=0; i<CMS_SIZE; i++) {
-		mt->cms_table[i] = NULL;
-	}
 	return mt;
 }
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -406,6 +406,8 @@ static void clean_table(unsigned int size, C_list **t)
 
 		while (NULL != *m)
 		{
+			assert(0 <= (*m)->c->suffix_id, "clean_table: suffix_id < 0 (%d)",
+			       (*m)->c->suffix_id);
 			if (0 == (*m)->c->suffix_id)
 				*m = (*m)->next;
 			else

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -754,7 +754,7 @@ static int power_prune(Sentence sent, Parse_Options opts, power_table *pt)
 }
 
 /* ===================================================================
-   PP Pruning
+   PP Pruning (original comments from version 3 - some not up to date).
 
    The "contains one" post-processing constraints give us a new way to
    prune.  Suppose there's a rule that says "a group that contains foo

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1102,6 +1102,11 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 		}
 	}
 
+	/* Iterate over all connectors and mark the bad trigger connectors.
+	 * If the marked connector is not the shallow one, note that the
+	 * shallow one on the same disjunct cannot be marked too (this could
+	 * facilitate faster detection by power_prune()) because this would be
+	 * wrongly reflected through the cms table. */
 	for (WordIdx w = 0; w < sent->length; w++)
 	{
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)


### PR DESCRIPTION
Main speedup methods:
- Use the `cms` table for checking the the trigger connectors. 
Relatively few connectors are needed to be checked v.s. all the connectors in the current implementation.
- Less match tries for criterion links - `#` do not generate match tries.
- `rule_satisfiable()` is called on each rule at most once per sentence.
- `cms` table insertion is done using the jet table.
- Bad connector marking uses the jet table and the jet sharing.
- The disjunct deletion is done by `power_prune()`, along with additional disjuncts that it then able to delete.
- MRU order is kept on table insertion, to speed up checking for uniqueness.

Minor speedup methods:
- No use of reference counts (they are useless at the current implementation). This also results in `cms` table element size of power of 2.
- The `cms` table lookup is done using connector descriptor comparisons (saving indirections).
- `cms` table init using `memset()`.

Speedup methods that are not implemented yet:
- Use memory pools for the `cms` table.
- Use descriptors also for PP links. This will allow fast hashing and fast pp links matching.
- Find a way to avoid reference counts in the power_table (it seems possible). This will make the `cms` table unnecessary and save its creation.

It may be a good idea maybe that I also add copyright on this file for these and the `power_prune()` changes. However, there is a planned cleanup PR and for this file, some more speedup ideas to try, and also I have several different changes for more aggressive pruning (WIP). I also still think how to unify the jet and power tables.

