### PR TITLE
Always pack the disuncts & connectors

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -704,7 +704,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 			else
 			{
 				newc = *tracon;
-				if (NULL == tl)
+				if (!ts->is_pruning)
 				{
 					if (o->nearest_word != newc->nearest_word)
 					{
@@ -731,7 +731,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 			newc = lcblock++;
 			*newc = *o;
 
-			if (NULL == ts->tracon_list)
+			if (!ts->is_pruning)
 			{
 				/* For the parsing sharing we need a unique ID. */
 				newc->tracon_id = ts->next_id[dir]++;
@@ -745,7 +745,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 		}
 		else
 		{
-			if (NULL != ts->tracon_list)
+			if (ts->is_pruning)
 			{
 				for (Connector *n = newc; NULL != n; n = n->next)
 					n->refcount++;
@@ -815,7 +815,7 @@ static Disjunct *pack_disjuncts(Tracon_sharing *ts, Disjunct *origd, int w)
 		newd->cost = t->cost;
 		newd->originating_gword = t->originating_gword;
 
-		if (NULL == ts->tracon_list)
+		if (!ts->is_pruning)
 		    token = (uintptr_t)t->originating_gword;
 
 		if (token != ts->last_token)
@@ -890,6 +890,7 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, bool is_pruning)
 	ts->word_offset = is_pruning ? 1 : WORD_OFFSET;
 	ts->next_id[0] = ts->next_id[1] = ts->word_offset;
 	ts->last_token = (uintptr_t)-1;
+	ts->is_pruning = is_pruning;
 
 	ts->csid[0] = tracon_set_create();
 	ts->csid[1] = tracon_set_create();

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -836,8 +836,13 @@ static Disjunct *pack_disjuncts(Tracon_sharing *ts, Disjunct *origd, int w)
 	return head.next;
 }
 
-#define WORD_OFFSET 256   /* Reserved for null connectors. */
 #define TLSZ 8192         /* Initial size of the tracon list table */
+
+/* Reserved tracon ID space for NULL connectors (zero-length tracons).
+ * Currently, tracons are unique per word. So this is actually the max.
+ * number of words in a sentence rounded up to a power of 2.
+ * FIXME: Derive it from MAX_SENTENCE. */
+#define WORD_OFFSET 256
 
 /** Create a context descriptor for disjuncts & connector memory "packing".
  *   Allocate a memory block for all the disjuncts & connectors.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1010,7 +1010,7 @@ Tracon_sharing *pack_sentence_for_pruning(Sentence sent)
 
 	if (NULL == ts->csid[0])
 	{
-		lgdebug(D_DISJ, "Debug: Encode for pruning (len %zu): None",
+		lgdebug(D_DISJ, "Debug: Encode for pruning (len %zu): None\n",
 		        sent->length);
 	}
 	else
@@ -1032,7 +1032,7 @@ Tracon_sharing *pack_sentence_for_parsing(Sentence sent)
 
 	if (NULL == ts->csid[0])
 	{
-		lgdebug(D_DISJ, "Debug: Encode for parsing (len %zu): None",
+		lgdebug(D_DISJ, "Debug: Encode for parsing (len %zu): None\n",
 		        sent->length);
 	}
 	else

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -112,13 +112,13 @@ struct tracon_sharing_s
 	void *memblock;             /* Memory block for disjuncts & connectors */
 	Connector *cblock_base;     /* Start of connector block */
 	Connector *cblock;          /* Next available memory for connector */
-	unsigned int num_connectors;
 	Disjunct *dblock;           /* Next available memory for disjunct */
+	unsigned int num_connectors;
 	unsigned int num_disjuncts;
-	int word_offset;            /* Start number for connector tracon_id */
 	Tracon_set *csid[2];        /* For generating unique IDs */
 	int next_id[2];
 	uintptr_t last_token;
+	int word_offset;            /* Start number for connector tracon_id */
 	Tracon_list *tracon_list;
 };
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -119,6 +119,7 @@ struct tracon_sharing_s
 	int next_id[2];             /* Next unique tracon ID */
 	uintptr_t last_token;       /* Tracons are only unique per "token" */
 	int word_offset;            /* Start number for connector tracon_id */
+	bool is_pruning;            /* true - for pruning; false - for parsing */
 	Tracon_list *tracon_list;   /* Used only for pruning */
 };
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -115,11 +115,11 @@ struct tracon_sharing_s
 	Disjunct *dblock;           /* Next available memory for disjunct */
 	unsigned int num_connectors;
 	unsigned int num_disjuncts;
-	Tracon_set *csid[2];        /* For generating unique IDs */
-	int next_id[2];
-	uintptr_t last_token;
+	Tracon_set *csid[2];        /* For generating unique tracon IDs */
+	int next_id[2];             /* Next unique tracon ID */
+	uintptr_t last_token;       /* Tracons are only unique per "token" */
 	int word_offset;            /* Start number for connector tracon_id */
-	Tracon_list *tracon_list;
+	Tracon_list *tracon_list;   /* Used only for pruning */
 };
 
 void *save_disjuncts(Sentence, Tracon_sharing *, Disjunct **);

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -104,12 +104,16 @@ typedef struct
 	uint32_t *table[2];         /* Indexed by entry number */
 	size_t entries[2];          /* Actual number of entries */
 	size_t table_size[2];       /* Allocated number of entries */
-	size_t memblock_sz;         /* Pruning memblock size  */
 } Tracon_list;
 
 struct tracon_sharing_s
 {
-	void *memblock;             /* Memory block for disjuncts & connectors */
+	union
+	{
+		void *memblock;             /* Memory block for disjuncts & connectors */
+		Disjunct *dblock_base;      /* Start of disjunct block */
+	};
+	size_t memblock_sz;         /* memblock size */
 	Connector *cblock_base;     /* Start of connector block */
 	Connector *cblock;          /* Next available memory for connector */
 	Disjunct *dblock;           /* Next available memory for disjunct */

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -279,27 +279,13 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent);
 	print_time(opts, "Encode connectors for pruning");
-	if (NULL == ts_pruning)
-	{
-		/* The sentence is considered too short for packing. */
-		if (one_step_parse)
-		{
-			/* Since no disjunct packing has been done, we will not be able
-			 * to restore them in case a parsing with null_count>0 is
-			 * needed.  Hence we must not optimize for null_count==0. */
-			needed_prune_level = 1;
-		}
-	}
-	else
-	{
-		free_sentence_disjuncts(sent);
+	free_sentence_disjuncts(sent);
 
-		if (one_step_parse)
-		{
-			/* Save the disjuncts in case we need to parse with null_count>0. */
-			disjuncts_copy = alloca(sent->length * sizeof(Disjunct *));
-			saved_memblock = save_disjuncts(sent, ts_pruning, disjuncts_copy);
-		}
+	if (one_step_parse)
+	{
+		/* Save the disjuncts in case we need to parse with null_count>0. */
+		disjuncts_copy = alloca(sent->length * sizeof(Disjunct *));
+		saved_memblock = save_disjuncts(sent, ts_pruning, disjuncts_copy);
 	}
 
 	for (int nl = min_null_count; nl <= max_null_count; nl++)


### PR DESCRIPTION
Currently, packing, connector encoding and connector sharing all are done together.
For very small sentences, this has a significant overhead so this step is skipped.
However, packing has the benefit that the disjuncts and connectors can be addressed as an array, and even when used as a lists, `uint32_t` indexes can be used instead of pointers  (reducing memory footprint on 64 bit CPUs).

Future code (WIP) takes benefit of this idea (for speedup).

In this PR:
- Always pack, disregarding sentence length. Connector encoding and connector sharing is still skipped for short sentences.
- Use the disjuncts as an array when enumerating them for short sentences.

This change happens to slightly increase the performance for short English sentences (by ~0.2%).

At the same occasion:
- Add comments and clarifications in existing code which is touched.
- Fix a debug printout in `pack_sentence_*()`.