### PR TITLE
Exp cleanup

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -15,6 +15,7 @@
 
 #include "api-structures.h"
 #include "dict-common/dict-utils.h"
+#include "dict-common/dict-api.h"      // for expression_strigify()
 #include "disjunct-utils.h"   // for free_sentence_disjuncts()
 #include "linkage/linkage.h"
 #include "memory-pool.h"
@@ -484,6 +485,7 @@ void sentence_delete(Sentence sent)
 	free_linkages(sent);
 	post_process_free(sent->postprocessor);
 	post_process_free(sent->constituent_pp);
+	expression_stringify(NULL);
 
 	global_rand_state = sent->rand_state;
 	pool_delete(sent->fm_Match_node);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -485,7 +485,7 @@ void sentence_delete(Sentence sent)
 	free_linkages(sent);
 	post_process_free(sent->postprocessor);
 	post_process_free(sent->constituent_pp);
-	expression_stringify(NULL);
+	lg_exp_stringify(NULL);
 
 	global_rand_state = sent->rand_state;
 	pool_delete(sent->fm_Match_node);

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -41,7 +41,6 @@ bool boolean_dictionary_lookup(const Dictionary, const char *);
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);
 
 void print_expression(const Exp *);
-const char *expression_stringify(const Exp *);
 
 LINK_END_DECLS
 

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -40,8 +40,6 @@ bool boolean_dictionary_lookup(const Dictionary, const char *);
 /* XXX the below probably does not belong ...  ?? */
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);
 
-void print_expression(const Exp *);
-
 LINK_END_DECLS
 
 #endif /* _LG_DICT_API_H_ */

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -41,7 +41,7 @@ bool boolean_dictionary_lookup(const Dictionary, const char *);
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);
 
 void print_expression(const Exp *);
-char *expression_stringify(const Exp *);
+const char *expression_stringify(const Exp *);
 
 LINK_END_DECLS
 

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -65,6 +65,7 @@ const char* lg_exp_get_string(const Exp*);
 static inline double lg_exp_get_cost(const Exp* exp) { return exp->cost; }
 static inline Exp* lg_exp_operand_first(Exp* exp) { return exp->operand_first; }
 static inline Exp* lg_exp_operand_next(Exp* exp) { return exp->operand_next; }
+const char *lg_exp_stringify(const Exp *);
 
 /**
  * The dictionary is stored as a binary tree comprised of the following

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -38,9 +38,9 @@ typedef enum
 /**
  * The Exp structure defined below comprises the expression trees that are
  * stored in the dictionary. The expression has a type (OR_type, AND_type
- * or CONNECTOR_type). If it is not a terminal "operand" points to its
+ * or CONNECTOR_type). If it is not a terminal "operand_first" points to its
  * list of operands (when each of them points to the next one through
- * "next"). Else "condesc" is the connector descriptor, when "dir"
+ * "operand_next"). Else "condesc" is the connector descriptor, when "dir"
  * indicates the connector direction.
  */
 struct Exp_struct

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -123,9 +123,7 @@ static bool exp_compare(Exp *e1, Exp *e2)
 static int exp_contains(Exp * super, Exp * sub)
 {
 #if 0 /* DEBUG */
-	printf("SUP: ");
-	if (super) print_expression(super);
-	printf("\n");
+	if (super) printf("SUP: %s\n", lg_exp_stringify(super));
 #endif
 
 	if (sub==NULL || super==NULL)
@@ -287,11 +285,8 @@ static bool dn_word_contains(Dictionary dict,
 	m_exp = m_dn->exp;
 
 #if 0 /* DEBUG */
-	printf("\nWORD: ");
-	print_expression(w_dn->exp);
-	printf("\nMACR: ");
-	print_expression(m_exp);
-	printf("\n");
+	printf("\nWORD: %s\n", lg_exp_stringify(w_dn->exp));
+	printf("\nMACR: %s\n", lg_exp_stringify(m_exp));
 #endif
 
 	for (;w_dn != NULL; w_dn = w_dn->right)

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -179,9 +179,18 @@ void print_expression(const Exp * n)
 
 const char *expression_stringify(const Exp *n)
 {
-	dyn_str *e = dyn_str_new();
+	static char *e_str;
 
-	return dyn_str_take(print_expression_parens(e, n, false));
+	if (e_str != NULL) free(e_str);
+	if (n == NULL)
+	{
+		e_str = NULL;
+		return "(null)";
+	}
+
+	dyn_str *e = dyn_str_new();
+	e_str = dyn_str_take(print_expression_parens(e, n, false));
+	return e_str;
 }
 
 /* ======================================================================= */
@@ -313,12 +322,11 @@ static char *display_expr(const char *word, Dict_node *dn)
 	append_string(s, "expressions:\n");
 	for (; dn != NULL; dn = dn->right)
 	{
-		char *expstr = expression_stringify(dn->exp);
+		const char *expstr = expression_stringify(dn->exp);
 
 		append_string(s, "    %-*s %s",
 		              display_width(DJ_COL_WIDTH, dn->string), dn->string,
 		              expstr);
-		free(expstr);
 		append_string(s, "\n\n");
 	}
 	return dyn_str_take(s);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -177,7 +177,7 @@ void print_expression(const Exp * n)
 	free(s);
 }
 
-char *expression_stringify(const Exp * n)
+const char *expression_stringify(const Exp *n)
 {
 	dyn_str *e = dyn_str_new();
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -177,7 +177,7 @@ void print_expression(const Exp * n)
 	free(s);
 }
 
-const char *expression_stringify(const Exp *n)
+const char *lg_exp_stringify(const Exp *n)
 {
 	static char *e_str;
 
@@ -322,7 +322,7 @@ static char *display_expr(const char *word, Dict_node *dn)
 	append_string(s, "expressions:\n");
 	for (; dn != NULL; dn = dn->right)
 	{
-		const char *expstr = expression_stringify(dn->exp);
+		const char *expstr = lg_exp_stringify(dn->exp);
 
 		append_string(s, "    %-*s %s",
 		              display_width(DJ_COL_WIDTH, dn->string), dn->string,

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -168,15 +168,6 @@ static dyn_str *print_expression_parens(dyn_str *e,
 	return e;
 }
 
-void print_expression(const Exp * n)
-{
-	dyn_str *e = dyn_str_new();
-
-	char *s = dyn_str_take(print_expression_parens(e, n, false));
-	err_msg(lg_Debug, "%s\n", s);
-	free(s);
-}
-
 const char *lg_exp_stringify(const Exp *n)
 {
 	static char *e_str;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1786,9 +1786,7 @@ static void rprint_dictionary_data(Dict_node * n)
 {
 	if (n == NULL) return;
 	rprint_dictionary_data(n->left);
-	printf("%s: ", n->string);
-	print_expression(n->exp);
-	printf("-6-\n");
+	printf("%s: %s\n", n->string, lg_exp_stringify(n->exp));
 	rprint_dictionary_data(n->right);
 }
 

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -257,11 +257,8 @@ db_lookup_exp(Dictionary dict, const char *s, cbdata* bs)
 
 	if (es != s) free(es);
 
-	if (verbosity_level(D_SQL+1))
-	{
-		printf("Found expression for class %s: ", s);
-		print_expression(bs->exp);
-	}
+	lgdebug(D_SQL+1, "Found expression for class %s: %s\n",
+	        s, lg_exp_stringify(bs->exp));
 }
 
 
@@ -354,8 +351,8 @@ static Dict_node * db_lookup_list(Dictionary dict, const char *s)
 	{
 		if (bs.dn)
 		{
-			printf("Found expression for word %s: ", s);
-			print_expression(bs.dn->exp);
+			printf("Found expression for word %s: %s\n",
+	        s, lg_exp_stringify(bs.dn->exp));
 		}
 		else
 		{
@@ -381,8 +378,8 @@ static Dict_node * db_lookup_wild(Dictionary dict, const char *s)
 	{
 		if (bs.dn)
 		{
-			printf("Found expression for glob %s: ", s);
-			print_expression(bs.dn->exp);
+			printf("Found expression for glob %s: %s\n",
+	        s, lg_exp_stringify(bs.dn->exp));
 		}
 		else
 		{

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -114,7 +114,14 @@ lg_error_formatmsg
 lg_error_printall
 lg_error_clearall
 lg_error_flush
+lg_exp_get_type
+lg_exp_get_dir
+lg_exp_get_multi
 lg_exp_get_string
+lg_exp_get_cost
+lg_exp_operand_first
+lg_exp_operand_next
+lg_exp_stringify
 prt_error
 lg_compute_disjunct_strings
 object_open

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -401,9 +401,9 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 	printf ("e=%p: %s", e, stringify_Exp_type(e->type));
 
 	if (is_ASAN_uninitialized((uintptr_t)e->operand_first))
-		printf(" (UNINITIALIZED operand)");
+		printf(" (UNINITIALIZED operand_first)");
 	if (is_ASAN_uninitialized((uintptr_t)e->operand_next))
-		printf(" (UNINITIALIZED next)");
+		printf(" (UNINITIALIZED operand_next)");
 
 	if (e->type != CONNECTOR_type)
 	{
@@ -413,7 +413,7 @@ GNUC_UNUSED void prt_exp_mem(Exp *e, int i)
 			operand_count++;
 			if (is_ASAN_uninitialized((uintptr_t)opd->operand_next))
 			{
-				printf(" (operand %d: UNINITIALIZED next)\n", operand_count);
+				printf(" (operand %d: UNINITIALIZED operand_next)\n", operand_count);
 				return;
 			}
 		}

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -15,8 +15,8 @@
 
 #include "build-disjuncts.h"
 #include "connectors.h"
-//#include "dict-common/print-dict.h"      // print_expression()
-#include "dict-common/dict-structures.h"   // Exp_struct()
+//#include "dict-common/dict-structurtes.h" // lg_exp_stringify
+#include "dict-common/dict-structures.h"  // Exp_struct
 #include "disjunct-utils.h"
 #include "utilities.h"
 
@@ -309,7 +309,7 @@ Disjunct * build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
 	                   /*num_elements*/32768, sizeof(Tconnector),
 	                   /*zero_out*/false, /*align*/false, /*exact*/false);
 
-	// print_expression(exp);  printf("\n");
+	// printf("%s\n", lg_exp_stringify(exp));
 	c = build_clause(exp, &ct);
 	// print_clause_list(c);
 	dis = build_disjunct(sent, c, word, cost_cutoff, opts);
@@ -343,7 +343,7 @@ GNUC_UNUSED static void print_clause_list(Clause * c)
 	}
 }
 
-/* There is a much better print_expression elsewhere
+/* There is a much better lg_exp_stringify() elsewhere
  * This one is for low-level debug. */
 GNUC_UNUSED void prt_exp(Exp *e, int i)
 {

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -29,10 +29,9 @@
 #define DBG(p, w, X) \
 	if (verbosity_level(+D_EXPRUNE))\
 	{\
-		char *e = expression_stringify(x->exp);\
+		const char *e = expression_stringify(x->exp);\
 		err_msg(lg_Trace, "pass%d w%zu: ", p, w);\
 		err_msg(lg_Trace, X ": %s\n", e);\
-		free(e);\
 	}
 #else /* !DEBUG */
 #define DBG(p, w, X)

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -29,9 +29,8 @@
 #define DBG(p, w, X) \
 	if (verbosity_level(+D_EXPRUNE))\
 	{\
-		const char *e = lg_exp_stringify(x->exp);\
 		err_msg(lg_Trace, "pass%d w%zu: ", p, w);\
-		err_msg(lg_Trace, X ": %s\n", e);\
+		err_msg(lg_Trace, X ": %s\n", lg_exp_stringify(x->exp));\
 	}
 #else /* !DEBUG */
 #define DBG(p, w, X)

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -16,7 +16,7 @@
 #include "build-disjuncts.h"             // allow using prt_exp_mem
 #endif
 #include "connectors.h"
-#include "dict-common/dict-api.h"        // expression_stringify
+#include "dict-common/dict-structures.h" // expression_stringify
 #include "dict-common/dict-utils.h"      // size_of_expression
 #include "print/print-util.h"            // dyn_str functions
 #include "string-set.h"
@@ -29,7 +29,7 @@
 #define DBG(p, w, X) \
 	if (verbosity_level(+D_EXPRUNE))\
 	{\
-		const char *e = expression_stringify(x->exp);\
+		const char *e = lg_exp_stringify(x->exp);\
 		err_msg(lg_Trace, "pass%d w%zu: ", p, w);\
 		err_msg(lg_Trace, X ": %s\n", e);\
 	}

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -26,7 +26,6 @@ extern "C" {
 #include "fast-sprintf.hpp"
 
 extern "C" {
-#include "dict-common/dict-api.h"    // for print_expression()
 #include "disjunct-utils.h"
 #include "linkage/analyze-linkage.h" // for compute_link_names()
 #include "linkage/linkage.h"
@@ -257,7 +256,7 @@ void SATEncoder::build_word_tags()
 
 #ifdef SAT_DEBUG
     cout << "Word ." << w << ".: " << N(_sent->word[w].unsplit_word) << endl;
-    print_expression(exp);
+    cout << lg_exp_stringify(exp);
     //prt_exp_mem(exp, 0);
     cout << endl;
 #endif
@@ -317,7 +316,7 @@ void SATEncoder::generate_satisfaction_conditions()
     cout << "Word " << w << ": " << N(_sent->word[w].unsplit_word);
     if (_sent->word[w].optional) cout << " (optional)";
     cout << endl;
-    //print_expression(exp);
+    cout << lg_exp_stringify(exp);
     cout << endl;
 #endif
 
@@ -1837,12 +1836,12 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
     add_anded_exp(_sent, exp_word[var->right_word], rcexp);
 
     if (verbosity_level(D_SAT)) {
-      //cout<< "Lexp[" <<left_xnode->word->subword <<"]: ";  print_expression(var->left_exp);
-      cout<< "w"<<var->left_word<<" LCexp[" <<left_xnode->word->subword <<"]: ";  print_expression(lcexp);
-      //cout<< "Rexp[" <<right_xnode->word->subword <<"]: "; print_expression(var->right_exp);
-      cout<< "w"<<var->right_word<<" RCexp[" <<right_xnode->word->subword <<"]: "; print_expression(rcexp);
-      cout<< "L+L: "; print_expression(exp_word[var->left_word]);
-      cout<< "R+R: "; print_expression(exp_word[var->right_word]);
+      //cout<< "Lexp[" <<left_xnode->word->subword <<"]: " << lg_exp_stringify(var->left_exp);
+      cout<< "w"<<var->left_word<<" LCexp[" <<left_xnode->word->subword <<"]: ", lg_exp_stringify(lcexp);
+      //cout<< "Rexp[" <<right_xnode->word->subword <<"]: ", lg_exp_stringify(var->right_exp);
+      cout<< "w"<<var->right_word<<" RCexp[" <<right_xnode->word->subword <<"]: ", lg_exp_stringify(rcexp);
+      cout<< "L+L: ", lg_exp_stringify(exp_word[var->left_word]);
+      cout<< "R+R: ", lg_exp_stringify(exp_word[var->right_word]);
     }
 
     if (xnode_word[var->left_word] && xnode_word[var->left_word] != left_xnode) {

--- a/link-grammar/sat-solver/word-tag.cpp
+++ b/link-grammar/sat-solver/word-tag.cpp
@@ -4,7 +4,6 @@
 extern "C" {
 #ifdef DEBUG
 #include "prepare/build-disjuncts.h"    // prt_exp_mem()
-#include "dict-common/dict-api.h"       // print_expression()
 #endif
 #include "error.h"
 #include "tokenize/tok-structures.h"
@@ -28,9 +27,9 @@ void WordTag::insert_connectors(Exp* exp, int& dfs_position,
     const char*type =
       ((const char *[]) {"OR_type", "AND_type", "CONNECTOR_type"}) [exp->type-1];
     printf("Expression type %s for Word%d, var %s:\n", type, _word, var);
-    //printf("parent_exp: "); print_expression(parent_exp);
-    printf("exp(%s) e=%.2f pc=%.2f ", word_xnode->string,exp->cost, parent_cost);
-    print_expression(exp);
+    //printf("parent_exp: %s\n", lg_exp_stringify(parent_exp));
+    printf("exp(%s) e=%.2f pc=%.2f %s\n",
+           word_xnode->string,exp->cost, parent_cost, lg_exp_stringify(exp));
     if (exp->cost > 0 || root) prt_exp_mem(exp, 0);
   }
 #endif

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3124,8 +3124,8 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 				 w->regex_name ? w->regex_name : "");
 		while (we)
 		{
-			prt_error("Debug:  string='%s' expr=", we->string);
-			print_expression(we->exp);
+			prt_error("Debug:  string='%s' expr=%s\n",
+			          we->string, lg_exp_stringify(we->exp));
 			we = we->next;
 		}
 	}


### PR DESCRIPTION
- Fix comments and printouts.
- Rename `expression_stringify()` to `lg_exp_stringify()`.
- Make it to return `const char *` to a static buffer that is freed on sentence delete.
- Add all the lg_exp_*() functions to link-grammar.def. They will still not be exported on Windows (need to
use `link_public_api` for that.)

I intend to later to add `lg_exp_stringify()` to Python in order to implement basic dict expression checks and  testing the dialect stuff (issue #402). BTW, the dialect stuff is already done but needs some cleanup and porting to the new dict code (that got slightly modified from then). 