### PR TITLE
Cleanup before the big modifications 

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -164,10 +164,11 @@ struct Sentence_s
 	String_id *connector_tracon_id; /* For connector trailing sequence IDs */
 	unsigned int num_tracon_id;     /* Currently unused. */
 
+	/* Connector encoding, packing & sharing. */
+	size_t min_len_encoding;     /* Do it from this sentence length. */
+	void *dc_memblock;           /* For packed disjuncts & connectors. */
+
 	jet_sharing_t jet_sharing;   /* Disjunct l/r duplication sharing */
-	size_t min_len_sharing;      /* Do trailing encoding + jet-sharing.
-	                                Disjunct/connector packing is also done
-	                                in that case (only). */
 
 	/* Wordgraph stuff. FIXME: create stand-alone struct for these. */
 	Gword *wordgraph;            /* Tokenization wordgraph */
@@ -200,7 +201,6 @@ struct Sentence_s
 #ifdef USE_SAT_SOLVER
 	void *hook;                 /* Hook for the SAT solver */
 #endif /* USE_SAT_SOLVER */
-	void *disjuncts_connectors_memblock;
 };
 
 #endif

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -454,10 +454,10 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 	/* Set the minimum length for trailing connectors encoding.
 	 * In that case disjunct jet-sharing (for power prune())
 	 * and disjunct/connector packing is done too. */
-	sent->min_len_sharing = SENTENCE_MIN_LENGTH_TRAILING_HASH;
-	const char *min_len_sharing = test_enabled("len-trailing-hash");
-	if (NULL != min_len_sharing)
-		sent->min_len_sharing = atoi(min_len_sharing+1);
+	sent->min_len_encoding = SENTENCE_MIN_LENGTH_TRAILING_HASH;
+	const char *min_len_encoding = test_enabled("len-trailing-hash");
+	if (NULL != min_len_encoding)
+		sent->min_len_encoding = atoi(min_len_encoding+1);
 
 	return sent;
 }

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -94,9 +94,7 @@ static void count_disjuncts_and_connectors(Sentence sent, int *dca, int *cca)
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
 		{
 			dcnt++;
-			if (NULL != d->left) d->left->shallow = true;
 			for (Connector *c = d->left; c != NULL; c = c->next) ccnt++;
-			if (NULL != d->right) d->right->shallow = true;
 			for (Connector *c = d->right; c !=NULL; c = c->next) ccnt++;
 		}
 	}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -44,10 +44,10 @@ void free_disjuncts(Disjunct *c)
 
 void free_sentence_disjuncts(Sentence sent)
 {
-	if (NULL != sent->disjuncts_connectors_memblock)
+	if (NULL != sent->dc_memblock)
 	{
-		free(sent->disjuncts_connectors_memblock);
-		sent->disjuncts_connectors_memblock = NULL;
+		free(sent->dc_memblock);
+		sent->dc_memblock = NULL;
 	}
 	else if (NULL != sent->Disjunct_pool)
 	{
@@ -828,7 +828,7 @@ bool pack_sentence(Sentence sent)
 {
 	int dcnt = 0;
 	int ccnt = 0;
-	bool do_share = sent->length >= sent->min_len_sharing;
+	bool do_share = sent->length >= sent->min_len_encoding;
 
 	if (!do_share)
 	{
@@ -846,7 +846,7 @@ bool pack_sentence(Sentence sent)
 	void *memblock = malloc(dsize + csize);
 	Disjunct *dblock = memblock;
 	Connector *cblock = (Connector *)((char *)memblock + dsize);
-	sent->disjuncts_connectors_memblock = memblock;
+	sent->dc_memblock = memblock;
 	pack_context pc =
 	{
 		.cblock_base = cblock,
@@ -1021,9 +1021,9 @@ void share_disjunct_jets(Sentence sent, bool rebuild)
 	jet_sharing_t *js = &sent->jet_sharing;
 
 	lgdebug(+D_DISJ, "skip=%d rebuild=%d table=%d\n",
-	        sent->length < sent->min_len_sharing, rebuild, NULL != js->table[0]);
+	        sent->length < sent->min_len_encoding, rebuild, NULL != js->table[0]);
 
-	if (sent->length < sent->min_len_sharing) return;
+	if (sent->length < sent->min_len_encoding) return;
 
 	size_t jet_table_size[2];
 	size_t jet_table_entries[2] = {0};

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -244,7 +244,7 @@ void free_extractor(extractor_t * pex)
 /**
  * Returns the pointer to this info, NULL if not there.
  * Note that there is no need to use (lw, rw) as keys because tracon_id
- * is also encoded by the word number.
+ * values are not shared between words.
  */
 static Pset_bucket * x_table_pointer(int lw, int rw,
                               Connector *le, Connector *re,


### PR DESCRIPTION
The main change here is a fix for a sight performance bug:
- count_disjuncts_and_connectors(): Remove forgotten shallow setup

The rest is just things that appear in the new big changes and are relevant to the current version.

I hope that this is the last intermediate PR and my intention is that the next PR will be the whole new tracon encoding and pruning version itself.