### PR TITLE
count.c: Fix broken compilation due missing closing bracket

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -652,13 +652,13 @@ static Count_bin do_count(
 				}
 
 				parse_count_clamp(&total);
+			}
 		}
 		pop_match_list(mchxt, mlb);
 	}
 	t->count = total;
 	return total;
 }
-
 
 /**
  * Returns the number of ways the sentence can be parsed with the


### PR DESCRIPTION
It happened one PR before the last one.
Of course, such broken compilation disturbs bisect tests, and regretfully I don't know how to mark such commits so they will get automatically skipped (I guess it can be done by using a special tag name and a script to skip so tagged commits).

EDIT:
> using a special tag name

with e.g. a numerical suffix for uniqueness.