### PR TITLE
Add missing shared-library export.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.6.2 (XXX 2019)
  * Bug-fix the SQL-backed dictionary.
+ * Add missing public symbol to shlib export list. 
 
 Version 5.6.1 (27 May 2019)
  * Performance improvement (approx 20%) in expressions #882.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Version 5.6.2 (XXX 2019)
  * Bug-fix the SQL-backed dictionary.
- * Add missing public symbol to shlib export list. 
+ * Add missing public symbol to shlib export list.
 
 Version 5.6.1 (27 May 2019)
  * Performance improvement (approx 20%) in expressions #882.

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -30,7 +30,7 @@ bool boolean_dictionary_lookup(const Dictionary, const char *);
 Dict_node * dictionary_lookup_list(const Dictionary, const char *);
 Dict_node * dictionary_lookup_wild(const Dictionary, const char *);
 
-bool find_word_in_dict(const Dictionary, const char *);
+bool dictionary_word_is_known(const Dictionary, const char *);
 
 void free_lookup_list(const Dictionary, Dict_node *);
 

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -25,14 +25,17 @@ LINK_BEGIN_DECLS
  * the public API to the link-parser system.
  */
 
-bool boolean_dictionary_lookup(const Dictionary, const char *);
 
 Dict_node * dictionary_lookup_list(const Dictionary, const char *);
 Dict_node * dictionary_lookup_wild(const Dictionary, const char *);
 
+/* Return true if word can be found. */
 bool dictionary_word_is_known(const Dictionary, const char *);
 
 void free_lookup_list(const Dictionary, Dict_node *);
+
+/* This was exported and used by mistake! */
+bool boolean_dictionary_lookup(const Dictionary, const char *);
 
 /* XXX the below probably does not belong ...  ?? */
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -130,6 +130,12 @@ void free_lookup_list(const Dictionary dict, Dict_node *llist)
 	dict->free_lookup(dict, llist);
 }
 
+bool dict_has_word(const Dictionary dict, const char *s)
+{
+	return dict->lookup(dict, s);
+}
+
+/* XXX Same as above. Exported and used by mistake. Deprecated. */
 bool boolean_dictionary_lookup(const Dictionary dict, const char *s)
 {
 	return dict->lookup(dict, s);
@@ -142,12 +148,12 @@ bool boolean_dictionary_lookup(const Dictionary dict, const char *s)
 bool dictionary_word_is_known(const Dictionary dict, const char * word)
 {
 	const char * regex_name;
-	if (boolean_dictionary_lookup (dict, word)) return true;
+	if (dict_has_word(dict, word)) return true;
 
 	regex_name = match_regex(dict->regex_root, word);
 	if (NULL == regex_name) return false;
 
-	return boolean_dictionary_lookup(dict, regex_name);
+	return dict_has_word(dict, regex_name);
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -139,7 +139,7 @@ bool boolean_dictionary_lookup(const Dictionary dict, const char *s)
  * Return true if word is in dictionary, or if word is matched by
  * regex.
  */
-bool find_word_in_dict(const Dictionary dict, const char * word)
+bool dictionary_word_is_known(const Dictionary dict, const char * word)
 {
 	const char * regex_name;
 	if (boolean_dictionary_lookup (dict, word)) return true;

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -143,6 +143,7 @@ struct Dictionary_s
  * and pretty much no one else. If you are not the tokenizer, you
  * probably don't need these. */
 
+bool dict_has_word(const Dictionary dict, const char *);
 Exp * Exp_create(Exp_list *);
 void add_empty_word(Sentence, X_node *);
 void free_Exp_list(Exp_list *);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -143,8 +143,6 @@ struct Dictionary_s
  * and pretty much no one else. If you are not the tokenizer, you
  * probably don't need these. */
 
-bool find_word_in_dict(const Dictionary dict, const char *);
-
 Exp * Exp_create(Exp_list *);
 void add_empty_word(Sentence, X_node *);
 void free_Exp_list(Exp_list *);

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -338,15 +338,15 @@ void dictionary_setup_locale(Dictionary dict)
 
 void dictionary_setup_defines(Dictionary dict)
 {
-	dict->left_wall_defined  = boolean_dictionary_lookup(dict, LEFT_WALL_WORD);
-	dict->right_wall_defined = boolean_dictionary_lookup(dict, RIGHT_WALL_WORD);
+	dict->left_wall_defined  = dict_has_word(dict, LEFT_WALL_WORD);
+	dict->right_wall_defined = dict_has_word(dict, RIGHT_WALL_WORD);
 
-	dict->unknown_word_defined = boolean_dictionary_lookup(dict, UNKNOWN_WORD);
+	dict->unknown_word_defined = dict_has_word(dict, UNKNOWN_WORD);
 	dict->use_unknown_word = true;
 
 	/* In version 5.5.0 UNKNOWN_WORD has been replaced by <UNKNOWN-WORD>. */
 	if (!dict->unknown_word_defined &&
-	    boolean_dictionary_lookup(dict, "UNKNOWN-WORD"))
+	    dict_has_word(dict, "UNKNOWN-WORD"))
 	{
 		prt_error("Warning: Old name \"UNKNOWN-WORD\" is defined in the "
 		          "dictionary. Please use \"<UNKNOWN-WORD>\" instead.\n");

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -111,7 +111,7 @@ int compile_regexs(Regex_node *rn, Dictionary dict)
 			}
 
 			/* Check that the regex name is defined in the dictionary. */
-			if ((NULL != dict) && !boolean_dictionary_lookup(dict, rn->name))
+			if ((NULL != dict) && !dict_has_word(dict, rn->name))
 			{
 				/* TODO: better error handing. Maybe remove the regex? */
 				prt_error("Error: Regex name %s not found in dictionary!\n",

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -10,6 +10,7 @@ dictionary_delete
 dictionary_get_data_dir
 dictionary_set_data_dir
 boolean_dictionary_lookup
+dictionary_word_is_known
 dictionary_lookup_list
 free_lookup_list
 dict_display_word_expr

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -9,6 +9,7 @@ dictionary_get_lang
 dictionary_delete
 dictionary_get_data_dir
 dictionary_set_data_dir
+boolean_dictionary_lookup
 dictionary_lookup_list
 free_lookup_list
 dict_display_word_expr

--- a/link-grammar/tokenize/regex-tokenizer.c
+++ b/link-grammar/tokenize/regex-tokenizer.c
@@ -285,7 +285,7 @@ static bool is_word(const char *word_start, int numchar, cgnum_t *cgnump)
 	}
 
 	lgdebug(7, "LOOKUP '%s' in %s: ", word, dict->name);
-	if (0 == afclass) return boolean_dictionary_lookup(dict, word);
+	if (0 == afclass) return dict_has_word(dict, word);
 
 	/* We don't have for now a tree representation of the affix file, only lists */
 #ifdef AFFIX_DICTIONARY_TREE

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -86,7 +86,7 @@ typedef enum
 #define WS_RUNON   (1<<3) /* Separated from words run-on */
 #define WS_HASALT  (1<<4) /* Has alternatives (one or more)*/
 #define WS_UNSPLIT (1<<5) /* It's an alternative to itself as an unsplit word */
-#define WS_INDICT  (1<<6) /* boolean_dictionary_lookup() is true */
+#define WS_INDICT  (1<<6) /* dict_has_word() is true */
 #define WS_FIRSTUPPER (1<<7) /* Subword is the lc version of its unsplit_word.
                                 The original word can be restored if needed
                                 through this unsplit_word. */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -326,7 +326,7 @@ static bool word_start_another_alternative(Dictionary dict,
 		lgdebug(D_WSAA, "Comparing alt %s\n\\", (*n)->subword);
 		if ((0 == strcmp((*n)->subword, altword0) ||
 		    ((0 == strncmp((*n)->subword, altword0, strlen((*n)->subword))) &&
-			 !find_word_in_dict(dict, altword0))))
+			 !dictionary_word_is_known(dict, altword0))))
 		{
 			lgdebug(+D_UN, "Preventing alt starts with %s due to existing %zu:%s\n",
 			        altword0, (*n)->node_num, (*n)->subword);
@@ -1330,12 +1330,12 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 
 				/* Check if the remainder is in the dictionary.
 				 * In case we try to split a contracted word, the first word
-				 * may match a regex. Hence find_word_in_dict() is used and
-				 * not boolean_dictionary_lookup().
-				 * Note: Not like a previous version, stems cannot match a regex
+				 * may match a regex. Hence dictionary_word_is_known() is
+				 * used and not boolean_dictionary_lookup().
+				 * Note: Unlike previous versions, stems cannot match a regex
 				 * here, and stem capitalization need to be handled elsewhere. */
 				if ((is_contraction_word(dict, w) &&
-				    find_word_in_dict(dict, newword)) ||
+				    dictionary_word_is_known(dict, newword)) ||
 				    boolean_dictionary_lookup(dict, newword))
 				{
 					did_split = true;
@@ -1515,7 +1515,7 @@ static bool mprefix_split(Sentence sent, Gword *unsplit_word, const char *word)
 					 * It has been added in separate_word() as a word */
 					break;
 				}
-				if (find_word_in_dict(dict, newword))
+				if (dictionary_word_is_known(dict, newword))
 				{
 					word_is_in_dict = true;
 					lgdebug(+D_UN, "Splitting off a prefix: %.*s-%s\n",
@@ -2462,7 +2462,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			strncpy(temp_word, word, sz);
 			temp_word[sz] = '\0';
 
-			if (find_word_in_dict(dict, temp_word))
+			if (dictionary_word_is_known(dict, temp_word))
 			{
 				issue_r_stripped(sent, unsplit_word, temp_word, NULL,
 										 r_stripped, units_n_stripped, "rR2");
@@ -2482,8 +2482,8 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			strncpy(temp_word, word, sz);
 			temp_word[sz] = '\0';
 
-			if (!find_word_in_dict(dict, unsplit_word->subword) ||
-			    (0 == sz) || find_word_in_dict(dict, temp_word))
+			if (!dictionary_word_is_known(dict, unsplit_word->subword) ||
+			    (0 == sz) || dictionary_word_is_known(dict, temp_word))
 			{
 				issue_r_stripped(sent, unsplit_word, temp_word, NULL,
 										 r_stripped, n_stripped, "rR3");
@@ -2661,7 +2661,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			 * FIXME? Issuing only known lc words prevents using the unknown-word
 			 * device for words in capitalizable position (when the word is a uc
 			 * version of an unknown word). */
-			if (find_word_in_dict(sent->dict, downcase))
+			if (dictionary_word_is_known(sent->dict, downcase))
 				issue_dictcap(sent, /*is_cap*/false, unsplit_word, downcase);
 
 			word_is_known = true; /* We could just return */
@@ -3425,7 +3425,7 @@ bool sentence_in_dictionary(Sentence sent)
 		for (ialt=0; NULL != sent->word[w].alternatives[ialt]; ialt++)
 		{
 			s = sent->word[w].alternatives[ialt];
-			if (!find_word_in_dict(dict, s))
+			if (!dictionary_word_is_known(dict, s))
 			{
 				if (ok_so_far)
 				{


### PR DESCRIPTION
Also rationalize the function names to fit the existing naming strategy.