### PR TITLE
Create fewer OR-expressions in the SQL dict-reader. 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 Version 5.6.3 (XXX 2019)
- * Something
+ * Minor efficiency improvements to the SQL-backed dictionary.
 
 Version 5.6.2 (24 June 2019)
  * Bug-fix the SQL-backed dictionary.

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 # accordingly.
 # Don't end the URLs with a slash even if it appears in the official address,
 # because we may append a component. Also, they cannot include "!".
-AC_INIT([link-grammar],[5.6.2],[https://github.com/opencog/link-grammar],,
+AC_INIT([link-grammar],[5.6.3],[https://github.com/opencog/link-grammar],,
 		  [https://www.abisource.com/projects/link-grammar])
 
 DISCUSSION_GROUP=https://groups.google.com/d/forum/link-grammar
@@ -23,7 +23,7 @@ LINK_MINOR_VERSION=6
 dnl     3) Increment when interfaces not changed at all,
 dnl        only bug fixes or internal changes made.
 dnl     4b) Set to zero when adding, removing or changing interfaces.
-LINK_MICRO_VERSION=2
+LINK_MICRO_VERSION=3
 dnl
 dnl     Set this too
 MAJOR_VERSION_PLUS_MINOR_VERSION=`expr $LINK_MAJOR_VERSION + $LINK_MINOR_VERSION`

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10,8 +10,8 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.6.2 (formatted as V5v6v2+)
-<dictionary-version-number>: V5v6v2+;
+% Dictionary version number is 5.6.3 (formatted as V5v6v3+)
+<dictionary-version-number>: V5v6v3+;
 <dictionary-locale>: EN4us+;
 
  % _ORGANIZATION OF THE DICTIONARY_

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -19,8 +19,8 @@ changecom(`%')
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.6.2 (formatted as V5v6v2+)
-<dictionary-version-number>: V5v6v2+;
+% Dictionary version number is 5.6.3 (formatted as V5v6v3+)
+<dictionary-version-number>: V5v6v3+;
 <dictionary-locale>: EN4us+;
 
  % _ORGANIZATION OF THE DICTIONARY_

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -113,6 +113,8 @@ static const char * make_expression(Dictionary dict,
 	}
 	else if ('o' == *p && 'r' == *(p+1))
 	{
+		/* Actually, the dict should never contain `or`;
+		 * `or` is handled with multiple entries. */
 		etype = OR_type; p+=2;
 	}
 	else
@@ -184,23 +186,35 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 		exp->cost = 1.0;
 	}
 
+	/* If the very first expression, just put it in place */
 	if (NULL == bs->exp)
 	{
 		bs->exp = exp;
 		return 0;
 	}
 
-	E_list *ell, *elr;
-	Exp* orn = malloc(sizeof(Exp));
-	orn->type = OR_type;
-	orn->cost = 0.0;
-	orn->u.l = ell = malloc(sizeof(E_list));
-	ell->next = elr = malloc(sizeof(E_list));
-	elr->next = NULL;
+	/* If the second expression, OR-it with the existing expression. */
+	if (OR_type != bs->exp->type)
+	{
+		E_list *ell, *elr;
+		Exp* orn = malloc(sizeof(Exp));
+		orn->type = OR_type;
+		orn->cost = 0.0;
+		orn->u.l = ell = malloc(sizeof(E_list));
+		ell->next = elr = malloc(sizeof(E_list));
+		elr->next = NULL;
 
-	ell->e = bs->exp;
-	elr->e = exp;
-	bs->exp = orn;
+		ell->e = exp;
+		elr->e = bs->exp;
+		bs->exp = orn;
+		return 0;
+	}
+
+	/* Extend the OR-chain for the third and lter expressions. */
+	E_list* more = malloc(sizeof(E_list));
+	more->e = exp;
+	more->next = bs->exp->u.l;
+	bs->exp->u.l = more;
 
 	return 0;
 }

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -210,7 +210,7 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 		return 0;
 	}
 
-	/* Extend the OR-chain for the third and lter expressions. */
+	/* Extend the OR-chain for the third and later expressions. */
 	E_list* more = malloc(sizeof(E_list));
 	more->e = exp;
 	more->next = bs->exp->u.l;


### PR DESCRIPTION
Pointless OR-exps were being created; these eat memory and hurt performance.