### PR TITLE
Eliminate E_list

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -127,7 +127,6 @@ struct Sentence_s
 	String_set *   string_set;  /* Used for assorted strings */
 	Pool_desc * fm_Match_node;  /* Fast-matcher Match_node memory pool */
 	Pool_desc * Table_connector_pool; /* Count memoizing memory pool */
-	Pool_desc * E_list_pool;
 	Pool_desc * Exp_pool;
 	Pool_desc * X_node_pool;
 	Pool_desc * Disjunct_pool;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -436,9 +436,6 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 	sent->dict = dict;
 	sent->string_set = string_set_create();
 	sent->rand_state = global_rand_state;
-	sent->E_list_pool = pool_new(__func__, "E_list", /*num_elements*/4096,
-	                             sizeof(E_list), /*zero_out*/false,
-	                             /*align*/false, /*exact*/false);
 	sent->Exp_pool = pool_new(__func__, "Exp", /*num_elements*/4096,
 	                             sizeof(Exp), /*zero_out*/false,
 	                             /*align*/false, /*exact*/false);
@@ -533,13 +530,11 @@ void sentence_delete(Sentence sent)
 	global_rand_state = sent->rand_state;
 	pool_delete(sent->fm_Match_node);
 	pool_delete(sent->Table_connector_pool);
-	pool_delete(sent->E_list_pool);
 	pool_delete(sent->Exp_pool);
 	pool_delete(sent->X_node_pool);
 	if (IS_DB_DICT(sent->dict))
 	{
 		condesc_reuse(sent->dict);
-		pool_reuse(sent->dict->E_list_pool);
 		pool_reuse(sent->dict->Exp_pool);
 	}
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -89,9 +89,9 @@ static size_t get_connectors_from_expression(condesc_t **conlist, const Exp *e)
 	}
 
 	size_t cl_size = 0;
-	for (E_list *l = e->operand_first; l != NULL; l = l->next)
+	for (Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
 	{
-		cl_size += get_connectors_from_expression(conlist, l->e);
+		cl_size += get_connectors_from_expression(conlist, opd);
 		if (NULL != conlist) conlist++;
 	}
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -84,12 +84,12 @@ static size_t get_connectors_from_expression(condesc_t **conlist, const Exp *e)
 {
 	if (e->type == CONNECTOR_type)
 	{
-		if (NULL != conlist) *conlist = e->u.condesc;
+		if (NULL != conlist) *conlist = e->condesc;
 		return 1;
 	}
 
 	size_t cl_size = 0;
-	for (E_list *l = e->u.l; l != NULL; l = l->next)
+	for (E_list *l = e->operand_first; l != NULL; l = l->next)
 	{
 		cl_size += get_connectors_from_expression(conlist, l->e);
 		if (NULL != conlist) conlist++;

--- a/link-grammar/corpus/cluster.c
+++ b/link-grammar/corpus/cluster.c
@@ -190,7 +190,7 @@ static Exp * make_exp(const char *djstr, double cost)
 	lhead = l;
 
 	e->type = AND_type;
-	e->u.l = lhead;
+	e->operand_first = lhead;
 	
 	return e;
 }
@@ -219,7 +219,7 @@ static Exp * or_exp(Exp *p1, Exp *p2)
 	l->e = p1;
 	lhead = l;
 
-	e->u.l = lhead;
+	e->operand_first = lhead;
 	return e;
 }
 #endif
@@ -228,7 +228,7 @@ static void free_exp(Exp *e)
 {
 	if (CONNECTOR_type != e->type)
 	{
-		E_list *l = e->u.l;
+		E_list *l = e->operand_first;
 		while(l)
 		{
 			E_list *ln = l->next;

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -260,7 +260,6 @@ static void free_dictionary(Dictionary dict)
 	free_dict_node_recursive(dict->root);
 	free_Word_file(dict->word_file_header);
 	pool_delete(dict->Exp_pool);
-	pool_delete(dict->E_list_pool);
 }
 
 static void affix_list_delete(Dictionary dict)

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -115,9 +115,7 @@ struct Dictionary_s
 	Word_file *     word_file_header;
 	ConTable        contable;
 
-	/* Memory pools */
 	Pool_desc  * Exp_pool;
-	Pool_desc  * E_list_pool;
 
 	/* Private data elements that come in play only while the
 	 * dictionary is being read, and are not otherwise used.

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -186,7 +186,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 		goto locale_error;
 	}
 
-	if (0 == strcmp(dn->exp->u.condesc->string, "C"))
+	if (0 == strcmp(dn->exp->condesc->string, "C"))
 	{
 		locale = string_set_add("C", dict->string_set);
 	}
@@ -194,7 +194,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 	{
 		char c;
 		char locale_ll[4], locale_cc[3];
-		int locale_numelement = sscanf(dn->exp->u.condesc->string, "%3[A-Z]4%2[a-z]%c",
+		int locale_numelement = sscanf(dn->exp->condesc->string, "%3[A-Z]4%2[a-z]%c",
 										locale_ll, locale_cc, &c);
 		if (2 != locale_numelement)
 		{
@@ -202,7 +202,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 			          "should be in the form LL4cc+\n"
 						 "\t(LL: language code; cc: territory code) "
 						 "\tor C+ for transliterated dictionaries.\n",
-						 dn->exp->u.condesc->string);
+						 dn->exp->condesc->string);
 			goto locale_error;
 		}
 
@@ -268,7 +268,7 @@ const char * linkgrammar_get_dict_version(Dictionary dict)
 	if (NULL == dn) return "[unknown]";
 
 	e = dn->exp;
-	ver = strdup(&e->u.condesc->string[1]);
+	ver = strdup(&e->condesc->string[1]);
 	p = strchr(ver, 'v');
 	while (p)
 	{

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -63,6 +63,8 @@ static inline char lg_exp_get_dir(const Exp* exp) { return exp->dir; }
 static inline bool lg_exp_get_multi(const Exp* exp) { return exp->multi; }
 const char* lg_exp_get_string(const Exp*);
 static inline double lg_exp_get_cost(const Exp* exp) { return exp->cost; }
+static inline Exp* lg_exp_operand_first(Exp* exp) { return exp->operand_first; }
+static inline Exp* lg_exp_operand_next(Exp* exp) { return exp->operand_next; }
 
 /**
  * The dictionary is stored as a binary tree comprised of the following

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -37,21 +37,24 @@ typedef enum
 } Exp_type;
 
 /**
- * The E_list and Exp structures defined below comprise the expression
- * trees that are stored in the dictionary.  The expression has a type
- * (OR_type, AND_type or CONNECTOR_type).  If it is not a terminal it
- * has a list (an E_list) of children. Else "condesc" is the connector
- * descriptor, when "dir" indicates the connector direction.
+ * The Exp structure defined below comprises the expression trees that are
+ * stored in the dictionary. The expression has a type (OR_type, AND_type
+ * or CONNECTOR_type). If it is not a terminal "operand" points to its
+ * list of operands (when each of them points to the next one through
+ * "next"). Else "condesc" is the connector descriptor, when "dir"
+ * indicates the connector direction.
  */
 struct Exp_struct
 {
+	Exp *operand_next; /* Next same-level operand. */
 	Exp_type type; /* One of three types: AND, OR, or connector. */
-	char dir;      /* The connector connects to: '-': the left; '+': the right */
-	bool multi;    /* TRUE if a multi-connector (for connector)  */
-	union {
-		E_list * l;           /* Only needed for non-terminals */
-		condesc_t * condesc;  /* Only needed if it's a connector */
-	} u;
+	char dir;      /* The connector connects to the left ('-') or right ('+'). */
+	bool multi;    /* TRUE if a multi-connector (for connector). */
+	union
+	{
+		E_list *operand_first; /* First operand (for non-terminals). */
+		condesc_t *condesc; /* Only needed if it's a connector. */
+	};
 	double cost;   /* The cost of using this expression. */
 };
 

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -52,7 +52,7 @@ struct Exp_struct
 	bool multi;    /* TRUE if a multi-connector (for connector). */
 	union
 	{
-		E_list *operand_first; /* First operand (for non-terminals). */
+		Exp *operand_first; /* First operand (for non-terminals). */
 		condesc_t *condesc; /* Only needed if it's a connector. */
 	};
 	double cost;   /* The cost of using this expression. */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -22,7 +22,6 @@ LINK_BEGIN_DECLS
 /* Forward decls */
 typedef struct Dict_node_struct Dict_node;
 typedef struct Exp_struct Exp;
-typedef struct E_list_struct E_list;
 typedef struct Word_file_struct Word_file;
 typedef struct condesc_struct condesc_t;
 
@@ -56,12 +55,6 @@ struct Exp_struct
 		condesc_t *condesc; /* Only needed if it's a connector. */
 	};
 	double cost;   /* The cost of using this expression. */
-};
-
-struct E_list_struct
-{
-	E_list * next;
-	Exp * e;
 };
 
 /* API to access the above structure. */

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -84,9 +84,9 @@ static bool exp_compare(Exp *e1, Exp *e2)
 
 	if (e1->type == CONNECTOR_type)
 	{
-		if (e1->dir != e2->dir)
-			return false;
 		if (e1->condesc != e2->condesc)
+			return false;
+		if (e1->dir != e2->dir)
 			return false;
 	}
 	else

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -61,9 +61,22 @@ Exp *copy_Exp(Exp *e, Pool_desc *Exp_pool)
 
 	*new_e = *e;
 
+#if 0 /* Not used - left here for documentation. */
 	new_e->operand_next = copy_Exp(e->operand_next, Exp_pool);
 	if (CONNECTOR_type == e->type) return new_e;
 	new_e->operand_first = copy_Exp(e->operand_first, Exp_pool);
+#else
+	if (CONNECTOR_type == e->type) return new_e;
+
+	/* Iterate operands to avoid a deep recursion due to a lot of operands. */
+	Exp **tmp_e_a = &new_e->operand_first;
+	for(Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
+	{
+		*tmp_e_a = copy_Exp(opd, Exp_pool);
+		tmp_e_a = &(*tmp_e_a)->operand_next;
+	}
+	*tmp_e_a = NULL;
+#endif
 
 	return new_e;
 }

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -69,43 +69,38 @@ Exp *copy_Exp(Exp *e, Pool_desc *Exp_pool)
 }
 
 /**
- * Compare two expressions, return true for equal, false for unequal
+ * Compare two expressions, return true for equal, false for unequal.
  */
-static bool exp_compare(Exp * e1, Exp * e2)
+static bool exp_compare(Exp *e1, Exp *e2)
 {
 	if ((e1 == NULL) && (e2 == NULL))
-	  return 1; /* they are equal */
+	  return true;
 	if ((e1 == NULL) || (e2 == NULL))
-	  return 0; /* they are not equal */
+	  return false;
 	if (e1->type != e2->type)
-		return 0;
+		return false;
 	if (fabs (e1->cost - e2->cost) > 0.001)
-		return 0;
+		return false;
+
 	if (e1->type == CONNECTOR_type)
 	{
 		if (e1->dir != e2->dir)
-			return 0;
-		/* printf("%s %s\n",e1->condesc->string,e2->condesc->string); */
+			return false;
 		if (e1->condesc != e2->condesc)
-			return 0;
+			return false;
 	}
 	else
 	{
-		e1 = e1->operand_first;
-		e2 = e2->operand_first;
-		/* while at least 1 is non-null */
-		for (;(e1!=NULL)||(e2!=NULL);) {
-		   /*fail if 1 is null */
-			if ((e1==NULL)||(e2==NULL))
-				return 0;
-			/* fail if they are not compared */
+		/* Iterate operands to avoid a deep recursion due to a lot of operands. */
+		for (e1 = e1->operand_first, e2 = e2->operand_first;
+		     e1 != NULL || e2 != NULL;
+		     e1 = e1->operand_next, e2 = e2->operand_next)
+		{
 			if (!exp_compare(e1, e2))
-				return 0;
-			e1 = e1->operand_next;
-			e2 = e2->operand_next;
+				return false;
 		}
 	}
-	return 1; /* if never returned 0, return 1 */
+	return true;
 }
 
 /**

--- a/link-grammar/dict-common/dict-utils.h
+++ b/link-grammar/dict-common/dict-utils.h
@@ -18,9 +18,8 @@
 
 /* Exp utilities ... */
 void free_Exp(Exp *);
-void free_E_list(E_list *);
 int  size_of_expression(Exp *);
-Exp * copy_Exp(Exp *, Pool_desc *, Pool_desc *);
+Exp * copy_Exp(Exp *, Pool_desc *);
 bool is_exp_like_empty_word(Dictionary dict, Exp *);
 
 /* X_node utilities ... */

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -242,14 +242,14 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 
 	/* ----- this code just sets up the node fields of the dn_list ----*/
 	nc = Exp_create(dict);
-	nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
+	nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '-';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;
 	nc->cost = 0;
 
 	n1 = Exp_create(dict);
-	n1->u.l = ell = pool_alloc(dict->Exp_pool);
+	n1->operand_first = ell = pool_alloc(dict->Exp_pool);
 	ell->next = elr = pool_alloc(dict->Exp_pool);
 	elr->next = NULL;
 	ell->e = nc;
@@ -268,12 +268,12 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 		n1 = Exp_create(dict);
 		n1->type = AND_type;
 		n1->cost = 0;
-		n1->u.l = ell = pool_alloc(dict->E_list_pool);
+		n1->operand_first = ell = pool_alloc(dict->E_list_pool);
 		ell->next = elr = pool_alloc(dict->E_list_pool);
 		elr->next = NULL;
 
 		nc = Exp_create(dict);
-		nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
+		nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '+';
 		nc->multi = false;
 		nc->type = CONNECTOR_type;
@@ -283,7 +283,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 		increment_current_name(dict);
 
 		nc = Exp_create(dict);
-		nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
+		nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '-';
 		nc->multi = false;
 		nc->type = CONNECTOR_type;
@@ -298,7 +298,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	/* now generate the last one */
 
 	nc = Exp_create(dict);
-	nc->u.condesc = condesc_add(&dict->contable, generate_id_connector(dict));
+	nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '+';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -216,7 +216,6 @@ static const char * generate_id_connector(Dictionary dict)
 void insert_idiom(Dictionary dict, Dict_node * dn)
 {
 	Exp * nc, * no, * n1;
-	E_list *ell, *elr;
 	const char * s;
 	Dict_node * dn_list, * xdn, * start_dn_list;
 
@@ -246,15 +245,13 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	nc->dir = '-';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;
+	nc->operand_next = no;
 	nc->cost = 0;
 
 	n1 = Exp_create(dict);
-	n1->operand_first = ell = pool_alloc(dict->Exp_pool);
-	ell->next = elr = pool_alloc(dict->Exp_pool);
-	elr->next = NULL;
-	ell->e = nc;
-	elr->e = no;
+	n1->operand_first = nc;
 	n1->type = AND_type;
+	n1->operand_next = NULL;
 	n1->cost = 0;
 
 	dn_list->exp = n1;
@@ -267,29 +264,29 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 
 		n1 = Exp_create(dict);
 		n1->type = AND_type;
+		n1->operand_next = NULL;
 		n1->cost = 0;
-		n1->operand_first = ell = pool_alloc(dict->E_list_pool);
-		ell->next = elr = pool_alloc(dict->E_list_pool);
-		elr->next = NULL;
 
 		nc = Exp_create(dict);
 		nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '+';
 		nc->multi = false;
 		nc->type = CONNECTOR_type;
+		nc->operand_next = NULL;
 		nc->cost = 0;
-		elr->e = nc;
+		n1->operand_first = nc;
 
 		increment_current_name(dict);
 
-		nc = Exp_create(dict);
-		nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
-		nc->dir = '-';
-		nc->multi = false;
-		nc->type = CONNECTOR_type;
-		nc->cost = 0;
+		no = Exp_create(dict);
+		no->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
+		no->dir = '-';
+		no->multi = false;
+		no->type = CONNECTOR_type;
+		no->operand_next = NULL;
+		no->cost = 0;
 
-		ell->e = nc;
+		nc->operand_next = no;
 
 		dn_list->exp = n1;
 
@@ -302,6 +299,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	nc->dir = '+';
 	nc->multi = false;
 	nc->type = CONNECTOR_type;
+	nc->operand_next = NULL;
 	nc->cost = 0;
 
 	dn_list->exp = nc;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -57,7 +57,7 @@ void print_expression(Exp * n)
 		if (icost == 0) printf("(");
 		if (n->type == AND_type) printf("& ");
 		if (n->type == OR_type) printf("or ");
-		for (el = n->u.l; el != NULL; el = el->next)
+		for (el = n->operand_first; el != NULL; el = el->next)
 		{
 			print_expression(el->e);
 		}
@@ -126,13 +126,13 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	{
 		for (i=0; i<icost; i++) dyn_strcat(e, "[");
 		if (n->multi) dyn_strcat(e, "@");
-		append_string(e, "%s%c", n->u.condesc?n->u.condesc->string:"(null)", n->dir);
+		append_string(e, "%s%c", n->condesc?n->condesc->string:"(null)", n->dir);
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
 		if (0 != dcost) append_string(e, COST_FMT, dcost);
 		return e;
 	}
 
-	el = n->u.l;
+	el = n->operand_first;
 	if (el == NULL)
 	{
 		for (i=0; i<icost; i++) dyn_strcat(e, "[");
@@ -146,7 +146,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 
 	/* look for optional, and print only that */
 	if ((n->type == OR_type) && el->e &&
-	    (el->e->type == AND_type) && el->e->cost == 0 && (NULL == el->e->u.l))
+	    (el->e->type == AND_type) && el->e->cost == 0 && (NULL == el->e->operand_first))
 	{
 		dyn_strcat(e, "{");
 		if (NULL == el->next) dyn_strcat(e, "error-no-next");
@@ -295,13 +295,13 @@ static unsigned int count_clause(Exp *e)
 	{
 		/* multiplicative combinatorial explosion */
 		cnt = 1;
-		for (e_list = e->u.l; e_list != NULL; e_list = e_list->next)
+		for (e_list = e->operand_first; e_list != NULL; e_list = e_list->next)
 			cnt *= count_clause(e_list->e);
 	}
 	else if (e->type == OR_type)
 	{
 		/* Just additive */
-		for (e_list = e->u.l; e_list != NULL; e_list = e_list->next)
+		for (e_list = e->operand_first; e_list != NULL; e_list = e_list->next)
 			cnt += count_clause(e_list->e);
 	}
 	else if (e->type == CONNECTOR_type)

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -106,7 +106,7 @@ dictionary_six_str(const char * lang,
 {
 	const char * t;
 	Dictionary dict;
-	size_t E_pool_size;   /* Exp & E_list memory pool sizes. */
+	size_t Exp_pool_size;
 
 	dict = (Dictionary) malloc(sizeof(struct Dictionary_s));
 	memset(dict, 0, sizeof(struct Dictionary_s));
@@ -137,7 +137,7 @@ dictionary_six_str(const char * lang,
 		dict->free_lookup = free_llist;
 		dict->lookup = file_boolean_lookup;
 		condesc_init(dict, 1<<13);
-		E_pool_size = 1<<13;
+		Exp_pool_size = 1<<13;
 	}
 	else
 	{
@@ -148,15 +148,12 @@ dictionary_six_str(const char * lang,
 		dict->insert_entry = load_affix;
 		dict->lookup = return_true;
 		condesc_init(dict, 1<<9);
-		E_pool_size = 1<<5;
+		Exp_pool_size = 1<<5;
 	}
 
-	dict->Exp_pool = pool_new(__func__, "Exp", /*num_elements*/E_pool_size,
+	dict->Exp_pool = pool_new(__func__, "Exp", /*num_elements*/Exp_pool_size,
 	                          sizeof(Exp), /*zero_out*/false,
 	                          /*align*/false, /*exact*/false);
-	dict->E_list_pool = pool_new(__func__, "E_list", /*num_elements*/E_pool_size,
-	                             sizeof(E_list), /*zero_out*/false,
-	                             /*align*/false, /*exact*/false);
 
 	/* Read dictionary from the input string. */
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -811,7 +811,7 @@ static Exp * make_zeroary_node(Dictionary dict)
 	Exp * n = Exp_create(dict);
 	n->type = AND_type;  /* these must be AND types */
 	n->cost = 0.0;
-	n->u.l = NULL;
+	n->operand_first = NULL;
 	return n;
 }
 
@@ -825,9 +825,9 @@ static Exp * make_unary_node(Dictionary dict, Exp * e)
 	n = Exp_create(dict);
 	n->type = AND_type;  /* these must be AND types */
 	n->cost = 0.0;
-	n->u.l = pool_alloc(dict->E_list_pool);
-	n->u.l->next = NULL;
-	n->u.l->e = e;
+	n->operand_first = pool_alloc(dict->E_list_pool);
+	n->operand_first->next = NULL;
+	n->operand_first->e = e;
 	return n;
 }
 
@@ -844,7 +844,7 @@ static Exp * make_and_node(Dictionary dict, Exp* nl, Exp* nr)
 	n->type = AND_type;
 	n->cost = 0.0;
 
-	n->u.l = ell = pool_alloc(dict->E_list_pool);
+	n->operand_first = ell = pool_alloc(dict->E_list_pool);
 	ell->next = elr = pool_alloc(dict->E_list_pool);
 	elr->next = NULL;
 
@@ -858,7 +858,7 @@ static Exp *make_op_Exp(Dictionary dict, Exp_type t)
 	Exp * n = Exp_create(dict);
 	n->type = t;
 	n->cost = 0.0;
-	n->u.l = NULL;
+	n->operand_first = NULL;
 
 	return n;
 }
@@ -886,7 +886,7 @@ static Exp * make_or_node(Dictionary dict, Exp* nl, Exp* nr)
 	n->type = OR_type;
 	n->cost = 0.0;
 
-	n->u.l = ell = pool_alloc(dict->E_list_pool);
+	n->operand_first = ell = pool_alloc(dict->E_list_pool);
 	ell->next = elr = pool_alloc(dict->E_list_pool);
 	elr->next = NULL;
 
@@ -929,9 +929,9 @@ static Exp * make_dir_connector(Dictionary dict, int i)
 		n->multi = false;
 	}
 
-	n->u.condesc = condesc_add(&dict->contable,
+	n->condesc = condesc_add(&dict->contable,
 	                            string_set_add(constring, dict->string_set));
-	if (NULL == n->u.condesc) return NULL; /* Table ovf */
+	if (NULL == n->condesc) return NULL; /* Table ovf */
 	n->type = CONNECTOR_type;
 	n->cost = 0.0;
 	return n;
@@ -1034,7 +1034,7 @@ static Exp *make_or_node_from_pool(Sentence sent, Exp *nl, Exp *nr)
 	n->type = OR_type;
 	n->cost = 0.0;
 
-	n->u.l = ell = (E_list *) pool_alloc(sent->E_list_pool);
+	n->operand_first = ell = (E_list *) pool_alloc(sent->E_list_pool);
 	ell->next = elr = (E_list *) pool_alloc(sent->E_list_pool);
 	elr->next = NULL;
 
@@ -1048,7 +1048,7 @@ static Exp *make_zeroary_node_from_pool(Sentence sent)
 	Exp * n = pool_alloc(sent->Exp_pool);
 	n->type = AND_type;  /* these must be AND types */
 	n->cost = 0.0;
-	n->u.l = NULL;
+	n->operand_first = NULL;
 	return n;
 }
 
@@ -1083,7 +1083,7 @@ void add_empty_word(Sentence sent, X_node *x)
 		/* zn points at {ZZZ+} */
 		zn = pool_alloc(sent->Exp_pool);
 		zn->dir = '+';
-		zn->u.condesc = condesc_add(&sent->dict->contable, ZZZ);
+		zn->condesc = condesc_add(&sent->dict->contable, ZZZ);
 		zn->multi = false;
 		zn->type = CONNECTOR_type;
 		zn->cost = 0.0;
@@ -1103,7 +1103,7 @@ void add_empty_word(Sentence sent, X_node *x)
 		an = pool_alloc(sent->Exp_pool);
 		an->type = AND_type;
 		an->cost = 0.0;
-		an->u.l = elist;
+		an->operand_first = elist;
 
 		x->exp = an;
 	}
@@ -1157,7 +1157,7 @@ static Exp *operator_exp(Dictionary dict, int type)
 		dict_error(dict, "An \"or\" or \"and\" of nothing");
 		return NULL;
 	}
-	n->u.l = first.next;
+	n->operand_first = first.next;
 	return n;
 }
 
@@ -1420,7 +1420,7 @@ static Exp *make_expression(Dictionary dict)
 		else
 		{
 			e_head = make_op_Exp(dict, op);
-			e_head->u.l = make_E_list_val(dict, nl);
+			e_head->operand_first = make_E_list_val(dict, nl);
 		}
 
 		if (!link_advance(dict)) {
@@ -1428,7 +1428,7 @@ static Exp *make_expression(Dictionary dict)
 		}
 
 		if (el_tail == NULL)
-			el_tail = e_head->u.l;
+			el_tail = e_head->operand_first;
 	}
 		/* unreachable */
 }
@@ -1545,7 +1545,7 @@ Dict_node *insert_dict(Dictionary dict, Dict_node *n, Dict_node *newnode)
 {
 	if (NULL == n) return newnode;
 
-	static Exp null_exp = { .type = AND_type, .u.l = NULL };
+	static Exp null_exp = { .type = AND_type, .operand_first = NULL };
 	int comp = dict_order_strict(newnode->string, n);
 	if (0 == comp &&
 	    /* Suppress reporting duplicate idioms until they are fixed. */

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -91,7 +91,7 @@ static const char * make_expression(Dictionary dict,
 			e->multi = false;
 		}
 
-		e->u.condesc = condesc_add(&dict->contable,
+		e->condesc = condesc_add(&dict->contable,
 		                           string_set_add(constr, dict->string_set));
 		*pex = e;
 	}
@@ -126,7 +126,7 @@ static const char * make_expression(Dictionary dict,
 	Exp* join = Exp_create(dict);
 	join->type = etype;
 	join->cost = 0.0;
-	E_list *ell = join->u.l = pool_alloc(dict->E_list_pool);
+	E_list *ell = join->operand_first = pool_alloc(dict->E_list_pool);
 	E_list *elr = ell->next = pool_alloc(dict->E_list_pool);
 	elr->next = NULL;
 
@@ -194,7 +194,7 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 		Exp* orn = Exp_create(dict);
 		orn->type = OR_type;
 		orn->cost = 0.0;
-		orn->u.l = ell = pool_alloc(dict->E_list_pool);
+		orn->operand_first = ell = pool_alloc(dict->E_list_pool);
 		ell->next = elr = pool_alloc(dict->E_list_pool);
 		elr->next = NULL;
 
@@ -207,8 +207,8 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 	/* Extend the OR-chain for the third and later expressions. */
 	E_list* more = pool_alloc(dict->E_list_pool);
 	more->e = exp;
-	more->next = bs->exp->u.l;
-	bs->exp->u.l = more;
+	more->next = bs->exp->operand_first;
+	bs->exp->operand_first = more;
 
 	return 0;
 }

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -78,6 +78,7 @@ static const char * make_expression(Dictionary dict,
 		Exp* e = Exp_create(dict);
 		e->dir = *p;
 		e->type = CONNECTOR_type;
+		e->operand_next = NULL;
 		e->cost = 0.0;
 		char * constr = NULL;
 		if ('@' == *con_start)
@@ -125,13 +126,13 @@ static const char * make_expression(Dictionary dict,
 	/* Join it all together. */
 	Exp* join = Exp_create(dict);
 	join->type = etype;
+	join->operand_next = NULL;
 	join->cost = 0.0;
-	E_list *ell = join->operand_first = pool_alloc(dict->E_list_pool);
-	E_list *elr = ell->next = pool_alloc(dict->E_list_pool);
-	elr->next = NULL;
 
-	ell->e = *pex;
-	elr->e = rest;
+	join->operand_first = *pex;
+	(*pex)->operand_next = rest;
+	rest->operand_next = NULL;
+
 	*pex = join;
 
 	return p;
@@ -190,25 +191,18 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 	/* If the second expression, OR-it with the existing expression. */
 	if (OR_type != bs->exp->type)
 	{
-		E_list *ell, *elr;
 		Exp* orn = Exp_create(dict);
 		orn->type = OR_type;
 		orn->cost = 0.0;
-		orn->operand_first = ell = pool_alloc(dict->E_list_pool);
-		ell->next = elr = pool_alloc(dict->E_list_pool);
-		elr->next = NULL;
 
-		ell->e = exp;
-		elr->e = bs->exp;
+		orn->operand_first = exp;
+		exp->operand_next = bs->exp;
 		bs->exp = orn;
 		return 0;
 	}
 
 	/* Extend the OR-chain for the third and later expressions. */
-	E_list* more = pool_alloc(dict->E_list_pool);
-	more->e = exp;
-	more->next = bs->exp->operand_first;
-	bs->exp->operand_first = more;
+	bs->exp->operand_next = exp;
 
 	return 0;
 }
@@ -493,9 +487,6 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->Exp_pool = pool_new(__func__, "Exp", /*num_elements*/4096,
 	                          sizeof(Exp), /*zero_out*/false,
 	                          /*align*/false, /*exact*/false);
-	dict->E_list_pool = pool_new(__func__, "E_list", /*num_elements*/4096,
-	                             sizeof(E_list), /*zero_out*/false,
-	                             /*align*/false, /*exact*/false);
 
 	/* Setup the affix table */
 	char *affix_name = join_path (lang, "4.0.affix");

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -155,7 +155,6 @@ static Tconnector * build_terminal(Exp *e, Pool_desc *tp)
 static Clause * build_clause(Exp *e, clause_context *ct)
 {
 	Clause *c = NULL, *c1, *c2, *c3, *c4, *c_head;
-	E_list * e_list;
 
 	assert(e != NULL, "build_clause called with null parameter");
 	if (e->type == AND_type)
@@ -165,9 +164,9 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 		c1->next = NULL;
 		c1->cost = 0.0;
 		c1->maxcost = 0.0;
-		for (e_list = e->operand_first; e_list != NULL; e_list = e_list->next)
+		for (Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
 		{
-			c2 = build_clause(e_list->e, ct);
+			c2 = build_clause(opd, ct);
 			c_head = NULL;
 			for (c3 = c1; c3 != NULL; c3 = c3->next)
 			{
@@ -194,11 +193,11 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 	}
 	else if (e->type == OR_type)
 	{
-		c = build_clause(e->operand_first->e, ct);
+		c = build_clause(e->operand_first, ct);
 		/* we'll catenate the lists of clauses */
-		for (e_list = e->operand_first->next; e_list != NULL; e_list = e_list->next)
+		for (Exp *opd = e->operand_first->operand_next; opd != NULL; opd = opd->operand_next)
 		{
-			c1 = build_clause(e_list->e, ct);
+			c1 = build_clause(opd, ct);
 			if (c1 == NULL) continue;
 			if (c == NULL)
 			{
@@ -351,15 +350,11 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	if (e == NULL) return;
 
 	for(int j =0; j<i; j++) printf(" ");
-	printf ("type=%d dir=%c multi=%d cost=%f\n", e->type, e->dir, e->multi, e->cost);
+	printf ("type=%d dir=%c multi=%d cost=%f\n",
+	        e->type, e->dir, e->multi, e->cost);
 	if (e->type != CONNECTOR_type)
 	{
-		E_list *l = e->operand_first;
-		while(l)
-		{
-			prt_exp(l->e, i+2);
-			l = l->next;
-		}
+		for (e = e->operand_next; e != NULL; e = e->operand_next) prt_exp(e, i+2);
 	}
 	else
 	{
@@ -368,48 +363,74 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	}
 }
 
+static const char *stringify_Exp_type(Exp_type type)
+{
+	static TLS char unknown_type[32] = "";
+	const char *type_str;
+
+	if (type > 0 && type <= 3)
+	{
+		type_str = ((const char *[]) {"OR", "AND", "CONNECTOR"}) [type-1];
+	}
+	else
+	{
+		snprintf(unknown_type, sizeof(unknown_type)-1, "unknown_type-%d", type);
+		type_str = unknown_type;
+	}
+
+	return type_str;
+}
+
+static bool is_ASAN_uninitialized(uintptr_t a)
+{
+	static const uintptr_t asan_uninitialized = 0xbebebebebebebebe;
+
+	return (a == asan_uninitialized);
+}
+
 GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 {
-	char unknown_type[32] = "";
-	const char *type;
-
+	if (is_ASAN_uninitialized((uintptr_t)e))
+	{
+		printf ("e=UNINITIALIZED\n");
+		return;
+	}
 	if (e == NULL) return;
 
-	if (e->type > 0 && e->type <= 3)
-	{
-		type = ((const char *[]) {"OR_type", "AND_type", "CONNECTOR_type"}) [e->type-1];
-	}
-	else
-	{
-		snprintf(unknown_type, sizeof(unknown_type)-1, "unknown-%d", e->type);
-		type = unknown_type;
-	}
-
 	for(int j =0; j<i; j++) printf(" ");
-	printf ("e=%p: %s cost=%f\n", e, type, e->cost);
+	printf ("e=%p: %s", e, stringify_Exp_type(e->type));
+
+	if (is_ASAN_uninitialized((uintptr_t)e->operand_first))
+		printf(" (UNINITIALIZED operand)");
+	if (is_ASAN_uninitialized((uintptr_t)e->operand_next))
+		printf(" (UNINITIALIZED next)");
+
 	if (e->type != CONNECTOR_type)
 	{
-		E_list *l;
-		for(int j =0; j<i+2; j++) printf(" ");
-		printf("E_list=%p (", e->operand_first);
-		for (l = e->operand_first; NULL != l; l = l->next)
+		int operand_count = 0;
+		for (Exp *opd = e->operand_first; NULL != opd; opd = opd->operand_next)
 		{
-			printf("%p", l->e);
-			if (NULL != l->next) printf(" ");
+			operand_count++;
+			if (is_ASAN_uninitialized((uintptr_t)opd->operand_next))
+			{
+				printf(" (operand %d: UNINITIALIZED next)\n", operand_count);
+				return;
+			}
 		}
-		printf(")\n");
+		printf(" (%d operand%s) cost=%f\n", operand_count,
+		       operand_count == 1 ? "" : "s", e->cost);
 
-		for (l = e->operand_first; NULL != l; l = l->next)
+		for (Exp *opd = e->operand_first; NULL != opd; opd = opd->operand_next)
 		{
-			prt_exp_mem(l->e, i+2);
+			prt_exp_mem(opd, i+2);
 		}
 	}
 	else
 	{
-		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s dir=%c multi=%d\n",
+		printf(" %s%s%c cost=%f\n",
+		       e->multi ? "@" : "",
 		       e->condesc ? e->condesc->string : "(condesc=(null))",
-		       e->dir, e->multi);
+		       e->dir, e->cost);
 	}
 }
 #endif /* DEBUG */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -165,7 +165,7 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 		c1->next = NULL;
 		c1->cost = 0.0;
 		c1->maxcost = 0.0;
-		for (e_list = e->u.l; e_list != NULL; e_list = e_list->next)
+		for (e_list = e->operand_first; e_list != NULL; e_list = e_list->next)
 		{
 			c2 = build_clause(e_list->e, ct);
 			c_head = NULL;
@@ -194,9 +194,9 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 	}
 	else if (e->type == OR_type)
 	{
-		c = build_clause(e->u.l->e, ct);
+		c = build_clause(e->operand_first->e, ct);
 		/* we'll catenate the lists of clauses */
-		for (e_list = e->u.l->next; e_list != NULL; e_list = e_list->next)
+		for (e_list = e->operand_first->next; e_list != NULL; e_list = e_list->next)
 		{
 			c1 = build_clause(e_list->e, ct);
 			if (c1 == NULL) continue;
@@ -278,7 +278,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			/* Build a list of connectors from the Tconnectors. */
 			for (Tconnector *t = cl->c; t != NULL; t = t->next)
 			{
-				Connector *n = connector_new(connector_pool, t->e->u.condesc, opts);
+				Connector *n = connector_new(connector_pool, t->e->condesc, opts);
 				Connector **loc = ('-' == t->e->dir) ? &ndis->left : &ndis->right;
 
 				n->multi = t->e->multi;
@@ -328,7 +328,7 @@ static void print_Tconnector_list(Tconnector *t)
 	for (; t != NULL; t = t->next)
 	{
 		if (t->e->multi) printf("@");
-		printf("%s", t->e->u.condesc->string);
+		printf("%s", t->e->condesc->string);
 		printf("%c", t->e->dir);
 		if (t->next != NULL) printf(" ");
 	}
@@ -354,7 +354,7 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	printf ("type=%d dir=%c multi=%d cost=%f\n", e->type, e->dir, e->multi, e->cost);
 	if (e->type != CONNECTOR_type)
 	{
-		E_list *l = e->u.l;
+		E_list *l = e->operand_first;
 		while(l)
 		{
 			prt_exp(l->e, i+2);
@@ -364,7 +364,7 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	else
 	{
 		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s\n", e->u.condesc->string);
+		printf("con=%s\n", e->condesc->string);
 	}
 }
 
@@ -391,15 +391,15 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 	{
 		E_list *l;
 		for(int j =0; j<i+2; j++) printf(" ");
-		printf("E_list=%p (", e->u.l);
-		for (l = e->u.l; NULL != l; l = l->next)
+		printf("E_list=%p (", e->operand_first);
+		for (l = e->operand_first; NULL != l; l = l->next)
 		{
 			printf("%p", l->e);
 			if (NULL != l->next) printf(" ");
 		}
 		printf(")\n");
 
-		for (l = e->u.l; NULL != l; l = l->next)
+		for (l = e->operand_first; NULL != l; l = l->next)
 		{
 			prt_exp_mem(l->e, i+2);
 		}
@@ -408,7 +408,7 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 	{
 		for(int j =0; j<i; j++) printf(" ");
 		printf("con=%s dir=%c multi=%d\n",
-		       e->u.condesc ? e->u.condesc->string : "(condesc=(null))",
+		       e->condesc ? e->condesc->string : "(condesc=(null))",
 		       e->dir, e->multi);
 	}
 }

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -219,7 +219,7 @@ static Exp* purge_Exp(exprune_context *ctxt, int w, Exp *e, char dir)
 	{
 		if (e->dir == dir)
 		{
-			if (!matches_S(ctxt->ct, w, e->u.condesc))
+			if (!matches_S(ctxt->ct, w, e->condesc))
 			{
 				ctxt->N_deleted++;
 				return NULL;
@@ -231,24 +231,24 @@ static Exp* purge_Exp(exprune_context *ctxt, int w, Exp *e, char dir)
 
 	if (e->type == AND_type)
 	{
-		if (!and_purge_E_list(ctxt, w, e->u.l, dir))
+		if (!and_purge_E_list(ctxt, w, e->operand_first, dir))
 		{
 			return NULL;
 		}
 	}
 	else /* if we are here, its OR_type */
 	{
-		e->u.l = or_purge_E_list(ctxt, w, e->u.l, dir);
-		if (e->u.l == NULL)
+		e->operand_first = or_purge_E_list(ctxt, w, e->operand_first, dir);
+		if (e->operand_first == NULL)
 		{
 			return NULL;
 		}
 	}
 
 	/* Unary node elimination (for a slight performance improvement). */
-	if ((e->u.l != NULL) && (e->u.l->next == NULL))
+	if ((e->operand_first != NULL) && (e->operand_first->next == NULL))
 	{
-		Exp *ne = e->u.l->e;
+		Exp *ne = e->operand_first->e;
 		ne->cost += e->cost;
 		return ne;
 	}
@@ -302,19 +302,19 @@ static void insert_connectors(exprune_context *ctxt, int w, Exp * e, int dir)
 	{
 		if (e->dir == dir)
 		{
-			assert(NULL != e->u.condesc, "NULL connector");
-			Connector c = { .desc = e->u.condesc };
+			assert(NULL != e->condesc, "NULL connector");
+			Connector c = { .desc = e->condesc };
 
 			set_connector_length_limit(&c, ctxt->opts);
 			int farthest_word = (dir == '-') ? -MAX(0, w-c.length_limit) :
 				                              w+c.length_limit;
-			insert_connector(ctxt, farthest_word, e->u.condesc);
+			insert_connector(ctxt, farthest_word, e->condesc);
 		}
 	}
 	else
 	{
 		E_list *l;
-		for (l=e->u.l; l!=NULL; l=l->next)
+		for (l=e->operand_first; l!=NULL; l=l->next)
 		{
 			insert_connectors(ctxt, w, l->e, dir);
 		}

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1001,11 +1001,11 @@ bool SATEncoder::connectivity_components(std::vector<int>& components) {
 
 #ifdef SAT_DEBUG
 #define MVALUE(s, v) (s->model[v] == l_True?'T':(s->model[v] == l_False?'f':'u'))
-static void pmodel(Solver *solver, int var) {
+GNUC_UNUSED static void pmodel(Solver *solver, int var) {
   printf("%c\n", MVALUE(solver, var));
 }
 
-static void pmodel(Solver *solver, vec<Lit> &clause) {
+GNUC_UNUSED static void pmodel(Solver *solver, vec<Lit> &clause) {
   vector<int> t;
   for (int i = 0; i < clause.size(); i++) {
     int v = var(clause[i]);

--- a/link-grammar/sat-solver/sat-encoder.hpp
+++ b/link-grammar/sat-solver/sat-encoder.hpp
@@ -100,7 +100,7 @@ protected:
   // Trailing connectors of a given direction in the given expression
   void trailing_connectors(int w, Exp* exp, char dir, int& dfs_position,
                            std::vector<PositionConnector*>& connectors);
-  bool trailing_connectors_and_aux(int w, E_list* l, char dir, int& dfs_position,
+  bool trailing_connectors_and_aux(int w, Exp* opd, char dir, int& dfs_position,
                                    std::vector<PositionConnector*>& connectors);
 
   // Connectors of the given direction that cannot be trailing
@@ -264,11 +264,6 @@ protected:
   // Join several expressions corresponding to different dictionary
   // entries of a word into a single expression.
   Exp* join_alternatives(int w);
-
-  // Erase auxiliary expression tree nodes obtained by joining several
-  // expressions into one.
-  void free_alternatives(Exp* e);
-
 
   /**
    * Decoding

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -44,7 +44,7 @@ Exp* null_exp()
   static Exp e;
 
   if (e.type) return &e;
-  e.u.l = NULL;
+  e.operand_first = NULL;
   e.type = AND_type;
   return &e;
 }
@@ -70,7 +70,7 @@ void add_anded_exp(Exp*& orig, Exp* addit)
       orig = (Exp*) malloc(sizeof(Exp));
       orig->type = AND_type;
       orig->cost = 0.0;
-      orig->u.l = elist;
+      orig->operand_first = elist;
     }
 }
 

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -4,6 +4,7 @@ extern "C" {
 #include "api-structures.h"
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
+#include "memory-pool.h"
 #include "utilities.h"
 };
 
@@ -41,37 +42,76 @@ void sat_free_linkages(Sentence sent, LinkageIdx next_linkage_index)
 
 Exp* null_exp()
 {
-  static Exp e;
+  static Exp e =
+  {
+    .operand_next = NULL,
+    .type = AND_type,
+    .operand_first = NULL,
+  };
 
-  if (e.type) return &e;
-  e.operand_first = NULL;
-  e.type = AND_type;
   return &e;
 }
 
-void add_anded_exp(Exp*& orig, Exp* addit)
+/* FIXME:
+ * 1. Remove unused Exp functions when disjuncts are directly built.
+ * 2. Unify remaining Exp functions with the similar ones in read-dict.c. */
+
+/**
+ * Allocate a new Exp node.
+ */
+Exp* Exp_create(Sentence sent)
+{
+  Exp* e = (Exp*)pool_alloc(sent->Exp_pool);
+  return e;
+}
+
+static Exp* make_unary_node(Sentence sent, Exp* e)
+{
+  Exp* n;
+  n = Exp_create(sent);
+  n->type = AND_type;  /* these must be AND types */
+  n->operand_next = NULL;
+  n->cost = 0.0;
+  n->operand_first = e;
+  return n;
+}
+
+/**
+ * Duplicate the given Exp node.
+ * This is needed in case it is to be participate more than once in an
+ * expression (one or more), so its operand_first and operand_next may be
+ * different.
+ */
+Exp *Exp_create_dup(Sentence sent, Exp *old_e)
+{
+  Exp *new_e = Exp_create(sent);
+
+  *new_e = *old_e;
+
+  return new_e;
+}
+
+/**
+ * Prepend the CONNECTOR node addit to the AND node orig.
+ * (If orig is NULL, first create an AND node.)
+ * Return the result.
+ */
+void add_anded_exp(Sentence sent, Exp*& orig, Exp* addit)
 {
     if (orig == NULL)
     {
-      orig = addit;
-    } else
-    {
-      // flist is orig
-      E_list* flist = (E_list*) malloc(sizeof(E_list));
-      flist->e = orig;
-      flist->next = NULL;
-
-      // elist is addit, orig
-      E_list* elist = (E_list*) malloc(sizeof(E_list));
-      elist->next = flist;
-      elist->e = addit;
-
-      // The updated orig is addit & orig
-      orig = (Exp*) malloc(sizeof(Exp));
-      orig->type = AND_type;
-      orig->cost = 0.0;
-      orig->operand_first = elist;
+      orig = make_unary_node(sent, Exp_create_dup(sent, addit));
+      orig->operand_first->operand_next = NULL;
     }
+    else
+    {
+      // Prepend addit to the existing operands
+      Exp *orig_operand_first = orig->operand_first;
+      orig->operand_first = Exp_create_dup(sent, addit);
+      orig->operand_first->operand_next = orig_operand_first;
+    }
+
+    // The updated orig is addit & orig
 }
 
 #if 0

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -13,6 +13,8 @@ void free_linkage_connectors_and_disjuncts(Linkage);
 void sat_free_linkages(Sentence, LinkageIdx);
 void sat_free_linkages(Sentence);
 Exp* null_exp();
-void add_anded_exp(Exp*&, Exp*);
+void add_anded_exp(Sentence, Exp*&, Exp*);
+Exp* Exp_create(Sentence);
+Exp *Exp_create_dup(Sentence, Exp *old);
 
 #endif

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -164,7 +164,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
 
 void WordTag::find_matches(int w, Connector* search_cntr, char dir, std::vector<PositionConnector*>& matches)
 {
-  // cout << "Look connection on: ." << _word << ". ." << w << ". " << search_cntr << dir << endl;
+  // cout << "Look connection on: ." << _word << ". ." << w << ". " << connector_string(search_cntr) << dir << endl;
 
   std::vector<PositionConnector>* connectors;
   switch(dir) {

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -61,7 +61,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       throw std::string("Unknown connector direction: ") + exp->dir;
     }
   } else if (exp->type == AND_type) {
-    if (exp->u.l == NULL) {
+    if (exp->operand_first == NULL) {
       /* zeroary and */
       if (cost != 0)
       {
@@ -70,9 +70,9 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
         _empty_connectors.push_back(EmptyConnector(_variables->string(var),cost));
       }
     } else
-      if (exp->u.l->next == NULL) {
+      if (exp->operand_first->next == NULL) {
         /* unary and - skip */
-        insert_connectors(exp->u.l->e, dfs_position, leading_right,
+        insert_connectors(exp->operand_first->e, dfs_position, leading_right,
              leading_left, eps_right, eps_left, var, root, cost, parent_exp, word_xnode);
       } else {
         int i;
@@ -86,7 +86,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
           last_var++;
         }
 
-        for (i = 0, l = exp->u.l; l != NULL; l = l->next, i++) {
+        for (i = 0, l = exp->operand_first; l != NULL; l = l->next, i++) {
           char* s = last_new_var;
           *s++ = 'c';
           fast_sprintf(s, i);
@@ -104,10 +104,10 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
         }
       }
   } else if (exp->type == OR_type) {
-    if (exp->u.l != NULL && exp->u.l->next == NULL) {
+    if (exp->operand_first != NULL && exp->operand_first->next == NULL) {
       /* unary or - skip */
-      insert_connectors(exp->u.l->e, dfs_position, leading_right, leading_left,
-          eps_right, eps_left, var, root, cost, exp->u.l->e, word_xnode);
+      insert_connectors(exp->operand_first->e, dfs_position, leading_right, leading_left,
+          eps_right, eps_left, var, root, cost, exp->operand_first->e, word_xnode);
     } else {
       int i;
       E_list* l;
@@ -129,7 +129,7 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
       }
 #endif
 
-      for (i = 0, l = exp->u.l; l != NULL; l = l->next, i++) {
+      for (i = 0, l = exp->operand_first; l != NULL; l = l->next, i++) {
         bool lr = leading_right, ll = leading_left;
         std::vector<int> er = eps_right, el = eps_left;
 

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -28,11 +28,11 @@ struct PositionConnector
       eps_right(er), eps_left(el), word_xnode(w_xnode)
   {
     if (word_xnode == NULL) {
-       cerr << "Internal error: Word" << w << ": " << "; connector: '" << e->u.condesc->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << e->condesc->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
     }
 
     // Initialize some fields in the connector struct.
-    connector.desc = e->u.condesc;
+    connector.desc = e->condesc;
     connector.multi = e->multi;
     set_connector_length_limit(&connector, opts);
     connector.originating_gword = &w_xnode->word->gword_set_head;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2996,7 +2996,7 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w, const char
 		y = (X_node *) pool_alloc(sent->X_node_pool);
 		y->next = x;
 		x = y;
-		x->exp = copy_Exp(dn->exp, sent->E_list_pool, sent->Exp_pool);
+		x->exp = copy_Exp(dn->exp, sent->Exp_pool);
 		if (NULL == s)
 		{
 			x->string = dn->string;


### PR DESCRIPTION
The main change here is the elimination of the E_list struct. I think the code is much clearer without it.
See my [post in issue 718](https://github.com/opencog/link-grammar/issues/718#issuecomment-510584753).
Add expression traversal API calls per the proposal there. Since most of the `lg_exp_*()` API are inline functions, the Exp struct definition still needs to be public.
(**But maybe these calls** can be made non-inline and moved to `link-includes.h` along with `Exp_type` and an opaque Exp definition.)

In the same occasion, change `copy_Exp()` and `exp_compare()` to iterate the expression operands instead of making recursive calls, to prevent extra stack usage on a very big operand list.

This change increases the Exp struct back to 32 bytes (it got reduced to 24 bytes in the recent PR #969).
If needed, it can be reduced again to 24 bytes using this definition:
``` c
struct Exp_struct
{
        Exp *operand_next; /* Next same-level operand. */
        float cost;   /* The cost of using this expression. */
        Exp_type type:8; /* One of three types: AND, OR, or connector. */
        char dir;      /* The connector connects to the left ('-') or right ('+'). */
        bool multi;    /* TRUE if a multi-connector (for connector). */
        union
        {
                Exp *operand_first; /* First operand (for non-terminals). */
                condesc_t *condesc; /* Only needed if it's a connector. */
        };
};
```
I will check the exact effect of the Exp struc sized when I implement my [cost definition cleanup proposal in issue 783](https://github.com/opencog/link-grammar/issues/783#issuecomment-509979884).

The total speedup is small - about 3% for the benchmarks of the `en` basic & fixes batches.

N.B If desired, I can also send PR for the needed change in `LGDictExpContainer.cc`.

