### PR TITLE
Cleanup t5

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -50,9 +50,8 @@
 #include "string-set.h"
 
 /* Performance tuning.
- * For short sentences, setting suffix IDs and packing takes more
- * resources than it saves. If this overhead is improved, these
- * limit can be set lower. */
+ * For short sentences, encoding takes more resources than it saves. If
+ * this overhead is improved, this limit can be set lower. */
 #define SENTENCE_MIN_LENGTH_TRAILING_HASH 6
 
 typedef struct Cost_Model_s Cost_Model;
@@ -135,7 +134,7 @@ struct Sentence_s
 	Pool_desc * Connector_pool;
 
 	/* Connector encoding, packing & sharing. */
-	size_t min_len_encoding;     /* Do it from this sentence length. */
+	size_t min_len_encoding;     /* Encode from this sentence length. */
 	void *dc_memblock;           /* For packed disjuncts & connectors. */
 
 	/* Wordgraph stuff. FIXME: create stand-alone struct for these. */

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -13,6 +13,8 @@
 
 #ifdef HAVE_SQLITE
 
+#define D_SQL 5 /* Verbosity levels for this module are 5 and 6. */
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -253,7 +255,7 @@ db_lookup_exp(Dictionary dict, const char *s, cbdata* bs)
 
 	if (es != s) free(es);
 
-	if (4 < verbosity)
+	if (verbosity_level(D_SQL+1))
 	{
 		printf("Found expression for class %s: ", s);
 		print_expression(bs->exp);
@@ -346,7 +348,7 @@ static Dict_node * db_lookup_list(Dictionary dict, const char *s)
 	bs.dict = dict;
 	bs.dn = NULL;
 	db_lookup_common(dict, s, "=", morph_cb, &bs);
-	if (3 < verbosity)
+	if (verbosity_level(D_SQL))
 	{
 		if (bs.dn)
 		{
@@ -373,7 +375,7 @@ static Dict_node * db_lookup_wild(Dictionary dict, const char *s)
 	bs.dict = dict;
 	bs.dn = NULL;
 	db_lookup_common(dict, s, "GLOB", morph_cb, &bs);
-	if (3 < verbosity)
+	if (verbosity_level(D_SQL))
 	{
 		if (bs.dn)
 		{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -683,7 +683,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 	{
 		newc = NULL;
 
-		if ((NULL != ts) && (NULL != ts->csid[dir]))
+		if (NULL != ts->csid[dir])
 		{
 			/* Encoding is used - share tracons. */
 			Connector **tracon = tracon_set_add(o, ts->csid[dir]);

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -121,7 +121,7 @@ struct tracon_sharing_s
 	unsigned int num_disjuncts;
 	Tracon_set *csid[2];        /* For generating unique tracon IDs */
 	int next_id[2];             /* Next unique tracon ID */
-	uintptr_t last_token;       /* Tracons are only unique per "token" */
+	uintptr_t last_token;       /* Tracons are the same only per this token */
 	int word_offset;            /* Start number for connector tracon_id */
 	bool is_pruning;            /* true - for pruning; false - for parsing */
 	Tracon_list *tracon_list;   /* Used only for pruning */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -110,8 +110,8 @@ struct tracon_sharing_s
 {
 	union
 	{
-		void *memblock;             /* Memory block for disjuncts & connectors */
-		Disjunct *dblock_base;      /* Start of disjunct block */
+		void *memblock;          /* Memory block for disjuncts & connectors */
+		Disjunct *dblock_base;   /* Start of disjunct block */
 	};
 	size_t memblock_sz;         /* memblock size */
 	Connector *cblock_base;     /* Start of connector block */

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -48,6 +48,8 @@ const char *feature_enabled(const char *, ...);
  *
  * Invoking lgdebug() with a level number preceded by a + (+level) adds
  * printing of the function name.
+ * FIXME: The level is then Trace and if the message starts with a level
+ * it is ignored.
  */
 #define lgdebug(level, ...) \
 	(( \

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -11,15 +11,15 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include "api-structures.h"  // For Sentence_s
+#include "api-structures.h"             // Sentence_s
 #include "connectors.h"
 #include "disjunct-utils.h"
 #include "fast-match.h"
 #include "string-set.h"
-#include "dict-common/dict-common.h"   // For contable
-#include "tokenize/word-structures.h"  // For Word_struct
+#include "dict-common/dict-common.h"    // contable
+#include "tokenize/word-structures.h"   // Word_struct
 #include "tokenize/wordgraph.h"
-#include "tokenize/tok-structures.h" // XXX TODO provide gword access methods!
+#include "tokenize/tok-structures.h"    // TODO provide gword access methods!
 #include "utilities.h"                  // UNREACHABLE
 
 /**
@@ -450,9 +450,12 @@ static bool alt_connection_possible(Connector *c1, Connector *c2,
 		return c_con->same_alternative;
 
 	/* Each of the loops is of one iteration most of the times. */
-	for (const gword_set *ga = c1->originating_gword; NULL != ga; ga = ga->next) {
-		for (const gword_set *gb = c2->originating_gword; NULL != gb; gb = gb->next) {
-			if (in_same_alternative(ga->o_gword, gb->o_gword)) {
+	for (const gword_set *ga = c1->originating_gword; NULL != ga; ga = ga->next)
+	{
+		for (const gword_set *gb = c2->originating_gword; NULL != gb; gb = gb->next)
+		{
+			if (in_same_alternative(ga->o_gword, gb->o_gword))
+			{
 				 same_alternative = true;
 				 break;
 			}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -135,7 +135,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	build_sentence_disjuncts(sent, opts->disjunct_cost, opts);
 	if (verbosity_level(D_PREP))
 	{
-		prt_error("Debug: After expanding expressions into disjuncts:\n");
+		prt_error("Debug: After expanding expressions into disjuncts:\n\\");
 		print_disjunct_counts(sent);
 	}
 	print_time(opts, "Built disjuncts");

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -376,7 +376,7 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 			unsigned int *sizep;
 			unsigned int sid_entries = tl->entries[dir];
 
-			if (dir== 0)
+			if (dir == 0)
 			{
 				tp = pt->l_table;
 				sizep = pt->l_table_size;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -710,7 +710,7 @@ static bool is_bad(Connector *c)
  *  pass by marking their connectors with the pass number in their
  *  tracon_id field.
  */
-static int power_prune(Sentence sent, Parse_Options opts, power_table *pt)
+static int power_prune(Sentence sent, power_table *pt, Parse_Options opts)
 {
 	prune_context pc;
 	int N_deleted[2] = {0}; /* [0] counts first deletions, [1] counts dups. */
@@ -1281,9 +1281,9 @@ void pp_and_power_prune(Sentence sent, Tracon_sharing *ts, Parse_Options opts)
 	power_table pt;
 	power_table_init(sent, ts, &pt);
 
-	power_prune(sent, opts, &pt);
+	power_prune(sent, &pt, opts);
 	if (pp_prune(sent, ts, opts) > 0)
-		power_prune(sent, opts, &pt);
+		power_prune(sent, &pt, opts);
 
 	/* No benefit for now to make additional pp_prune() & power_prune() -
 	 * additional deletions are very rare and even then most of the

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -266,7 +266,7 @@ static void power_table_alloc(Sentence sent, power_table *pt)
  */
 static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 {
-	Tracon_list *tl = (NULL == ts) ? NULL : ts->tracon_list;
+	Tracon_list *tl = ts->tracon_list;
 	unsigned int i;
 #define TOPSZ 32768
 	size_t lr_table_max_usage = MIN(sent->dict->contable.num_con, TOPSZ);
@@ -1143,7 +1143,7 @@ static int pp_prune(Sentence sent, Tracon_sharing *ts, Parse_Options opts)
 	knowledge = sent->postprocessor->knowledge;
 	cmt = cms_table_new();
 
-	Tracon_list *tl = (NULL == ts) ? NULL : ts->tracon_list;
+	Tracon_list *tl = ts->tracon_list;
 	if (NULL != tl)
 	{
 		for (int dir = 0; dir < 2; dir++)

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -14,12 +14,12 @@
 #include "api-structures.h"
 #include "connectors.h"
 #include "corpus/corpus.h"
-#include "dict-common/dict-utils.h"   // For size_of_expression()
+#include "dict-common/dict-utils.h"     // size_of_expression
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
-#include "post-process/post-process.h" // for compute_domain_names()
+#include "post-process/post-process.h"  // compute_domain_names
 #include "print.h"
-#include "tokenize/word-structures.h" // For Word_struct
+#include "tokenize/word-structures.h"   // Word_struct
 #include "wcwidth.h"
 
 #define LEFT_WALL_SUPPRESS ("Wd") /* If this connector is used on the wall, */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -922,7 +922,7 @@ int main(int argc, char * argv[])
 		 * However, if "-test=one-step-parse" is used and we are said to
 		 * parse with null links, allow parsing here with null links too. */
 		bool one_step_parse = !copts->batch_mode && copts->allow_null &&
-		                    test_enabled(test, "one-step-parse");
+		                      test_enabled(test, "one-step-parse");
 		int max_null_count = one_step_parse ? sentence_length(sent) : 0;
 
 		parse_options_set_min_null_count(opts, 0);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -44,6 +44,7 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <unistd.h>
 #else
 #include <windows.h>
@@ -631,6 +632,13 @@ fail:
 #endif /* _WIN32 */
 }
 
+#ifdef INTERRUPT_EXIT
+static void interrupt_exit(int n)
+{
+	exit(128+n);
+}
+#endif
+
 int main(int argc, char * argv[])
 {
 	FILE            *input_fh = stdin;
@@ -676,6 +684,11 @@ int main(int argc, char * argv[])
 	sigemptyset (&winch_act.sa_mask);
 	winch_act.sa_flags = 0;
 	sigaction (SIGWINCH, &winch_act, NULL);
+#endif
+
+#ifdef INTERRUPT_EXIT
+	(void)signal(SIGINT, interrupt_exit);
+	(void)signal(SIGTERM, interrupt_exit);
 #endif
 
 	copts = command_options_create();


### PR DESCRIPTION
The main change in this PR is:
- read-sql.c: Use verbosity_level()
to avoid an unconditional high-volume debug output.
Another fix for debug convenience is:
- link-parser.c: Add interrupt_exit()

Also included:
- Comment fixes.
- Whitespace and code cleanups.
- Debug message fix.
