### PR TITLE
Small efficiency fixes

### DIFF
--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -119,15 +119,13 @@ static int max_postfix_found(Dict_node * d)
 static const char * build_idiom_word_name(Dictionary dict, const char * s)
 {
 	char buff[2*MAX_WORD];
-	size_t bufsz = 2*MAX_WORD;
 	int count;
 
 	Dict_node *dn = dictionary_lookup_list(dict, s);
 	count = max_postfix_found(dn) + 1;
 	free_lookup_list(dict, dn);
 
-	size_t l = lg_strlcpy(buff, s, bufsz);
-	snprintf(buff+l, bufsz-l, "%cI%d", SUBSCRIPT_MARK, count);
+	snprintf(buff, sizeof(buff), "%s%cI%d", s, SUBSCRIPT_MARK, count);
 
 	return string_set_add(buff, dict->string_set);
 }

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -591,7 +591,7 @@ static inline Dict_node * dict_node_new(void)
  * not match the dictionary string s. The matching is dictionary matching:
  * subscripted entries will match "bare" entries.
  */
-static Dict_node * prune_lookup_list(Dict_node *llist, const char * s)
+static Dict_node * prune_lookup_list(Dict_node * restrict llist, const char * restrict s)
 {
 	Dict_node *dn, *dnx, *list_new;
 
@@ -643,9 +643,9 @@ static bool subscr_match(const char *s, const Dict_node * dn)
  * make a copy of that node, and append it to llist.
  */
 static Dict_node *
-rdictionary_lookup(Dict_node *llist,
-                   const Dict_node * dn,
-                   const char * s,
+rdictionary_lookup(Dict_node * restrict llist,
+                   const Dict_node * restrict dn,
+                   const char * restrict s,
                    bool match_idiom,
                    int (*dict_order)(const char *, const Dict_node *))
 {

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -786,13 +786,13 @@ static void enumerate_connector_suffixes(pack_context *pc, Disjunct *d)
 		{
 			if ((*cp)->multi)
 				cstr[l++] = '@'; /* May have different linkages. */
-			l += lg_strlcpy(cstr+l, connector_string((*cp)), sizeof(cstr)-l);
+			l += lg_strlcpy(cstr+l, connector_string(*cp), sizeof(cstr)-l);
 
 			if (l > sizeof(cstr)-2)
 			{
 				/* This is improbable, given the big cstr buffer. */
-				prt_error("Warning: set_connector_hash(): Buffer overflow.\n"
-							 "Parsing may be wrong.\n");
+				prt_error("Warning: enumerate_connector_suffixes(): "
+				          "Buffer overflow.\nParsing may be wrong.\n");
 			}
 
 			int id = string_id_add(cstr, pc->csid) + WORD_OFFSET;
@@ -1138,8 +1138,8 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 				if (l > sizeof(cstr)-2)
 				{
 					/* This is improbable, given the big cstr buffer. */
-					prt_error("Warning: share_disjunct_jets(): Buffer overflow.\n"
-								 "Parsing may be wrong.\n");
+					prt_error("Warning: share_disjunct_jets(): "
+					          "Buffer overflow.\nParsing may be wrong.\n");
 				}
 
 				if (jet_table_entries[dir] + 1 >= jet_table_size[dir])

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -583,7 +583,7 @@ static Connector *pack_connectors(pack_context *pc, Connector *origc, int dir)
 			{
 				/* The first time we encounter this connector sequence.
 				 * It will be copied to this cached location (below). */
-				cblock_index = lcblock - pc->cblock_base;
+				cblock_index = (int)(lcblock - pc->cblock_base);
 				pc->id_table[id_index] = cblock_index;
 			}
 			else
@@ -602,7 +602,7 @@ static Connector *pack_connectors(pack_context *pc, Connector *origc, int dir)
 					newc = NULL; /* Don't share it. */
 
 					/* Slightly increase cache hit (MRU). */
-					cblock_index = lcblock - pc->cblock_base;
+					cblock_index = (int)(lcblock - pc->cblock_base);
 					pc->id_table[id_index] = cblock_index;
 				}
 #if 1 /* Extra validation - validate the next connectors in the sequence. */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1110,8 +1110,6 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 		Disjunct *prev = &head;
 		unsigned int numc[2] = {0}; /* Current word different connectors. */
 
-		char cstr[((MAX_LINK_NAME_LENGTH + 3) * MAX_LINKS)];
-
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
 		{
 			Disjunct *n = pool_alloc(sent->Disjunct_pool);
@@ -1119,11 +1117,12 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 			prev->next = n;
 			prev = n;
 
+			char cstr[((MAX_LINK_NAME_LENGTH + 3) * MAX_LINKS)];
+			cstr[0] = (char)(w + 1); /* Avoid '\0'. */
+
 			for (int dir = 0; dir < 2; dir ++)
 			{
-				cstr[0] = "-+"[dir];
-				cstr[1] = (char)(w + 1); /* Avoid '\0'. */
-				size_t l = 2;
+				size_t l = 1;
 
 				Connector *first_c = (0 == dir) ? d->left : d->right;
 				if (NULL == first_c) continue;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -710,7 +710,7 @@ static int enumerate_connectors_sequentially(Sentence sent)
 	return id + 1;
 }
 
-#define CONSEP "&"      /* Connector string separator in the suffix sequence. */
+#define CONSEP '&'      /* Connector string separator in the suffix sequence. */
 #define MAX_LINK_NAME_LENGTH 10 // XXX Use a global definition
 #define MAX_LINKS 20            // XXX Use a global definition
 
@@ -788,7 +788,7 @@ static void enumerate_connector_suffixes(pack_context *pc, Disjunct *d)
 				cstr[l++] = '@'; /* May have different linkages. */
 			l += lg_strlcpy(cstr+l, connector_string(*cp), sizeof(cstr)-l);
 
-			if (l > sizeof(cstr)-2)
+			if (l > sizeof(cstr)-2) /* Leave room for CONSEP */
 			{
 				/* This is improbable, given the big cstr buffer. */
 				prt_error("Warning: enumerate_connector_suffixes(): "
@@ -799,8 +799,8 @@ static void enumerate_connector_suffixes(pack_context *pc, Disjunct *d)
 			(*cp)->suffix_id = id;
 			//printf("ID %d trail=%s\n", id, cstr);
 
-			if (cp != &cstack[0]) /* Efficiency. */
-				l += lg_strlcpy(cstr+l, CONSEP, sizeof(cstr)-l);
+			if (cp != &cstack[0]) /* string_id_add() efficiency. */
+				cstr[l++] = CONSEP;
 		}
 	}
 }
@@ -1132,8 +1132,9 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 					if (c->multi)
 						cstr[l++] = '@'; /* Why does this matter for power pruning? */
 					l += lg_strlcpy(cstr+l, connector_string(c), sizeof(cstr)-l);
-					if (NULL != c->next) /* Efficiency. */
-						l += lg_strlcpy(cstr+l, CONSEP, sizeof(cstr)-l);
+					if (l > sizeof(cstr)-3) break;  /* Leave room for CONSEP + '@' */
+					if (NULL != c->next) /* string_id_add() efficiency. */
+						cstr[l++] = CONSEP;
 				}
 				if (l > sizeof(cstr)-2)
 				{

--- a/link-grammar/lg_assert.h
+++ b/link-grammar/lg_assert.h
@@ -36,3 +36,9 @@
 		DEBUG_TRAP;  /* leave stack trace in debugger */                      \
 	}                                                                        \
 }
+
+#ifdef DEBUG
+#define dassert assert
+#else
+#define dassert(...)
+#endif

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -58,7 +58,6 @@ void lg_compute_disjunct_strings(Linkage lkg)
 
 	if (lkg->disjunct_list_str) return;
 	lkg->disjunct_list_str = malloc(nwords * sizeof(char *));
-	memset(lkg->disjunct_list_str, 0, nwords * sizeof(char *));
 
 	for (WordIdx w = 0; w < nwords; w++)
 	{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -971,10 +971,9 @@ static void insert_in_cms_table(multiset_table *cmt, Connector *c)
 		/* MRU order */
 		if (prev != NULL)
 		{
-			Cms *t = cms->next;
+			prev->next = cms->next;
 			cms->next = cmt->cms_table[h];
 			cmt->cms_table[h] = cms;
-			prev->next = t;
 		}
 	}
 }

--- a/link-grammar/tokenize/regex-tokenizer.c
+++ b/link-grammar/tokenize/regex-tokenizer.c
@@ -221,7 +221,7 @@ static void printov(const char *str, ov_t *pov, int top, callout_data_t *cd, boo
 			{
 				if ('a' == cgnump->lookup_mark_pos)
 				{
-					safe_strcpy(lookup_mark, cgnump->lookup_mark, sizeof(lookup_mark));
+					lg_strlcpy(lookup_mark, cgnump->lookup_mark, sizeof(lookup_mark));
 					sm = strrchr(lookup_mark, SUBSCRIPT_MARK);
 					if (NULL != sm) *sm = '.';
 					a = lookup_mark;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3429,7 +3429,7 @@ bool sentence_in_dictionary(Sentence sent)
 			{
 				if (ok_so_far)
 				{
-					safe_strcpy(temp, "The following words are not in the dictionary:", sizeof(temp));
+					lg_strlcpy(temp, "The following words are not in the dictionary:", sizeof(temp));
 					ok_so_far = false;
 				}
 				safe_strcat(temp, " \"", sizeof(temp));

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -64,17 +64,50 @@ void safe_strcpy(char *u, const char * v, size_t usize)
 /**
  * A version of strlcpy, for those systems that don't have it.
  */
-size_t lg_strlcpy(char * dest, const char *src, size_t size)
+/*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t
+lg_strlcpy(char * restrict dst, const char * restrict src, size_t dsize)
 {
-	size_t i=0;
-	while ((i<size) && (src[i] != 0x0))
-	{
-		dest[i] = src[i];
-		i++;
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
 	}
-	if (i < size) { dest[i] = 0x0; size = i; }
-	else if (0 < size) { size --; dest[size] = 0x0;}
-	return size;
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';      /* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1); /* count does not include NUL */
 }
 
 /**

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -52,16 +52,6 @@ char *safe_strdup(const char *u)
 }
 
 /**
- * Copies as much of v into u as it can assuming u is of size usize
- * guaranteed to terminate u with a '\0'.
- */
-void safe_strcpy(char *u, const char * v, size_t usize)
-{
-	strncpy(u, v, usize-1);
-	u[usize-1] = '\0';
-}
-
-/**
  * A version of strlcpy, for those systems that don't have it.
  */
 /*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
@@ -270,7 +260,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t local
 
 	from += nbh;
 	to += nbl;
-	safe_strcpy(to, from, usize-nbl);
+	lg_strlcpy(to, from, usize-nbl);
 }
 
 #if 0
@@ -313,7 +303,7 @@ void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t locale)
 
 	from += nbh;
 	to += nbl;
-	safe_strcpy(to, from, usize-nbl);
+	lg_strlcpy(to, from, usize-nbl);
 }
 #endif
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -466,7 +466,6 @@ void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t);
 #endif
 
 size_t lg_strlcpy(char * dest, const char *src, size_t size);
-void safe_strcpy(char *u, const char * v, size_t usize);
 void safe_strcat(char *u, const char *v, size_t usize);
 char *safe_strdup(const char *u);
 


### PR DESCRIPTION
- Several small efficiency improvements:
-- insert_in_cms_table(): Avoid temp in MRU move
-- exprune.c: Put N_deleted in the context struct
-- share_disjunct_jets(): Remove the direction indication at the start
-- build_idiom_word_name(): Remove the use of lg_strcpy()
-- lg_strlcpy(): Replace by a better version
-- Replace safe_strcpy() by lg_strcpy()
-- enumerate_connector_suffixes()/share_disjunct_jets(): save lg_strlcpy
-- read-dict.c: Add "restrict" where it matters
- One bug (currently not harmful) fix:
-- Included in: lg_strlcpy(): Replace by a better version
-  Fixes related to code rot/warning/debug:
-- pack_connectors(): Avoid integer truncation warnings
-- Add debug assertion dassert()
-- enumerate_connector_suffixes()/share_disjunct_jets(): Fix code rot

The total speedup is modest (based on 500 parallel runs as 100x5):
```
 2.085000 -   2.0520 =   -0.0330 +1.6%    data/en/corpus-basic.batch
 6.051000 -   5.9950 =   -0.0560 +0.9%    data/en/corpus-fixes.batch
 1.633000 -   1.6220 =   -0.0110 +0.7%    data/ru/corpus-basic.batch
```
(For long sentences the speedup is even smaller.)