### PR TITLE
left_connector_list_update(I): Bug fix - ub may be too big

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -604,7 +604,7 @@ right_connector_list_update(prune_context *pc, Connector *c,
 
 	/* ub is now the rightmost word we need to check */
 	ub = w + c->length_limit;
-	if (ub > sent_length) ub = sent_length - 1;
+	if (ub >= sent_length) ub = sent_length - 1;
 
 	/* n is now the leftmost word we need to check */
 	for (; n <= ub ; n++)


### PR DESCRIPTION
`ub` may be equal to sent_length, and refer beyond the end of the `l_table` (will actually refer to `r_table[0]`).

Because it refers to a valid address, no memory access fault may happen.
It is also undetected by ASAN etc.

Here is how come it refers to the first element of the next table:
``` c
    215         pt->l_table_size = xalloc (2 * sent->length * sizeof(unsigned int));
    216         pt->r_table_size = pt->l_table_size + sent->length;
```
In principle it may cause wrong results due to the lookup in the wrong table.

We have some more similar "continuous allocations" that in principle could have such problems.
`assert()` calls can be added in places they are accessed,  but this may add to the runtime.
Maybe we can define `dassert()` to be an assert in debug mode only, and then it can be used deliberately and even in critical sections.