### PR TITLE
Tracon-version partial back-porting

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -159,10 +159,10 @@ struct Sentence_s
 	Pool_desc * Disjunct_pool;
 	Pool_desc * Connector_pool;
 
-	/* Trailing connector encoding stuff (suffix_id), used for speeding up
+	/* Trailing connector encoding stuff (tracon_id), used for speeding up
 	 * parsing (the classic one for now) of long sentences. */
-	String_id *connector_suffix_id; /* For connector trailing sequence IDs */
-	unsigned int num_suffix_id;     /* Currently unused. */
+	String_id *connector_tracon_id; /* For connector trailing sequence IDs */
+	unsigned int num_tracon_id;     /* Currently unused. */
 
 	jet_sharing_t jet_sharing;   /* Disjunct l/r duplication sharing */
 	size_t min_len_sharing;      /* Do trailing encoding + jet-sharing.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -527,7 +527,7 @@ void sentence_delete(Sentence sent)
 	wordgraph_delete(sent);
 	free_jet_sharing(sent);
 	string_set_delete(sent->string_set);
-	string_id_delete(sent->connector_suffix_id);
+	string_id_delete(sent->connector_tracon_id);
 	free_linkages(sent);
 	post_process_free(sent->postprocessor);
 	post_process_free(sent->constituent_pp);

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -69,7 +69,7 @@ Connector * connector_new(Pool_desc *connector_pool, const condesc_t *desc,
 	c->desc = desc;
 	c->nearest_word = 0;
 	c->multi = false;
-	c->suffix_id = 0;
+	c->tracon_id = 0;
 	c->originating_gword = NULL;
 	set_connector_length_limit(c, opts);
 	//assert(0 != c->length_limit, "Connector_new(): Zero length_limit");

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -107,7 +107,7 @@ struct Connector_struct
 	                         this could ever connect to.  Computed by
 	                         setup_connectors() */
 	bool multi;           /* TRUE if this is a multi-connector */
-	int suffix_id;        /* Suffix sequence identifier (see disjunct-utils.c) */
+	int tracon_id;        /* Suffix sequence identifier (see disjunct-utils.c) */
 	const condesc_t *desc;
 	Connector *next;
 	union

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -107,7 +107,7 @@ struct Connector_struct
 	                         this could ever connect to.  Computed by
 	                         setup_connectors() */
 	bool multi;           /* TRUE if this is a multi-connector */
-	int tracon_id;        /* Suffix sequence identifier (see disjunct-utils.c) */
+	int tracon_id;        /* Tracon identifier (see disjunct-utils.c) */
 	const condesc_t *desc;
 	Connector *next;
 	union

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -114,7 +114,11 @@ struct Connector_struct
 	{
 		const gword_set *originating_gword; /* Used while and after parsing */
 		/* For pruning use only */
-		bool shallow;      /* TRUE if this is a shallow connector */
+		struct
+		{
+			int refcount;      /* Memory-sharing reference count */
+			bool shallow;      /* TRUE if this is a shallow connector */
+		};
 	};
 };
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -463,7 +463,7 @@ void word_record_in_disjunct(const Gword * gw, Disjunct * d)
  * optional m: "@" for multi (else nothing)
  * Cname: Connector name
  * Optional D: "-" / "+" (if dir != -1)
- * Optional <suffix>: tracon_id (if not 0)
+ * Optional <tracon_id>: tracon_id (if not 0)
  * Optional (nearest_word, length_limit): if both are not 0
  * x: Shallow/deep indication as "s" / "d" (if shallow != -1)
  */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -987,7 +987,7 @@ static Connector *connectors_copy(Pool_desc *connector_pool, Connector *c,
  *
  * For each disjunct side separately, a unique ID per jet (which starts
  * from 1 so 0 is an invalid ID) is used to identify it. The IDs are
- * shared by all the words for efficiency. The tracon_id field of the
+ * shared by all the words for efficiency. The refcount field of the
  * shallow connector is used as a counter of the number of shared jets
  * in a particular table slot.
  *
@@ -1127,11 +1127,11 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 						connectors_copy(sent->Connector_pool, first_c, &numc[dir]);
 					/* Very subtle - for potential disjunct save
 					 * (one-step-parse) that is done after the previous
-					 * jet-sharing since it has set non-0 tracon_id. */
-					jet_table[dir][id].c->tracon_id = 0;
+					 * jet-sharing since it has set non-0 refcount. */
+					jet_table[dir][id].c->refcount = 0;
 				}
 				*((0 == dir) ? &n->left : &n->right) = jet_table[dir][id].c;
-				jet_table[dir][id].c->tracon_id++;
+				jet_table[dir][id].c->refcount++;
 #if 0
 				printf("w%zu%c: ", w, dir?'+':'-');
 				print_connector_list(first_c);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -472,7 +472,12 @@ void print_one_connector(Connector * e, int dir, int shallow)
 	printf("%s%s", e->multi ? "@" : "", connector_string(e));
 	if (-1 != dir) printf("%c", "-+"[dir]);
 	if (e->tracon_id)
-		printf("<%d>", e->tracon_id);
+	{
+		if (e->refcount)
+			printf("<%d,%d>", e->tracon_id, e->refcount);
+		else
+			printf("<%d>", e->tracon_id);
+	}
 	if ((0 != e->nearest_word) || (0 != e->length_limit))
 		printf("(%d,%d)", e->nearest_word, e->length_limit);
 	if (-1 != shallow)

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -48,7 +48,7 @@ static void assert_same_disjunct(Linkage, WordIdx, const char *);
  * compute_chosen_disjuncts()).
  *
  * In order that multi-connectors will not be extracted several times
- * for each disjunct (if they connect to multiple words) their suffix_id
+ * for each disjunct (if they connect to multiple words) their tracon_id
  * is checked for duplication.
  */
 void lg_compute_disjunct_strings(Linkage lkg)
@@ -65,7 +65,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 
 		for (int dir = 0; dir < 2; dir++)
 		{
-			int last_multi_suffix_id = 0; /* last multi-connector */
+			int last_multi_tracon_id = 0; /* last multi-connector */
 
 			for (LinkIdx i = lkg->num_links-1; i != (WordIdx)-1; i--)
 			{
@@ -85,8 +85,8 @@ void lg_compute_disjunct_strings(Linkage lkg)
 
 				if (c->multi)
 				{
-					if (last_multi_suffix_id == c->suffix_id) continue; /* already included */
-					last_multi_suffix_id = c->suffix_id;
+					if (last_multi_tracon_id == c->tracon_id) continue; /* already included */
+					last_multi_tracon_id = c->tracon_id;
 					djstr[len++] = '@';
 				}
 				len += lg_strlcpy(djstr+len, connector_string(c), sizeof(djstr)-len);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -171,8 +171,8 @@ static Table_connector * table_store(count_context_t *ctxt,
                                      Connector *le, Connector *re,
                                      unsigned int null_count)
 {
-	int l_id = (NULL != le) ? le->suffix_id : lw;
-	int r_id = (NULL != re) ? re->suffix_id : rw;
+	int l_id = (NULL != le) ? le->tracon_id : lw;
+	int r_id = (NULL != re) ? re->tracon_id : rw;
 	unsigned int h = pair_hash(ctxt->table_size, lw, rw, l_id, r_id, null_count);
 	Table_connector *t = ctxt->table[h];
 	Table_connector *n = pool_alloc(ctxt->sent->Table_connector_pool);
@@ -193,8 +193,8 @@ find_table_pointer(count_context_t *ctxt,
                    Connector *le, Connector *re,
                    unsigned int null_count)
 {
-	int l_id = (NULL != le) ? le->suffix_id : lw;
-	int r_id = (NULL != re) ? re->suffix_id : rw;
+	int l_id = (NULL != le) ? le->tracon_id : lw;
+	int r_id = (NULL != re) ? re->tracon_id : rw;
 	unsigned int h = pair_hash(ctxt->table_size, lw, rw, l_id, r_id, null_count);
 	Table_connector *t = ctxt->table[h];
 
@@ -307,7 +307,7 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 	(verbosity_level(D_COUNT_TRACE, "do_count") ? \
 	 prt_error("%-*s", LBLSZ, STRINGIFY(l)) : 0, do_count)
 #define V(c) (!c?"(nil)":connector_string(c))
-#define ID(c,w) (!c?w:c->suffix_id)
+#define ID(c,w) (!c?w:c->tracon_id)
 static Count_bin do_count1(int lineno, count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -243,7 +243,7 @@ void free_extractor(extractor_t * pex)
 
 /**
  * Returns the pointer to this info, NULL if not there.
- * Note that there is no need to use (lw, rw) as keys because suffix_id
+ * Note that there is no need to use (lw, rw) as keys because tracon_id
  * is also encoded by the word number.
  */
 static Pset_bucket * x_table_pointer(int lw, int rw,
@@ -251,8 +251,8 @@ static Pset_bucket * x_table_pointer(int lw, int rw,
                               unsigned int null_count, extractor_t * pex)
 {
 	Pset_bucket *t;
-	int l_id = (NULL != le) ? le->suffix_id : lw;
-	int r_id = (NULL != re) ? re->suffix_id : rw;
+	int l_id = (NULL != le) ? le->tracon_id : lw;
+	int r_id = (NULL != re) ? re->tracon_id : rw;
 	t = pex->x_table[pair_hash(pex->x_table_size, lw, rw, l_id, r_id, null_count)];
 
 	for (; t != NULL; t = t->next) {
@@ -276,8 +276,8 @@ static Pset_bucket * x_table_store(int lw, int rw,
 	n->set.lw = lw;
 	n->set.rw = rw;
 	n->set.null_count = null_count;
-	n->set.l_id = (NULL != le) ? le->suffix_id : lw;
-	n->set.r_id = (NULL != re) ? re->suffix_id : rw;
+	n->set.l_id = (NULL != le) ? le->tracon_id : lw;
+	n->set.r_id = (NULL != re) ? re->tracon_id : rw;
 	n->set.count = 0;
 	n->set.first = NULL;
 	n->set.tail = NULL;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -309,14 +309,14 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			if ((0 < nl) || (0 == max_null_count) )
 				free_jet_sharing(sent); /* Not needed for rebuild. */
 #if 0 // See below
-			bool real_suffix_ids =
+			bool real_tracon_ids =
 #endif
 				pack_sentence(sent);
 			gword_record_in_connector(sent);
 			if (is_null_count_0) opts->min_null_count = 0;
 			if (resources_exhausted(opts->resources)) break;
 
-			/* If parsing with no nulls or we are using fake suffix_id's
+			/* If parsing with no nulls or we are using fake tracon_id's
 			 * (because it is a short sentence) always allocate the count
 			 * connector table. Else allocate it only if this is a parse with
 			 * nulls only. So in case of one-step parse (min_null_count==0 &&
@@ -329,7 +329,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			// Test sentence: He was too far gone to come back from such a loss
 			// (117 vs 111 linkages.)
 #if 0
-			if (!real_suffix_ids || (nl == 0) || !is_null_count_0)
+			if (!real_tracon_ids || (nl == 0) || !is_null_count_0)
 #endif
 			{
 				free_count_context(ctxt, sent);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -425,9 +425,9 @@ bool optional_gap_collapse(Sentence sent, int w1, int w2)
 }
 
 /**
- * This takes two connectors (and whether these are shallow or not)
- * (and the two words that these came from) and returns TRUE if it is
- * possible for these two to match based on local considerations.
+ * This takes two connectors (and the two words that these came from) and
+ * returns TRUE if it is possible for these two to match based on local
+ * considerations.
  */
 static bool possible_connection(prune_context *pc,
                                 Connector *lc, Connector *rc,

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -199,7 +199,7 @@ static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list ** t,
                                  Connector * c, bool shal)
 {
 	unsigned int h = connector_uc_num(c) & (size-1);
-	assert(c->suffix_id>0, "suffix_id %d", c->suffix_id);
+	assert(c->tracon_id>0, "tracon_id %d", c->tracon_id);
 
 	C_list *m = pool_alloc(mp);
 	m->next = t[h];
@@ -226,13 +226,13 @@ static void power_table_alloc(Sentence sent, power_table *pt)
  * match loop can stop when there are no more shallow connectors in that
  * slot (since if both are deep, they cannot be matched).
  *
- * The suffix_id of each connector serves as its reference count.
+ * The tracon_id of each connector serves as its reference count.
  * Hence, it should always be > 0.
  *
  * There are two code paths for initializing the power tables:
  * 1. When disjunct-jets sharing is not done. The words then are
  * directly scanned for their disjuncts and connectors. Each ones
- * is inserted with a reference count (as suffix_id) set to 1.
+ * is inserted with a reference count (as tracon_id) set to 1.
  * 2. Using the disjunct-jet tables (left and right). Each slot
  * contains only a pointer to a disjunct-jet. The word number is
  * extracted from the deepest connector (that has been assigned to it by
@@ -299,10 +299,10 @@ static void power_table_init(Sentence sent, power_table *pt)
 				c = d->right;
 				if (c != NULL)
 				{
-					c->suffix_id = 1;
+					c->tracon_id = 1;
 					for (c = c->next; c != NULL; c = c->next)
 					{
-						c->suffix_id = 1;
+						c->tracon_id = 1;
 						put_into_power_table(mp, r_size, r_t, c, false);
 					}
 				}
@@ -310,10 +310,10 @@ static void power_table_init(Sentence sent, power_table *pt)
 				c = d->left;
 				if (c != NULL)
 				{
-					c->suffix_id = 1;
+					c->tracon_id = 1;
 					for (c = c->next; c != NULL; c = c->next)
 					{
-						c->suffix_id = 1;
+						c->tracon_id = 1;
 						put_into_power_table(mp, l_size, l_t, c, false);
 					}
 				}
@@ -369,7 +369,7 @@ static void power_table_init(Sentence sent, power_table *pt)
 
 				for (Connector *c = htc->next; NULL != c; c = c->next)
 				{
-					c->suffix_id = htc->suffix_id;
+					c->tracon_id = htc->tracon_id;
 					put_into_power_table(mp, sizep[w], tp[w], c, false);
 				}
 			}
@@ -398,9 +398,9 @@ static void clean_table(unsigned int size, C_list **t)
 
 		while (NULL != *m)
 		{
-			assert(0 <= (*m)->c->suffix_id, "clean_table: suffix_id < 0 (%d)",
-			       (*m)->c->suffix_id);
-			if (0 == (*m)->c->suffix_id)
+			assert(0 <= (*m)->c->tracon_id, "clean_table: tracon_id < 0 (%d)",
+			       (*m)->c->tracon_id);
+			if (0 == (*m)->c->tracon_id)
 				*m = (*m)->next;
 			else
 				m = &(*m)->next;
@@ -618,7 +618,7 @@ static void mark_jet_for_dequeue(Connector *c, bool mark_bad_word)
 
 	for (; NULL != c; c = c->next)
 	{
-		c->suffix_id--; /* Reference count. */
+		c->tracon_id--; /* Reference count. */
 	}
 }
 
@@ -633,7 +633,7 @@ static bool is_bad(Connector *c)
 /** The return value is the number of disjuncts deleted.
  *  Implementation notes:
  *  Normally all the identical disjunct-jets are memory shared.
- *  The suffix_id of each connector serves as its reference count
+ *  The tracon_id of each connector serves as its reference count
  *  in the power table. Each time when a connector that cannot match
  *  is discovered, its reference count is decreased, and its
  *  nearest_word field is assigned BAD_WORD. Due to the memory sharing,
@@ -1068,7 +1068,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			{
 				for (Connector *c = js->table[dir][id].c; NULL != c; c = c->next)
 				{
-					if (0 == c->suffix_id) continue;
+					if (0 == c->tracon_id) continue;
 					insert_in_cms_table(cmt, c);
 				}
 			}
@@ -1155,7 +1155,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			{
 				for (Connector *c = js->table[dir][id].c; NULL != c; c = c->next)
 				{
-					if (0 == c->suffix_id) continue;
+					if (0 == c->tracon_id) continue;
 					if (mark_bad_connectors(cmt, c))
 					{
 						D_deleted++;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1141,7 +1141,7 @@ static int pp_prune(Sentence sent, Parse_Options opts)
 			if ((rule_ok[i] == 0) || !rule_satisfiable(cmt, link_set))
 			{
 				rule_ok[i] = 0;
-				ppdebug("DELETE %s\n", connector_string(c));
+				ppdebug("DELETE %s refcount %d\n", connector_string(c), c->refcount);
 				c->nearest_word = BAD_WORD;
 				Cname_deleted++;
 				rule->use_count++;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -581,11 +581,11 @@ right_connector_list_update(prune_context *pc, Connector *c,
 {
 	int n, ub;
 	int sent_length = (int)pc->sent->length;
-	int foundmatch = sent_length;
+	int foundmatch = BAD_WORD;
 
 	if (c == NULL) return w;
 	n = right_connector_list_update(pc, c->next, w, false) + 1;
-	if (sent_length <= n) return sent_length;
+	if (sent_length <= n) return BAD_WORD;
 	if (c->nearest_word > n) n = c->nearest_word;
 
 	/* ub is now the rightmost word we need to check */
@@ -611,7 +611,11 @@ right_connector_list_update(prune_context *pc, Connector *c,
 
 static void mark_jet_for_dequeue(Connector *c, bool mark_bad_word)
 {
+	/* The following can actually be omitted as long as (unsigned char)-1
+	 * is equal to BAD_WORD. However, The question is how to define
+	 * BAD_WORD cleanly so it will be immune to increasing MAX_SENTENCE. */
 	if (mark_bad_word) c->nearest_word = BAD_WORD;
+
 	for (; NULL != c; c = c->next)
 	{
 		c->suffix_id--; /* Reference count. */


### PR DESCRIPTION
As I wrote before, the tracon-based version has a large number of messy commits, which include development bug fixes and intermediate development printout that are added and removed.

This PR is an additional ones in the series of separating this version to clean commits.

Changes here:
- Rename suffix_id to tracon_id (the appropriate comment changes will be included in the final PR).
- Add a connector field "refcount"  (currently the suffix_id is also used as refcount).
- Update some comment rot as the result of current and previous chnages.
- Don't process again good jets (it will be very much more effective when tracons are used instead of jets).
- Improve the DELETE debug message of pp_prune().