### PR TITLE
Connector shallow field

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -110,7 +110,12 @@ struct Connector_struct
 	int suffix_id;        /* Suffix sequence identifier (see preparations.c) */
 	const condesc_t *desc;
 	Connector *next;
-	const gword_set *originating_gword;
+	union
+	{
+		const gword_set *originating_gword; /* Used while and after parsing */
+		/* For pruning use only */
+		bool shallow;      /* TRUE if this is a shallow connector */
+	};
 };
 
 void condesc_init(Dictionary, size_t);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -94,8 +94,10 @@ static void count_disjuncts_and_connectors(Sentence sent, int *dca, int *cca)
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
 		{
 			dcnt++;
-			for (Connector *c = d->right; c !=NULL; c = c->next) ccnt++;
+			if (NULL != d->left) d->left->shallow = true;
 			for (Connector *c = d->left; c != NULL; c = c->next) ccnt++;
+			if (NULL != d->right) d->right->shallow = true;
+			for (Connector *c = d->right; c !=NULL; c = c->next) ccnt++;
 		}
 	}
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -51,12 +51,12 @@ static int set_dist_fields(Connector * c, size_t w, int delta)
  */
 static void setup_connectors(Sentence sent)
 {
-	size_t w;
-	Disjunct * d, * xd, * head;
-	for (w=0; w<sent->length; w++)
+	for (WordIdx w = 0; w < sent->length; w++)
 	{
-		head = NULL;
-		for (d=sent->word[w].d; d!=NULL; d=xd)
+		Disjunct *head = NULL;
+		Disjunct *xd;
+
+		for (Disjunct *d = sent->word[w].d; d != NULL; d = xd)
 		{
 			xd = d->next;
 			if ((set_dist_fields(d->left, w, -1) < 0) ||

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -44,9 +44,10 @@ static int set_dist_fields(Connector * c, size_t w, int delta)
 }
 
 /**
- * Initialize the word fields of the connectors, and
+ * Initialize the word fields of the connectors,
  * eliminate those disjuncts that are so long, that they
- * would need to connect past the end of the sentence.
+ * would need to connect past the end of the sentence,
+ * and mark the shallow connectors.
  */
 static void setup_connectors(Sentence sent)
 {
@@ -67,6 +68,9 @@ static void setup_connectors(Sentence sent)
 			{
 				d->next = head;
 				head = d;
+				if (NULL != d->left) d->left->shallow = true;
+				if (NULL != d->right) d->right->shallow = true;
+
 			}
 		}
 		sent->word[w].d = head;

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -62,7 +62,7 @@ static void setup_connectors(Sentence sent)
 			if ((set_dist_fields(d->left, w, -1) < 0) ||
 			    (set_dist_fields(d->right, w, 1) >= (int) sent->length))
 			{
-				d->next = NULL;
+				; /* Skip this disjunct. */
 			}
 			else
 			{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -45,7 +45,6 @@ struct c_list_s
 {
 	C_list * next;
 	Connector * c;
-	bool shallow;
 };
 
 typedef struct power_table_s power_table;
@@ -206,7 +205,6 @@ static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list ** t,
 	m->next = t[h];
 	t[h] = m;
 	m->c = c;
-	m->shallow = shal;
 }
 
 static void power_table_alloc(Sentence sent, power_table *pt)
@@ -489,7 +487,7 @@ right_table_search(prune_context *pc, int w, Connector *c,
 	for (cl = pt->r_table[w][h]; cl != NULL; cl = cl->next)
 	{
 		/* Two deep connectors can't work */
-		if (!shallow && !cl->shallow) return false;
+		if (!shallow && !cl->c->shallow) return false;
 
 		if (possible_connection(pc, cl->c, c, w, word_c))
 			return true;
@@ -514,7 +512,7 @@ left_table_search(prune_context *pc, int w, Connector *c,
 	for (cl = pt->l_table[w][h]; cl != NULL; cl = cl->next)
 	{
 		/* Two deep connectors can't work */
-		if (!shallow && !cl->shallow) return false;
+		if (!shallow && !cl->c->shallow) return false;
 
 		if (possible_connection(pc, c, cl->c, word_c, w))
 			return true;


### PR DESCRIPTION
For the upcoming speed enhancement, I rewrote the connector sharing code.  In this code, it is needed to consider whether a tracon starts with a shallow connector, and it seemed a good idea to include such a field in the Connector itself.
In order to keep the connector as 32 bytes (and considering that **more fields** will be needed) it shares memory with `originating_gword` that is not used during the pruning step.
(BTW, this `originating_gword` can be eliminated if the need for that arises, by adding the disjuncts as arguments to `do_count()` similarely to what is done in `mk_parse_set()`).

This PR defines and sets this field.
It also uses it in power_prune() instead of including it in the power table. The related performance enhancement is negligible for now.

BTW, the performance-enhancement WIP that I am now trying to clean up is big, messy and complex (many tens of commits, some of them are big and unclean), so I am trying to break it up to small PRs like that and the previous one.