### PR TITLE
Fix MAX_S_PRIME (missing closing paren)

### DIFF
--- a/link-grammar/const-prime.h
+++ b/link-grammar/const-prime.h
@@ -21,7 +21,7 @@ static const size_t s_prime[] =
 	419, 1259, 3779, 11317, 33939, 101817, 305471, 916361, 2749067,
 	8247199, 24741547, 74224603, 222673783, 668021359, 2004064039,
 };
-#define MAX_S_PRIME (sizeof(s_prime) / sizeof(s_prime[0])
+#define MAX_S_PRIME (sizeof(s_prime) / sizeof(s_prime[0]))
 
 #define PNAME(n) prime##n
 #define FPNAME(n) fprime##n


### PR DESCRIPTION
It is not in use now.
(Separated from the next PR).