### PR TITLE
Preparations for the "pruning per null count" version

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -50,7 +50,7 @@ messages of the lower ones.
 * 101: Print all the connectors, along with their length limit.
        A length limit of 0 means the value of the short\_length option is used.
 
-* 102: do_count() memoizing table statistics (in DEBUG mode only).
+* 102: Print all disjuncts before pruning.
 
 * 103: Show unsubscripted dictionary words and subscripted ones which share
        the same base word.

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -693,7 +693,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 				/* The first time we encounter this tracon. */
 				*tracon = lcblock; /* Save its future location in the tracon_set. */
 
-				if (ts->is_pruning)
+				if (NULL != tl)
 				{
 					tlsz_check(tl, tl->entries[dir], dir);
 					uint32_t cblock_index = (uint32_t)(lcblock - ts->cblock_base);
@@ -704,7 +704,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 			else
 			{
 				newc = *tracon;
-				if (!ts->is_pruning)
+				if (NULL == tl)
 				{
 					if (o->nearest_word != newc->nearest_word)
 					{
@@ -731,7 +731,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 			newc = lcblock++;
 			*newc = *o;
 
-			if (ts->is_pruning)
+			if (NULL != tl)
 			{
 				/* Initializations for the pruning step. */
 				newc->refcount = 1;  /* The first connector at this location. */
@@ -750,7 +750,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 		}
 		else
 		{
-			if (ts->is_pruning)
+			if (NULL != tl)
 			{
 				for (Connector *n = newc; NULL != n; n = n->next)
 					n->refcount++;
@@ -902,7 +902,6 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, bool is_pruning,
 	ts->word_offset = is_pruning ? 1 : WORD_OFFSET;
 	ts->next_id[0] = ts->next_id[1] = ts->word_offset;
 	ts->last_token = (uintptr_t)-1;
-	ts->is_pruning = is_pruning;
 
 	if (do_encoding)
 	{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -733,8 +733,8 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 
 			if (NULL != tl)
 			{
-				/* Initializations for the pruning step. */
-				newc->refcount = 1;  /* The first connector at this location. */
+				/* Initialize for the pruning step when no sharing is done yet. */
+				newc->refcount = 1;  /* No sharing yet. */
 				newc->tracon_id = 0; /* Used in power_prune() for pass number. */
 				if (NULL != tl)
 					tl->num_cnctrs_per_word[dir][w]++;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -818,15 +818,12 @@ static Disjunct *pack_disjuncts(Tracon_sharing *ts, Disjunct *origd, int w)
 		if (!ts->is_pruning)
 		    token = (uintptr_t)t->originating_gword;
 
-		if (token != ts->last_token)
+		if ((token != ts->last_token) && (NULL != ts->csid[0]))
 		{
 			ts->last_token = token;
-			if (NULL != ts->csid[0])
-			{
-				//printf("Token %ld\n", token);
-				tracon_set_reset(ts->csid[0]);
-				tracon_set_reset(ts->csid[1]);
-			}
+			//printf("Token %ld\n", token);
+			tracon_set_reset(ts->csid[0]);
+			tracon_set_reset(ts->csid[1]);
 		}
 		newd->left = pack_connectors(ts, t->left, 0, w);
 		newd->right = pack_connectors(ts, t->right, 1,  w);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -946,11 +946,10 @@ void free_tracon_sharing(Tracon_sharing *ts)
 		}
 	}
 
-	if (NULL != ts->tracon_list)
-	{
-		free(ts->tracon_list);
-		ts->tracon_list = NULL;
-	}
+	if (NULL != ts->d) free(ts->d);
+	free(ts->tracon_list);
+	ts->tracon_list = NULL;
+
 	free(ts);
 }
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -23,6 +23,8 @@
 // Can undefine VERIFY_MATCH_LIST when done debugging...
 #define VERIFY_MATCH_LIST
 
+/* On a 64-bit machine, this struct should be exactly 8*8=64 bytes long.
+ * Lets try to keep it that way (for performance). */
 struct Disjunct_struct
 {
 	Disjunct *next;

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -123,7 +123,6 @@ struct tracon_sharing_s
 	int next_id[2];             /* Next unique tracon ID */
 	uintptr_t last_token;       /* Tracons are the same only per this token */
 	int word_offset;            /* Start number for connector tracon_id */
-	bool is_pruning;            /* true - for pruning; false - for parsing */
 	Tracon_list *tracon_list;   /* Used only for pruning */
 };
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -117,6 +117,7 @@ struct tracon_sharing_s
 	Connector *cblock_base;     /* Start of connector block */
 	Connector *cblock;          /* Next available memory for connector */
 	Disjunct *dblock;           /* Next available memory for disjunct */
+	Disjunct **d;               /* The disjuncts (indexed by word number) */
 	unsigned int num_connectors;
 	unsigned int num_disjuncts;
 	Tracon_set *csid[2];        /* For generating unique tracon IDs */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -127,8 +127,8 @@ struct tracon_sharing_s
 	Tracon_list *tracon_list;   /* Used only for pruning */
 };
 
-void *save_disjuncts(Sentence, Tracon_sharing *, Disjunct **);
-void restore_disjuncts(Sentence, Disjunct **, void *, Tracon_sharing *);
+void *save_disjuncts(Sentence, Tracon_sharing *);
+void restore_disjuncts(Sentence, void *, Tracon_sharing *);
 void free_saved_disjuncts(Sentence);
 
 /** Get tracon by (dir, tracon_id). */

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -281,7 +281,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		saved_memblock = save_disjuncts(sent, ts_pruning);
 	}
 
-	print_time(opts, "Encode connectors for pruning%s%s",
+	print_time(opts, "Encode for pruning%s%s",
 	           (NULL == ts_pruning->tracon_list) ? " (skipped)" : "",
 	           (one_step_parse) ? " (one-step)" : "");
 
@@ -311,7 +311,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 				needed_prune_level++; /* In case we need to prune again. */
 
 			Tracon_sharing *ts_parsing = pack_sentence_for_parsing(sent);
-			print_time(opts, "Encode connectors for parsing");
+			print_time(opts, "Encode for parsing");
 			if (NULL != ts_parsing)
 			{
 				sent->dc_memblock = ts_parsing->memblock;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -267,7 +267,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	Disjunct **disjuncts_copy = NULL;
 	void *saved_memblock = NULL;
 	int min_null_count = opts->min_null_count;
-	int current_prune_level = -1;
+	int current_prune_level = -1; /* -1: No pruning has been done yet. */
 	int needed_prune_level = opts->min_null_count;
 
 	unsigned int max_null_count = opts->max_null_count;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -258,7 +258,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 {
 	fast_matcher_t * mchxt = NULL;
 	count_context_t * ctxt = NULL;
-	Disjunct **disjuncts_copy = NULL;
 	void *saved_memblock = NULL;
 	int min_null_count = opts->min_null_count;
 	int current_prune_level = -1; /* -1: No pruning has been done yet. */
@@ -279,9 +278,8 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 	if (one_step_parse)
 	{
-		/* Save the disjuncts in case we need to parse with null_count>0. */
-		disjuncts_copy = alloca(sent->length * sizeof(Disjunct *));
-		saved_memblock = save_disjuncts(sent, ts_pruning, disjuncts_copy);
+		/* Save the disjuncts for possible parse w/ an increased null count. */
+		saved_memblock = save_disjuncts(sent, ts_pruning);
 	}
 
 	for (unsigned int nl = opts->min_null_count; nl <= max_null_count; nl++)
@@ -296,7 +294,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			   (needed_prune_level > 0) && (-1 != current_prune_level))
 			{
 				/* We need to prune *again*. Restore the original disjuncts. */
-				restore_disjuncts(sent, disjuncts_copy, saved_memblock, ts_pruning);
+				restore_disjuncts(sent, saved_memblock, ts_pruning);
 				/* Free the memory of the previous pack_sentence_for_parsing(). */
 				free(sent->dc_memblock);
 				sent->dc_memblock = NULL;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -253,12 +253,6 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
  * disjuncts which are not appropriate to continue do_parse() tries with
  * null_count>0. To solve that, we need to restore the original
  * disjuncts of the sentence and call pp_and_power_prune() once again.
- * Note:
- * The original sentence disjuncts are saved only when disjunct packing
- * is done by pack_sentence_for_pruning(), and it is not done for
- * sentences shorter than a certain limit. In that case the pruning is
- * done with no null_count==0 optimization so restoring the disjuncts is
- * not needed.
  */
 void classic_parse(Sentence sent, Parse_Options opts)
 {

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -350,7 +350,8 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		total = (total < 0) ? INT_MAX : total;
 
 		sent->num_linkages_found = (int) total;
-		print_time(opts, "Counted parses");
+		print_time(opts, "Counted parses (%lld w/%zu null%s)", hist_total(&hist),
+		           sent->null_count, (sent->null_count != 1) ? "s" : "");
 
 		if (verbosity >= D_USER_INFO)
 		{

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -266,11 +266,13 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	count_context_t * ctxt = NULL;
 	Disjunct **disjuncts_copy = NULL;
 	void *saved_memblock = NULL;
-	int max_null_count = MIN((int)sent->length, opts->max_null_count);
 	int min_null_count = opts->min_null_count;
-	bool one_step_parse = (0 == opts->min_null_count) && (0 < max_null_count);
 	int current_prune_level = -1;
 	int needed_prune_level = opts->min_null_count;
+
+	unsigned int max_null_count = opts->max_null_count;
+	max_null_count = (unsigned int)MIN(max_null_count, sent->length);
+	bool one_step_parse = (0 == opts->min_null_count) && (0 < max_null_count);
 	const int max_prune_level = 1;
 
 	/* Build lists of disjuncts */
@@ -288,7 +290,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		saved_memblock = save_disjuncts(sent, ts_pruning, disjuncts_copy);
 	}
 
-	for (int nl = min_null_count; nl <= max_null_count; nl++)
+	for (unsigned int nl = opts->min_null_count; nl <= max_null_count; nl++)
 	{
 		Count_bin hist;
 		s64 total;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -273,7 +273,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	if (resources_exhausted(opts->resources)) return;
 
 	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent);
-	print_time(opts, "Encode connectors for pruning");
 	free_sentence_disjuncts(sent);
 
 	if (one_step_parse)
@@ -281,6 +280,10 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		/* Save the disjuncts for possible parse w/ an increased null count. */
 		saved_memblock = save_disjuncts(sent, ts_pruning);
 	}
+
+	print_time(opts, "Encode connectors for pruning%s%s",
+	           (NULL == ts_pruning->tracon_list) ? " (skipped)" : "",
+	           (one_step_parse) ? " (one-step)" : "");
 
 	for (unsigned int nl = opts->min_null_count; nl <= max_null_count; nl++)
 	{

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -157,4 +157,6 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 
 	setup_connectors(sent);
+
+	if (verbosity_level(D_SPEC+2)) print_all_disjuncts(sent);
 }

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -418,7 +418,7 @@ static void clean_table(unsigned int size, C_list **t)
 	/* Table entry tombstone. */
 	static condesc_t desc_no_match =
 	{
-		.uc_num = (connector_hash_t)-1, /* Invalid uppercase part. */
+		.uc_num = (connector_hash_t)-1, /* get_power_table_entry() will skip. */
 	};
 	static Connector con_no_match =
 	{
@@ -480,6 +480,7 @@ static bool possible_connection(prune_context *pc,
                                 int lword, int rword)
 {
 	int dist;
+	assert(lc->desc->uc_num != (connector_hash_t)-1);
 	if (!lc_easy_match(lc->desc, rc->desc)) return false;
 
 	if ((lc->nearest_word > rword) || (rc->nearest_word < lword)) return false;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -418,8 +418,6 @@ static void clean_table(unsigned int size, C_list **t)
 	/* Table entry tombstone. */
 	static condesc_t desc_no_match =
 	{
-		.lc_letters = 0,                /* Invalid lowercase part. */
-		.lc_mask = (lc_enc_t)-1,        /* Ensure mismatch. */
 		.uc_num = (connector_hash_t)-1, /* Invalid uppercase part. */
 	};
 	static Connector con_no_match =


### PR DESCRIPTION
The upcoming major PR is for performing power-pruning, optimized for a particular null count, before parsing with each increased null count (typically 2x-3x faster parsing for long sentences in the batch examples). It also includes a reimplementation of incremental connector encoding and sharing of the previous count table (the things that got removed in PR #900). In order to ease review and debugging I separated many of its commits into a an additional PR, submitted here.

In this PR:
- Improve and fix comments for the current code.
- Debugging: Add printing all disjuncts at `-v=102` and enhance a timing debug message at `-v=2`.
- Keep the original sentence disjuncts in a Tracon_sharing_struct field.
- Factorizing `pack_disjuncts()` (needed for the upcoming PR, but is cleaner anyway).
- Misc. code changes extracted from the upcoming PR.
