### PR TITLE
Vector implementation for (Gword *) list

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -142,6 +142,7 @@ liblink_grammar_la_SOURCES =        \
 	tokenize/wg-display.c            \
 	tokenize/wordgraph.c             \
 	utilities.c                      \
+	vc_vector/vc_vector.c            \
 	                                 \
 	api-structures.h                 \
 	api-types.h                      \
@@ -199,7 +200,8 @@ liblink_grammar_la_SOURCES =        \
 	tokenize/tokenize.h              \
 	tokenize/word-structures.h       \
 	tokenize/wordgraph.h             \
-	utilities.h
+	utilities.h                      \
+	vc_vector/vc_vector.h
 
 liblink_grammar_includedir = $(includedir)/link-grammar
 liblink_grammar_include_HEADERS =   \
@@ -217,7 +219,10 @@ EXTRA_DIST=                         \
 	dict-sql/dict.sql                \
 	dict-sql/demo.sql                \
 	dict-sql/README.md               \
-	tokenize/README.md
+	tokenize/README.md               \
+	vc_vector/LICENSE.md
+
+
 
 # -----------------------------------------------------------
 install-data-local: install-libtool-import-lib

--- a/link-grammar/linkage/freeli.c
+++ b/link-grammar/linkage/freeli.c
@@ -29,9 +29,10 @@ void free_linkage(Linkage linkage)
 
 	linkage_free_pp_domains(linkage);
 
-	/* XXX FIXME */
-	free(linkage->wg_path);
-	free(linkage->wg_path_display);
+	if (NULL != linkage->wg_path)
+		gwordlist_delete(linkage->wg_path);
+	if (NULL != linkage->wg_path_display)
+		gwordlist_delete(linkage->wg_path_display);
 }
 
 void free_linkages(Sentence sent)

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -223,14 +223,16 @@ void remove_empty_words(Linkage lkg)
 	size_t i, j;
 	Disjunct **cdj = lkg->chosen_disjuncts;
 	int *remap = alloca(lkg->num_words * sizeof(*remap));
+
 	Gword **wgp = gwordlist_begin(lkg->wg_path);
+	Gword **wgp_end = gwordlist_end(lkg->wg_path);
 
 	for (i = 0, j = 0; i < lkg->num_words; i++)
 	{
 		/* Discard optional words that are not real null-words.  Note that
 		 * if optional words don't have non-optional words after them,
 		 * wg_path doesn't include them. */
-		if ((gwordlist_end(lkg->wg_path) == wgp) || ((*wgp)->sent_wordidx != i))
+		if ((wgp_end == wgp) || ((*wgp)->sent_wordidx != i))
 		{
 			assert((NULL == cdj[i]) && lkg->sent->word[i].optional);
 			remap[i] = -1;
@@ -242,8 +244,7 @@ void remove_empty_words(Linkage lkg)
 		cdj[i] = cdtmp; /* The SAT parser frees chosen_disjuncts elements. */
 		remap[i] = j;
 		j++;
-		if (gwordlist_end(lkg->wg_path) != wgp)
-			wgp = gwordlist_next(lkg->wg_path, wgp);
+		if (wgp_end != wgp) wgp = gwordlist_next(lkg->wg_path, wgp);
 	}
 	if (lkg->num_words != j)
 	{

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -502,7 +502,8 @@ void compute_chosen_words(Sentence sent, Linkage linkage, Parse_Options opts)
 					 * for joining... */
 
 					const Gword *unsplit_word = w->unsplit_word;
-					for (wgaltp = wgp, j = i; wgaltp != gwordlist_end(lwg_path); wgaltp++, j++)
+					Gword **wgaltp_end = gwordlist_end(lwg_path);
+					for (wgaltp = wgp, j = i; wgaltp != wgaltp_end; wgaltp++, j++)
 					{
 
 						if ((*wgaltp)->unsplit_word != unsplit_word) break;

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include "api-types.h"
 #include "link-includes.h" // Needed for typedef WordIdx
+#include "tokenize/wordgraph.h"
 
 /**
  * This summarizes the linkage status.
@@ -66,8 +67,8 @@ struct Linkage_s
 	Sense **        sense_list;   /* Word senses, inferred from disjuncts */
 #endif
 
-	Gword **wg_path;              /* Linkage Wordgraph path */
-	Gword **wg_path_display;      /* Wordgraph path after morpheme combining */
+	Gwordlist *wg_path;              /* Linkage Wordgraph path */
+	Gwordlist *wg_path_display;      /* Wordgraph path after morpheme combining */
 
 	Linkage_info    lifo;         /* Parse_set index and cost information */
 	PP_domains *    pp_domains;   /* PP domain info, one for each link */

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -192,12 +192,12 @@ static size_t num_islands(const Linkage lkg, const Gwordlist *wg_path)
 	int inum = -1;
 	Disjunct **cdj = lkg->chosen_disjuncts;
 	Gword **wg_path_p = gwordlist_begin(wg_path);
+	Gword **wg_path_p_end = gwordlist_end(wg_path);
 
 	for (WordIdx w = 0; w < lkg->sent->length; w++)
 	{
 		/* Skip null words which are optional words. */
-		if ((gwordlist_end(wg_path) == wg_path_p) ||
-		    ((*wg_path_p)->sent_wordidx != w))
+		if ((wg_path_p_end == wg_path_p) || ((*wg_path_p)->sent_wordidx != w))
 		{
 			assert(word[w].prev == word[w].next);
 			assert((NULL == cdj[w]) && lkg->sent->word[w].optional);
@@ -207,7 +207,7 @@ static size_t num_islands(const Linkage lkg, const Gwordlist *wg_path)
 			continue;
 		}
 
-		if (gwordlist_end(wg_path) != wg_path_p)
+		if (wg_path_p_end != wg_path_p)
 			wg_path_p = gwordlist_next(wg_path, wg_path_p);
 		if (NO_WORD == word[w].prev) continue;
 
@@ -291,8 +291,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 
 	/* Populate the path word queue, initializing the path to NULL. */
 	Gwordlist *glsent = sent->wordgraph->next;
+	Gword **sent_end = gwordlist_end(glsent);
 	for (Gword **gw = gwordlist_begin(glsent);
-	             gw != gwordlist_end(glsent);
+	             gw != sent_end;
 	             gw = gwordlist_next(glsent, gw))
 	{
 		wordgraph_path_append(&wp_new, /*path*/NULL, /*add_word*/NULL, *gw);
@@ -350,8 +351,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 				 * from the null words in the word array of the Linkage structure.
 				 */
 				Gwordlist *wn = wpp->word->next;
+				Gword **gw_end = gwordlist_end(wn);
 				for (Gword **gw = gwordlist_begin(wn);
-				             gw != gwordlist_end(wn);
+				             gw != gw_end;
 				             gw = gwordlist_next(wn, gw))
 				{
 					if (MT_INFRASTRUCTURE != wpp->word->morpheme_type)
@@ -398,8 +400,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 				{
 					match_found = true;
 					Gwordlist *wn = wpp->word->next;
+					Gword **gw_end = gwordlist_end(wn);
 					for (Gword **gw = gwordlist_begin(wn);
-		                      gw != gwordlist_end(wn);
+		                      gw != gw_end;
 		                      gw = gwordlist_next(wn, gw))
 					{
 						wordgraph_path_append(&wp_new, wpp->path, wpp->word, *gw);
@@ -472,8 +475,9 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 		print_lwg_path(wpp->path, "Linkage");
 #endif
 		i = 0;
+		Gword **w_end = gwordlist_end(wpp->path);
 		for (Gword **w = gwordlist_begin(wpp->path);
-		             w != gwordlist_end(wpp->path);
+		             w != w_end;
 		             w = gwordlist_next(wpp->path, w))
 
 		{

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -18,6 +18,7 @@
 #include <stddef.h>
 #include "api-types.h"
 #include "link-includes.h"
+#include "wordgraph.h"
 
 // TODO provide gword access methods!
 
@@ -125,8 +126,8 @@ struct Gword_struct
 	const char *end;     /* subword end position. */
 
 	Gword *unsplit_word; /* Upward-going co-tree */
-	Gword **next;        /* Right-going tree */
-	Gword **prev;        /* Left-going tree */
+	Gwordlist *next;     /* Right-going tree */
+	Gwordlist *prev;     /* Left-going tree */
 	Gword *chain_next;   /* Next word in the chain of all words */
 
 	/* Disjuncts and connectors point back to their originating Gword(s). */
@@ -162,17 +163,17 @@ struct Gword_struct
 	Gword *alternative_id;       /* Alternative start - a unique identifier of
 	                                the alternative to which the word belongs. */
 	const char *regex_name;      /* Subword matches this regex.
-                                   FIXME? Extend for multiple regexes. */
+	                                FIXME? Extend for multiple regexes. */
 
 	/* Only used by wordgraph_flatten() */
 	const Gword **hier_position; /* Unsplit_word/alternative_id pointer list, up
-                                   to the original sentence word. */
+	                                to the original sentence word. */
 	size_t hier_depth;           /* Number of pointer pairs in hier_position */
 
 	/* XXX Experimental. Only used after the linkage (by compute_chosen_words())
 	 * for an element in the linkage display wordgraph path that represents
 	 * a block of null words that are morphemes of the same word. */
-	Gword **null_subwords;       /* Null subwords represented by this word */
+	Gwordlist *null_subwords;    /* Null subwords represented by this word */
 };
 
 /* Wordgraph path word-positions,
@@ -186,7 +187,7 @@ struct Wordgraph_pathpos_s
 	bool next_ok;     /* OK to proceed to the next Wordgraph word */
 	bool used;        /* Debug - the word has been issued */
 	/* Only for sane_morphism(). */
-	const Gword **path; /* Linkage candidate wordgraph path */
+	Gwordlist *path;  /* Linkage candidate wordgraph path */
 };
 
 #endif

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -221,8 +221,9 @@ static dyn_str *wordgraph2dot(Sentence sent, unsigned int mode, const char *mode
 			/* In this mode nodes that are only unsplit_word are not shown. */
 			for (wu = sent->wordgraph; wu; wu = wu->chain_next)
 			{
+				Gword **wu_next_end = gwordlist_end(wu->next);
 				for (Gword **wp = gwordlist_begin(wu->next);
-								 wp != gwordlist_end(wu->next);
+								 wp != wu_next_end;
 								 wp = gwordlist_next(wu->next, wp))
 				{
 					if (w == *wp)
@@ -277,8 +278,9 @@ static dyn_str *wordgraph2dot(Sentence sent, unsigned int mode, const char *mode
 
 		dyn_strcat(wgd, "\"];\n");
 
+		Gword **w_next_end = gwordlist_end(w->next);
 		for (Gword **wp = gwordlist_begin(w->next);
-						 wp != gwordlist_end(w->next);
+						 wp != w_next_end;
 						 wp = gwordlist_next(w->next, wp))
 		{
 			append_string(wgd, "%s->\"%p\" [label=next color=red];\n",
@@ -286,8 +288,9 @@ static dyn_str *wordgraph2dot(Sentence sent, unsigned int mode, const char *mode
 		}
 		if (mode & WGR_PREV)
 		{
+			Gword **w_prev_end = gwordlist_end(w->prev);
 			for (Gword **wp = gwordlist_begin(w->prev);
-							 wp != gwordlist_end(w->prev);
+							 wp != w_prev_end;
 							 wp = gwordlist_next(w->prev, wp))
 			{
 				append_string(wgd, "%s->\"%p\" [label=prev color=blue];\n",

--- a/link-grammar/tokenize/wordgraph.c
+++ b/link-grammar/tokenize/wordgraph.c
@@ -201,8 +201,9 @@ bool wordgraph_pathpos_add(Wordgraph_pathpos **wp, Gword *p, bool used,
 void print_lwg_path(Gwordlist *gl, const char *title)
 {
 	lgdebug(+0, "%s: ", title);
+	Gword **w_end = gwordlist_end(gl);
 	for (Gword **w = gwordlist_begin(gl);
-	             w != gwordlist_end(gl);
+	             w != w_end;
 	             w = gwordlist_next(gl, w))
 	{
 		lgdebug(0, "%s ", (*w)->subword);

--- a/link-grammar/tokenize/wordgraph.h
+++ b/link-grammar/tokenize/wordgraph.h
@@ -2,6 +2,8 @@
 #define _WORDGRAPH_H
 
 #include "api-structures.h"
+#include "vc_vector/vc_vector.h"
+#include "utilities.h"
 
 #ifdef USE_WORDGRAPH_DISPLAY
 /* Wordgraph display representation modes. */
@@ -21,10 +23,7 @@
 #define IS_SENTENCE_WORD(sent, gword) (gword->unsplit_word == sent->wordgraph)
 
 Gword *gword_new(Sentence, const char *);
-size_t gwordlist_len(const Gword **);
-void gwordlist_append(Gword ***, Gword *);
 void gword_set_print(const gword_set *);
-void print_lwg_path(Gword **, const char *);
 Gword *wg_get_sentence_word(const Sentence, Gword *);
 #if 0
 void gwordlist_append_list(const Gword ***, const Gword **);
@@ -41,4 +40,81 @@ bool wordgraph_pathpos_add(Wordgraph_pathpos **, Gword *, bool, bool, bool);
 
 const char *gword_status(Sentence, const Gword *);
 const char *gword_morpheme(Sentence sent, const Gword *w);
+
+/* ======================= Gwordlist access methods ======================= */
+STYPEDEF(vc_vector, Gwordlist);
+
+void print_lwg_path(Gwordlist *, const char *);
+
+static inline Gwordlist *gwordlist_new(size_t n)
+{
+	return (Gwordlist *)vc_vector_create(n, sizeof(Gword *), NULL);
+}
+
+static inline void gwordlist_delete(const Gwordlist *gl)
+{
+	vc_vector_release((vc_vector *)gl);
+}
+
+static inline size_t gwordlist_len(const Gwordlist *gl)
+{
+	return vc_vector_count((vc_vector *)gl);
+}
+
+static inline bool gwordlist_append(Gwordlist *gl, Gword **p)
+{
+	return vc_vector_push_back((vc_vector *)gl, p);
+}
+
+static inline bool gwordlist_replace(Gwordlist *gl, size_t index, Gword **p)
+{
+	return vc_vector_replace((vc_vector *)gl, index, p);
+}
+
+/** Return a pointer to the gword pointer at the given index.
+ * If the index is is after the last element, return a pointer to
+ * a null pointer, to keep the code expectation (it originally referred
+ * directly to the gwordlist array elements, when the last one was NULL).
+ */
+static inline Gword **gwordlist_at(const Gwordlist *gl, size_t index)
+{
+	static Gword *null_gword = NULL;
+	if (index >= gwordlist_len(gl)) return &null_gword;
+
+	return (Gword **)vc_vector_at((vc_vector *)gl, index);
+}
+
+static inline Gwordlist *gwordlist_copy(const Gwordlist *gl)
+{
+	return (Gwordlist *)vc_vector_create_copy((vc_vector *)gl);
+}
+
+static inline bool gwordlist_empty(const Gwordlist *gl)
+{
+	return vc_vector_count((vc_vector *)gl) == 0;
+}
+
+/* ====== Gwordlist iteration ===== */
+/*
+ * for (Gword *gw = gwordlist_begin(gl);
+ *             gw != gwordlist_end(gl);
+ *             gw = gwordlist_next(gl, gw)) { ... }
+ */
+
+static inline Gword **gwordlist_begin(const Gwordlist *gl)
+{
+	return (Gword **)vc_vector_begin((vc_vector *)gl);
+}
+
+static inline Gword **gwordlist_end(const Gwordlist *gl)
+{
+	return (Gword **)vc_vector_end((vc_vector *)gl);
+}
+
+static inline Gword **gwordlist_next(const Gwordlist *gl, Gword **gp)
+{
+	return (Gword **)vc_vector_next((vc_vector *)gl, (void *)gp);
+}
+/* ======================================================================== */
+
 #endif /* _WORDGRAPH_H */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -508,4 +508,9 @@ static inline size_t next_power_of_two_up(size_t i)
 	return j;
 }
 
+/* "strict type" definition. E.g: STYPEDEF(vc_vector, g1); */
+#define STYPEDEF(type, name) \
+	struct name##_stypedef { int x; }; \
+	typedef struct name##_stypedef name
+
 #endif /* _LINK_GRAMMAR_UTILITIES_H_ */

--- a/link-grammar/vc_vector/LICENSE.md
+++ b/link-grammar/vc_vector/LICENSE.md
@@ -1,0 +1,21 @@
+#The MIT License (MIT)
+
+*Copyright (c) 2016 Skogorev Anton*
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/link-grammar/vc_vector/README.md
+++ b/link-grammar/vc_vector/README.md
@@ -1,0 +1,92 @@
+# vc_vector
+Fast simple C vector implementation
+
+[![Build Status: make && make test](https://travis-ci.org/skogorev/vc_vector.svg)](https://travis-ci.org/skogorev/vc_vector)
+
+## Usage
+
+### Basic
+```c
+#include "vc_vector.h"
+
+int main() {
+  // Creates an empty vector with the default reserved size
+  // and without custom deleter. Vector will contain 'int'
+  vc_vector* v = vc_vector_create(0, sizeof(int), NULL);
+  if (!v) {
+    return 1;
+  }
+
+  const int count = 10;
+  for (int i = 0; i < count; ++i) {
+    // The function takes a pointer to the elements,
+    // but the vector will make a copy of the element
+    vc_vector_push_back(v, &i);
+  }
+
+  // Print each vector element
+  for (void* i = vc_vector_begin(v);
+             i != vc_vector_end(v);
+             i = vc_vector_next(v, i)) {
+    printf("%u; ", *(int*)i);
+  }
+
+  vc_vector_release(v);
+  return 0;
+}
+```
+
+### Advanced
+```c
+#include "vc_vector.h"
+
+struct Item {
+  int val1;
+  int val2;
+};
+
+int main() {
+  const int n = 10;
+
+  // Creates an empty vector with the reserved size for the 'n' elements
+  // and with custom deleter 'free'. Vector will contain pointers to 'Item'
+  vc_vector* v = vc_vector_create(n, sizeof(struct Node*), free);
+  if (!v) {
+    return 1;
+  }
+
+  struct Item* item = NULL;
+  const int count = n + 1;
+  // Vector automatically increases the reserved size when 'n + 1' will be added
+  for (int i = 0; i < count; ++i) {
+    // Creating item
+    item = malloc(sizeof(struct Item));
+    if (!item) {
+      continue;
+    }
+
+    item->val1 = i;
+    item->val2 = 0;
+
+    // Pushing to the end of the vector
+    if (!vc_vector_push_back(v, item)) {
+      // If the item was not pushed, you have to delete it
+      free(item);
+    }
+  }
+
+  // ...
+
+  // Calls custom deleter 'free' for all items
+  // and releases the vector
+  vc_vector_release(v);
+  return 0;
+}
+```
+
+## Projects that use vc_vector
+[kraken.io](https://kraken.io/)
+
+## License
+
+[MIT License](LICENSE.md)

--- a/link-grammar/vc_vector/vc_vector.c
+++ b/link-grammar/vc_vector/vc_vector.c
@@ -22,7 +22,7 @@ struct vc_vector {
 
 // Auxiliary methods
 
-bool vc_vector_realloc(vc_vector* vector, size_t new_count) {
+static bool vc_vector_realloc(vc_vector* vector, size_t new_count) {
   const size_t new_size = new_count * vector->element_size;
   char* new_data = (char*)realloc(vector->data, new_size);
   if (!new_data) {
@@ -35,13 +35,13 @@ bool vc_vector_realloc(vc_vector* vector, size_t new_count) {
 }
 
 // [first_index, last_index)
-void vc_vector_call_deleter(vc_vector* vector, size_t first_index, size_t last_index) {
+static void vc_vector_call_deleter(vc_vector* vector, size_t first_index, size_t last_index) {
   for (size_t i = first_index; i < last_index; ++i) {
     vector->deleter(vc_vector_at(vector, i));
   }
 }
 
-void vc_vector_call_deleter_all(vc_vector* vector) {
+static void vc_vector_call_deleter_all(vc_vector* vector) {
   vc_vector_call_deleter(vector, 0, vc_vector_count(vector));
 }
 
@@ -112,15 +112,15 @@ bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2) {
   return memcmp(vector1->data, vector2->data, size_vector1) == 0;
 }
 
-float vc_vector_get_growth_factor() {
+float vc_vector_get_growth_factor(void) {
   return GROWTH_FACTOR;
 }
 
-size_t vc_vector_get_default_count_of_elements() {
+size_t vc_vector_get_default_count_of_elements(void) {
   return DEFAULT_COUNT_OF_ELEMENTS;
 }
 
-size_t vc_vector_struct_size() {
+size_t vc_vector_struct_size(void) {
   return sizeof(vc_vector);
 }
 

--- a/link-grammar/vc_vector/vc_vector.c
+++ b/link-grammar/vc_vector/vc_vector.c
@@ -1,0 +1,329 @@
+#include "vc_vector.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define GROWTH_FACTOR 1.5
+#define DEFAULT_COUNT_OF_ELEMENTS 8
+#define MINIMUM_COUNT_OF_ELEMENTS 2
+
+// ----------------------------------------------------------------------------
+
+// vc_vector structure
+
+struct vc_vector {
+  size_t count;
+  size_t element_size;
+  size_t reserved_size;
+  char* data;
+  vc_vector_deleter* deleter;
+};
+
+// ----------------------------------------------------------------------------
+
+// Auxiliary methods
+
+bool vc_vector_realloc(vc_vector* vector, size_t new_count) {
+  const size_t new_size = new_count * vector->element_size;
+  char* new_data = (char*)realloc(vector->data, new_size);
+  if (!new_data) {
+    return false;
+  }
+
+  vector->reserved_size = new_size;
+  vector->data = new_data;
+  return true;
+}
+
+// [first_index, last_index)
+void vc_vector_call_deleter(vc_vector* vector, size_t first_index, size_t last_index) {
+  for (size_t i = first_index; i < last_index; ++i) {
+    vector->deleter(vc_vector_at(vector, i));
+  }
+}
+
+void vc_vector_call_deleter_all(vc_vector* vector) {
+  vc_vector_call_deleter(vector, 0, vc_vector_count(vector));
+}
+
+// ----------------------------------------------------------------------------
+
+// Control
+
+vc_vector* vc_vector_create(size_t count_elements, size_t size_of_element, vc_vector_deleter* deleter) {
+  vc_vector* v = (vc_vector*)malloc(sizeof(vc_vector));
+  if (v != NULL) {
+    v->data = NULL;
+    v->count = 0;
+    v->element_size = size_of_element;
+    v->deleter = deleter;
+
+    if (count_elements < MINIMUM_COUNT_OF_ELEMENTS) {
+      count_elements = DEFAULT_COUNT_OF_ELEMENTS;
+    }
+
+    if (size_of_element < 1 ||
+                 !vc_vector_realloc(v, count_elements)) {
+      free(v);
+      v = NULL;
+    }
+  }
+
+  return v;
+}
+
+vc_vector* vc_vector_create_copy(const vc_vector* vector) {
+  vc_vector* new_vector = vc_vector_create(vector->reserved_size / vector->count,
+                                           vector->element_size,
+                                           vector->deleter);
+  if (!new_vector) {
+    return new_vector;
+  }
+
+  if (memcpy(vector->data,
+                      new_vector->data,
+                      new_vector->element_size * vector->count) == NULL) {
+    vc_vector_release(new_vector);
+    new_vector = NULL;
+    return new_vector;
+  }
+
+  new_vector->count = vector->count;
+  return new_vector;
+}
+
+void vc_vector_release(vc_vector* vector) {
+  if (vector->deleter != NULL) {
+    vc_vector_call_deleter_all(vector);
+  }
+
+  if (vector->reserved_size != 0) {
+    free(vector->data);
+  }
+
+  free(vector);
+}
+
+bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2) {
+  const size_t size_vector1 = vc_vector_size(vector1);
+  if (size_vector1 != vc_vector_size(vector2)) {
+    return false;
+  }
+
+  return memcmp(vector1->data, vector2->data, size_vector1) == 0;
+}
+
+float vc_vector_get_growth_factor() {
+  return GROWTH_FACTOR;
+}
+
+size_t vc_vector_get_default_count_of_elements() {
+  return DEFAULT_COUNT_OF_ELEMENTS;
+}
+
+size_t vc_vector_struct_size() {
+  return sizeof(vc_vector);
+}
+
+// ----------------------------------------------------------------------------
+
+// Element access
+
+void* vc_vector_at(vc_vector* vector, size_t index) {
+  return vector->data + index * vector->element_size;
+}
+
+void* vc_vector_front(vc_vector* vector) {
+  return vector->data;
+}
+
+void* vc_vector_back(vc_vector* vector) {
+  return vector->data + (vector->count - 1) * vector->element_size;
+}
+
+void* vc_vector_data(vc_vector* vector) {
+  return vector->data;
+}
+
+// ----------------------------------------------------------------------------
+
+// Iterators
+
+void* vc_vector_begin(vc_vector* vector) {
+  return vector->data;
+}
+
+void* vc_vector_end(vc_vector* vector) {
+  return vector->data + vector->element_size * vector->count;
+}
+
+void* vc_vector_next(vc_vector* vector, void* i) {
+  return (char *)i + vector->element_size;
+}
+
+// ----------------------------------------------------------------------------
+
+// Capacity
+
+bool vc_vector_empty(vc_vector* vector) {
+  return vector->count == 0;
+}
+
+size_t vc_vector_count(const vc_vector* vector) {
+  return vector->count;
+}
+
+size_t vc_vector_size(const vc_vector* vector) {
+  return vector->count * vector->element_size;
+}
+
+size_t vc_vector_max_count(const vc_vector* vector) {
+  return vector->reserved_size / vector->element_size;
+}
+
+size_t vc_vector_max_size(const vc_vector* vector) {
+  return vector->reserved_size;
+}
+
+bool vc_vector_reserve_count(vc_vector* vector, size_t new_count) {
+  if (new_count < vector->count) {
+    return false;
+  }
+
+  size_t new_size = vector->element_size * new_count;
+  if (new_size == vector->reserved_size) {
+    return true;
+  }
+
+  return vc_vector_realloc(vector, new_count);
+}
+
+bool vc_vector_reserve_size(vc_vector* vector, size_t new_size) {
+  return vc_vector_reserve_count(vector, new_size / vector->element_size);
+}
+
+// ----------------------------------------------------------------------------
+
+// Modifiers
+
+void vc_vector_clear(vc_vector* vector) {
+  if (vector->deleter != NULL) {
+    vc_vector_call_deleter_all(vector);
+  }
+
+  vector->count = 0;
+}
+
+bool vc_vector_insert(vc_vector* vector, size_t index, const void* value) {
+  if (vc_vector_max_count(vector) < vector->count + 1) {
+    if (!vc_vector_realloc(vector, vc_vector_max_count(vector) * GROWTH_FACTOR)) {
+      return false;
+    }
+  }
+
+  if (!memmove(vc_vector_at(vector, index + 1),
+                        vc_vector_at(vector, index),
+                        vector->element_size * (vector->count - index))) {
+
+    return false;
+  }
+
+  if (memcpy(vc_vector_at(vector, index),
+                      value,
+                      vector->element_size) == NULL) {
+    return false;
+  }
+
+  ++vector->count;
+  return true;
+}
+
+bool vc_vector_erase(vc_vector* vector, size_t index) {
+  if (vector->deleter != NULL) {
+    vector->deleter(vc_vector_at(vector, index));
+  }
+
+  if (!memmove(vc_vector_at(vector, index),
+                        vc_vector_at(vector, index + 1),
+                        vector->element_size * (vector->count - index))) {
+    return false;
+  }
+
+  vector->count--;
+  return true;
+}
+
+bool vc_vector_erase_range(vc_vector* vector, size_t first_index, size_t last_index) {
+  if (vector->deleter != NULL) {
+    vc_vector_call_deleter(vector, first_index, last_index);
+  }
+
+  if (!memmove(vc_vector_at(vector, first_index),
+                        vc_vector_at(vector, last_index),
+                        vector->element_size * (vector->count - last_index))) {
+    return false;
+  }
+
+  vector->count -= last_index - first_index;
+  return true;
+}
+
+bool vc_vector_append(vc_vector* vector, const void* values, size_t count) {
+  const size_t count_new = count + vc_vector_count(vector);
+
+  if (vc_vector_max_count(vector) < count_new) {
+    size_t max_count_to_reserved = vc_vector_max_count(vector) * GROWTH_FACTOR;
+    while (count_new > max_count_to_reserved) {
+      max_count_to_reserved *= GROWTH_FACTOR;
+    }
+
+    if (!vc_vector_realloc(vector, max_count_to_reserved)) {
+      return false;
+    }
+  }
+
+  if (memcpy(vector->data + vector->count * vector->element_size,
+                      values,
+                      vector->element_size * count) == NULL) {
+    return false;
+  }
+
+  vector->count = count_new;
+  return true;
+}
+
+bool vc_vector_push_back(vc_vector* vector, const void* value) {
+  if (!vc_vector_append(vector, value, 1)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool vc_vector_pop_back(vc_vector* vector) {
+  if (vector->deleter != NULL) {
+    vector->deleter(vc_vector_back(vector));
+  }
+
+  vector->count--;
+  return true;
+}
+
+bool vc_vector_replace(vc_vector* vector, size_t index, const void* value) {
+  if (vector->deleter != NULL) {
+    vector->deleter(vc_vector_at(vector, index));
+  }
+
+  return memcpy(vc_vector_at(vector, index),
+                value,
+                vector->element_size) != NULL;
+}
+
+bool vc_vector_replace_multiple(vc_vector* vector, size_t index, const void* values, size_t count) {
+  if (vector->deleter != NULL) {
+    vc_vector_call_deleter(vector, index, index + count);
+  }
+
+  return memcpy(vc_vector_at(vector, index),
+                values,
+                vector->element_size * count) != NULL;
+}

--- a/link-grammar/vc_vector/vc_vector.c
+++ b/link-grammar/vc_vector/vc_vector.c
@@ -266,22 +266,17 @@ bool vc_vector_erase_range(vc_vector* vector, size_t first_index, size_t last_in
 bool vc_vector_append(vc_vector* vector, const void* values, size_t count) {
   const size_t count_new = count + vc_vector_count(vector);
 
-  if (vc_vector_max_count(vector) < count_new) {
-    size_t max_count_to_reserved = vc_vector_max_count(vector) * GROWTH_FACTOR;
-    while (count_new > max_count_to_reserved) {
-      max_count_to_reserved *= GROWTH_FACTOR;
-    }
-
+  size_t new_size = count_new * vector->element_size;
+  if (new_size > vector->reserved_size) {
+    size_t max_count_to_reserved = new_size * GROWTH_FACTOR;
     if (!vc_vector_realloc(vector, max_count_to_reserved)) {
       return false;
     }
   }
 
-  if (memcpy(vector->data + vector->count * vector->element_size,
-                      values,
-                      vector->element_size * count) == NULL) {
-    return false;
-  }
+  memcpy(vector->data + vector->count * vector->element_size,
+         values,
+         vector->element_size * count);
 
   vector->count = count_new;
   return true;

--- a/link-grammar/vc_vector/vc_vector.c
+++ b/link-grammar/vc_vector/vc_vector.c
@@ -72,20 +72,16 @@ vc_vector* vc_vector_create(size_t count_elements, size_t size_of_element, vc_ve
 }
 
 vc_vector* vc_vector_create_copy(const vc_vector* vector) {
-  vc_vector* new_vector = vc_vector_create(vector->reserved_size / vector->count,
+  vc_vector* new_vector = vc_vector_create(vector->reserved_size / vector->element_size,
                                            vector->element_size,
                                            vector->deleter);
   if (!new_vector) {
     return new_vector;
   }
 
-  if (memcpy(vector->data,
-                      new_vector->data,
-                      new_vector->element_size * vector->count) == NULL) {
-    vc_vector_release(new_vector);
-    new_vector = NULL;
-    return new_vector;
-  }
+  memcpy(new_vector->data,
+                      vector->data,
+                      vector->element_size * vector->count);
 
   new_vector->count = vector->count;
   return new_vector;

--- a/link-grammar/vc_vector/vc_vector.h
+++ b/link-grammar/vc_vector/vc_vector.h
@@ -24,13 +24,13 @@ void vc_vector_release(vc_vector* vector);
 bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2);
 
 // Returns constant value of the vector growth factor.
-float vc_vector_get_growth_factor();
+float vc_vector_get_growth_factor(void);
 
 // Returns constant value of the vector default count of elements.
-size_t vc_vector_get_default_count_of_elements();
+size_t vc_vector_get_default_count_of_elements(void);
 
 // Returns constant value of the vector struct size.
-size_t vc_vector_struct_size();
+size_t vc_vector_struct_size(void);
 
 // ----------------------------------------------------------------------------
 // Element access

--- a/link-grammar/vc_vector/vc_vector.h
+++ b/link-grammar/vc_vector/vc_vector.h
@@ -1,0 +1,120 @@
+#ifndef VCVECTOR_H
+#define VCVECTOR_H
+
+#include <stdbool.h>
+#include <stdio.h>
+
+typedef struct vc_vector vc_vector;
+typedef void (vc_vector_deleter)(void *);
+
+// ----------------------------------------------------------------------------
+// Control
+// ----------------------------------------------------------------------------
+
+// Constructs an empty vector with an reserver size for count_elements.
+vc_vector* vc_vector_create(size_t count_elements, size_t size_of_element, vc_vector_deleter* deleter);
+
+// Constructs a copy of an existing vector.
+vc_vector* vc_vector_create_copy(const vc_vector* vector);
+
+// Releases the vector.
+void vc_vector_release(vc_vector* vector);
+
+// Compares vector content
+bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2);
+
+// Returns constant value of the vector growth factor.
+float vc_vector_get_growth_factor();
+
+// Returns constant value of the vector default count of elements.
+size_t vc_vector_get_default_count_of_elements();
+
+// Returns constant value of the vector struct size.
+size_t vc_vector_struct_size();
+
+// ----------------------------------------------------------------------------
+// Element access
+// ----------------------------------------------------------------------------
+
+// Returns the item at index position in the vector.
+void* vc_vector_at(vc_vector* vector, size_t index);
+
+// Returns the first item in the vector.
+void* vc_vector_front(vc_vector* vector);
+
+// Returns the last item in the vector.
+void* vc_vector_back(vc_vector* vector);
+
+// Returns a pointer to the data stored in the vector. The pointer can be used to access and modify the items in the vector.
+void* vc_vector_data(vc_vector* vector);
+
+// ----------------------------------------------------------------------------
+// Iterators
+// ----------------------------------------------------------------------------
+
+// Returns a pointer to the first item in the vector.
+void* vc_vector_begin(vc_vector* vector);
+
+// Returns a pointer to the imaginary item after the last item in the vector.
+void* vc_vector_end(vc_vector* vector);
+
+// Returns a pointer to the next element of vector after 'i'.
+void* vc_vector_next(vc_vector* vector, void* i);
+
+// ----------------------------------------------------------------------------
+// Capacity
+// ----------------------------------------------------------------------------
+
+// Returns true if the vector is empty; otherwise returns false.
+bool vc_vector_empty(vc_vector* vector);
+
+// Returns the number of elements in the vector.
+size_t vc_vector_count(const vc_vector* vector);
+
+// Returns the size (in bytes) of occurrences of value in the vector.
+size_t vc_vector_size(const vc_vector* vector);
+
+// Returns the maximum number of elements that the vector can hold.
+size_t vc_vector_max_count(const vc_vector* vector);
+
+// Returns the maximum size (in bytes) that the vector can hold.
+size_t vc_vector_max_size(const vc_vector* vector);
+
+// Resizes the container so that it contains n elements.
+bool vc_vector_reserve_count(vc_vector* vector, size_t new_count);
+
+// Resizes the container so that it contains new_size / element_size elements.
+bool vc_vector_reserve_size(vc_vector* vector, size_t new_size);
+
+// ----------------------------------------------------------------------------
+// Modifiers
+// ----------------------------------------------------------------------------
+
+// Removes all elements from the vector (without reallocation).
+void vc_vector_clear(vc_vector* vector);
+
+// The container is extended by inserting a new element at position.
+bool vc_vector_insert(vc_vector* vector, size_t index, const void* value);
+
+// Removes from the vector a single element by 'index'
+bool vc_vector_erase(vc_vector* vector, size_t index);
+
+// Removes from the vector a range of elements '[first_index, last_index)'.
+bool vc_vector_erase_range(vc_vector* vector, size_t first_index, size_t last_index);
+
+// Inserts multiple values at the end of the vector.
+bool vc_vector_append(vc_vector* vector, const void* values, size_t count);
+
+// Inserts value at the end of the vector.
+bool vc_vector_push_back(vc_vector* vector, const void* value);
+
+// Removes the last item in the vector.
+bool vc_vector_pop_back(vc_vector* vector);
+
+// Replace value by index in the vector.
+bool vc_vector_replace(vc_vector* vector, size_t index, const void* value);
+
+// Replace multiple values by index in the vector.
+bool vc_vector_replace_multiple(vc_vector* vector, size_t index, const void* values, size_t count);
+
+#endif // VCVECTOR_H

--- a/link-grammar/vc_vector/vc_vector_test.c
+++ b/link-grammar/vc_vector/vc_vector_test.c
@@ -1,0 +1,353 @@
+#include "vc_vector_test.h"
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include "vc_vector.h"
+
+#define ASSERT_EQ(expected, actual)                                          \
+  do {                                                                       \
+    if ((expected) != (actual)) {                                            \
+      fprintf(stderr,                                                        \
+              "Failed line %u. Expected: %"PRIuMAX". Actual: %"PRIuMAX".\n", \
+              __LINE__, (uintmax_t)(expected), (uintmax_t)(actual));         \
+      abort();                                                               \
+    }                                                                        \
+  } while (0)
+
+#define ASSERT_NE(not_expected, actual)                                 \
+  do {                                                                  \
+    if ((not_expected) == (actual)) {                                   \
+      fprintf(stderr,                                                   \
+              "Failed line %u. Unexpected actual value: %"PRIuMAX".\n", \
+             __LINE__, (uintmax_t)(actual));                            \
+      abort();                                                          \
+    }                                                                   \
+  } while (0)
+
+#define ASSERT_TRUE(actual) ASSERT_EQ(true, (actual))
+
+#define ASSERT_FALSE(actual) ASSERT_EQ(false, (actual))
+
+#define PRINT_VECTOR(vector, type, format)   \
+  do {                                       \
+    for (void* i = vc_vector_begin(vector);  \
+         i != vc_vector_end(vector);         \
+         i = vc_vector_next(vector, i)) {    \
+      fprintf(stderr, format, *(type*)i);    \
+    }                                        \
+    fprintf(stderr, "\n");                   \
+  } while (0)
+
+#define PRINT_VECTOR_INT(vector) PRINT_VECTOR(vector, int, "%d; ")
+#define PRINT_VECTOR_STR(vector) PRINT_VECTOR(vector, char *, "%s; ")
+
+char *mystrdup(const char *s) {
+  size_t size = strlen(s) + 1;
+  char *copy = malloc(size);
+  if (copy != NULL)
+    memcpy(copy, s, size);
+  return copy;
+}
+
+// ----------------------------------------------------------------------------
+
+void test_vc_vector_create() {
+  const size_t size_of_type = sizeof(int);
+  const size_t default_count_of_elements = vc_vector_get_default_count_of_elements();
+
+  // Creating vector with default count of elements
+  vc_vector* vector = vc_vector_create(0, size_of_type, NULL);
+  ASSERT_NE(NULL, vector);
+  ASSERT_EQ(0, vc_vector_count(vector));
+  ASSERT_EQ(0, vc_vector_size(vector));
+  ASSERT_EQ(default_count_of_elements, vc_vector_max_count(vector));
+  ASSERT_EQ(size_of_type * default_count_of_elements, vc_vector_max_size(vector));
+  vc_vector_release(vector);
+
+  // Creating vector with custom count of elements
+  const size_t test_count_of_elements = 7;
+  vector = vc_vector_create(test_count_of_elements, size_of_type, NULL);
+  ASSERT_NE(NULL, vector);
+  ASSERT_EQ(0, vc_vector_count(vector));
+  ASSERT_EQ(0, vc_vector_size(vector));
+  ASSERT_EQ(test_count_of_elements, vc_vector_max_count(vector));
+  ASSERT_EQ(size_of_type * test_count_of_elements, vc_vector_max_size(vector));
+  vc_vector_release(vector);
+
+  // Creating vector with zero size of single element
+  vector = vc_vector_create(0, 0, NULL);
+  ASSERT_EQ(NULL, vector);
+
+  // Creating copy of vector
+  vector = vc_vector_create(0, size_of_type, NULL);
+  ASSERT_NE(NULL, vector);
+  for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
+  }
+
+  vc_vector* vector_copy = vc_vector_create_copy(vector);
+  ASSERT_NE(NULL, vector_copy);
+  ASSERT_TRUE(vc_vector_is_equals(vector, vector_copy));
+
+  vc_vector_release(vector_copy);
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
+void test_vc_vector_element_access() {
+  const int test_num_start = 18;
+  const int test_num_end = 36;
+  const size_t size_of_type = sizeof(test_num_start);
+
+  vc_vector* vector = vc_vector_create(0, size_of_type, NULL);
+  ASSERT_NE(0, vector);
+  for (int i = test_num_start; i <= test_num_end; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
+  }
+
+  ASSERT_EQ(test_num_start, *(int*)vc_vector_front(vector));
+  ASSERT_EQ(test_num_start, *(int*)vc_vector_data(vector));
+  ASSERT_EQ(test_num_end, *(int*)vc_vector_back(vector));
+
+  for (int i = test_num_start, j = 0; i <= test_num_end; ++i, ++j) {
+    ASSERT_EQ(i, *(int*)vc_vector_at(vector, j));
+  }
+
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
+void test_vc_vector_iterators() {
+  vc_vector* vector = vc_vector_create(0, sizeof(int), NULL);
+  ASSERT_NE(NULL, vector);
+
+  const size_t test_count_of_elements = 23;
+  for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
+  }
+
+  int j = 0;
+  for (void* i = vc_vector_begin(vector);
+       i != vc_vector_end(vector);
+       i = vc_vector_next(vector, i), ++j) {
+    ASSERT_EQ(j, *(int*)i);
+  }
+
+  ASSERT_EQ(test_count_of_elements, (size_t)j);
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
+void test_vc_vector_capacity() {
+  const size_t size_of_element = sizeof(int);
+  const float growth_factor = vc_vector_get_growth_factor();
+  ASSERT_EQ(1.5, growth_factor);
+
+  const size_t count_of_elements_initialized = 22;
+  const size_t max_size_of_vector_initialized = count_of_elements_initialized * size_of_element;
+  const size_t count_of_elements_ended = 23;
+  const size_t size_of_vector_ended = count_of_elements_ended * size_of_element;
+  const size_t max_count_of_vector_ended = count_of_elements_initialized * growth_factor;
+  const size_t max_size_of_vector_ended = max_count_of_vector_ended * size_of_element;
+
+  vc_vector* vector = vc_vector_create(count_of_elements_initialized, size_of_element, NULL);
+  ASSERT_NE(NULL, vector);
+
+  ASSERT_EQ(0, vc_vector_count(vector));
+  ASSERT_TRUE(vc_vector_empty(vector));
+  ASSERT_EQ(0, vc_vector_size(vector));
+  ASSERT_EQ(count_of_elements_initialized, vc_vector_max_count(vector));
+  ASSERT_EQ(max_size_of_vector_initialized, vc_vector_max_size(vector));
+
+  for (int i = 0; (size_t)i < count_of_elements_ended; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
+  }
+
+  ASSERT_EQ(count_of_elements_ended, vc_vector_count(vector));
+  ASSERT_FALSE(vc_vector_empty(vector));
+  ASSERT_EQ(size_of_vector_ended, vc_vector_size(vector));
+  ASSERT_EQ(max_count_of_vector_ended, vc_vector_max_count(vector));
+  ASSERT_EQ(max_size_of_vector_ended, vc_vector_max_size(vector));
+
+  const size_t test_reserve_count_fail = 10;
+  ASSERT_FALSE(vc_vector_reserve_count(vector, test_reserve_count_fail));
+
+  const size_t test_reserve_count = 35;
+  ASSERT_TRUE(vc_vector_reserve_count(vector, test_reserve_count));
+  ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
+  ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
+
+  // Second time with the same value
+  ASSERT_TRUE(vc_vector_reserve_count(vector, test_reserve_count));
+  ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
+  ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
+
+  const size_t test_reserve_size = 123 * size_of_element;
+  ASSERT_TRUE(vc_vector_reserve_size(vector, test_reserve_size));
+  ASSERT_EQ(test_reserve_size / size_of_element, vc_vector_max_count(vector));
+  ASSERT_EQ(test_reserve_size, vc_vector_max_size(vector));
+
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
+void test_vc_vector_modifiers() {
+  const int begin[] = {
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
+  };
+  const size_t size_of_element = sizeof(begin[0]);
+  const size_t count_of_elements = sizeof(begin) / size_of_element;
+
+  // After deleting first, last and one middle elements
+  const int after_deleting_some_elements[] = {
+    /* 1, */ 2, 3, 4, 5, 6, 7, 8, 9, 10, /* 11, */ 12, 13, 14, 15, 16, 17, 18, 19, /* 20 */
+  };
+
+  // After deleting first 3 elemets from begin, 4 from middle and 3 from end
+  const int after_deleting_some_ranges[] = {
+    /* 1, 2, 3, */ 4, 5, 6, 7, 8, /* 9, 10, 11, 12, */ 13, 14, 15, 16, 17, /* 18, 19, 20 */
+  };
+
+  vc_vector* vector = vc_vector_create(0, size_of_element, NULL);
+  ASSERT_NE(NULL, vector);
+
+  // Append test
+
+  ASSERT_TRUE(vc_vector_append(vector, begin, count_of_elements));
+
+  ASSERT_EQ(count_of_elements, vc_vector_count(vector));
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
+    ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
+  }
+
+  // Pop back test
+
+  while (vc_vector_count(vector) > 0) {
+    ASSERT_TRUE(vc_vector_pop_back(vector));
+  }
+
+  ASSERT_TRUE(vc_vector_empty(vector));
+
+  // Push back test
+
+  for (size_t i = 0; i < count_of_elements; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &begin[i]));
+  }
+
+  ASSERT_EQ(count_of_elements, vc_vector_count(vector));
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
+    ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
+  }
+
+  // Erase test
+
+  vc_vector_clear(vector);
+  ASSERT_TRUE(vc_vector_append(vector, begin, count_of_elements));
+
+  ASSERT_TRUE(vc_vector_erase(vector, 0));
+  ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) - 1));
+  ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) / 2));
+
+  ASSERT_EQ(sizeof(after_deleting_some_elements) / size_of_element, vc_vector_count(vector));
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
+    ASSERT_EQ(after_deleting_some_elements[i], *(int*)vc_vector_at(vector, i));
+  }
+
+  // Erase range test
+
+  vc_vector_clear(vector);
+  ASSERT_TRUE(vc_vector_append(vector, begin, count_of_elements));
+
+  ASSERT_TRUE(vc_vector_erase_range(vector, 0, 3));
+  ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) - 3, vc_vector_count(vector)));
+  ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) / 2 - 2, vc_vector_count(vector) / 2 + 2));
+
+  ASSERT_EQ(sizeof(after_deleting_some_ranges) / size_of_element, vc_vector_count(vector));
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
+    ASSERT_EQ(after_deleting_some_ranges[i], *(int*)vc_vector_at(vector, i));
+  }
+
+  // Insert test
+
+  vc_vector_clear(vector);
+  for (size_t i = 1; i < count_of_elements - 1; ++i) {
+    ASSERT_TRUE(vc_vector_insert(vector, i - 1, &begin[i]));
+  }
+
+  ASSERT_TRUE(vc_vector_insert(vector, 0, &begin[0]));
+  ASSERT_TRUE(vc_vector_insert(vector, vc_vector_count(vector), &begin[count_of_elements - 1]));
+
+  ASSERT_EQ(count_of_elements, vc_vector_count(vector));
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
+    ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
+  }
+
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
+void test_vc_vector_strfreefunc(void *data) {
+  free(*(char **)data);
+}
+
+void test_vc_vector_with_strfreefunc() {
+  // creates a vector of pointers to char, i.e. a vector of variable sized strings
+  vc_vector* vector = vc_vector_create(3, sizeof(char *), test_vc_vector_strfreefunc);
+  ASSERT_NE(NULL, vector);
+
+  char *strs[] = {
+    mystrdup("abcde"),
+    mystrdup("edcba"),
+    mystrdup("1234554321"),
+    mystrdup("!@#$%"),
+    mystrdup("not empty string"),
+    mystrdup(""),
+    mystrdup("Hello World"),
+    mystrdup("xxxxx"),
+    mystrdup("yyyyy")
+  };
+
+  for (size_t i = 0; i < 3; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &strs[i]));
+  }
+
+  ASSERT_EQ(3, vc_vector_count(vector));
+
+  for (size_t i = 3; i < 6; ++i) {
+    ASSERT_TRUE(vc_vector_insert(vector, i, &strs[i]));
+  }
+
+  ASSERT_EQ(6, vc_vector_count(vector));
+  vc_vector_clear(vector); // strs[0-6] were freed
+  ASSERT_EQ(0, vc_vector_count(vector));
+
+  for (size_t i = 6; i < 9; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &strs[i]));
+  }
+
+  ASSERT_EQ(3, vc_vector_count(vector));
+
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
+void vc_vector_run_tests() {
+  test_vc_vector_create();
+  test_vc_vector_element_access();
+  test_vc_vector_iterators();
+  test_vc_vector_capacity();
+  test_vc_vector_modifiers();
+  test_vc_vector_with_strfreefunc();
+}
+
+int main() {
+ vc_vector_run_tests();
+ printf("Tests passed.\n");
+ return 0;
+}

--- a/link-grammar/vc_vector/vc_vector_test.h
+++ b/link-grammar/vc_vector/vc_vector_test.h
@@ -1,0 +1,6 @@
+#ifndef VCVECTORTESTS_H
+#define VCVECTORTESTS_H
+
+void vc_vector_run_tests();
+
+#endif // VCVECTORTESTS_H


### PR DESCRIPTION
The vector implementation is from https://github.com/augfab/vc_vector.
The original is https://github.com/skogorev/vc_vector but it is not maintained.
I had to fix many compilation warnings, and bad bugs in one function. I also improved performance of appending elements by converting a division to multiplication in the memory size computation.

There is still a small room for performance improvement of `vc_vector` by holding the current memory size in the vector header. Currently, this size is computed by multiplication on each append and vector-end operations. In addition, the implementation is small enough to maybe put in a header file for inlining.

It is also possible to improve the relevant LG code to make much less use of vector copy
(by moving the vector to the next word in case no alternatives are involved). Much of the Gword vector use can also be eliminated for sentences that don't have optional words. But for now I will put the efforts in the other WIP changes.


Benchmarks of `en` >"basic"/"fixes" doesn't indicate a performance change.
For Russian I saw about  ~1% speedup.
For long sentences there is about ~1% slowness, but didn't do too many tests ( 3x3 test as opposed to a 15x5 test for "basic"/"fixes").

