### PR TITLE
pack_sentence_for_*(): Fix crash w/ verbosity>=5 on short sentences

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -987,11 +987,20 @@ Tracon_sharing *pack_sentence_for_pruning(Sentence sent)
 {
 	Tracon_sharing *ts = pack_sentence(sent, true);
 
-	lgdebug(D_DISJ, "Debug: Trailing hash for pruning (len %zu): "
-	        "tracon_id %zu (%zu+,%zu-), shared connectors %ld\n", sent->length,
-	        ts->tracon_list->entries[0]+ts->tracon_list->entries[1],
-	        ts->tracon_list->entries[0], ts->tracon_list->entries[1],
-	        &ts->cblock_base[ts->num_connectors] - ts->cblock);
+	if (ts == NULL)
+	{
+		lgdebug(D_DISJ, "Debug: Trailing hash for pruning (len %zu): None",
+		        sent->length);
+	}
+	else
+	{
+		lgdebug(D_DISJ, "Debug: Trailing hash for pruning (len %zu): "
+		        "tracon_id %zu (%zu+,%zu-), shared connectors %ld\n",
+		        sent->length,
+		        ts->tracon_list->entries[0]+ts->tracon_list->entries[1],
+		        ts->tracon_list->entries[0], ts->tracon_list->entries[1],
+				  &ts->cblock_base[ts->num_connectors] - ts->cblock);
+	}
 
 	return ts;
 }
@@ -1000,11 +1009,20 @@ Tracon_sharing *pack_sentence_for_parsing(Sentence sent)
 {
 	Tracon_sharing *ts = pack_sentence(sent, false);
 
-	lgdebug(D_DISJ, "Debug: Trailing hash for parsing (len %zu): "
-	        "tracon_id %d (%d+,%d-), shared connectors %ld\n", sent->length,
-	        (ts->next_id[0]-ts->word_offset)+(ts->next_id[1]-ts->word_offset),
-	        ts->next_id[0]-ts->word_offset, ts->next_id[1]-ts->word_offset,
-	        &ts->cblock_base[ts->num_connectors] - ts->cblock);
+	if (ts == NULL)
+	{
+		lgdebug(D_DISJ, "Debug: Trailing hash for parsing (len %zu): None",
+		        sent->length);
+	}
+	else
+	{
+		lgdebug(D_DISJ, "Debug: Trailing hash for parsing (len %zu): "
+		        "tracon_id %d (%d+,%d-), shared connectors %ld\n",
+		        sent->length,
+		        (ts->next_id[0]-ts->word_offset)+(ts->next_id[1]-ts->word_offset),
+		        ts->next_id[0]-ts->word_offset, ts->next_id[1]-ts->word_offset,
+		        &ts->cblock_base[ts->num_connectors] - ts->cblock);
+	}
 
 	return ts;
 }

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -989,12 +989,12 @@ Tracon_sharing *pack_sentence_for_pruning(Sentence sent)
 
 	if (ts == NULL)
 	{
-		lgdebug(D_DISJ, "Debug: Trailing hash for pruning (len %zu): None",
+		lgdebug(D_DISJ, "Debug: Encode for pruning (len %zu): None",
 		        sent->length);
 	}
 	else
 	{
-		lgdebug(D_DISJ, "Debug: Trailing hash for pruning (len %zu): "
+		lgdebug(D_DISJ, "Debug: Encode for pruning (len %zu): "
 		        "tracon_id %zu (%zu+,%zu-), shared connectors %ld\n",
 		        sent->length,
 		        ts->tracon_list->entries[0]+ts->tracon_list->entries[1],
@@ -1011,12 +1011,12 @@ Tracon_sharing *pack_sentence_for_parsing(Sentence sent)
 
 	if (ts == NULL)
 	{
-		lgdebug(D_DISJ, "Debug: Trailing hash for parsing (len %zu): None",
+		lgdebug(D_DISJ, "Debug: Encode for parsing (len %zu): None",
 		        sent->length);
 	}
 	else
 	{
-		lgdebug(D_DISJ, "Debug: Trailing hash for parsing (len %zu): "
+		lgdebug(D_DISJ, "Debug: Encode for parsing (len %zu): "
 		        "tracon_id %d (%d+,%d-), shared connectors %ld\n",
 		        sent->length,
 		        (ts->next_id[0]-ts->word_offset)+(ts->next_id[1]-ts->word_offset),


### PR DESCRIPTION
Repeat by:
`echo x | link-parser -v=5`
