### PR TITLE
String-set speedup

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -146,6 +146,7 @@ liblink_grammar_la_SOURCES =        \
 	api-structures.h                 \
 	api-types.h                      \
 	connectors.h                     \
+	const-prime.h                    \
 	dict-common/dict-affix.h         \
 	dict-common/dict-api.h           \
 	dict-common/dict-common.h        \

--- a/link-grammar/const-prime.h
+++ b/link-grammar/const-prime.h
@@ -1,0 +1,68 @@
+/*************************************************************************/
+/* Copyright 2018 Amir Plivatsky                                         */
+/* All rights reserved                                                   */
+/*                                                                       */
+/* Use of the link grammar parsing system is subject to the terms of the */
+/* license set forth in the LICENSE file included with this software.    */
+/* This license allows free redistribution and use in source and binary  */
+/* forms, with or without modification, subject to certain conditions.   */
+/*                                                                       */
+/*************************************************************************/
+#ifndef _CONST_PRIME_H_
+#define _CONST_PRIME_H_
+
+#include <stddef.h>
+
+/* Optimizing compilers use a multiplication for modulo constant prime.
+ * The code here adds support for that. */
+
+static const size_t s_prime[] =
+{
+	419, 1259, 3779, 11317, 33939, 101817, 305471, 916361, 2749067,
+	8247199, 24741547, 74224603, 222673783, 668021359, 2004064039,
+};
+#define MAX_S_PRIME (sizeof(s_prime) / sizeof(s_prime[0])
+
+#define PNAME(n) prime##n
+#define FPNAME(n) fprime##n
+#define PFUNC(p) \
+	static inline unsigned int FPNAME(p)(size_t h)\
+	{ return (unsigned int)h % s_prime[p]; }
+
+PFUNC(0)
+PFUNC(1)
+PFUNC(2)
+PFUNC(3)
+PFUNC(4)
+PFUNC(5)
+PFUNC(6)
+PFUNC(7)
+PFUNC(8)
+PFUNC(9)
+PFUNC(10)
+PFUNC(11)
+PFUNC(12)
+PFUNC(13)
+PFUNC(14)
+
+typedef unsigned int (*prime_mod_func_t)(size_t);
+
+static const prime_mod_func_t prime_mod_func[] =
+{
+	FPNAME(0),
+	FPNAME(1),
+	FPNAME(2),
+	FPNAME(3),
+	FPNAME(4),
+	FPNAME(5),
+	FPNAME(6),
+	FPNAME(7),
+	FPNAME(8),
+	FPNAME(9),
+	FPNAME(10),
+	FPNAME(11),
+	FPNAME(12),
+	FPNAME(13),
+	FPNAME(14),
+};
+#endif /* _CONST_PRIME_H_ */

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -177,8 +177,7 @@ static void grow_table(String_set *ss)
 			ss->table[p] = old.table[i];
 		}
 	}
-	/* printf("growing from %d to %d\n", old.size, ss->size); */
-	/* fflush(stdout); */
+	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
 	free(old.table);
 }
 

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -146,16 +146,16 @@ const char * string_set_add(const char * source_string, String_set * ss)
 	p = find_place(source_string, ss);
 	if (ss->table[p] != NULL) return ss->table[p];
 
-	len = strlen(source_string);
+	len = strlen(source_string) + 1;
 #ifdef DEBUG
 	/* Store the String_set structure address for debug verifications */
-	len = ((len+1)&~(sizeof(ss)-1)) + 2*sizeof(ss);
-	str = (char *) malloc(len);
-	*(String_set **)&str[len-sizeof(ss)] = ss;
+	size_t mlen = (len&~(sizeof(ss)-1)) + 2*sizeof(ss);
+	str = (char *) malloc(mlen);
+	*(String_set **)&str[mlen-sizeof(ss)] = ss;
 #else
-	str = (char *) malloc(len+1);
+	str = (char *) malloc(len);
 #endif
-	strcpy(str, source_string);
+	memcpy(str, source_string, len);
 	ss->table[p] = str;
 	ss->count++;
 

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -169,14 +169,12 @@ static void grow_table(String_set *ss)
 	ss->mod_func = prime_mod_func[ss->prime_idx];
 	ss->table = malloc(ss->size * sizeof(ss_slot));
 	memset(ss->table, 0, ss->size*sizeof(ss_slot));
-	ss->count = 0;
 	for (i=0; i<old.size; i++)
 	{
 		if (old.table[i].str != NULL)
 		{
 			p = find_place(old.table[i].str, old.table[i].hash, ss);
 			ss->table[p] = old.table[i];
-			ss->count++;
 		}
 	}
 	/* printf("growing from %d to %d\n", old.size, ss->size); */

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -16,13 +16,16 @@
 #include <stddef.h>
 
 #include "api-types.h"
+#include "const-prime.h"
 #include "lg_assert.h"
 
 struct String_set_s
 {
-   size_t size;       /* the current size of the table */
-   size_t count;      /* number of things currently in the table */
-   char ** table;     /* the table itself */
+	size_t size;                /* the current size of the table */
+	size_t count;               /* number of things currently in the table */
+	char ** table;              /* the table itself */
+	unsigned int prime_idx;     /* current prime number table index */
+	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
 };
 
 String_set * string_set_create(void);

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -19,11 +19,17 @@
 #include "const-prime.h"
 #include "lg_assert.h"
 
+typedef struct
+{
+	const char *str;
+	unsigned int hash;
+} ss_slot;
+
 struct String_set_s
 {
 	size_t size;                /* the current size of the table */
 	size_t count;               /* number of things currently in the table */
-	char ** table;              /* the table itself */
+	ss_slot *table;             /* the table itself */
 	unsigned int prime_idx;     /* current prime number table index */
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
 };

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -14,10 +14,21 @@
 
 #include <string.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "api-types.h"
 #include "const-prime.h"
 #include "lg_assert.h"
+
+#define STR_POOL
+#define MEM_POOL_INIT (8*1024)
+#define MEM_POOL_INCR (16*1024)
+typedef struct str_mem_pool
+{
+	struct str_mem_pool *prev;
+	size_t size;
+	char block[0];
+} str_mem_pool;
 
 typedef struct
 {
@@ -32,6 +43,9 @@ struct String_set_s
 	ss_slot *table;             /* the table itself */
 	unsigned int prime_idx;     /* current prime number table index */
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
+	ssize_t pool_free_count;    /* string pool free space */
+	char *alloc_next;           /* next string address */
+	str_mem_pool *string_pool;  /* string memory pool */
 };
 
 String_set * string_set_create(void);


### PR DESCRIPTION
Speedup, based on 200 runs:
``` 
Parameters: -n 50 -r 4
 2.022000 -   1.9910 =   -0.0310  +1.6%    data/en/corpus-basic.batch
 5.853000 -   5.8070 =   -0.0460  +0.8%    data/en/corpus-fixes.batch
 1.593000 -   1.5290 =   -0.0640  +4.2%    data/ru/corpus-basic.batch
```

For an additional speedup, similar changes could be done for string-id.
However, I already rewrote it to directly hash tracons (i.e. without first stringifying the connectors) which saves more CPU (named tracon-id instead - to be submitted soon).

EDIT: Forced-push to fix includes.
EDIT: Forced-push to add a commit.