### PR TITLE
Fast match improvements

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -490,7 +490,7 @@ void print_one_connector(Connector * e, int dir, int shallow)
 	if (-1 != dir) printf("%c", "-+"[dir]);
 	if (e->tracon_id)
 	{
-		if (e->refcount)
+		if ((-1 != shallow) && e->refcount)
 			printf("<%d,%d>", e->tracon_id, e->refcount);
 		else
 			printf("<%d>", e->tracon_id);

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -211,10 +211,6 @@ static void put_into_match_table(Sentence sent, unsigned int size,
 
 fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 {
-	unsigned int size;
-	size_t w;
-	Match_node ** t;
-	Disjunct * d;
 	fast_matcher_t *ctxt;
 
 	ctxt = (fast_matcher_t *) xalloc(sizeof(fast_matcher_t));
@@ -242,14 +238,17 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 	}
 
 	size_t max_size = next_power_of_two_up(sent->dict->contable.num_uc);
-	for (w=0; w<sent->length; w++)
+	for (WordIdx w = 0; w < sent->length; w++)
 	{
+		unsigned int size;
+		Match_node **t;
+
 		size = next_power_of_two_up(3 * ncu[0][w]); /* At least 66% free. */
 		ctxt->l_table_size[w] = MIN(max_size,  size);
 		t = ctxt->l_table[w] = (Match_node **) xalloc(size * sizeof(Match_node *));
 		memset(t, 0, size * sizeof(Match_node *));
 
-		for (d = sent->word[w].d; d != NULL; d = d->next)
+		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
 		{
 			if (d->left != NULL)
 			{
@@ -263,7 +262,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 		t = ctxt->r_table[w] = (Match_node **) xalloc(size * sizeof(Match_node *));
 		memset(t, 0, size * sizeof(Match_node *));
 
-		for (d = sent->word[w].d; d != NULL; d = d->next)
+		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
 		{
 			if (d->right != NULL)
 			{

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -45,6 +45,10 @@
 #define MATCH_LIST_SIZE_INIT 4096 /* the initial size of the match-list stack */
 #define MATCH_LIST_SIZE_INC 2     /* match-list stack increase size factor */
 
+#ifndef ML_COMPAT
+#define ML_COMPAT 0 /* 1: Disjunct order compatible to V5.6.2 (slower). */
+#endif /* ML_COMPAT */
+
 /*
  * Each lookup table entry points to list of disjuncts whose shallow
  * connector has the same uppercase part. These lists are sorted according
@@ -56,6 +60,9 @@ typedef struct sortbin_s sortbin;
 struct sortbin_s
 {
 	Match_node *head;
+#if ML_COMPAT
+	Match_node *tail;
+#endif
 };
 
 /**
@@ -200,8 +207,21 @@ static void init_sortbin(sortbin *sbin, size_t sent_length)
 static void sort_by_nearest_word(Match_node *m, sortbin *sbin)
 {
 
+#if ML_COMPAT
+		if (NULL == sbin->head)
+		{
+			sbin->head = m;
+		}
+		else
+		{
+			sbin->tail->next = m;
+		}
+		sbin->tail = m;
+		m->next = NULL;
+#else
 		m->next = sbin->head;
 		sbin->head = m;
+#endif
 
 }
 

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -231,7 +231,7 @@ static void put_into_match_table(Sentence sent, unsigned int size,
 	}
 }
 
-fast_matcher_t* alloc_fast_matcher(const Sentence sent)
+fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 {
 	unsigned int size;
 	size_t w;

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -267,10 +267,16 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 			Match_node **t;
 			unsigned int len = ncu[dir][w];
 
-			if (0 == len) len = 1; /* Avoid parse-time table size checks. */
+			if (0 == len)
+			{
+				size = 1; /* Avoid parse-time table size checks. */
+			}
+			else
+			{
+				size = next_power_of_two_up(3 * len); /* At least 66% free. */
+				size = MIN(max_size,  size);
+			}
 
-			size = next_power_of_two_up(3 * ncu[dir][w]); /* At least 66% free. */
-			size = MIN(max_size,  size);
 			t = malloc(size * sizeof(Match_node *));
 			memset(t, 0, size * sizeof(Match_node *));
 

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -43,7 +43,7 @@ struct fast_matcher_s
 };
 
 /* See the source file for documentation. */
-fast_matcher_t* alloc_fast_matcher(const Sentence);
+fast_matcher_t* alloc_fast_matcher(const Sentence, unsigned int *[]);
 void free_fast_matcher(Sentence sent, fast_matcher_t*);
 
 size_t form_match_list(fast_matcher_t *, int, Connector *, int, Connector *, int);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -276,6 +276,10 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	bool one_step_parse = (unsigned int)opts->min_null_count != max_null_count;
 	int max_prune_level = (int)max_null_count;
 
+	unsigned int *ncu[2];
+	ncu[0] = alloca(sent->length * sizeof(*ncu[0]));
+	ncu[1] = alloca(sent->length * sizeof(*ncu[1]));
+
 	if (opts->islands_ok) max_prune_level = 0; /* Cannot optimize for > 0. */
 
 	/* The special pruning per null-count is costly for sentences whose
@@ -330,7 +334,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			else
 				needed_prune_level = MAX_SENTENCE;
 
-			pp_and_power_prune(sent, ts_pruning, current_prune_level, opts);
+			pp_and_power_prune(sent, ts_pruning, current_prune_level, opts, ncu);
 
 			more_pruning_possible =
 				one_step_parse && (current_prune_level != MAX_SENTENCE);
@@ -366,7 +370,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			}
 
 			free_fast_matcher(sent, mchxt);
-			mchxt = alloc_fast_matcher(sent);
+			mchxt = alloc_fast_matcher(sent, ncu);
 			print_time(opts, "Initialized fast matcher");
 		}
 

--- a/link-grammar/parse/prune.h
+++ b/link-grammar/parse/prune.h
@@ -16,8 +16,8 @@
 #include "api-types.h"                  // Tracon_sharing
 #include "link-includes.h"
 
-void       pp_and_power_prune(Sentence, Tracon_sharing *, unsigned int,
-                              Parse_Options);
+void       pp_and_power_prune(Sentence, Tracon_sharing *,  unsigned int,
+                              Parse_Options, unsigned int *[]);
 bool       optional_gap_collapse(Sentence, int, int);
 
 #endif /* _PRUNE_H */


### PR DESCRIPTION
The main change in this PR is:
- fast-match.c: Reimplement sorting by nearest_word
Use O(N) algo for sorting word disjuncts (when N is the number of disjuncts).

This way building the match list hash tables scales well with the number of disjuncts (it remains negligible even for long sentences /complex cases).

Also implement several small speed improvements.

A very noticeable speedup happens in the case of issue ##537:
`Сдержанная улыбка, игравшая постоянно на лице Анны Павловны, хотя и не шла к ее отжившим чертам, выражала, как у избалованных детей, постоянное сознание своего милого недостатка, от которого она не хочет, не может и не находит нужным исправляться.`

Originally, PR #673 reduced the parse time (with nulls - it has 4) of this sentence from about 1 hour to about 1 minute. Later changes reduced by a large factor - to ~7.5s on 5.6.2 (for me).
However, in the recent PR #981, it got increased to ~9s because the repeated pruning on each increased null_count level, which leads to the need for repeating building of the fast-match tables.  Since building the fast-match tables uses an O(N) algo for nearest_word sorting, it doesn't scale well for sentences with a biog number of disjuncts like this one.

The time of the O(N) sort implemented here remains negligible even for a large number of disjuncts.
Here is a side-by-side word-diff for this sentence.
- `[...]`: Times before this PR.
- `{...}`: Times with this PR.

**Note the `Initialized fast matcher` lines!**
```
[-%/tmp/link-grammar/master-] {+%/tmp/link-grammar/fast-match-3+}
...
verbosity set to 2
link-grammar: Info: Dictionary found at ../ru/4.0.dict
link-grammar: Info: ru: Spell checker disabled.
link-grammar: Info: Dictionary version 5.3.15, locale ru_RU.UTF-8
link-grammar: Info: Library version link-grammar-5.7.0. Enter "!help" for help.
++++ Finished expression pruning                 0.00 seconds
++++ Built disjuncts                             [-0.35-]     {+0.32+} seconds
++++ Eliminated duplicate disjuncts              0.20 seconds
++++ Encode for pruning                          [-0.19-]     {+0.20+} seconds
++++ power pruned (for 0 nulls)                  0.02 seconds
++++ Encode for parsing                          0.00 seconds
++++ Initialized fast matcher                    [-1.46-]     {+0.01+} seconds
++++ Counted parses (0 w/0 nulls)                [-0.09-]     {+0.08+} seconds
++++ Built parse set                             0.00 seconds
++++ Finished parse                              0.00 seconds
No complete linkages found.
++++ Finished expression pruning                 0.00 seconds
++++ Built disjuncts                             [-0.33-]     {+0.31+} seconds
++++ Eliminated duplicate disjuncts              [-0.21-]     {+0.20+} seconds
++++ Encode for pruning (one-step)               0.28 seconds
++++ power pruned (for 1 null)                   0.02 seconds
++++ Encode for parsing                          0.00 seconds
++++ Initialized fast matcher                    [-1.47-]     {+0.02+} seconds
++++ Counted parses (0 w/1 null)                 [-0.23-]     {+0.22+} seconds
++++ Built parse set                             0.00 seconds
++++ power pruned (for 2 nulls)                  0.11 seconds
++++ Encode for parsing (incr)                   0.00 seconds
++++ Initialized fast matcher                    [-1.29-]     {+0.00+} seconds
++++ Counted parses (0 w/2 nulls)                [-0.36-]     {+0.34+} seconds
++++ Built parse set                             0.00 seconds
++++ power pruned (for 3 nulls)                  0.07 seconds
++++ Encode for parsing (incr)                   0.00 seconds
++++ Initialized fast matcher                    [-1.45-]     {+0.00+} seconds
++++ Counted parses (0 w/3 nulls)                0.62 seconds
++++ Built parse set                             0.00 seconds
++++ power pruned (for 4 nulls)                  0.07 seconds
++++ Encode for parsing (incr)                   0.00 seconds
++++ Initialized fast matcher                    [-1.45-]     {+0.00+} seconds
++++ Counted parses (3483648 w/4 nulls)          [-0.95-]     {+0.92+} seconds
++++ Built parse set                             0.00 seconds
++++ Sorted all linkages                         0.02 seconds
++++ Finished parse                              0.00 seconds
++++ Time                                        [-8.93-]     {+3.23+} seconds [-(8.93-] {+(3.23+} total)
Found 3483648 linkages (1000 of 1000 random linkages had no P.P. violations) at null count 4
        Linkage 1, cost vector = (UNUSED=4 DIS=34.00 [-LEN=132)

```

So the time for this sentence now is only ~3.5s, which is about twice faster than in the recent release (5.6.2).

A side effect of this PR is that it build the match lists in the exact opposite order of disjuncts. This leads to different order of equal-metric parses, and makes it difficult to compare to the current results when the number of parses is big. However, when `ML_COMPAT` (see  833429b here) is defined to 1, the resulted parses are the same.

BTW:
1. An important observation, found while testing this PR, is that one needs to be very careful when scanning disjuncts etc. - to always do that in an increased memory order. Else there are strong caching effects that causes to an unstable big slow-down. Apparently the rest of the code still contains several points in which the scanning order can be improved (to be checked).

2. The branch from this PR has been derived contains more fast-match speedup changes (hopefully considerably speeding up the parsing step) but they need reimplementation and more checks before releasing them.

3. Testing `corpus-failures.batch` with this PR gets more 2 errors. This is because the different disjunct order (see above) which by chance reduces the density of the good-PP solutions on these 2 affected sentences. But if the current `!limit=1000` is increased to `!limit=20000` these sentences parse fine. A possible solution for the general low good-PP density for long English sentences may be to apply some of the postprocessing **before** extracting the linkages (still investigated).

