### PR TITLE
link-parser option related fixes

### DIFF
--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -787,9 +787,10 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if ((0 == strcasecmp(y, "true")) || (0 == strcasecmp(y, "t"))) val = 1;
 			if ((0 == strcasecmp(y, "false")) || (0 == strcasecmp(y, "f"))) val = 0;
 
-			if (val < 0)
+			if ((val != 0) && (val != 1))
 			{
-				prt_error("Error: Invalid value %s for variable \"%s\". Type \"!help\" or \"!variables\"\n", y, as[j].string);
+				prt_error("Error: Invalid value %s for variable \"%s\". %s\n",
+				          y, as[j].string, helpmsg);
 				return -1;
 			}
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -622,6 +622,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 	char *s, *x, *y;
 	int count, j;
 	const Switch *as = default_switches;
+	const char helpmsg[] = "Type \"!help\" or \"!variables\".";
 
 	/* Handle a request for a particular command help. */
 	if (NULL != dict)
@@ -654,11 +655,10 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 				}
 
 				if (count > 1)
-					prt_error("Ambiguous command: \"%s\".  ", s);
+					prt_error("Ambiguous command: \"%s\".  %s\n", s, helpmsg);
 				else
-					prt_error("Undefined command: \"%s\".  ", s);
+					prt_error("Undefined command: \"%s\".  %s\n", s, helpmsg);
 
-				prt_error("Type \"!help\" or \"!variables\"\n");
 				return -1;
 			}
 		}
@@ -684,7 +684,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 	if (count > 1)
 	{
-		prt_error("Ambiguous command \"%s\".  Type \"!help\" or \"!variables\"\n", s);
+		prt_error("Ambiguous command \"%s\".  %s\n", s, helpmsg);
 		return -1;
 	}
 	else if (count == 1)
@@ -775,7 +775,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 		if (count > 1)
 		{
-			prt_error("Error: Ambiguous variable \"%s\".  Type \"!help\" or \"!variables\"\n", x);
+			prt_error("Error: Ambiguous variable \"%s\".  %s\n", x, helpmsg);
 			return -1;
 		}
 
@@ -805,7 +805,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			double val = strtod(y, &err);
 			if (('\0' == *y) || ('\0' != *err))
 			{
-				prt_error("Error: Invalid value %s for variable \"%s\". Type \"!help\" or \"!variables\"\n", y, as[j].string);
+				prt_error("Error: Invalid value %s for variable \"%s\". %s\n",
+				          y, as[j].string, helpmsg);
 				return -1;
 			}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -760,11 +760,14 @@ int main(int argc, char * argv[])
 
 	check_winsize(copts);
 
-	prt_error("Info: Dictionary version %s, locale %s\n",
-		linkgrammar_get_dict_version(dict),
-		linkgrammar_get_dict_locale(dict));
-	prt_error("Info: Library version %s. Enter \"!help\" for help.\n",
-		linkgrammar_get_version());
+	if (verbosity > 0)
+	{
+		prt_error("Info: Dictionary version %s, locale %s\n",
+			linkgrammar_get_dict_version(dict),
+			linkgrammar_get_dict_locale(dict));
+		prt_error("Info: Library version %s. Enter \"!help\" for help.\n",
+			linkgrammar_get_version());
+	}
 
 	/* Main input loop */
 	while (true)

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -698,6 +698,8 @@ int main(int argc, char * argv[])
 		language = argv[1];
 	}
 
+	/* Process options used by GNU programs. */
+	int quiet_start = 0; /* Iff > 0, inhibit the initial messages */
 	for (int i = 1; i < argc; i++)
 	{
 		if (strcmp("--help", argv[i]) == 0)
@@ -711,11 +713,19 @@ int main(int argc, char * argv[])
 			printf("%s\n", linkgrammar_get_configuration());
 			exit(0);
 		}
+
+		if ((strcmp("--quite", argv[i]) == 0) ||
+		    (strcmp("--silent", argv[i]) == 0))
+		{
+			quiet_start = i;
+		}
 	}
 
 	/* Process command line variable-setting commands (only). */
 	for (int i = 1; i < argc; i++)
 	{
+		if (i == quiet_start) continue;
+
 		if (argv[i][0] == '-')
 		{
 			const char *var = argv[i] + ((argv[i][1] != '-') ? 1 : 2);
@@ -760,7 +770,7 @@ int main(int argc, char * argv[])
 
 	check_winsize(copts);
 
-	if (verbosity > 0)
+	if ((parse_options_get_verbosity(opts)) > 0 && (quiet_start == 0))
 	{
 		prt_error("Info: Dictionary version %s, locale %s\n",
 			linkgrammar_get_dict_version(dict),

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -714,7 +714,7 @@ int main(int argc, char * argv[])
 			exit(0);
 		}
 
-		if ((strcmp("--quite", argv[i]) == 0) ||
+		if ((strcmp("--quiet", argv[i]) == 0) ||
 		    (strcmp("--silent", argv[i]) == 0))
 		{
 			quiet_start = i;

--- a/man/link-parser.1
+++ b/man/link-parser.1
@@ -86,7 +86,7 @@ link\-parser \- parse natural language sentences using Link Grammar
 .br
 .nf
 .B link\-parser [\fIlanguage\fP|\fIdict\_location\fP] \
-[\fI\-<special\_"!"\_command>\fP...]
+\fR[\-\-quiet]\fP [\fI\-<special\_"!"\_command>\fP...]
 .fi
 .SH DESCRIPTION
 .PP
@@ -231,6 +231,9 @@ Print usage and exit.
 .TP
 .B \-\-version
 Print program version and configuration details, and exit.
+.TP
+.B \-\-quiet
+Suppress the version messages on startup.
 
 .SS Special "!" commands
 The special "!" commands can be specified as command-line options in the


### PR DESCRIPTION
- command-line.c: Don't allow values > 1 for booleans
It applies to things like:
``` text
linkparser> !walls=2
walls set to 2
```
- command-line.c: Use a pre-defined help message
It just looks better.

- link-parser.c: Don't print version on -verbosity=0
Because it is requested to be with zero verbosity.

- link-parser.c: Add --quite
See: https://www.gnu.org/prep/standards/standards.html#Option-Table
This is a common GNU program flag. Add also --silent as described there.
