### PR TITLE
Clean up SYM_AND dict reading

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -537,7 +537,11 @@ void sentence_delete(Sentence sent)
 	pool_delete(sent->Exp_pool);
 	pool_delete(sent->X_node_pool);
 	if (IS_DB_DICT(sent->dict))
+	{
 		condesc_reuse(sent->dict);
+		pool_reuse(sent->dict->E_list_pool);
+		pool_reuse(sent->dict->Exp_pool);
+	}
 
 	free(sent);
 }

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -247,36 +247,6 @@ int delete_dictionary_words(Dictionary dict, const char * s)
 }
 #endif /* USEFUL_BUT_NOT_CURRENTLY_USED */
 
-/**
- * The following two functions free the Exp s and the
- * E_lists of the dictionary.  Not to be confused with
- * free_E_list in dict-utils.c.
- */
-static void free_Elist(E_list * l)
-{
-	E_list * l1;
-
-	for (; l != NULL; l = l1) {
-		l1 = l->next;
-		free(l);
-	}
-}
-
-void free_Exp_list(Exp_list * eli)
-{
-	Exp * e1;
-	Exp * e = eli->exp_list;
-	for (; e != NULL; e = e1)
-	{
-		e1 = e->next;
-		if (e->type != CONNECTOR_type)
-		{
-		   free_Elist(e->u.l);
-		}
-		free(e);
-	}
-}
-
 static void free_dict_node_recursive(Dict_node * dn)
 {
 	if (dn == NULL) return;
@@ -289,7 +259,8 @@ static void free_dictionary(Dictionary dict)
 {
 	free_dict_node_recursive(dict->root);
 	free_Word_file(dict->word_file_header);
-	free_Exp_list(&dict->exp_list);
+	pool_delete(dict->Exp_pool);
+	pool_delete(dict->E_list_pool);
 }
 
 static void affix_list_delete(Dictionary dict)

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -17,6 +17,7 @@
 #include "api-types.h"                  // pp_knowledge
 #include "connectors.h"                 // ConTable
 #include "dict-structures.h"
+#include "memory-pool.h"                // Pool_desc
 #include "utilities.h"                  // locale_t
 
 #define EMPTY_CONNECTOR "ZZZ"
@@ -25,14 +26,7 @@
 
 /* Forward decls */
 typedef struct Afdict_class_struct Afdict_class;
-typedef struct Exp_list_s Exp_list;
 typedef struct Regex_node_s Regex_node;
-
-/* Used for memory management */
-struct Exp_list_s
-{
-	Exp * exp_list;
-};
 
 typedef struct X_node_struct X_node;
 struct X_node_struct
@@ -121,10 +115,9 @@ struct Dictionary_s
 	Word_file *     word_file_header;
 	ConTable        contable;
 
-	/* exp_list links together all the Exp structs that are allocated
-	 * in reading this dictionary.  Needed for freeing the dictionary
-	 */
-	Exp_list        exp_list;
+	/* Memory pools */
+	Pool_desc  * Exp_pool;
+	Pool_desc  * E_list_pool;
 
 	/* Private data elements that come in play only while the
 	 * dictionary is being read, and are not otherwise used.
@@ -144,8 +137,7 @@ struct Dictionary_s
  * probably don't need these. */
 
 bool dict_has_word(const Dictionary dict, const char *);
-Exp * Exp_create(Exp_list *);
+Exp * Exp_create(Dictionary);
 void add_empty_word(Sentence, X_node *);
-void free_Exp_list(Exp_list *);
 
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -52,8 +52,7 @@ struct Exp_struct
 		E_list * l;           /* Only needed for non-terminals */
 		condesc_t * condesc;  /* Only needed if it's a connector */
 	} u;
-	double cost;   /* The cost of using this expression.
-	                  Only used for non-terminals */
+	double cost;   /* The cost of using this expression. */
 };
 
 struct E_list_struct

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -45,7 +45,6 @@ typedef enum
  */
 struct Exp_struct
 {
-	Exp * next;    /* Used only for memory management, for freeing */
 	Exp_type type; /* One of three types: AND, OR, or connector. */
 	char dir;      /* The connector connects to: '-': the left; '+': the right */
 	bool multi;    /* TRUE if a multi-connector (for connector)  */

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -241,16 +241,16 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	/* note that the last word of the idiom is first in our list */
 
 	/* ----- this code just sets up the node fields of the dn_list ----*/
-	nc = Exp_create(&dict->exp_list);
+	nc = Exp_create(dict);
 	nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '-';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;
 	nc->cost = 0;
 
-	n1 = Exp_create(&dict->exp_list);
-	n1->u.l = ell = (E_list *) malloc(sizeof(E_list));
-	ell->next = elr = (E_list *) malloc(sizeof(E_list));
+	n1 = Exp_create(dict);
+	n1->u.l = ell = pool_alloc(dict->Exp_pool);
+	ell->next = elr = pool_alloc(dict->Exp_pool);
 	elr->next = NULL;
 	ell->e = nc;
 	elr->e = no;
@@ -265,14 +265,14 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	{
 		/* generate the expression for a middle idiom word */
 
-		n1 = Exp_create(&dict->exp_list);
+		n1 = Exp_create(dict);
 		n1->type = AND_type;
 		n1->cost = 0;
-		n1->u.l = ell = (E_list *) malloc(sizeof(E_list));
-		ell->next = elr = (E_list *) malloc(sizeof(E_list));
+		n1->u.l = ell = pool_alloc(dict->E_list_pool);
+		ell->next = elr = pool_alloc(dict->E_list_pool);
 		elr->next = NULL;
 
-		nc = Exp_create(&dict->exp_list);
+		nc = Exp_create(dict);
 		nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '+';
 		nc->multi = false;
@@ -282,7 +282,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 
 		increment_current_name(dict);
 
-		nc = Exp_create(&dict->exp_list);
+		nc = Exp_create(dict);
 		nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '-';
 		nc->multi = false;
@@ -297,7 +297,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	}
 	/* now generate the last one */
 
-	nc = Exp_create(&dict->exp_list);
+	nc = Exp_create(dict);
 	nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '+';
 	nc->multi = false;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -106,6 +106,7 @@ dictionary_six_str(const char * lang,
 {
 	const char * t;
 	Dictionary dict;
+	size_t E_pool_size;   /* Exp & E_list memory pool sizes. */
 
 	dict = (Dictionary) malloc(sizeof(struct Dictionary_s));
 	memset(dict, 0, sizeof(struct Dictionary_s));
@@ -136,6 +137,7 @@ dictionary_six_str(const char * lang,
 		dict->free_lookup = free_llist;
 		dict->lookup = file_boolean_lookup;
 		condesc_init(dict, 1<<13);
+		E_pool_size = 1<<13;
 	}
 	else
 	{
@@ -146,7 +148,15 @@ dictionary_six_str(const char * lang,
 		dict->insert_entry = load_affix;
 		dict->lookup = return_true;
 		condesc_init(dict, 1<<9);
+		E_pool_size = 1<<5;
 	}
+
+	dict->Exp_pool = pool_new(__func__, "Exp", /*num_elements*/E_pool_size,
+	                          sizeof(Exp), /*zero_out*/false,
+	                          /*align*/false, /*exact*/false);
+	dict->E_list_pool = pool_new(__func__, "E_list", /*num_elements*/E_pool_size,
+	                             sizeof(E_list), /*zero_out*/false,
+	                             /*align*/false, /*exact*/false);
 
 	/* Read dictionary from the input string. */
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -13,10 +13,10 @@
 
 #include <string.h>
 
-#include "api-structures.h"           // For Sentence_s (add_empty_word())
-#include "dict-common/dict-affix.h"   // For is_stem()
+#include "api-structures.h"             // Sentence_s (add_empty_word)
+#include "dict-common/dict-affix.h"     // is_stem
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h" // For SUBSCRIPT_MARK
+#include "dict-common/dict-defines.h"   // SUBSCRIPT_MARK
 #include "dict-common/file-utils.h"
 #include "dict-common/idiom.h"
 #include "error.h"
@@ -24,7 +24,7 @@
 #include "externs.h"
 #include "read-dict.h"
 #include "string-set.h"
-#include "tokenize/tok-structures.h" // needed for MT_WALL
+#include "tokenize/tok-structures.h"    // MT_WALL
 #include "utilities.h"
 #include "word-file.h"
 
@@ -631,7 +631,7 @@ static bool subscr_match(const char *s, const Dict_node * dn)
 	if (NULL == s_sub) return true;
 	t_sub = strrchr(dn->string, SUBSCRIPT_MARK);
 	if (NULL == t_sub) return false;
-	if ( 0 == strcmp(s_sub, t_sub)) return true;
+	if (0 == strcmp(s_sub, t_sub)) return true;
 
 	return false;
 }

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -794,13 +794,11 @@ static Dict_node * strict_lookup_list(const Dictionary dict, const char *s)
 
 /* ======================================================================== */
 /**
- * Allocate a new Exp node and link it into the exp_list for freeing later.
+ * Allocate a new Exp node.
  */
-Exp * Exp_create(Exp_list *eli)
+Exp *Exp_create(Dictionary dict)
 {
-	Exp * e = malloc(sizeof(Exp));
-	e->next = eli->exp_list;
-	eli->exp_list = e;
+	Exp *e = pool_alloc(dict->Exp_pool);
 	return e;
 }
 
@@ -808,9 +806,9 @@ Exp * Exp_create(Exp_list *eli)
  * This creates a node with zero children.  Initializes
  * the cost to zero.
  */
-static Exp * make_zeroary_node(Exp_list * eli)
+static Exp * make_zeroary_node(Dictionary dict)
 {
-	Exp * n = Exp_create(eli);
+	Exp * n = Exp_create(dict);
 	n->type = AND_type;  /* these must be AND types */
 	n->cost = 0.0;
 	n->u.l = NULL;
@@ -821,13 +819,13 @@ static Exp * make_zeroary_node(Exp_list * eli)
  * This creates a node with one child (namely e).  Initializes
  * the cost to zero.
  */
-static Exp * make_unary_node(Exp_list * eli, Exp * e)
+static Exp * make_unary_node(Dictionary dict, Exp * e)
 {
 	Exp * n;
-	n = Exp_create(eli);
+	n = Exp_create(dict);
 	n->type = AND_type;  /* these must be AND types */
 	n->cost = 0.0;
-	n->u.l = (E_list *) malloc(sizeof(E_list));
+	n->u.l = pool_alloc(dict->E_list_pool);
 	n->u.l->next = NULL;
 	n->u.l->e = e;
 	return n;
@@ -837,17 +835,17 @@ static Exp * make_unary_node(Exp_list * eli, Exp * e)
  * Create an AND_type expression. The expressions nl, nr will be
  * AND-ed together.
  */
-static Exp * make_and_node(Exp_list * eli, Exp* nl, Exp* nr)
+static Exp * make_and_node(Dictionary dict, Exp* nl, Exp* nr)
 {
 	E_list *ell, *elr;
 	Exp* n;
 
-	n = Exp_create(eli);
+	n = Exp_create(dict);
 	n->type = AND_type;
 	n->cost = 0.0;
 
-	n->u.l = ell = (E_list *) malloc(sizeof(E_list));
-	ell->next = elr = (E_list *) malloc(sizeof(E_list));
+	n->u.l = ell = pool_alloc(dict->E_list_pool);
+	ell->next = elr = pool_alloc(dict->E_list_pool);
 	elr->next = NULL;
 
 	ell->e = nl;
@@ -855,9 +853,9 @@ static Exp * make_and_node(Exp_list * eli, Exp* nl, Exp* nr)
 	return n;
 }
 
-static Exp *make_op_Exp(Exp_list *eli, Exp_type t)
+static Exp *make_op_Exp(Dictionary dict, Exp_type t)
 {
-	Exp * n = Exp_create(eli);
+	Exp * n = Exp_create(dict);
 	n->type = t;
 	n->cost = 0.0;
 	n->u.l = NULL;
@@ -865,9 +863,9 @@ static Exp *make_op_Exp(Exp_list *eli, Exp_type t)
 	return n;
 }
 
-static E_list *make_E_list_val(Exp* nr)
+static E_list *make_E_list_val(Dictionary dict, Exp* nr)
 {
-	E_list *elr = (E_list *) malloc(sizeof(E_list));
+	E_list *elr = pool_alloc(dict->E_list_pool);
 
 	elr->e = nr;
 	elr->next = NULL;
@@ -879,17 +877,17 @@ static E_list *make_E_list_val(Exp* nr)
  * Create an OR_type expression. The expressions nl, nr will be
  * OR-ed together.
  */
-static Exp * make_or_node(Exp_list *eli, Exp* nl, Exp* nr)
+static Exp * make_or_node(Dictionary dict, Exp* nl, Exp* nr)
 {
 	E_list *ell, *elr;
 	Exp* n;
 
-	n = Exp_create(eli);
+	n = Exp_create(dict);
 	n->type = OR_type;
 	n->cost = 0.0;
 
-	n->u.l = ell = (E_list *) malloc(sizeof(E_list));
-	ell->next = elr = (E_list *) malloc(sizeof(E_list));
+	n->u.l = ell = pool_alloc(dict->E_list_pool);
+	ell->next = elr = pool_alloc(dict->E_list_pool);
 	elr->next = NULL;
 
 	ell->e = nl;
@@ -902,9 +900,9 @@ static Exp * make_or_node(Exp_list *eli, Exp* nl, Exp* nr)
  * and the other as zeroary node.  This has the effect of creating
  * what used to be called an optional node.
  */
-static Exp * make_optional_node(Exp_list *eli, Exp * e)
+static Exp *make_optional_node(Dictionary dict, Exp *e)
 {
-	return make_or_node(eli, make_zeroary_node(eli), e);
+	return make_or_node(dict, make_zeroary_node(dict), e);
 }
 
 /**
@@ -915,7 +913,7 @@ static Exp * make_optional_node(Exp_list *eli, Exp * e)
  */
 static Exp * make_dir_connector(Dictionary dict, int i)
 {
-	Exp* n = Exp_create(&dict->exp_list);
+	Exp* n = Exp_create(dict);
 	char *constring;
 
 	n->dir = dict->token[i];
@@ -974,7 +972,7 @@ static Exp * make_connector(Dictionary dict)
 		}
 
 		/* Wrap it in a unary node as a placeholder for a cost if needed. */
-		n = make_unary_node(&dict->exp_list, dn->exp);
+		n = make_unary_node(dict, dn->exp);
 
 		file_free_lookup(dn_head);
 	}
@@ -1003,7 +1001,7 @@ static Exp * make_connector(Dictionary dict)
 			min = make_dir_connector(dict, i);
 			if (NULL == min) return NULL;
 
-			n = make_or_node(&dict->exp_list, plu, min);
+			n = make_or_node(dict, plu, min);
 		}
 		else
 		{
@@ -1131,13 +1129,13 @@ static bool is_number(const char * str)
 /* #if ! defined INFIX_NOTATION */
 #if 0
 
-static Exp * expression(Dictionary dict);
+static Exp *expression(Dictionary dict);
 /**
  * We're looking at the first of the stuff after an "and" or "or".
  * Build a Exp node for this expression.  Set the cost and optional
  * fields to the default values.  Set the type field according to type
  */
-static Exp * operator_exp(Dictionary dict, int type)
+static Exp *operator_exp(Dictionary dict, int type)
 {
 	Exp * n;
 	E_list first;
@@ -1147,7 +1145,7 @@ static Exp * operator_exp(Dictionary dict, int type)
 	n->cost = 0.0;
 	elist = &first;
 	while((!is_equal(dict, ')')) && (!is_equal(dict, ']')) && (!is_equal(dict, '}'))) {
-		elist->next = (E_list *) malloc(sizeof(E_list));
+		elist->next = pool_alloc(dict->E_list_pool);
 		elist = elist->next;
 		elist->next = NULL;
 		elist->e = expression(dict);
@@ -1191,7 +1189,7 @@ static Exp * in_parens(Dictionary dict)
  * with the current token.  At the end, the token is the first one not
  * part of this expression.
  */
-static Exp * expression(Dictionary dict)
+static Exp *expression(Dictionary dict)
 {
 	Exp * n;
 	if (is_equal(dict, '(')) {
@@ -1255,7 +1253,7 @@ static Exp * expression(Dictionary dict)
  * with the current token.  At the end, the token is the first one not
  * part of this expression.
  */
-static Exp * make_expression(Dictionary dict)
+static Exp *make_expression(Dictionary dict)
 {
 	Exp *nl = NULL;
 	Exp *e_head = NULL;
@@ -1297,7 +1295,7 @@ static Exp * make_expression(Dictionary dict)
 			if (!link_advance(dict)) {
 				return NULL;
 			}
-			nl = make_optional_node(&dict->exp_list, nl);
+			nl = make_optional_node(dict, nl);
 		}
 		else if (is_equal(dict, '['))
 		{
@@ -1353,7 +1351,7 @@ static Exp * make_expression(Dictionary dict)
 		else if (is_equal(dict, ')') || is_equal(dict, ']'))
 		{
 			/* allows "()" or "[]" */
-			nl = make_zeroary_node(&dict->exp_list);
+			nl = make_zeroary_node(dict);
 		}
 		else
 		{
@@ -1373,9 +1371,9 @@ static Exp * make_expression(Dictionary dict)
 
 			/* Expand A ^ B into the expr ((A & B) or (B & A)).
 			 * It can be mixed with ordinary ands at the same level. */
-			na = make_and_node(&dict->exp_list, nl, nr);
-			nb = make_and_node(&dict->exp_list, nr, nl);
-			or = make_or_node(&dict->exp_list, na, nb);
+			na = make_and_node(dict, nl, nr);
+			nb = make_and_node(dict, nr, nl);
+			or = make_or_node(dict, na, nb);
 
 			(*elp)->e = or;
 			is_sym_and = false;
@@ -1384,7 +1382,7 @@ static Exp * make_expression(Dictionary dict)
 		{
 			/* This is Non-commuting AND or Commuting OR.
 			 * Append the just read expression (nl) to its E_list chain. */
-			el_tail->next = make_E_list_val(nl);
+			el_tail->next = make_E_list_val(dict, nl);
 			el_tail = el_tail->next;
 		}
 
@@ -1427,8 +1425,8 @@ static Exp * make_expression(Dictionary dict)
 		}
 		else
 		{
-			e_head = make_op_Exp(&dict->exp_list, op);
-			e_head->u.l = make_E_list_val(nl);
+			e_head = make_op_Exp(dict, op);
+			e_head->u.l = make_E_list_val(dict, nl);
 		}
 
 		if (!link_advance(dict)) {
@@ -1549,7 +1547,7 @@ static Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
  * before being used.  The DSW algo below is ideal for that.
  */
 NO_SAN_DICT
-Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode)
+Dict_node *insert_dict(Dictionary dict, Dict_node *n, Dict_node *newnode)
 {
 	if (NULL == n) return newnode;
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1362,20 +1362,14 @@ static Exp *make_expression(Dictionary dict)
 		if (is_sym_and)
 		{
 			/* Part 2/2 of SYM_AND processing */
-			E_list **elp; /* LHS argument and the SYM_AND result placeholder */
-			Exp *nr, *na, *nb, *or;
 
-			elp = (el_tail == NULL) ? &e_head->u.l : &el_tail;
-			nr = nl; /* last expression is actually the RHS */
-			nl = (*elp)->e;
+			/* Expand A ^ B into the expr ((A & B) or (B & A)). */
 
-			/* Expand A ^ B into the expr ((A & B) or (B & A)).
-			 * It can be mixed with ordinary ands at the same level. */
-			na = make_and_node(dict, nl, nr);
-			nb = make_and_node(dict, nr, nl);
-			or = make_or_node(dict, na, nb);
+			Exp *na = make_and_node(dict, el_tail->e, nl);
+			Exp *nb = make_and_node(dict, nl, el_tail->e);
+			Exp *or = make_or_node(dict, na, nb);
 
-			(*elp)->e = or;
+			el_tail->e = or;
 			is_sym_and = false;
 		}
 		else if (el_tail != NULL)
@@ -1406,7 +1400,7 @@ static Exp *make_expression(Dictionary dict)
 		else if (is_equal(dict, SYM_AND) || (strcmp(dict->token, "sym") == 0))
 		{
 			/* Part 1/2 of SYM_AND processing */
-			op = AND_type;
+			op = AND_type; /* allow mixing with ordinary ands at the same level */
 			is_sym_and = true; /* processing to be completed after next argument */
 		}
 		else

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -79,7 +79,6 @@ static const char * make_expression(Dictionary dict,
 		e->dir = *p;
 		e->type = CONNECTOR_type;
 		e->cost = 0.0;
-		e->u.l = NULL;
 		char * constr = NULL;
 		if ('@' == *con_start)
 		{

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -82,18 +82,17 @@ static const char * make_expression(Dictionary dict,
 		char * constr = NULL;
 		if ('@' == *con_start)
 		{
-			constr = strndup(con_start+1, p-con_start-1);
+			constr = strndupa(con_start+1, p-con_start-1);
 			e->multi = true;
 		}
 		else
 		{
-			constr = strndup(con_start, p-con_start);
+			constr = strndupa(con_start, p-con_start);
 			e->multi = false;
 		}
 
 		e->u.condesc = condesc_add(&dict->contable,
 		                           string_set_add(constr, dict->string_set));
-		free(constr);
 		*pex = e;
 	}
 

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -107,8 +107,8 @@ void pool_delete (const char *func, Pool_desc *mp)
 #ifdef DEBUG /* Macro-added first argument. */
 	from_func = func;
 #endif
-	lgdebug(+D_MEMPOOL, "Used %zu elements (%s deleted pool '%s' created in %s())\n",
-	        mp->curr_elements, from_func, mp->name, mp->func);
+	lgdebug(+D_MEMPOOL, "Used %zu (%zu) elements (%s deleted pool '%s' created in %s())\n",
+	        mp->curr_elements, mp->num_elements, from_func, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */
 	char *c_next;


### PR DESCRIPTION
Note: This PR is based on #969, which has not been merged yet.
It includes the changes of this #969, and thus **shouldn't be merged** without verifying that GitHub rebases it automatically after this #969 is actually merged. In cased it is not so please tell me and I will force-update it after rebasing.

---
Fix code bloat in the dict reading of SYM_AND.

(I detected that in my WIP of eliminating `E_list` and submit it here separately to make this future PR clearer, since its SYM_AND reading handling contains  a special change related to the `E_list` elimination).