### PR TITLE
Detecting "mutual" cross links - YA speedup for long sentences

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -450,20 +450,28 @@ static bool possible_connection(prune_context *pc,
 	{
 		return false;
 	}
-	/* If the words are NOT next to each other, then there must be
-	 * at least one intervening connector (i.e. cannot have both
-	 * lc->next and rc->next being null).  But we only enforce this
-	 * when we think its still possible to have a complete parse,
-	 * i.e. before we allow null-linked words.
-	 */
 	else
-	if (!pc->null_links &&
-	    (lc->next == NULL) &&
-	    (rc->next == NULL) &&
-	    (!lc->multi) && (!rc->multi) &&
-	    !optional_gap_collapse(pc->sent, lword, rword))
 	{
-		return false;
+		/* If the words are NOT next to each other, then there must be
+		 * at least one intervening connector (i.e. cannot have both
+		 * lc->next and rc->next being null).  But we only enforce this
+		 * when we think its still possible to have a complete parse,
+		 * i.e. before we allow null-linked words.
+		 */
+		if (!pc->null_links &&
+			 (lc->next == NULL) &&
+			 (rc->next == NULL) &&
+			 (!lc->multi) && (!rc->multi) &&
+			 !optional_gap_collapse(pc->sent, lword, rword))
+		{
+			return false;
+		}
+
+		if ((lc->next != NULL) && (rc->next != NULL))
+		{
+			if (lc->next->nearest_word > rc->next->nearest_word)
+				return false; /* Cross link. */
+		}
 	}
 
 	return true;


### PR DESCRIPTION
As you may remember, I have a WIP for some cross-link pruning. However, it handles only the `null_count==0` case.

This PR adds an extremely simple "mutual" cross link check that works for **any** `null_count`. It is effective mainly for long sentences (partly because it adds some small overhead).

**The speedup is ~20% for the `fix-long` corpus, and ~25% for the `failures` corpus.**

Interestingly, on 2 (similar) sentences in the `basic` corpus it reduces the number of linkages due to discarding all the disjuncts that would create some PP criterion link:
``` diff
*** 85133,85135 ****
  There is going to be an important meeting in January
! Found 3240 linkages (684 had no P.P. violations)
  	Linkage 1, cost vector = (UNUSED=0 DIS= 0.05 LEN=18)
--- 85133,85135 ----
  There is going to be an important meeting in January
! Found 4248 linkages (684 had no P.P. violations)
  	Linkage 1, cost vector = (UNUSED=0 DIS= 0.05 LEN=18)
***************
*** 100003,100005 ****
  There is going to be an important meeting next January
! Found 522 linkages (120 had no P.P. violations)
  	Linkage 1, cost vector = (UNUSED=0 DIS= 0.05 LEN=19)
--- 100003,100005 ----
  There is going to be an important meeting next January
! Found 642 linkages (120 had no P.P. violations)
  	Linkage 1, cost vector = (UNUSED=0 DIS= 0.05 LEN=19)
```
