### PR TITLE
Install linkgrammar jar into local Maven repository

### DIFF
--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -41,9 +41,21 @@ endif
 
 install-data-hook:
 	${LN_SF} ${javadir}/${java_DATA} ${DESTDIR}${javadir}/linkgrammar.jar
+if HAVE_MVN
+	# Install linkgrammar into the local maven repository
+	mvn install:install-file \
+	  -Dfile=${java_DATA} \
+	  -DgroupId=org.opencog \
+	  -DartifactId=linkgrammar \
+	  -Dversion=@VERSION@ \
+	  -Dpackaging=jar
+endif
 
 uninstall-hook:
 	-rm ${DESTDIR}${javadir}/linkgrammar.jar
+if HAVE_MVN
+	-rm -rf ~/.m2/repository/org/opencog/linkgrammar/@VERSION@
+endif
 
 dist-hook:
 if HAVE_ANT

--- a/configure.ac
+++ b/configure.ac
@@ -759,9 +759,14 @@ if test "x$enable_java_bindings" = "xyes"; then
 	AC_CHECK_PROG(ANTfound, ant, yes, no)
 	AM_CONDITIONAL(HAVE_ANT, test x${ANTfound} = xyes)
 
+	# If Maven is found then use it to install the jar library
+	# into the local maven repository
+	AC_CHECK_PROG(MVNfound, mvn, yes, no)
+	AM_CONDITIONAL(HAVE_MVN, test x${MVNfound} = xyes)
 else
    AM_CONDITIONAL(HAVE_JAVA, false)
    AM_CONDITIONAL(HAVE_ANT, false)
+   AM_CONDITIONAL(HAVE_MVN, false)
 fi
 
 # ===================================================================


### PR DESCRIPTION
This is the request from the discussion https://github.com/opencog/relex/pull/282#discussion_r272276153
The proposed fix checks that Maven is present and if yes installs it into local maven repository.

There are several issues with it:
- make install is called using sudo. It leads that the 'mvn install:install-file'  installs linkgrammar jar into the root user local repository. I believe that it is not that was originally required.
It would possible to call it way 'sudo -u $USER mvn install:install-file' but it is not clear for me is it a good idea to use 'sudo' in make script and how it works in Docker.
- There is the way to clean the jar from the local maven repository using 'purge-local-repository' but it requires to have pom.xml file in the directory there Maven is executed.
There is the fix [MDEP-537](https://issues.apache.org/jira/browse/MDEP-537) that claims that it is not necessary to have local maven project to clean the local repository when 'manualInclude' is used but it does not work on my side even it has been fixed in Maven 3.0.0 and I have installed Maven 3.5.2.
So I just use 'rm -rf ~/.m2/repository/org/opencog/linkgrammar/@VERSION@' to remove the linkgrammar jar but really it removes the file from the local user, not the root where this jar is installed.