### PR TITLE
Implement power_table-hashing of unique uppercase parts

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -166,6 +166,15 @@ Connector * connector_new(Pool_desc *, const condesc_t *, Parse_Options);
 void set_connector_length_limit(Connector *, Parse_Options);
 void free_connectors(Connector *);
 
+/**
+ * Compare only the uppercase part of two connectors.
+ * Return true if they are the same, else false.
+ */
+static inline bool connector_uc_eq(const Connector *c1, const Connector *c2)
+{
+	return (connector_uc_num(c1) == connector_uc_num(c2));
+}
+
 /* Length-limits for how far connectors can reach out. */
 #define UNLIMITED_LEN 255
 

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -169,15 +169,6 @@ static Match_node * add_to_left_table_list(Match_node * m, Match_node * l)
 	return l;  /* return pointer to original head */
 }
 
-/**
- * Compare only the uppercase part of two connectors.
- * Return true if they are the same, else false.
- */
-static bool con_uc_eq(const Connector *c1, const Connector *c2)
-{
-	return (connector_uc_num(c1) == connector_uc_num(c2));
-}
-
 static Match_node **get_match_table_entry(unsigned int size, Match_node **t,
                                           Connector * c, int dir)
 {
@@ -188,7 +179,7 @@ static Match_node **get_match_table_entry(unsigned int size, Match_node **t,
 	if (dir == 1) {
 		while (NULL != t[h])
 		{
-			if (con_uc_eq(t[h]->d->right, c)) break;
+			if (connector_uc_eq(t[h]->d->right, c)) break;
 
 			/* Increment and try again. Every hash bucket MUST have
 			 * a unique upper-case part, since later on, we only
@@ -204,7 +195,7 @@ static Match_node **get_match_table_entry(unsigned int size, Match_node **t,
 	{
 		while (NULL != t[h])
 		{
-			if (con_uc_eq(t[h]->d->left, c)) break;
+			if (connector_uc_eq(t[h]->d->left, c)) break;
 			h = (h + 1) & (size-1);
 			if (h == s) return NULL;
 		}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -14,15 +14,15 @@
 #include "api-structures.h"
 #include "connectors.h"
 #include "disjunct-utils.h"
-#include "dict-common/dict-common.h"     // For contable
+#include "dict-common/dict-common.h"    // contable
 #include "post-process/post-process.h"
 #include "post-process/pp-structures.h"
-#include "print/print.h"  // For print_disjunct_counts()
+#include "print/print.h"                // print_disjunct_counts
 
 #include "prune.h"
 #include "resources.h"
 #include "string-set.h"
-#include "tokenize/word-structures.h" // for Word_struct
+#include "tokenize/word-structures.h"   // Word_struct
 #include "tokenize/wordgraph.h"
 
 #define D_PRUNE 5 /* Debug level for this file. */
@@ -35,7 +35,7 @@
 #define ppdebug(...)
 #endif
 
-typedef Connector * connector_table;
+typedef Connector *connector_table;
 
 /* Indicator that this connector cannot be used -- that its "obsolete".  */
 #define BAD_WORD (MAX_SENTENCE+1)
@@ -43,8 +43,8 @@ typedef Connector * connector_table;
 typedef struct c_list_s C_list;
 struct c_list_s
 {
-	C_list * next;
-	Connector * c;
+	C_list *next;
+	Connector *c;
 };
 
 typedef struct power_table_s power_table;
@@ -61,7 +61,7 @@ struct power_table_s
 typedef struct cms_struct Cms;
 struct cms_struct
 {
-	Cms * next;
+	Cms *next;
 	Connector *c;
 };
 
@@ -69,7 +69,7 @@ struct cms_struct
 typedef struct multiset_table_s multiset_table;
 struct multiset_table_s
 {
-	Cms * cms_table[CMS_SIZE];
+	Cms *cms_table[CMS_SIZE];
 };
 
 typedef struct prune_context_s prune_context;
@@ -196,11 +196,11 @@ static void power_table_delete(power_table *pt)
  * The disjunct d (whose left or right pointer points to c) is put
  * into the appropriate hash table
  */
-static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list ** t,
-                                 Connector * c, bool shal)
+static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list **t,
+                                 Connector *c, bool shal)
 {
 	unsigned int h = connector_uc_num(c) & (size-1);
-	assert(c->refcount>0, "refcount %d", c->refcount);
+	assert(c->refcount > 0, "refcount %d", c->refcount);
 
 	C_list *m = pool_alloc(mp);
 	m->next = t[h];
@@ -867,7 +867,7 @@ static int power_prune(Sentence sent, Parse_Options opts, power_table *pt)
 
   */
 
-static multiset_table * cms_table_new(void)
+static multiset_table *cms_table_new(void)
 {
 	multiset_table *mt = (multiset_table *) xalloc(sizeof(multiset_table));
 	memset(mt, 0, sizeof(multiset_table));
@@ -877,7 +877,7 @@ static multiset_table * cms_table_new(void)
 
 static void cms_table_delete(multiset_table *mt)
 {
-	Cms * cms, *xcms;
+	Cms *cms, *xcms;
 	int i;
 	for (i=0; i<CMS_SIZE; i++)
 	{
@@ -890,7 +890,7 @@ static void cms_table_delete(multiset_table *mt)
 	xfree(mt, sizeof(multiset_table));
 }
 
-static unsigned int cms_hash(const char * s)
+static unsigned int cms_hash(const char *s)
 {
 	unsigned int i = 5381;
 	if (islower((int) *s)) s++; /* skip head-dependent indicator */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -197,7 +197,7 @@ static void power_table_delete(power_table *pt)
  * into the appropriate hash table
  */
 static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list **t,
-                                 Connector *c, bool shal)
+                                 Connector *c)
 {
 	unsigned int h = connector_uc_num(c) & (size-1);
 	assert(c->refcount > 0, "refcount %d", c->refcount);
@@ -305,7 +305,7 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 					for (c = c->next; c != NULL; c = c->next)
 					{
 						c->refcount = 1;
-						put_into_power_table(mp, r_size, r_t, c, false);
+						put_into_power_table(mp, r_size, r_t, c);
 					}
 				}
 
@@ -316,7 +316,7 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 					for (c = c->next; c != NULL; c = c->next)
 					{
 						c->refcount = 1;
-						put_into_power_table(mp, l_size, l_t, c, false);
+						put_into_power_table(mp, l_size, l_t, c);
 					}
 				}
 			}
@@ -329,12 +329,12 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 				c = d->right;
 				if (c != NULL)
 				{
-					put_into_power_table(mp, r_size, r_t, c, true);
+					put_into_power_table(mp, r_size, r_t, c);
 				}
 				c = d->left;
 				if (c != NULL)
 				{
-					put_into_power_table(mp, l_size, l_t, c, true);
+					put_into_power_table(mp, l_size, l_t, c);
 				}
 			}
 		}
@@ -371,7 +371,7 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 
 					int w = get_tracon_word_number(c, dir);
 
-					put_into_power_table(mp, sizep[w], tp[w], c, c->shallow);
+					put_into_power_table(mp, sizep[w], tp[w], c);
 				}
 			}
 		}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -192,6 +192,28 @@ static void power_table_delete(power_table *pt)
 	xfree(pt->l_table, 2 * pt->power_table_size * sizeof(C_list **));
 }
 
+static C_list **get_power_table_entry(unsigned int size, C_list **t,
+                                      Connector *c)
+{
+	unsigned int h, s;
+
+	h = s = connector_uc_num(c) & (size-1);
+	while (NULL != t[h])
+	{
+		if (connector_uc_eq(t[h]->c, c)) break;
+
+		/* Increment and try again. Every hash bucket MUST have a unique
+		 * upper-case part, since later on, we only compare the lower-case
+		 * parts, assuming upper-case parts are already equal. So just look
+		 * for the next unused hash bucket.
+		 */
+		h = (h + 1) & (size-1);
+		if (h == s) return NULL;
+	}
+
+	return &t[h];
+}
+
 /**
  * The disjunct d (whose left or right pointer points to c) is put
  * into the appropriate hash table


### PR DESCRIPTION
Power table hash slots contain connectors that happen to have the same hash key, and they often have different UC part. This was the case with the fast-matcher tables until my fast-matcher rewrite.

This PR implements the same idea used in fast-matcher also in the power table. A main different implementation detail is that the power table should support entry removals. The solution implemented here is a common one for that case - deleted entry "tombstone".  Like in the rewritten fast-matcher, the fact that each slot contains only connectors with the same UC allows matching only the LC parts of the connectors.

A benchmark of 1500 runs (250 x (best of 6)) gave these minor speedups:
``` 
1.718000 -   1.7130 =   -0.0050  +0.3%    data/en/corpus-basic.batch
4.833000 -   4.8240 =   -0.0090  +0.2%    data/en/corpus-fixes.batch
```
(I didn't make a benchmark of this PR for long sentences yet.)

The motivation behind this PR is a fast-matcher rewrite I am now doing. For that end, I needed the exact matcher disjunct table sizes per word and direction. It turns out the power table has this info, but it is cumbersome and inefficient to extract it due to the said current mix of different UC parts.

BTW, the immediate motivation for totally rewriting the fast-matcher yet again was, in addition to removing a major bottleneck for long sentences, my WIP of power-prune per null-count (combined with incremental count tables - I totally reimplemented the code that I recently removed). But if power-prune is redone for each increased null-count, the fast-matcher tables need to be rebuilt again and again. The O(n^2) `nearest_word` sorting there turned out to be a bottleneck when there are a lot of disjuncts per word (like the case of the Russian sentence from issue #537 ). Among other things, I reimplemented it (still a WIP) as O(n).