### PR TITLE
sat-solver: Fix to handle long expression chains

### DIFF
--- a/bindings/python-examples/parses-sat-en.txt
+++ b/bindings/python-examples/parses-sat-en.txt
@@ -15,3 +15,10 @@ C(S (NP this.p)
 C   (VP is.v
 C       (NP a test.n)))
 C
+
+% This sentence should not have a complete linkage (fixed in issue #972).
+% (If the SAT parser is fixed to produce incomplete linkages, include
+% the incomplete linkage here.)
+II saw make some changes in the program
+O
+O

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1149,7 +1149,6 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             wordpos = ""
             linkages = Sentence(sent, lgdict, popt).parse()
             linkage = next(linkages, None)
-            self.assertTrue(linkage, "at {}:{}: Sentence has no linkages".format(testfile, lineno))
 
         # Generate the next linkage of the last input sentence
         elif line[0] == 'N':
@@ -1163,9 +1162,14 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
         # It ends with an empty line
         elif line[0] == 'O':
             diagram += line[1:]
-            if line[1] == '\n' and len(diagram) > 1:
-                self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
-                diagram = None
+            if line[1] == '\n':
+                if diagram == 'C\nC\n':
+                    self.assertFalse(linkage)
+                    diagram = None
+                elif len(diagram) > 2:
+                    self.assertTrue(linkage, "at {}:{}: Sentence has no linkages".format(testfile, lineno))
+                    self.assertEqual(linkage.diagram(), diagram, "at {}:{}".format(testfile, lineno))
+                    diagram = None
 
         # Lines starting with C are the constituent output (type 1)
         # It ends with an empty line


### PR DESCRIPTION
Fix issue #932.

[ @linas, please apply this before PR #971. I will append ASAP the no-E_list fix for the SAT-parser to #971 to make it ready for merging. ]

Due to the way the ordering constrains are generated, they are actually not transitive as clammed in section 2.4 of the SAT-parser paper (Conjunction order constraints). So invoking `generate_conjunct_order_constraints()` for each pair of a long expression chain (length > 2) misses necessary connector ordering conditions. As a result, solutions in which connectors are connected in wrong order are produced.

Repeat by:
```
*A few times may I have taken cocaine, but I inhaled at no time
*I saw make some changes in the program
*Joe doesn't matter what Ted does
*Stravinsky was in Paris that Debussy first heard Balinese music
*The big mind on everybody's question is who killed OJ
```

Work around this bug by converting the expression, on the fly, to a 2-component chain, just before `invoking generate_conjunct_order_constraints()`.
**EDIT**: It is not actually converted to 2-components, just handled as 2 components, the first operand and the AND of the rest of operands.

**Problem example:**
Sentence: `*I saw make some changes in the program`
In word 2 we get here this subexpression (among many others):
`(K+ & {[[@MV+]]} & (O*n+ or ()))`  (& chain length = 3)

The generated constrains are only:
(Decoding: `(word-number _ connector-position _ connector-string) _ to-word-number)`
Clause: `-link_cw_(2_4_K)_6 -link_cw_(2_5_MV)_6`
Clause: `-link_cw_(2_5_MV)_6 -link_cw_(2_6_O*n)_4`
(Reading: If MV connects from word 2 to word 6, then O*n cannot connect from word 2 to word 4).
Clause: `-link_cw_(2_5_MV)_6 -link_cw_(2_6_O*n)_5`

However, the following, which are generated when the chain length is limited to 2, are missing:
Clause: `-link_cw_(2_4_K)_6 -link_cw_(2_6_O*n)_4`
Clause: `-link_cw_(2_4_K)_6 -link_cw_(2_6_O*n)_5`
Clearly, they cannot be concluded transitively.
                                                                 


