### PR TITLE
Minor fixes before major ones

### DIFF
--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -16,8 +16,8 @@
 
 #include "api-structures.h"
 #include "connectors.h"
-#include "dict-common/dict-affix.h"  // for INFIX_MARK from dict.
-#include "dict-common/dict-defines.h" // for SUBSCRIPT_MARK
+#include "dict-common/dict-affix.h"     // INFIX_MARK
+#include "dict-common/dict-defines.h"   // SUBSCRIPT_MARK
 #include "dict-common/idiom.h"
 #include "disjunct-utils.h"
 #include "link-includes.h"
@@ -27,7 +27,7 @@
 #include "string-set.h"
 #include "tokenize/wordgraph.h"
 #include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
-#include "tokenize/word-structures.h" // For Word_struct
+#include "tokenize/word-structures.h"    // Word_struct
 
 #define INFIX_MARK_L 1 /* INFIX_MARK is 1 character */
 #define STEM_MARK_L  1 /* stem mark is 1 character */

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -378,7 +378,6 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 				lgdebug(D_SLM, "\n");
 			}
 
-			//if (NULL != wpp->word) break; /* Extra null count; XXX always false*/
 			continue;
 		}
 

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -99,21 +99,20 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 	}
 	(*nwp)[n].word = p;
 
-	if (MT_INFRASTRUCTURE == p->prev[0]->morpheme_type)
+	if (NULL == path)
 	{
-			/* Previous word is the Wordgraph dummy word. Initialize the path. */
 			(*nwp)[n].path = NULL;
 	}
 	else
 	{
 		/* Duplicate the path from the current one. */
-		assert(NULL != path, "wordgraph_path_append(): Duplicating a null path");
-
 		size_t path_arr_size = (gwordlist_len(path)+1)*sizeof(*path);
 
 		(*nwp)[n].path = malloc(path_arr_size);
 		memcpy((*nwp)[n].path, path, path_arr_size);
 	}
+
+	if (NULL == current_word) return;
 
 	/* If we queue the same word again, its path remains the same.
 	 * Else append the current word to it. */

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -35,8 +35,8 @@
  * is constructed when the Wordgraph termination word is encountered.
  *
  * Note: The final path doesn't match the linkage word indexing if the linkage
- * contains empty words, at least until empty words are eliminated from the
- * linkage (in compute_chosen_words()). Further processing of the path is done
+ * contains optional words which are null, until the are eliminated from the
+ * linkage (in remove_empty_words()). Further processing of the path is done
  * there in case morphology splits are to be hidden or there are morphemes with
  * null linkage.
  */

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -10,16 +10,16 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "api-structures.h"  // for Sentence_s
+#include "api-structures.h"             // Sentence_s
 #include "api-types.h"
-#include "dict-common/regex-morph.h" // for match_regex
-#include "connectors.h" // for MAX_SENTENCE
-#include "disjunct-utils.h"  // for Disjunct_struct
+#include "dict-common/regex-morph.h"    // match_regex
+#include "connectors.h"                 // MAX_SENTENCE
+#include "disjunct-utils.h"             // Disjunct_struct
 #include "lg_assert.h"
 #include "linkage.h"
 #include "sane.h"
-#include "tokenize/tok-structures.h" // Needed for Wordgraph_pathpos_s
-#include "tokenize/word-structures.h" // for Word_struct
+#include "tokenize/tok-structures.h"    // Wordgraph_pathpos_s
+#include "tokenize/word-structures.h"   // Word_struct
 #include "tokenize/wordgraph.h"
 #include "utilities.h"
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -623,7 +623,7 @@ right_connector_list_update(prune_context *pc, Connector *c,
 	return foundmatch;
 }
 
-static void mark_connector_sequence_for_dequeue(Connector *c, bool mark_bad_word)
+static void mark_jet_for_dequeue(Connector *c, bool mark_bad_word)
 {
 	for (; NULL != c; c = c->next)
 	{
@@ -679,8 +679,8 @@ static int power_prune(Sentence sent, Parse_Options opts, power_table *pt)
 				bool bad = is_bad(d->left);
 				if (bad || left_connector_list_update(&pc, d->left, w, true) < 0)
 				{
-					mark_connector_sequence_for_dequeue(d->left, true);
-					mark_connector_sequence_for_dequeue(d->right, false);
+					mark_jet_for_dequeue(d->left, true);
+					mark_jet_for_dequeue(d->right, false);
 
 					/* discard the current disjunct */
 					*dd = d->next; /* NEXT - set current disjunct to the next one */
@@ -716,8 +716,8 @@ static int power_prune(Sentence sent, Parse_Options opts, power_table *pt)
 				bool bad = is_bad(d->right);
 				if (bad || right_connector_list_update(&pc, d->right, w, true) >= sent->length)
 				{
-					mark_connector_sequence_for_dequeue(d->right, true);
-					mark_connector_sequence_for_dequeue(d->left, false);
+					mark_jet_for_dequeue(d->right, true);
+					mark_jet_for_dequeue(d->left, false);
 
 					/* Discard the current disjunct. */
 					*dd = d->next; /* NEXT - set current disjunct to the next one */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -119,28 +119,6 @@ static bool contains_digits(const char * s, locale_t dict_locale)
 	}
 	return false;
 }
-
-#if 0
-/**
- * Return true if an alternative has been issued for the given word.
- * If there is an alternative, the previous word points to it.
- * Its unsplit_word is the given word.
- *
- * Return true if an alternative is found, else false.
- * XXX need to check correctness.
- * XXX It seems this function is not needed any more. Remove if so.
- */
-static bool word_has_alternative(const Gword *word)
-{
-	const Gword **n;
-
-	for (n = word->prev[0]->next; *n; n++)
-	{
-		if ((*n)->unsplit_word == word) return true;
-	}
-	return false;
-}
-#endif
 #endif /* defined HAVE_HUNSPELL || defined HAVE_ASPELL */
 
 /**
@@ -367,32 +345,6 @@ static bool word_start_another_alternative(Dictionary dict,
  * FIXME? Try to work-around the current need of this functions.
  */
 static char const *contraction_char[] = { "'", "’" };
-
-#if 0
-static bool is_contraction_suffix(const char *s)
-{
-	size_t len = strlen(s);
-
-	for (size_t i = 0; i < ARRAY_SIZE(contraction_char); i++)
-	{
-		size_t cclen = strlen(contraction_char[i]);
-		if (len < cclen) continue;
-		if (0 == strncmp(s+len-cclen, contraction_char[i], cclen)) return true;
-	}
-
-	return false;
-}
-
-static bool is_contraction_prefix(const char *s)
-{
-	for (size_t i = 0; i < ARRAY_SIZE(contraction_char); i++)
-	{
-		size_t cclen = strlen(contraction_char[i]);
-		if (0 == strncmp(s, contraction_char[i], cclen)) return true;
-	}
-	return false;
-}
-#endif
 
 static bool is_contraction_word(Dictionary dict, const char *s)
 {
@@ -3181,21 +3133,6 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 	return true;
 }
 #undef D_DWE
-
-#if 0 /* unused */
-/**
- * Find whether w1 and w2 have been generated together in the same alternative.
- */
-static bool is_alternative_next_word(const Gword *w1, const Gword *w2)
-{
-	assert(NULL != w1->alternative_id, "Word '%s' NULL alternative_id",
-	       w1->subword);
-	lgdebug(+6, "w1='%s' (%p=%s) w2='%s' (%p=%s) \n",
-	        w1->subword, w1->alternative_id, w1->alternative_id->subword,
-	        w2->subword, w2->alternative_id, w2->alternative_id->subword);
-	return (w1->alternative_id == w2->alternative_id);
-}
-#endif
 
 #ifdef FIXIT /* unused */
 /* XXX WS_UNSPLIT */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3297,7 +3297,8 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 		for (wpp_old = wp_old; NULL != wpp_old->word; wpp_old++)
 		{
 			wg_word = wpp_old->word;
-			if (NULL == wg_word->next) continue; /* XXX avoid termination */
+			if (MT_INFRASTRUCTURE == wg_word->morpheme_type)
+				continue; /* XXX avoid termination word */
 
 			if (wpp_old->same_word)
 			{
@@ -3338,7 +3339,8 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 		for (wpp_old = wp_old; NULL != wpp_old->word; wpp_old++)
 		{
 			wg_word = wpp_old->word;
-			if (NULL == wg_word->next) continue; /* XXX avoid termination word */
+			if (MT_INFRASTRUCTURE == wg_word->morpheme_type)
+				continue; /* XXX avoid termination word */
 
 			/* Here wg_word->next cannot be NULL. */
 			assert(NULL != wg_word->next[0], "Bad wordgraph: "
@@ -3381,7 +3383,8 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 			{
 				bool same_alternative = false;
 
-				if (NULL == wg_word->next) continue; /* termination word */
+				if (MT_INFRASTRUCTURE == wg_word->morpheme_type)
+					continue; /* termination word */
 
 				if (NULL != wp_new)
 				{

--- a/link-grammar/tokenize/wordgraph.c
+++ b/link-grammar/tokenize/wordgraph.c
@@ -40,21 +40,6 @@ Gword *gword_new(Sentence sent, const char *s)
 	return gword;
 }
 
-/* FIXME: Remove it. */
-Gword *empty_word(void)
-{
-	/*
-	static Gword e = {
-		.subword = EMPTY_WORD_MARK,
-		.unsplit_word = &e,
-		.morpheme_type = MT_EMPTY,
-		.alternative_id = &e,
-		.status = WS_INDICT,
-	};
-	*/
-	return NULL;
-}
-
 static Gword **gwordlist_resize(Gword **arr, size_t len)
 {
 	arr = realloc(arr, (len+2) * sizeof(Gword *));

--- a/link-grammar/tokenize/wordgraph.h
+++ b/link-grammar/tokenize/wordgraph.h
@@ -21,7 +21,6 @@
 #define IS_SENTENCE_WORD(sent, gword) (gword->unsplit_word == sent->wordgraph)
 
 Gword *gword_new(Sentence, const char *);
-Gword *empty_word(void); /* FIXME: Remove it. */
 size_t gwordlist_len(const Gword **);
 void gwordlist_append(Gword ***, Gword *);
 void gword_set_print(const gword_set *);


### PR DESCRIPTION
Assorted minor fixes:
- Comments, formatting, removing old code, renaming.
- Fix a currently non-harmful bug (it is harmful for the next PR).
- Fix checks for end of Wordgraph (the current way is incompatible with the next PR).

The next PR (still a WIP) is for using vector access methods for Gword lists.
This enables to do more efficient memory allocations (instead of allocating elements one-by-one).
Gword lists exist in 2 places:
1. Wordgraph `next` and `prev`.
2. Wordgraph paths (temporary ones during sane morphism, and 2 kind of "permanent" ones in the linkage struct).
The converting work turned out to be harder than expected.
