### PR TITLE
Temporary patch

### DIFF
--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -63,6 +63,9 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 		{
 			if (p == wpt->word)
 			{
+// Temporary hack! There is a crash; I don't understand the root
+// cause; this prevents the crash and seems to give OK results.
+if (NULL == path) return;
 				lgdebug(D_WPA, "Word %s (after %zu) exists (after %zu)\n",
 				        p->subword,
 				        wpt->path[gwordlist_len(wpt->path)-1]->sent_wordidx,


### PR DESCRIPTION
@ampli Could you take a look at this?  I am getting a crash here, because `path` is null. The fix below seems to work and give valid results, but I do not understand the root cause. This happens on a custom dict, which I can provide. 

The problem sentence is "I swooned to the floor"  Note I is capitalized.  With this patch I get:
```
linkparser> I swooned to the floor
No complete linkages found.
Found 4 linkages (4 had no P.P. violations) at null count 2
	Linkage 1, cost vector = (UNUSED=2 DIS=-11.73 LEN=1)

                 +------TOM------+
                 +-TVAQ-+---TNA--+
                 |      |        |
[i] [swooned] to.387 the.331 floor.13

Press RETURN for the next linkage.
```
Note the lower-case `i`.  Both `I` and `i` are in the dictionary; but `swooned` is missing, and the dict does not contain `UNKNOWN-WORD`. The dict also does not contain `RIGHT-WALL` or `LEFT-WALL`. 

Printfs show that both I and i are explored, then `swooned` which gets to this multi-path part, and fails cause path is null.