### PR TITLE
Immediate fixes for Python test errors

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1116,8 +1116,8 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         words_char = []
         words_byte = []
         for wi, w in enumerate(lkg.words()):
-            words_char.append(w + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
-            words_byte.append(w + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
+            words_char.append(w + str((int(linkage.word_char_start(wi)), int(linkage.word_char_end(wi)))))
+            words_byte.append(w + str((int(linkage.word_byte_start(wi)), int(linkage.word_byte_end(wi)))))
         return ' '.join(words_char) + '\n' + ' '.join(words_byte) + '\n'
 
     # Function code and file format sanity check

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -365,13 +365,13 @@ link_public_api(const char *)
      linkage_get_violation_name(const Linkage linkage);
 
 /* Experimental API - subject to changes. */
-link_public_api(size_t)
+link_public_api(WordIdx)
      linkage_get_word_byte_start(const Linkage linkage, WordIdx w);
-link_public_api(size_t)
+link_public_api(WordIdx)
      linkage_get_word_byte_end(const Linkage linkage, WordIdx w);
-link_public_api(size_t)
+link_public_api(WordIdx)
      linkage_get_word_char_start(const Linkage linkage, WordIdx w);
-link_public_api(size_t)
+link_public_api(WordIdx)
      linkage_get_word_char_end(const Linkage linkage, WordIdx w);
 
 

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -914,13 +914,13 @@ double linkage_corpus_cost(const Linkage linkage)
 
 WordIdx linkage_get_word_byte_start(const Linkage linkage, WordIdx w)
 {
-	if (linkage->num_words <= w) return 0; /* bounds-check */
+	if (linkage->num_words <= w) return (WordIdx)-1; /* bounds-check */
 	return linkage->wg_path_display[w]->start - linkage->sent->orig_sentence;
 }
 
 WordIdx linkage_get_word_byte_end(const Linkage linkage, WordIdx w)
 {
-	if (linkage->num_words <= w) return 0; /* bounds-check */
+	if (linkage->num_words <= w) return (WordIdx)-1; /* bounds-check */
 	return linkage->wg_path_display[w]->end - linkage->sent->orig_sentence;
 }
 
@@ -930,7 +930,7 @@ WordIdx linkage_get_word_byte_end(const Linkage linkage, WordIdx w)
 
 WordIdx linkage_get_word_char_start(const Linkage linkage, WordIdx w)
 {
-	if (linkage->num_words <= w) return 0; /* bounds-check */
+	if (linkage->num_words <= w) return (WordIdx)-1; /* bounds-check */
 	int pos = (int)(linkage->wg_path_display[w]->start - linkage->sent->orig_sentence);
 	char *sentchunk = strndupa(linkage->sent->orig_sentence, pos);
 	return utf8_strlen(sentchunk);
@@ -938,7 +938,7 @@ WordIdx linkage_get_word_char_start(const Linkage linkage, WordIdx w)
 
 WordIdx linkage_get_word_char_end(const Linkage linkage, WordIdx w)
 {
-	if (linkage->num_words <= w) return 0; /* bounds-check */
+	if (linkage->num_words <= w) return (WordIdx)-1; /* bounds-check */
 	int pos = (int)(linkage->wg_path_display[w]->end - linkage->sent->orig_sentence);
 	char *sentchunk = strndupa(linkage->sent->orig_sentence, pos);
 	return utf8_strlen(sentchunk);

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -912,13 +912,13 @@ double linkage_corpus_cost(const Linkage linkage)
 
 /* =========== Get word sentence positions ============================== */
 
-size_t linkage_get_word_byte_start(const Linkage linkage, WordIdx w)
+WordIdx linkage_get_word_byte_start(const Linkage linkage, WordIdx w)
 {
 	if (linkage->num_words <= w) return 0; /* bounds-check */
 	return linkage->wg_path_display[w]->start - linkage->sent->orig_sentence;
 }
 
-size_t linkage_get_word_byte_end(const Linkage linkage, WordIdx w)
+WordIdx linkage_get_word_byte_end(const Linkage linkage, WordIdx w)
 {
 	if (linkage->num_words <= w) return 0; /* bounds-check */
 	return linkage->wg_path_display[w]->end - linkage->sent->orig_sentence;
@@ -928,7 +928,7 @@ size_t linkage_get_word_byte_end(const Linkage linkage, WordIdx w)
  * not be efficient if more than one position is needed. If needed, it can
  * be changed to use caching of already-calculated positions. */
 
-size_t linkage_get_word_char_start(const Linkage linkage, WordIdx w)
+WordIdx linkage_get_word_char_start(const Linkage linkage, WordIdx w)
 {
 	if (linkage->num_words <= w) return 0; /* bounds-check */
 	int pos = (int)(linkage->wg_path_display[w]->start - linkage->sent->orig_sentence);
@@ -936,7 +936,7 @@ size_t linkage_get_word_char_start(const Linkage linkage, WordIdx w)
 	return utf8_strlen(sentchunk);
 }
 
-size_t linkage_get_word_char_end(const Linkage linkage, WordIdx w)
+WordIdx linkage_get_word_char_end(const Linkage linkage, WordIdx w)
 {
 	if (linkage->num_words <= w) return 0; /* bounds-check */
 	int pos = (int)(linkage->wg_path_display[w]->end - linkage->sent->orig_sentence);


### PR DESCRIPTION
This fixes the  `IWordPositionTestCase` errors from issue #954, that happen on Python which is not configured with `LongInts`.

Also, `WordIdx` is used for consistency as discussed there.