### PR TITLE
Comment cleanup

### DIFF
--- a/data/en/4.0.knowledge
+++ b/data/en/4.0.knowledge
@@ -305,7 +305,7 @@ MX#a  ,  TO  TOf  TH  MVp  TOt  QI  OF  MVt  MVz  MVh  Ytm Ya  MJ E EA
 			                    , "Bad use of adjective65"    ,
 
 ; There's no JUNK connector, which means that Oxn is
-; prohibited from ever occuring. 4.0.batch covers this.
+; prohibited from ever occurring. 4.0.batch covers this.
  Oxn   ,  JUNK                              , "Bad use of pronoun66" ,
  MVh   ,  EExk   EAxk   D##k                , "Incorrect use of that67" ,
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -104,8 +104,9 @@ struct Connector_struct
 	uint8_t length_limit; /* Can be different than in the descriptor */
 	uint8_t nearest_word;
 	                      /* The nearest word to my left (or right) that
-	                         this could ever connect to.  Computed by
-	                         setup_connectors() */
+	                         this could ever connect to.  Initialized by
+	                         setup_connectors(). Final value is found in
+	                         the power pruning. */
 	bool multi;           /* TRUE if this is a multi-connector */
 	int tracon_id;        /* Tracon identifier (see disjunct-utils.c) */
 	const condesc_t *desc;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -616,8 +616,9 @@ void print_all_disjuncts(Sentence sent)
  * to disjuncts of different alternatives may have different linkage
  * counts because some alternatives-connectivity checks (to the middle
  * disjunct) are done in the fast-matcher. These restrictions are
- * implemented by using different tracon IDs per Gword.
- *
+ * implemented by using a different tracon ID per Gword (FIXME - this is
+ * more strict then needed - a different tracon IDs per alternative would
+ * suffice).
  * The tracon memory sharing is currently not directly used in the
  * parsing algo besides reducing the needed CPU cache by a large factor.
  *

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -711,7 +711,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 						/* This is a rare case in which a shallow and deep
 						 * connectors don't have the same nearest_word, because
 						 * a shallow connector may mach a deep connector
-						 * earlier. Because the nearest word is different, we we
+						 * earlier. Because the nearest word is different, we
 						 * cannot share it. (Such shallow and deep Tracons could
 						 * be shared separately, but because this is a rare
 						 * event there is no need to do that.)

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -525,9 +525,8 @@ void print_all_disjuncts(Sentence sent)
 /* ============= Connector encoding, sharing and packing ============= */
 
 /*
- * sentence_pack() copies the disjuncts and connectors to a continuous
- * memory block. This facilitate a better memory caching for long
- * sentences.
+ * sentence_pack() copies the disjuncts and connectors to a contiguous
+ * memory. This facilitate a better memory caching for long sentences.
  *
  * In addition, it shares the memory of identical trailing connector
  * sequences, aka "tracons". Tracons are considered identical if they

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -934,24 +934,17 @@ void free_tracon_sharing(Tracon_sharing *ts)
 }
 
 /**
- * Pack all disjunct and connectors into a one big memory block.
- * This facilitate a better memory caching for long sentences
- * (a performance gain of a few percents).
+ * Pack all disjunct and connectors into a one big memory block, share
+ * tracon memory and generate tracon IDs (for parsing) or tracon lists
+ * with reference count (for pruning).
  *
- * The current Connector struct size is 32 bit, and future ones may be
- * smaller, but still with a power-of-2 size.
- * The idea is to put an integral number of connectors in each cache line
- * (assumed to be >= Connector struct size, e.g. 64 bytes),
- * so one connector will not need 2 cache lines.
+ * The disjunct and connectors packing n a contiguous memory facilitate a
+ * better memory caching for long sentences (a performance gain of a few
+ * percents).
  *
- * The allocated memory includes 3 sections , in that order:
- * 1. A block for disjuncts, when it start is not aligned (the disjunct size
- * is currently 56 bytes and cannot be reduced much).
- * 2. A small alignment gap, that ends in a 64-byte boundary.
- * 3. A block of connectors, which is so aligned to 64-byte boundary.
- *
- * A trailing sequence encoding and sharing is done too.
- * Note: Connector sharing, trailing hash and packing always go together.
+ * The tracon IDs (if invoked for the parsing step) or tracon lists (if
+ * invoked for pruning step) allow for a huge performance boost at these
+ * steps.
  */
 static Tracon_sharing *pack_sentence(Sentence sent, bool is_pruning)
 {

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -4,7 +4,7 @@
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */
-/* license set forth in the LICENSE file included with this softwares.   */
+/* license set forth in the LICENSE file included with this software.   */
 /* This license allows free redistribution and use in source and binary  */
 /* forms, with or without modification, subject to certain conditions.   */
 /*                                                                       */

--- a/link-grammar/parse/extract-links.h
+++ b/link-grammar/parse/extract-links.h
@@ -4,7 +4,7 @@
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */
-/* license set forth in the LICENSE file included with this softwares.   */
+/* license set forth in the LICENSE file included with this software.   */
 /* This license allows free redistribution and use in source and binary  */
 /* forms, with or without modification, subject to certain conditions.   */
 /*                                                                       */

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -97,7 +97,7 @@ void free_fast_matcher(Sentence sent, fast_matcher_t *mchxt)
 	}
 
 	free(mchxt->match_list);
-	lgdebug(6, "Sentence size %zu, match_list_size %zu\n",
+	lgdebug(6, "Sentence length %zu, match_list_size %zu\n",
 	        mchxt->size, mchxt->match_list_size);
 
 	xfree(mchxt->l_table_size, mchxt->size * sizeof(unsigned int));

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -258,7 +258,7 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
  * is done by pack_sentence_for_pruning(), and it is not done for
  * sentences shorter than a certain limit. In that case the pruning is
  * done with no null_count==0 optimization so restoring the disjuncts is
- * no needed.
+ * not needed.
  */
 void classic_parse(Sentence sent, Parse_Options opts)
 {

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -232,14 +232,13 @@ static void power_table_alloc(Sentence sent, power_table *pt)
  * should always be > 0.
  *
  * There are two code paths for initializing the power tables:
- * 1. When a trailing connectors sharing is not done. The words then
- * are directly scanned for their disjuncts and connectors. Each one is
- * inserted with a refcount set to 1 (because there is no connector memory
- * sharing).
- * 2. Using the shared trailing connector tables (left and right). Each
- * slot is an index into the connector memory block, which is the first
- * connector in a trailing sequence. The word number is extracted from the
- * deepest connector (assigned to it by setup_connectors()).
+ * 1. When a tracon sharing is not done. The words then are directly
+ * scanned for their disjuncts and connectors. Each one is inserted with a
+ * refcount set to 1 (because there is no connector memory sharing).
+ * 2. Using the tracon list tables (left and right). Each slot is an index
+ * into the connector memory block, which is the start of the
+ * corresponding tracon. The word number is extracted from the deepest
+ * connector (assigned to it by setup_connectors()).
  */
 static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 {

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -651,7 +651,7 @@ static bool is_bad(Connector *c)
  *  sharing, each change of the reference count and the assignment of
  *  BAD_WORD affects simultaneously all the identical tracons (and the
  *  corresponding connectors in the power table). The corresponding
- *  disjuncts are discarded on the fly, and additional disjuncts with Jets
+ *  disjuncts are discarded on the fly, and additional disjuncts with jets
  *  so marked with BAD_WORD are discarded when encountered without a
  *  further check. Each tracon is handled only once in the same main loop
  *  pass by marking their connectors with the pass number in their

--- a/link-grammar/prepare/expand.h
+++ b/link-grammar/prepare/expand.h
@@ -3,7 +3,7 @@
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */
-/* license set forth in the LICENSE file included with this softwares.   */
+/* license set forth in the LICENSE file included with this software.   */
 /* This license allows free redistribution and use in source and binary  */
 /* forms, with or without modification, subject to certain conditions.   */
 /*                                                                       */

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -182,7 +182,7 @@ struct Wordgraph_pathpos_s
 {
 	Gword *word;      /* Position in the Wordgraph */
 	/* Only for wordgraph_flatten(). */
-	bool same_word;   /* Still the same word - issue an empty word */
+	bool same_word;   /* Still the same word - mark it as "optional" */
 	bool next_ok;     /* OK to proceed to the next Wordgraph word */
 	bool used;        /* Debug - the word has been issued */
 	/* Only for sane_morphism(). */

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -26,11 +26,11 @@
  *
  * A tracon is identified by (the address of) its first connector.
  *
- * The API here is similar to that of string_set, with this differences:
+ * The API here is similar to that of string_set, with these differences:
  *
  * 1. tracon_set_add() returns a pointer to the hash slot of the tracon if
  * it finds it. Else it returns a pointer to a NULL hash slot, and
- * he caller is expected to assign to it the tracon (its address
+ * the caller is expected to assign to it the tracon (its address
  * after it is copied to the destination buffer).
  *
  * 2. A new API tracon_set_shallow() is used to require that tracons


### PR DESCRIPTION
- Use "tracon" instead of "trailing connectors" etc.
- Fix typos.
- Fix comment rot.
- Add FIXME.

There is a remaining comment rot(and code)  related to the Disjunct size, to be fixed next.