### PR TITLE
Extract random links speedup

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -747,17 +747,26 @@ static void list_random_links(Linkage lkg, unsigned int *rand_state,
 	int num_pc, new_index;
 
 	if (set == NULL || set->first == NULL) return;
-	num_pc = 0;
-	for (pc = set->first; pc != NULL; pc = pc->next) {
-		num_pc++;
+
+	/* Most of the times there is only one list element. */
+	if (set->first->next == NULL)
+	{
+		pc = set->first;
 	}
+	else
+	{
+		num_pc = 0;
+		for (pc = set->first; pc != NULL; pc = pc->next) {
+			num_pc++;
+		}
 
-	new_index = rand_r(rand_state) % num_pc;
+		new_index = rand_r(rand_state) % num_pc;
 
-	num_pc = 0;
-	for (pc = set->first; pc != NULL; pc = pc->next) {
-		if (new_index == num_pc) break;
-		num_pc++;
+		num_pc = 0;
+		for (pc = set->first; pc != NULL; pc = pc->next) {
+			if (new_index == num_pc) break;
+			num_pc++;
+		}
 	}
 
 	issue_links_for_choice(lkg, pc);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -740,7 +740,8 @@ static void list_links(Linkage lkg, const Parse_set * set, int index)
 	 list_links(lkg, pc->set[1], index / pc->set[0]->count);
 }
 
-static void list_random_links(Linkage lkg, extractor_t * pex, const Parse_set * set)
+static void list_random_links(Linkage lkg, unsigned int *rand_state,
+                              const Parse_set * set)
 {
 	Parse_choice *pc;
 	int num_pc, new_index;
@@ -751,7 +752,7 @@ static void list_random_links(Linkage lkg, extractor_t * pex, const Parse_set * 
 		num_pc++;
 	}
 
-	new_index = rand_r(&pex->rand_state) % num_pc;
+	new_index = rand_r(rand_state) % num_pc;
 
 	num_pc = 0;
 	for (pc = set->first; pc != NULL; pc = pc->next) {
@@ -760,8 +761,8 @@ static void list_random_links(Linkage lkg, extractor_t * pex, const Parse_set * 
 	}
 
 	issue_links_for_choice(lkg, pc);
-	list_random_links(lkg, pex, pc->set[0]);
-	list_random_links(lkg, pex, pc->set[1]);
+	list_random_links(lkg, rand_state, pc->set[0]);
+	list_random_links(lkg, rand_state, pc->set[1]);
 }
 
 /**
@@ -777,7 +778,7 @@ void extract_links(extractor_t * pex, Linkage lkg)
 		bool repeatable = false;
 		if (0 == pex->rand_state) repeatable = true;
 		if (repeatable) pex->rand_state = index;
-		list_random_links(lkg, pex, pex->parse_set);
+		list_random_links(lkg, &pex->rand_state, pex->parse_set);
 		if (repeatable)
 			pex->rand_state = 0;
 		else


### PR DESCRIPTION
A slight speedup results by eliminating the rand_r() calls and some other code for most linkages.
I used the "In 1608 [...]" sentence as a benchmark because it has an overflow with a relatively small parse time. In the CPU profile below, absolutely most of the CPU time (>95%) is due to producing 1000000 (a million) linkages (it takes ~20s of total CPU, when the tokenizing/parsing takes ~0.25s).
```
    9120  35.0%  35.0%    14603  56.1% link-grammar/post-process/post-process.c
    6349  24.4%  59.4%     6524  25.1% malloc/malloc.c
    2169   8.3%  67.8%     3356  12.9% link-grammar/post-process/pp_linkset.c
    1857   7.1%  74.9%     2017   7.8% link-grammar/parse/extract-links.c
    1135   4.4%  79.3%     5215  20.0% link-grammar/linkage/sane.c
    1130   4.3%  83.6%     2627  10.1% link-grammar/tokenize/wordgraph.c
    1062   4.1%  87.7%     1062   4.1% multiarch/strcmp-sse2-unaligned.S
     575   2.2%  89.9%     1077   4.1% link-grammar/linkage/analyze-linkage.c
     379   1.5%  91.4%      379   1.5% multiarch/memmove-vec-unaligned-erms.S
     223   0.9%  92.2%      223   0.9% link-grammar/linkage/score.c
     193   0.7%  93.0%    25906  99.6% link-grammar/api.c
     165   0.6%  93.6%      165   0.6% link-grammar/connectors.h
     165   0.6%  94.2%      165   0.6% ctype/../include/ctype.h
     144   0.6%  94.8%      144   0.6% multiarch/memset-vec-unaligned-erms.S
     114   0.4%  95.2%      114   0.4% stdlib/rand_r.c
     110   0.4%  95.6%      110   0.4% multiarch/../strlen.S
     106   0.4%  96.1%      106   0.4% link-grammar/parse/fast-match.c
     105   0.4%  96.5%      268   1.0% link-grammar/parse/count.c
      91   0.3%  97.2%      376   1.4% stdlib/msort.c
      81   0.3%  97.5%       81   0.3% link-grammar/linkage/linkage.c
      60   0.2%  97.8%       60   0.2% sysdeps/unix/sysv/linux/x86_64/brk.c
      58   0.2%  98.0%       83   0.3% link-grammar/string-set.c
      46   0.2%  98.6%       86   0.3% link-grammar/dict-file/read-dict.c
      45   0.2%  98.8%       45   0.2% sysdeps/unix/syscall-template.S
      39   0.1%  98.9%    25303  97.2% link-grammar/parse/parse.c
      30   0.1%  99.0%       44   0.2% link-grammar/disjunct-utils.c
      20   0.1%  99.2%     2035   7.8% link-grammar/linkage/freeli.c
      20   0.1%  99.3%       20   0.1% multiarch/strcpy-sse2-unaligned.S
```
This profiling is from the `new-pp_prune` branch (before applying this PR). 
Much of the malloc overhead is from Gword stuff during the post-linkage processing.
It allocates one element at a time for vectors, and a vast speedup could be done by allocating in bigger chunks. But this needs some redesign. Most of the PP-stage CPU can be also eliminated (the code there is not efficient, I already improved part of it).