### PR TITLE
Cost cleanup

### DIFF
--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -35,6 +35,9 @@ typedef enum
 	CONNECTOR_type
 } Exp_type;
 
+static const int cost_max_dec_places = 3;
+static const double cost_epsilon = 1E-5;
+
 /**
  * The Exp structure defined below comprises the expression trees that are
  * stored in the dictionary. The expression has a type (OR_type, AND_type

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -61,6 +61,7 @@ struct Exp_struct
 };
 
 bool cost_eq(double cost1, double cost2);
+const char *cost_stringify(double cost);
 
 /* API to access the above structure. */
 static inline Exp_type lg_exp_get_type(const Exp* exp) { return exp->type; }

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -60,6 +60,8 @@ struct Exp_struct
 	double cost;   /* The cost of using this expression. */
 };
 
+bool cost_eq(double cost1, double cost2);
+
 /* API to access the above structure. */
 static inline Exp_type lg_exp_get_type(const Exp* exp) { return exp->type; }
 static inline char lg_exp_get_dir(const Exp* exp) { return exp->dir; }

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -14,8 +14,6 @@
  * Miscellaneous utilities for dealing with word types.
  */
 
-#include <math.h>  // for fabs()
-
 #include "connectors.h"
 #include "dict-api.h"
 #include "string-set.h"
@@ -92,7 +90,7 @@ static bool exp_compare(Exp *e1, Exp *e2)
 	  return false;
 	if (e1->type != e2->type)
 		return false;
-	if (fabs (e1->cost - e2->cost) > 0.001)
+	if (!cost_eq(e1->cost, e2->cost))
 		return false;
 
 	if (e1->type == CONNECTOR_type)

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -11,6 +11,7 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include <math.h>                   // fabs
 #include <string.h>
 
 #include "api-structures.h" // for Parse_Options_s  (seems hacky to me)
@@ -22,10 +23,14 @@
 #include "dict-file/word-file.h"
 #include "dict-file/read-dict.h"
 
-
 /* ======================================================================== */
 
 #define COST_FMT "%.3f"
+bool cost_eq(double cost1, double cost2)
+{
+	return (fabs(cost1 - cost2) < cost_epsilon);
+}
+
 /**
  * print the expression, in infix-style
  */
@@ -42,12 +47,12 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		return e;
 	}
 
-	if (n->cost < -10E-4)
+	if (n->cost < -cost_epsilon)
 	{
 		icost = 1;
 		dcost = n->cost;
 	}
-	else if ((n->cost > -10E-4) && (n->cost < 0))
+	else if (cost_eq(n->cost, 0.0))
 	{
 		/* avoid [X+]-0.00 */
 		icost = 0;
@@ -57,7 +62,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	{
 		icost = (int) (n->cost);
 		dcost = n->cost - icost;
-		if (dcost > 10E-4)
+		if (dcost > cost_epsilon)
 		{
 			dcost = n->cost;
 			icost = 1;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -25,10 +25,22 @@
 
 /* ======================================================================== */
 
-#define COST_FMT "%.3f"
 bool cost_eq(double cost1, double cost2)
 {
 	return (fabs(cost1 - cost2) < cost_epsilon);
+}
+
+/**
+ * Convert cost to a string with at most cost_max_dec_places decimal places.
+ */
+const char *cost_stringify(double cost)
+{
+	static TLS char buf[16];
+
+	int l = snprintf(buf, sizeof(buf), "%.*f", cost_max_dec_places, cost);
+	if ((l < 0) || (l >= (int)sizeof(buf))) return "ERR_COST";
+
+	return buf;
 }
 
 /**
@@ -89,7 +101,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		if (n->multi) dyn_strcat(e, "@");
 		append_string(e, "%s%c", n->condesc?n->condesc->string:"(null)", n->dir);
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
-		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		if (0 != dcost) dyn_strcat(e, cost_stringify(dcost));
 		return e;
 	}
 
@@ -99,7 +111,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		for (i=0; i<icost; i++) dyn_strcat(e, "[");
 		dyn_strcat(e, "()");
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
-		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		if (0 != dcost) dyn_strcat(e, cost_stringify(dcost));
 		return e;
 	}
 
@@ -114,7 +126,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 		 else print_expression_parens(e, operand->operand_next, false);
 		dyn_strcat(e, "}");
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
-		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		if (0 != dcost) dyn_strcat(e, cost_stringify(dcost));
 		return e;
 	}
 
@@ -127,7 +139,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	if ((n->type == AND_type) && (operand->operand_next == NULL))
 	{
 		for (i=0; i<icost; i++) dyn_strcat(e, "]");
-		if (0 != dcost) append_string(e, COST_FMT, dcost);
+		if (0 != dcost) dyn_strcat(e, cost_stringify(dcost));
 		if ((icost == 0) && need_parens) dyn_strcat(e, ")");
 		return e;
 	}
@@ -167,7 +179,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	}
 
 	for (i=0; i<icost; i++) dyn_strcat(e, "]");
-	if (0 != dcost) append_string(e, COST_FMT, dcost);
+	if (0 != dcost) dyn_strcat(e, cost_stringify(dcost));
 	if ((icost == 0) && need_parens) dyn_strcat(e, ")");
 
 	return e;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -350,8 +350,8 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	if (e == NULL) return;
 
 	for(int j =0; j<i; j++) printf(" ");
-	printf ("type=%d dir=%c multi=%d cost=%f\n",
-	        e->type, e->dir, e->multi, e->cost);
+	printf ("type=%d dir=%c multi=%d cost=%s\n",
+	        e->type, e->dir, e->multi, cost_stringify(e->cost));
 	if (e->type != CONNECTOR_type)
 	{
 		for (e = e->operand_next; e != NULL; e = e->operand_next) prt_exp(e, i+2);
@@ -417,8 +417,8 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 				return;
 			}
 		}
-		printf(" (%d operand%s) cost=%f\n", operand_count,
-		       operand_count == 1 ? "" : "s", e->cost);
+		printf(" (%d operand%s) cost=%s\n", operand_count,
+		       operand_count == 1 ? "" : "s", cost_stringify(e->cost));
 
 		for (Exp *opd = e->operand_first; NULL != opd; opd = opd->operand_next)
 		{
@@ -427,10 +427,10 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 	}
 	else
 	{
-		printf(" %s%s%c cost=%f\n",
+		printf(" %s%s%c cost=%s\n",
 		       e->multi ? "@" : "",
 		       e->condesc ? e->condesc->string : "(condesc=(null))",
-		       e->dir, e->cost);
+		       e->dir, cost_stringify(e->cost));
 	}
 }
 #endif /* DEBUG */


### PR DESCRIPTION
Mostly per [my post](https://github.com/opencog/link-grammar/issues/783#issuecomment-509979884) at PR #783:
>1. Define cost type (currently "double") so it could be easily changed to float if desired.
I propose `cost_t`.

Not implemented. If needed,  the cost type in `Exp` or `Disjunct` can be changed to `float`, so these are the only places in which cost_t would be of use. (There is no benefit to change the cost variables that are used for calculation (as opposed to storage) to `float`).
Changing all of them to `short` (scaled, so cost 1 is represented internally by 1024) may have enough benefit only if more `Exp` or `Disjunct` space will be needed and there will be no other alternative (not  the case with my current or planned WIPs).

>2. Define print format (currently 2,3,4,6 digits after the decimal point are printed in various places).
I propose `const unsigned int cost_precision = 3;`

Implemented as `cost_max_dec_places`.
I also implemented here `cost_stringify()`, that prints the cost in the shortest possible floating point notation (up to `cost_max_dec_places` decimal places). These is how costs mostly appear in the `en` dict.
E.g.:

current |this PR
-- | --
0.500|.5
0.650|.65
-0.100|-.1

>3. Define function costs_eq(cost1, cost2) (currently comparing cost1-cost2)to an inconsistent value 1E-4 or 1E-5).
I propose `const cost_t cost_epsilon = 1E-5;`.

Implemented as `const double cost_epsilon = 1E-5;`.

I don't know whether to put `cost_stringify()` in the public API along with the "`lg_exp_*()` stuff.
In that case it should maybe called `lg_exp_cost_stringify()`.
For now it is not in the public API.  I will also take `expression_stringify()` out of the API.
But if expression traversing is part of the API, maybe also printing expressions should be.
So if desired in the API I think its API name should be `lg_exp_stringify()`.
I will decide shortly (next PR) but of course I can do it either way if according to what you think.
