### PR TITLE
Version 5.6.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Version 5.6.3 (XXX 2019)
+ * Something
+
 Version 5.6.2 (24 June 2019)
  * Bug-fix the SQL-backed dictionary.
  * Add missing public symbol to shlib export list.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
-Version 5.6.2 (XXX 2019)
+Version 5.6.2 (24 June 2019)
  * Bug-fix the SQL-backed dictionary.
  * Add missing public symbol to shlib export list.
+ * English dict: additions of paraphrasing verbs.
 
 Version 5.6.1 (27 May 2019)
  * Performance improvement (approx 20%) in expressions #882.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Link Grammar Parser
 ===================
-***Version 5.6.1***
+***Version 5.6.2***
 
 The Link Grammar Parser implements the Sleator/Temperley/Lafferty
 theory of natural language parsing. This version of the parser is
@@ -185,7 +185,7 @@ corruption of the dataset during download, and to help ensure that
 no malicious changes were made to the code internals by third
 parties. The signatures can be checked with the gpg command:
 
-`gpg --verify link-grammar-5.6.1.tar.gz.asc`
+`gpg --verify link-grammar-5.6.2.tar.gz.asc`
 
 which should generate output identical to (except for the date):
 ```
@@ -200,7 +200,7 @@ verify the check-sums, issue `md5sum -c MD5SUM` at the command line.
 Tags in `git` can be verified by performing the following:
 ```
 gpg --recv-keys --keyserver keyserver.ubuntu.com EB6AA534E0C0651C
-git tag -v link-grammar-5.6.1
+git tag -v link-grammar-5.6.2
 ```
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # accordingly.
 # Don't end the URLs with a slash even if it appears in the official address,
 # because we may append a component. Also, they cannot include "!".
-AC_INIT([link-grammar],[5.6.1],[https://github.com/opencog/link-grammar],,
+AC_INIT([link-grammar],[5.6.2],[https://github.com/opencog/link-grammar],,
 		  [https://www.abisource.com/projects/link-grammar])
 
 DISCUSSION_GROUP=https://groups.google.com/d/forum/link-grammar
@@ -23,7 +23,7 @@ LINK_MINOR_VERSION=6
 dnl     3) Increment when interfaces not changed at all,
 dnl        only bug fixes or internal changes made.
 dnl     4b) Set to zero when adding, removing or changing interfaces.
-LINK_MICRO_VERSION=1
+LINK_MICRO_VERSION=2
 dnl
 dnl     Set this too
 MAJOR_VERSION_PLUS_MINOR_VERSION=`expr $LINK_MAJOR_VERSION + $LINK_MINOR_VERSION`


### PR DESCRIPTION
I published version 5.6.4 4 days ago, but apparently failed to update github.   This branch is the 
"master" for version-5.6.2; it is being merged after-the-fact...