### PR TITLE
Development infrastructure

### DIFF
--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -276,6 +276,7 @@ static bool char_is_special(char c)
  * This reads the next token from the input into 'token'.
  * Return 1 if a character was read, else return 0 (and print a warning).
  */
+NO_SAN_DICT
 static bool link_advance(Dictionary dict)
 {
 	utf8char c;
@@ -489,6 +490,7 @@ int dict_order_strict(char *s, char *t)
 
 /* terse version */
 /* If one word contains a dot, the other one must also! */
+NO_SAN_DICT
 static inline int dict_order_strict(const char *s, const Dict_node * dn)
 {
 	const char * t = dn->string;
@@ -511,7 +513,7 @@ static inline int dict_order_strict(const char *s, const Dict_node * dn)
  * If the dictionary string contains a SUBSCRIPT_MARK, then replace the
  * mark by "\0", and take the difference.
  */
-
+NO_SAN_DICT
 static inline int dict_order_bare(const char *s, const Dict_node * dn)
 {
 	const char * t = dn->string;
@@ -1495,6 +1497,7 @@ static Dict_node * dsw_tree_to_vine (Dict_node *root)
 	return vh.right;
 }
 
+NO_SAN_DICT
 static void dsw_compression (Dict_node *root, unsigned int count)
 {
 	unsigned int j;
@@ -1545,6 +1548,7 @@ static Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
  * The resulting tree is highly unbalanced. It needs to be rebalanced
  * before being used.  The DSW algo below is ideal for that.
  */
+NO_SAN_DICT
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
 {
 	if (NULL == n) return newnode;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -467,16 +467,32 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
 
 
 /* ================ Pack disjuncts and connectors ============== */
+/* Print one connector with all the details.
+ * mCnameD<suffix_id>(nearest_word, length_limit)x
+ * optional m: "@" for multi (else nothing)
+ * Cname: Connector name
+ * Optional D: "-" / "+" (if dir != -1)
+ * Optional <suffix>: suffix_id (if not 0)
+ * Optional (nearest_word, length_limit): if both are not 0
+ * x: Shallow/deep indication as "s" / "d" (if shallow != -1)
+ */
+void print_one_connector(Connector * e, int dir, int shallow)
+{
+	printf("%s%s", e->multi ? "@" : "", connector_string(e));
+	if (-1 != dir) printf("%c", "-+"[dir]);
+	if (e->suffix_id)
+		printf("<%d>", e->suffix_id);
+	if ((0 != e->nearest_word) || (0 != e->length_limit))
+		printf("(%d,%d)", e->nearest_word, e->length_limit);
+	if (-1 != shallow)
+		printf("%c", (0 == shallow) ? 'd' : 's');
+}
+
 void print_connector_list(Connector * e)
 {
 	for (;e != NULL; e=e->next)
 	{
-		printf("%s%s", e->multi ? "@" : "", connector_string(e));
-		if (e->suffix_id)
-			printf("<%d>", e->suffix_id);
-		if ((0 != e->nearest_word) || (0 != e->length_limit))
-			printf("(%d,%d)", e->nearest_word, e->length_limit);
-
+		print_one_connector(e, /*dir*/-1, /*shallow*/-1);
 		if (e->next != NULL) printf(" ");
 	}
 }

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -55,6 +55,7 @@ bool pack_sentence(Sentence);
 void share_disjunct_jets(Sentence, bool);
 void free_jet_sharing(Sentence);
 
+void print_one_connector(Connector *, int, int);
 void print_connector_list(Connector *);
 void print_disjunct_list(Disjunct *);
 void print_all_disjuncts(Sentence);

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -122,19 +122,6 @@ static void build_sentence_disjuncts(Sentence sent, double cost_cutoff,
 	}
 }
 
-#if 0
-static void print_connector_list(const char *s, const char *t, Connector * e)
-{
-	printf("%s %s: ", s, t);
-	for (;e != NULL; e=e->next)
-	{
-		printf("%s%s", e->multi?"@":"", connector_string(e));
-		if (e->next != NULL) printf(" ");
-	}
-	printf("\n");
-}
-#endif
-
 /**
  * Assumes that the sentence expression lists have been generated.
  */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -258,10 +258,22 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 #define UNREACHABLE(x) (__extension__ ({if (x) __builtin_unreachable();}))
 #define GNUC_MALLOC __attribute__ ((malloc))
 #define GNUC_UNUSED __attribute__ ((unused))
+#define NO_SAN __attribute__ ((no_sanitize_address, no_sanitize_undefined))
+
+/* Define when configuring with ASAN/UBSAN - for fast dict load (of course
+ * only when not debugging dict code.) */
+#ifdef NO_SAN_DICT
+#undef NO_SAN_DICT
+#define NO_SAN_DICT NO_SAN
+#else
+#define NO_SAN_DICT
+#endif
+
 #else
 #define UNREACHABLE(x)
 #define GNUC_MALLOC
 #define GNUC_UNUSED
+#define NO_SAN_DICT
 #endif
 
 


### PR DESCRIPTION
Two additions:
- Add definition NO_SAN_DICT
It prevents much wasted time when using ASAN/UBSAN. Just also add `-DNO_SAN_DICT` to the configuration flags. Of course this shouldn't be used when developing dict code.
- Add print_one_connector()
It is designed to be used when printing connector tables for debug.