### PR TITLE
Add configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+
+install:
+  - sudo apt-get update
+  - sudo apt-get install -y make m4 gcc g++ autoconf autoconf-archive pkg-config libtool  # link-grammar required dependencies
+  - sudo apt-get install -y swig flex ant graphviz  # link-grammar optional dependencies
+
+script:
+  - ./autogen.sh
+  - ./configure --disable-python-bindings  # TODO: fix tests that fail with python bindings enabled
+  - make
+  - make check
+  - sudo make install
+  - sudo ldconfig
+  - make installcheck
+  - echo "The needs of the many outweigh the needs of the few." | /usr/local/bin/link-parser
+
+notifications:
+  email: false


### PR DESCRIPTION
As per https://github.com/opencog/link-grammar/issues/161#issuecomment-500248571, adds Travis CI configuration

If this is merged, next steps to complete setting up Travis CI would be to:
1. Register/setup the `opencog` organization and the `link-grammar` repo on [travis-ci.com](https://travis-ci.com)
2. Set up the [Travis CI integration with GitHub](https://github.com/marketplace/travis-ci)