### PR TITLE
*-set cleanup

### DIFF
--- a/link-grammar/const-prime.h
+++ b/link-grammar/const-prime.h
@@ -21,7 +21,7 @@ static const size_t s_prime[] =
 	419, 1259, 3779, 11317, 33939, 101817, 305471, 916361, 2749067,
 	8247199, 24741547, 74224603, 222673783, 668021359, 2004064039,
 };
-#define MAX_S_PRIME (sizeof(s_prime) / sizeof(s_prime[0]))
+#define MAX_S_PRIMES (sizeof(s_prime) / sizeof(s_prime[0]))
 
 #define FPNAME(n) fprime##n
 #define PFUNC(p) \

--- a/link-grammar/const-prime.h
+++ b/link-grammar/const-prime.h
@@ -23,7 +23,6 @@ static const size_t s_prime[] =
 };
 #define MAX_S_PRIME (sizeof(s_prime) / sizeof(s_prime[0]))
 
-#define PNAME(n) prime##n
 #define FPNAME(n) fprime##n
 #define PFUNC(p) \
 	static inline unsigned int FPNAME(p)(size_t h)\

--- a/link-grammar/const-prime.h
+++ b/link-grammar/const-prime.h
@@ -25,8 +25,7 @@ static const size_t s_prime[] =
 
 #define FPNAME(n) fprime##n
 #define PFUNC(p) \
-	static inline unsigned int FPNAME(p)(size_t h)\
-	{ return (unsigned int)h % s_prime[p]; }
+	static inline unsigned int FPNAME(p)(size_t h) { return h % s_prime[p]; }
 
 PFUNC(0)
 PFUNC(1)

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -49,7 +49,7 @@ static unsigned int hash_string(const char *str, const String_set *ss)
 {
 	unsigned int accum = 0;
 	for (;*str != '\0'; str++)
-		accum = (7 * accum) + (unsigned char)*str;
+		accum = (139 * accum) + (unsigned char)*str;
 	return accum;
 }
 

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -138,7 +138,7 @@ static unsigned int find_place(const char *str, unsigned int h, String_set *ss)
 	while (!place_found(str, &ss->table[key], h, ss))
 	{
 		key += 2 * ++coll_num - 1;
-		if (key >= ss->size) key -= ss->size;
+		if (key >= ss->size) key = ss->mod_func(key);
 	}
 
 	return key;

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -156,7 +156,7 @@ static unsigned int find_place(const Connector *c, unsigned int h, Tracon_set *s
 	{
 		PRT_STAT(coll_count++;)
 		key += 2 * ++coll_num - 1;
-		if (key >= ss->size) key -= ss->size;
+		if (key >= ss->size) key = ss->mod_func(key);
 	}
 
 	return key;

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -48,7 +48,7 @@ static unsigned int hash_connectors(const Connector *c, unsigned int shallow)
 
 	for (; c != NULL; c = c->next)
 	{
-		accum = (7 * accum) +
+		accum = (19 * accum) +
 		((c->desc->uc_num)<<18) +
 		(((unsigned int)c->multi)<<31) +
 		(unsigned int)c->desc->lc_letters;

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -60,7 +60,7 @@ static unsigned int hash_connectors(const Connector *c, unsigned int shallow)
 static unsigned int find_prime_for(size_t count)
 {
 	size_t i;
-	for (i = 0; i < MAX_S_PRIME; i ++)
+	for (i = 0; i < MAX_S_PRIMES; i ++)
 		if ((8 * count) < (3 * s_prime[i])) return i;
 
 	assert(0, "find_prime_for(%zu): Absurdly big count", count);


### PR DESCRIPTION
The main fix here is:
- find_place(): Fix key upper limit

A crash due to that has never been observed, and I think this is because the tables are big and there is a need for an extremely big number of collisions (especially just at the end of the table) to get a key overflow.

N.B.: In `const-prime.,h` I couldn't make the `size_t` to be `unsigned int` without severely degrading the generated code.