### PR TITLE
Cleanup1+

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -124,7 +124,6 @@ liblink_grammar_la_SOURCES =        \
 	print/wcwidth.c                  \
 	resources.c                      \
 	string-set.c                     \
-	string-id.c                      \
 	tokenize/anysplit.c              \
 	tokenize/spellcheck-aspell.c     \
 	tokenize/spellcheck-hun.c        \
@@ -183,7 +182,6 @@ liblink_grammar_la_SOURCES =        \
 	print/wcwidth.h                  \
 	resources.h                      \
 	string-set.h                     \
-	string-id.h                      \
 	tokenize/anysplit.h              \
 	tokenize/spellcheck.h            \
 	tokenize/regex-tokenizer.h       \

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -138,6 +138,7 @@ struct Sentence_s
 	/* Connector encoding, packing & sharing. */
 	size_t min_len_encoding;     /* Encode from this sentence length. */
 	void *dc_memblock;           /* For packed disjuncts & connectors. */
+	unsigned int num_disjuncts;  /* Number of disjuncts in dc_memblock. */
 
 	/* Wordgraph stuff. FIXME: create stand-alone struct for these. */
 	Gword *wordgraph;            /* Tokenization wordgraph */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -962,6 +962,7 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, unsigned int dcnt,
 		 * It will be freed at sentence_delete(). */
 		if (sent->dc_memblock) free(sent->dc_memblock);
 		sent->dc_memblock = ts->memblock;
+		sent->num_disjuncts = ts->num_disjuncts;
 	}
 
 	return ts;

--- a/link-grammar/lg_assert.h
+++ b/link-grammar/lg_assert.h
@@ -29,10 +29,14 @@
  *    pointer like lg_exit(code) to allow the LG library to be embedded in an
  *    application like an editor. If not set, the default will still be
  *    DEBUG_TRAP. */
-#define assert(ex, ...) {                                                   \
-	if (!(ex)) {                                                             \
+#define assert(ex, ...)                                                     \
+{                                                                           \
+	if (!(ex))                                                               \
+	{                                                                        \
+		fflush(stdout);                                                       \
 		fprintf(stderr, "Fatal error: \nAssertion (" #ex ") failed at " FILELINE ": " __VA_ARGS__);  \
 		fprintf(stderr, "\n");                                                \
+		fflush(stderr);                                                       \
 		DEBUG_TRAP;  /* leave stack trace in debugger */                      \
 	}                                                                        \
 }

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -57,13 +57,13 @@ static void free_table(count_context_t *ctxt)
 
 static void init_table(count_context_t *ctxt, size_t sent_len)
 {
-	unsigned int shift;
+	if (ctxt->table) free_table(ctxt);
+
 	/* A piecewise exponential function determines the size of the
 	 * hash table. Probably should make use of the actual number of
 	 * disjuncts, rather than just the number of words.
 	 */
-	if (ctxt->table) free_table(ctxt);
-
+	unsigned int shift;
 	if (sent_len >= 10)
 	{
 		shift = 12 + (sent_len) / 4 ;
@@ -81,8 +81,6 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 	ctxt->table = (Table_connector**)
 		xalloc(ctxt->table_size * sizeof(Table_connector*));
 	memset(ctxt->table, 0, ctxt->table_size*sizeof(Table_connector*));
-
-
 }
 
 //#define DEBUG_TABLE_STAT

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -601,11 +601,11 @@ static Count_bin do_count(
 				}
 
 #define CACHE_COUNT(c, how_to_count, do_count) \
-{ \
-	Count_bin count = (hist_total(&c) == NO_COUNT) ? \
-		TRACE_LABEL(c, do_count) : c; \
-	how_to_count; \
-}
+	{ \
+		Count_bin count = (hist_total(&c) == NO_COUNT) ? \
+			TRACE_LABEL(c, do_count) : c; \
+		how_to_count; \
+	}
 			 /* If the pseudocounting above indicates one of the terms
 			 * in the count multiplication is zero,
 			 * we know that the true total is zero. So we don't

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -330,12 +330,12 @@ static int num_optional_words(count_context_t *ctxt, int w1, int w2)
 static Count_bin do_count1(int lineno, count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,
-                          int null_count);
+                          unsigned int null_count);
 
 static Count_bin do_count(int lineno, count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,
-                          int null_count)
+                          unsigned int null_count)
 {
 	static int level;
 
@@ -367,14 +367,15 @@ static Count_bin do_count(
                           count_context_t *ctxt,
                           int lw, int rw,
                           Connector *le, Connector *re,
-                          int null_count)
+                          unsigned int null_count)
 {
 	Count_bin zero = hist_zero();
 	Count_bin total;
 	int start_word, end_word, w;
 	Table_connector *t;
 
-	assert (0 <= null_count, "Bad null count");
+	/* TODO: static_assert() that null_count is an unsigned int. */
+	assert (null_count < INT_MAX, "Bad null count");
 
 	t = find_table_pointer(ctxt, lw, rw, le, re, null_count);
 
@@ -384,7 +385,7 @@ static Count_bin do_count(
 	 * linkage count before we return. */
 	t = table_store(ctxt, lw, rw, le, re, null_count);
 
-	int unparseable_len = rw-lw-1;
+	unsigned int unparseable_len = rw-lw-1;
 
 #if 1
 	/* This check is not necessary for correctness, as it is handled in
@@ -502,7 +503,7 @@ static Count_bin do_count(
 			assert(id == d->match_id, "Modified id (%d!=%d)", id, d->match_id);
 #endif
 
-			for (int lnull_cnt = 0; lnull_cnt <= null_count; lnull_cnt++)
+			for (unsigned int lnull_cnt = 0; lnull_cnt <= null_count; lnull_cnt++)
 			{
 				int rnull_cnt = null_count - lnull_cnt;
 				/* Now lnull_cnt and rnull_cnt are the null-counts we're

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -717,11 +717,6 @@ Count_bin do_parse(Sentence sent,
 	ctxt->current_resources = opts->resources;
 	ctxt->exhausted = false;
 	ctxt->checktimer = 0;
-	ctxt->sent = sent;
-
-	/* consecutive blocks of this many words are considered as
-	 * one null link. */
-	/* ctxt->null_block = 1; */
 	ctxt->islands_ok = opts->islands_ok;
 	ctxt->mchxt = mchxt;
 
@@ -737,6 +732,11 @@ count_context_t * alloc_count_context(Sentence sent)
 {
 	count_context_t *ctxt = (count_context_t *) xalloc (sizeof(count_context_t));
 	memset(ctxt, 0, sizeof(count_context_t));
+
+	ctxt->sent = sent;
+	/* consecutive blocks of this many words are considered as
+	 * one null link. */
+	/* ctxt->null_block = 1; */
 
 	if (NULL != sent->Table_connector_pool)
 	{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -31,7 +31,7 @@ struct Table_connector_s
 	Table_connector  *next;      /* FIXME: eliminate */
 	int              l_id, r_id;
 	Count_bin        count;
-	unsigned short   null_count; /* FIXME: eliminate */
+	unsigned int     null_count; /* FIXME: eliminate */
 };
 
 struct count_context_s

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -40,6 +40,7 @@ struct String_set_s
 {
 	size_t size;                /* the current size of the table */
 	size_t count;               /* number of things currently in the table */
+	size_t available_count;     /* number of available entries */
 	ss_slot *table;             /* the table itself */
 	unsigned int prime_idx;     /* current prime number table index */
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
@@ -47,6 +48,10 @@ struct String_set_s
 	char *alloc_next;           /* next string address */
 	str_mem_pool *string_pool;  /* string memory pool */
 };
+
+/* If the table gets too big, we grow it. Too big is defined as being
+ * more than 3/8 full. There's a huge boost from keeping this sparse. */
+#define MAX_STRING_SET_TABLE_SIZE(s) ((s) * 3 / 8)
 
 String_set * string_set_create(void);
 const char * string_set_add(const char * source_string, String_set * ss);

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -61,7 +61,7 @@ static unsigned int find_prime_for(size_t count)
 {
 	size_t i;
 	for (i = 0; i < MAX_S_PRIMES; i ++)
-		if ((8 * count) < (3 * s_prime[i])) return i;
+	   if (count < MAX_TRACON_SET_TABLE_SIZE(s_prime[i])) return i;
 
 	assert(0, "find_prime_for(%zu): Absurdly big count", count);
 	return 0;
@@ -71,6 +71,9 @@ void tracon_set_reset(Tracon_set *ss)
 {
 	size_t ncount = MAX(ss->count, ss->ocount);
 
+	/* Table sizing heuristic: The number of tracons as a function of
+	 * word number is usually first increasing and then decreasing.
+	 * Continue the trend of the last 2 words. */
 	if (ss->count > ss->ocount)
 		ncount = ncount * 3 / 4;
 	else
@@ -83,6 +86,7 @@ void tracon_set_reset(Tracon_set *ss)
 	memset(ss->table, 0, ss->size*sizeof(clist_slot));
 	ss->ocount = ss->count;
 	ss->count = 0;
+	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
 }
 
 Tracon_set *tracon_set_create(void)
@@ -96,6 +100,8 @@ Tracon_set *tracon_set_create(void)
 	memset(ss->table, 0, ss->size*sizeof(clist_slot));
 	ss->count = ss->ocount = 0;
 	ss->shallow = false;
+	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
+
 	return ss;
 }
 
@@ -180,6 +186,8 @@ static void grow_table(Tracon_set *ss)
 			ss->table[p] = old.table[i];
 		}
 	}
+	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size);
+
 	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
 	PRT_STAT(fp_count = fp_count_save);
 	free(old.table);
@@ -194,10 +202,9 @@ Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 {
 	assert(clist != NULL, "Connector-ID: Can't insert a null list");
 
-	/* We may need to add it to the table.  If the table got too big, first
-	 * we grow it.  Too big is defined as being more than 3/8 full.
-	 * There's a huge boost from keeping this sparse. */
-	if ((8 * ss->count) > (3 * ss->size)) grow_table(ss);
+	/* We may need to add it to the table. If the table got too big,
+	 * first we grow it. */
+	if (ss->available_count == 0) grow_table(ss);
 
 	unsigned int h = hash_connectors(clist, ss->shallow);
 	unsigned int p = find_place(clist, h, ss);
@@ -207,6 +214,7 @@ Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 
 	ss->table[p].hash = h;
 	ss->count++;
+	ss->available_count--;
 
 	return &ss->table[p].clist;
 }

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -31,12 +31,17 @@ typedef struct
 {
 	size_t size;       /* the current size of the table */
 	size_t count;      /* number of things currently in the table */
+	size_t available_count;     /* number of available entries */
 	size_t ocount;     /* the count before reset */
-	clist_slot *table;    /* the table itself */
+	clist_slot *table; /* the table itself */
 	unsigned int prime_idx;     /* current prime number table index */
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
 	bool shallow;      /* consider shallow connector */
 } Tracon_set;
+
+/* If the table gets too big, we grow it. Too big is defined as being
+ * more than 3/8 full. There's a huge boost from keeping this sparse. */
+#define MAX_TRACON_SET_TABLE_SIZE(s) ((s) * 3 / 8)
 
 Tracon_set *tracon_set_create(void);
 Connector **tracon_set_add(Connector *, Tracon_set *);

--- a/msvc/LinkGrammar.vcxproj
+++ b/msvc/LinkGrammar.vcxproj
@@ -278,7 +278,6 @@
     <ClInclude Include="..\link-grammar\print\print.h" />
     <ClInclude Include="..\link-grammar\print\wcwidth.h" />
     <ClInclude Include="..\link-grammar\resources.h" />
-    <ClInclude Include="..\link-grammar\string-id.h" />
     <ClInclude Include="..\link-grammar\string-set.h" />
     <ClInclude Include="..\link-grammar\tokenize\anysplit.h" />
     <ClInclude Include="..\link-grammar\tokenize\regex-tokenizer.h" />
@@ -331,7 +330,6 @@
     <ClCompile Include="..\link-grammar\print\print.c" />
     <ClCompile Include="..\link-grammar\print\wcwidth.c" />
     <ClCompile Include="..\link-grammar\resources.c" />
-    <ClCompile Include="..\link-grammar\string-id.c" />
     <ClCompile Include="..\link-grammar\string-set.c" />
     <ClCompile Include="..\link-grammar\tokenize\anysplit.c" />
     <ClCompile Include="..\link-grammar\tokenize\regex-tokenizer.c" />

--- a/msvc/LinkGrammar.vcxproj.filters
+++ b/msvc/LinkGrammar.vcxproj.filters
@@ -162,9 +162,6 @@
     <ClCompile Include="..\link-grammar\memory-pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\link-grammar\string-id.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\link-grammar\api-structures.h">
@@ -333,9 +330,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="link-grammar\link-features.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\link-grammar\string-id.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Extracted commits from my current WIP:

- Fix an assert() bug (add fflush()).
- Remove the now unused `string-id.[ch]`.
- Minor efficiency changes.
The `string-set/tracon-set: Centralize the table-full criteria` has a speedup of ~1% on the `basic` batch benchmark.
- Sentence_s: Add num_disjuncts.
It is needed for the upcoming PRs.
- Code cleanups.