### PR TITLE
Pruning per null count

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -53,6 +53,11 @@
  * this overhead is improved, this limit can be set lower. */
 #define SENTENCE_MIN_LENGTH_TRAILING_HASH 6
 
+/* Pruning per null-count is costly for sentences whose parsing time
+ * is relatively small. If a better pruning per null-count is implemented,
+ * this limit can be set lower. */
+#define SENTENCE_MIN_LENGTH_MULTI_PRUNING 30
+
 typedef struct Cost_Model_s Cost_Model;
 struct Cost_Model_s
 {
@@ -141,6 +146,8 @@ struct Sentence_s
 	word_queue_t *word_queue_last;
 	size_t gword_node_num;       /* Debug - for differentiating between
 	                                wordgraph nodes with identical subwords. */
+
+	size_t min_len_multi_pruning; /* Do it from this sentence length. */
 
 	/* Parse results */
 	int    num_linkages_found;  /* Total number before postprocessing.  This

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -415,6 +415,12 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 	if (NULL != min_len_encoding)
 		sent->min_len_encoding = atoi(min_len_encoding+1);
 
+	/* Set the minimum length for pruning per null-count. */
+	sent->min_len_multi_pruning = SENTENCE_MIN_LENGTH_MULTI_PRUNING;
+	const char *min_len_multi_pruning = test_enabled("len-multi-pruning");
+	if (NULL != min_len_multi_pruning)
+		sent->min_len_multi_pruning = atoi(min_len_multi_pruning+1);
+
 	return sent;
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1081,9 +1081,24 @@ Tracon_sharing *pack_sentence_for_parsing(Sentence sent, unsigned int dcnt,
 	return ts;
 }
 
+/**
+ * Enumerate the disjuncts for incremental connector encoding.
+ * */
+static void enumerate_disjuncts(Sentence sent)
+{
+	int i = 1; /* 0 is invalid disjunct ordinal - for debug verification. */
+	for (WordIdx w = 0; w < sent->length; w++)
+	{
+		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
+			d->ordinal = i++;
+	}
+}
+
 /* ============ Save and restore sentence disjuncts ============ */
 void *save_disjuncts(Sentence sent, Tracon_sharing *ts)
 {
+	enumerate_disjuncts(sent);
+
 	void *saved_memblock = malloc(ts->memblock_sz);
 	memcpy(saved_memblock, ts->memblock, ts->memblock_sz);
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -498,13 +498,21 @@ void print_disjunct_list(Disjunct * dj)
 {
 	int i = 0;
 	char word[MAX_WORD + 32];
+	bool print_disjunct_address = test_enabled("disjunct-address");
+	bool print_disjunct_ordinal = test_enabled("disjunct-ordinal");
 
 	for (;dj != NULL; dj=dj->next)
 	{
 		lg_strlcpy(word, dj->word_string, sizeof(word));
 		patch_subscript_mark(word);
-		printf("%16s: ", word);
+
+		printf("%16s", word);
+		if (print_disjunct_address) printf("(%p)", dj);
+		printf(": ");
+
+		if (print_disjunct_ordinal) printf("<%d>", dj->ordinal);
 		printf("[%d](%4.2f) ", i++, dj->cost);
+
 		print_connector_list(dj->left);
 		printf(" <--> ");
 		print_connector_list(dj->right);
@@ -806,6 +814,7 @@ static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 	uintptr_t token = (uintptr_t)w;
 
 	newd = (ts->dblock)++;
+	newd->ordinal = d->ordinal;
 	newd->word_string = d->word_string;
 	newd->cost = d->cost;
 	newd->originating_gword = d->originating_gword;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -904,14 +904,13 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, unsigned int dcnt,
                                           unsigned int ccnt, Tracon_sharing *ts,
                                           bool is_pruning, bool do_encoding)
 {
-#define CONN_ALIGNMENT sizeof(Connector)
-	size_t dsize = dcnt * sizeof(Disjunct);
-	dsize = ALIGN(dsize, CONN_ALIGNMENT); /* Align connector block. */
-	size_t csize = ccnt * sizeof(Connector);
-	size_t memblock_sz = dsize + csize;
-
 	if (NULL == ts)
 	{
+		size_t dsize = dcnt * sizeof(Disjunct);
+#define CONN_ALIGNMENT sizeof(Connector)
+		dsize = ALIGN(dsize, CONN_ALIGNMENT); /* Align connector block. */
+		size_t csize = ccnt * sizeof(Connector);
+		size_t memblock_sz = dsize + csize;
 		void *memblock = malloc(memblock_sz);
 		Disjunct *dblock = memblock;
 		Connector *cblock = (Connector *)((char *)memblock + dsize);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -907,8 +907,14 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, unsigned int dcnt,
 	if (NULL == ts)
 	{
 		size_t dsize = dcnt * sizeof(Disjunct);
-#define CONN_ALIGNMENT sizeof(Connector)
-		dsize = ALIGN(dsize, CONN_ALIGNMENT); /* Align connector block. */
+		switch (sizeof(Disjunct))
+		{
+			case 64:
+				/* No connector block alignment is needed. */
+				break;
+			default:
+				dsize = ALIGN(dsize, sizeof(Connector));
+		}
 		size_t csize = ccnt * sizeof(Connector);
 		size_t memblock_sz = dsize + csize;
 		void *memblock = malloc(memblock_sz);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -961,6 +961,15 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, unsigned int dcnt,
 		}
 	}
 
+	if (!is_pruning && (NULL != ts) &&
+	    (ts->memblock != sent->dc_memblock))
+	{
+		/* The disjunct & connector content is stored in dc_memblock.
+		 * It will be freed at sentence_delete(). */
+		if (sent->dc_memblock) free(sent->dc_memblock);
+		sent->dc_memblock = ts->memblock;
+	}
+
 	return ts;
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1003,6 +1003,22 @@ static void locate_added_disjuncts(Sentence sent, Tracon_sharing *old_ts)
 		return;
 	}
 
+	if (verbosity_level(D_SPEC+2))
+	{
+		printf("Current disjuncts\n");
+		for (WordIdx w = 0; w < sent->length; w++)
+		{
+			printf("Word %zu:\n", w);
+			print_disjunct_list(sent->word[w].d);
+		}
+		printf("\nOld disjuncts\n");
+		for (WordIdx w = 0; w < sent->length; w++)
+		{
+			printf("Word %zu:\n", w);
+			print_disjunct_list(old_ts->d[w]);
+		}
+	}
+
 	for (WordIdx w = 0; w < sent->length; w++)
 	{
 		Disjunct *od = old_ts->d[w];

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -23,25 +23,38 @@
 // Can undefine VERIFY_MATCH_LIST when done debugging...
 #define VERIFY_MATCH_LIST
 
-/* On a 64-bit machine, this struct should be exactly 8*8=64 bytes long.
+/* On a 64-bit machine, this struct should be exactly (6+2)*8=64 bytes long.
  * Lets try to keep it that way (for performance). */
 struct Disjunct_struct
 {
+	/* 48 bytes of common stuff. */
 	Disjunct *next;
-	Disjunct *dup_table_next;
 	Connector *left, *right;
 	double cost;
+	gword_set *originating_gword; /* Set of originating gwords */
+	const char *word_string;      /* Subscripted dictionary word */
 
-	/* match_left, right used only during parsing, for the match list. */
-	bool match_left, match_right;
-
+	/* Shared by different steps. | For what and when. */
 	union
 	{
-		unsigned int match_id;     /* verify the match list integrity */
-		unsigned int dup_hash;     /* hash value for duplicate elimination */
-	};
-	gword_set *originating_gword; /* Set of originating gwords */
-	const char * word_string;     /* subscripted dictionary word */
+		Disjunct *dup_table_next; /* Duplicate elimination - before pruning */
+		Disjunct *old;            /* Old disjuncts - before parsing */
+	}; /* 8 bytes */
+
+	/* Shared by different steps. | For what and when. */
+	union
+	{
+		uint32_t dup_hash;        /* Duplicate elimination - before pruning */
+		uint32_t ordinal;         /* Old disjuncts - before and during parsing */
+	}; /* 4 bytes */
+
+	struct
+	{
+		bool match_left, match_right;
+#ifdef VERIFY_MATCH_LIST
+		uint16_t match_id;
+#endif
+	}; /* 4 bytes - during parsing */
 };
 
 /* Disjunct utilities ... */

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -68,9 +68,10 @@ void word_record_in_disjunct(const Gword *, Disjunct *);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
-Tracon_sharing *pack_sentence_for_pruning(Sentence);
-Tracon_sharing *pack_sentence_for_parsing(Sentence);
+Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int);
+Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int);
 void free_tracon_sharing(Tracon_sharing *);
+void count_disjuncts_and_connectors(Sentence, unsigned int *, unsigned int *);
 
 void print_one_connector(Connector *, int, int);
 void print_connector_list(Connector *);

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -68,8 +68,10 @@ void word_record_in_disjunct(const Gword *, Disjunct *);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
-Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int);
-Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int);
+Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int,
+                                          bool);
+Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int,
+                                          Tracon_sharing *, bool);
 void free_tracon_sharing(Tracon_sharing *);
 void count_disjuncts_and_connectors(Sentence, unsigned int *, unsigned int *);
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -297,7 +297,10 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	prepare_to_parse(sent, opts);
 	if (resources_exhausted(opts->resources)) return;
 
-	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent);
+	unsigned int dcnt = 0, ccnt = 0; /* Allocated number (for memory block). */
+	count_disjuncts_and_connectors(sent, &dcnt, &ccnt);
+
+	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent, dcnt, ccnt);
 	free_sentence_disjuncts(sent);
 
 	if (one_step_parse)
@@ -336,7 +339,8 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 			pp_and_power_prune(sent, ts_pruning, current_prune_level, opts);
 
-			Tracon_sharing *ts_parsing = pack_sentence_for_parsing(sent);
+			Tracon_sharing *ts_parsing = pack_sentence_for_parsing(sent, dcnt,
+																					 ccnt);
 			print_time(opts, "Encode for parsing");
 			if (NULL != ts_parsing)
 			{

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -274,6 +274,25 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 	if (opts->islands_ok) max_prune_level = 0; /* Cannot optimize for > 0. */
 
+	/* The special pruning per null-count is costly for sentences whose
+	 * parsing takes tens of milliseconds or so. To solve that problem, the
+	 * check below starts to do that from a certain sentence length only.
+	 * FIXME: Implement "adaptive pruning", in which a special pruning per
+	 * null-count is done when the previous parse takes more than a certain
+	 * amount of CPU (tried - this needs sharing the previous count table).*/
+	if (sent->length < sent->min_len_multi_pruning)
+	{
+		if (opts->min_null_count == 0)
+		{
+			max_prune_level = 0;
+		}
+		else
+		{
+			needed_prune_level = MAX_SENTENCE;
+			one_step_parse = false;
+		}
+	}
+
 	/* Build lists of disjuncts */
 	prepare_to_parse(sent, opts);
 	if (resources_exhausted(opts->resources)) return;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -339,15 +339,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			print_time(opts, "Encode for parsing%s",
 							  share_count_context ? " (incr)" : "");
 
-			if ((NULL != ts_parsing) &&
-			    (ts_parsing->memblock != sent->dc_memblock))
-			{
-				/* The disjunct & connector content is stored in dc_memblock.
-				 * It will be freed at sentence_delete(). */
-				if (sent->dc_memblock) free(sent->dc_memblock);
-				sent->dc_memblock = ts_parsing->memblock;
-			}
-
 			if (!more_pruning_possible)
 			{
 				/* At this point no further pruning will be done. Free the

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -241,17 +241,23 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
  * opts->min_null_count up to (including) opts->max_null_count, until a
  * parse is found.
  *
- * A note about the disjuncts save/restore that is done here:
- * To increase the parsing speed, before invoking do_parse(),
- * pp_and_power_prune() is invoked to remove connectors which have no
- * possibility to connect. It includes a significant optimization when
- * null_count==0 that makes a more aggressive removal, but this
- * optimization is not appropriate when null_count>0.
+ * To increase the parsing speed, before invoking do_parse(), invoke
+ * pp_and_power_prune() to remove connectors which have no possibility to
+ * connect. Since power_prune() includes a significant optimization if it
+ * assumes that the linkage has no more than a specific number of null
+ * links (aka null_count), call it with the current number of null_count
+ * for which do_count() is invoked.
  *
- * So in case this optimization has been done and a complete parse (i.e.
+ * In order to be able to so repeat the pruning step, we need to keep
+ * the original disjunct/connectors in order to prune them again.
+ * This is done only when needed, i.e. when we are invoked with
+ * min_null_count != max_null_count (a typical case is that they are
+ * both 0).
+ *
+ * So in case this optimization has been done and a parse (e.g.
  * a parse when null_count==0) is not found, we are left with sentence
  * disjuncts which are not appropriate to continue do_parse() tries with
- * null_count>0. To solve that, we need to restore the original
+ * a greater null_count. To solve that, we need to restore the original
  * disjuncts of the sentence and call pp_and_power_prune() once again.
  */
 void classic_parse(Sentence sent, Parse_Options opts)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -470,14 +470,18 @@ bool optional_gap_collapse(Sentence sent, int w1, int w2)
 	return true;
 }
 
-static int num_non_opt_words(Sentence sent, int w1, int w2)
+static bool non_opt_words_gt(unsigned int nl, Sentence sent, int w1, int w2)
 {
-	int non_optional_word = 0;
+	unsigned int non_optional_word = 0;
 
 	for (int w = w1+1; w < w2; w++)
-		if (!sent->word[w].optional) non_optional_word++;
+	{
+		if (sent->word[w].optional) continue;
+		non_optional_word++;
+		if (non_optional_word > nl) return true;
+	}
 
-	return non_optional_word;
+	return false;
 }
 
 /**
@@ -524,7 +528,7 @@ static bool possible_connection(prune_context *pc,
 		 */
 		if ((lc->next == NULL) && (rc->next == NULL) &&
 			 (!lc->multi) && (!rc->multi) &&
-			 num_non_opt_words(pc->sent, lword, rword) > (int)pc->null_links)
+			 non_opt_words_gt(pc->null_links, pc->sent, lword, rword))
 		{
 			return false;
 		}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -825,7 +825,8 @@ static int power_prune(Sentence sent, power_table *pt,
 
 	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc.power_cost);
 
-	print_time(opts, "power pruned");
+	print_time(opts, "power pruned (for %d null%s)",
+	           null_count, (null_count != 1) ? "s" : "");
 	if (verbosity_level(D_PRUNE))
 	{
 		prt_error("\n\\");

--- a/link-grammar/parse/prune.h
+++ b/link-grammar/parse/prune.h
@@ -16,7 +16,8 @@
 #include "api-types.h"                  // Tracon_sharing
 #include "link-includes.h"
 
-void       pp_and_power_prune(Sentence, Tracon_sharing *, Parse_Options);
+void       pp_and_power_prune(Sentence, Tracon_sharing *, unsigned int,
+                              Parse_Options);
 bool       optional_gap_collapse(Sentence, int, int);
 
 #endif /* _PRUNE_H */


### PR DESCRIPTION
This PR implements the following for parsing with null words:
1. Use the previous connector-pair count table on each increased null-count parse.
The feature was disabled in PR #900, and per the discussion there it is re-enabled here (after a complete reimplementation). This saves parse time for parsing again with the previous null-counts on each increased null-count.
2. For each increased null-count, prune again, with an optimization for that particular null count. For long sentences. For long sentences, each parsing step is then very much faster. But even the "fixes" batch, when null are allowed, runs faster (~6%).

See for example a diff of a run with `-verbosity=2` of parsing the "And yet..." sentence, which currently parsed with a `null_count==1` due to the unparsable `quite alone`: ["And yet ..." diff](https://gist.github.com/ampli/3050f0580143eaa5e6af3119b23bb957/revisions)  (speed up ~2x).

Another nice test is this sentence from the `failures` batch:
``` text
Subsequently, sequence analysis identified KRC as a member of the ZAS family of proteins which share the ability to bind ?B-like motifs [15]. DNA competition analysis showed that KRC fusion proteins containing the ZAS-C domain bind specifically to both the RSS and to the ?B motif [14 28]. DNA footprinting analysis further showed that KRC/ZAS-C binds to specific nucleotides within the ?B and the heptamer of the RSS [14]. In this study, using a PCR-based DNA - binding site - selection and amplification procedure, we demonstrated that both the N-terminal ZAS-N and the C-terminal ZAS-C domains are able to bind GT - rich DNA sequences, and confirmed that the RSS and ?B motifs are the high-affinity targets of KRC.
```
Test it  using: `link-parser -v=2 -time=300 -limit=30000 -spell=0`
(parsed with `null_count==3`, speed up ~50%).

However, the complex Russian sentence from PR #537 takes 33% slower (the only example for a slower long sentence I found). This is because it is parsed with `null_count==41` and a fast-matcher initialization is needed for every null-count level, which takes about 1.5s each - due to O(n^2) `nearest_word` sorting. In a WIP I change that to O(n) sorting and then even this sentence runs much faster with the per-null-count pruning of this PR.

The last 4 commits are "cleanup" ones, for efficiency and clarity.