### PR TITLE
Keeping the order of Disjuncts + a surprising speedup

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -346,17 +346,16 @@ static gword_set *gword_set_union(gword_set *kept, gword_set *eliminated)
  */
 Disjunct *eliminate_duplicate_disjuncts(Disjunct *dw)
 {
-	unsigned int h, count;
-	Disjunct *dx;
+	unsigned int count = 0;
 	disjunct_dup_table *dt;
 
-	count = 0;
 	dt = disjunct_dup_table_new(next_power_of_two_up(2 * count_disjuncts(dw)));
 
 	for (Disjunct **dd = &dw; *dd != NULL; /* See: NEXT */)
 	{
+		Disjunct *dx;
 		Disjunct *d = *dd;
-		h = old_hash_disjunct(dt, d);
+		unsigned int h = old_hash_disjunct(dt, d);
 
 		for (dx = dt->dup_table[h]; dx != NULL; dx = dx->dup_table_next)
 		{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -108,7 +108,7 @@ typedef struct disjunct_dup_table_s disjunct_dup_table;
 struct disjunct_dup_table_s
 {
 	size_t dup_table_size;
-	Disjunct ** dup_table;
+	Disjunct *dup_table[];
 };
 
 /**
@@ -246,22 +246,19 @@ static Disjunct *disjuncts_dup(Pool_desc *Disjunct_pool, Pool_desc *Connector_po
 
 static disjunct_dup_table * disjunct_dup_table_new(size_t sz)
 {
-	size_t i;
 	disjunct_dup_table *dt;
-	dt = (disjunct_dup_table *) xalloc(sizeof(disjunct_dup_table));
 
+	dt = malloc(sz * sizeof(Disjunct *) + sizeof(disjunct_dup_table));
 	dt->dup_table_size = sz;
-	dt->dup_table = (Disjunct **) xalloc(sz * sizeof(Disjunct *));
 
-	for (i=0; i<sz; i++) dt->dup_table[i] = NULL;
+	memset(dt->dup_table, 0, sz * sizeof(Disjunct *));
 
 	return dt;
 }
 
 static void disjunct_dup_table_delete(disjunct_dup_table *dt)
 {
-	xfree(dt->dup_table, dt->dup_table_size * sizeof(Disjunct *));
-	xfree(dt, sizeof(disjunct_dup_table));
+	free(dt);
 }
 
 #ifdef DEBUG

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -342,7 +342,6 @@ static gword_set *gword_set_union(gword_set *kept, gword_set *eliminated)
 /**
  * Takes the list of disjuncts pointed to by d, eliminates all
  * duplicates, and returns a pointer to a new list.
- * It frees the disjuncts that are eliminated.
  */
 Disjunct *eliminate_duplicate_disjuncts(Disjunct *dw)
 {

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -27,7 +27,6 @@ struct Disjunct_struct
 	Disjunct *dup_table_next;
 	Connector *left, *right;
 	double cost;
-	bool marked;               /* unmarked disjuncts get deleted */
 
 	/* match_left, right used only during parsing, for the match list. */
 	bool match_left, match_right;

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -24,6 +24,7 @@
 struct Disjunct_struct
 {
 	Disjunct *next;
+	Disjunct *dup_table_next;
 	Connector *left, *right;
 	double cost;
 	bool marked;               /* unmarked disjuncts get deleted */


### PR DESCRIPTION
For the purpose of  a more efficient Tracon sharing (A WIP that results in a significant speedup) I had to preserve the order of Disjuncts, so it will remain according to the order of the Xnodes. To that end I modified `eliminate_duplicate_disjuncts()` to discard the duplicate disjuncts on the fly instead of rebuilding the Disjunct list from the hash table, thus preserving their order.

For that, I had to add a a `dup_table_next` field to the Disjunct struct. It made it 64 bytes instead of 56 bytes. These caused a surprisingly large speedup, especially for long sentences.
I guess this is a CPU cache effect, because with 56 bytes most Disjunct accesses use 2 cache lines (on X86_64).

I also introduced additional efficiency changes in this code, but most of the saving is still due to the increased Disjunct size.

A benchmark of 25 runs (avg 5 best of 5):
``` text
 2.096000 -   2.0000 =   -0.0960  +4.8%    data/en/corpus-basic.batch
 6.047000 -   5.8210 =   -0.2260  +3.9%    data/en/corpus-fixes.batch
 1.628000 -   1.5650 =   -0.0630  +4.0%    data/ru/corpus-basic.batch
71.680000 -  60.3600 =  -11.3200 +18.8%    data/en/corpus-fix-long.batch
```

