### PR TITLE
link-parser "!file" fixes

### DIFF
--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -422,6 +422,12 @@ char *lg_readline(const char *mb_prompt)
 
 	byte_len = wcstombs(NULL, wc_line, 0) + 4;
 	free(mb_line);
+	if (byte_len == (size_t)-1)
+	{
+		printf("Error: Unable to process UTF8 in input string.\n");
+		mb_line = strdup(""); /* Just ignore it. */
+		return mb_line;
+	}
 	mb_line = malloc(byte_len);
 	wcstombs(mb_line, wc_line, byte_len);
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -824,15 +824,16 @@ int main(int argc, char * argv[])
 			}
 
 			if ('\n' == filename[fnlen-1]) filename[fnlen-1] = '\0';
+			char *eh_filename = expand_homedir(filename);
 
 			struct stat statbuf;
-			if ((0 == stat(filename, &statbuf)) && statbuf.st_mode & S_IFDIR)
+			if ((0 == stat(eh_filename, &statbuf)) && statbuf.st_mode & S_IFDIR)
 			{
 				errno = EISDIR;
 				goto open_error;
 			}
 
-			input_fh = fopen(filename, "r");
+			input_fh = fopen(eh_filename, "r");
 
 			if (NULL == input_fh)
 			{
@@ -840,10 +841,12 @@ int main(int argc, char * argv[])
 				goto open_error;
 			}
 
+			free(eh_filename);
 			continue;
 
 open_error:
-			prt_error("Error: Cannot open %s: %s\n", filename, strerror(errno));
+			prt_error("Error: Cannot open %s: %s\n", eh_filename, strerror(errno));
+			free(eh_filename);
 			continue;
 		}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -816,15 +816,12 @@ int main(int argc, char * argv[])
 		{
 			char *command_end = &input_string[strcspn(input_string, WHITESPACE)];
 			char *filename = &command_end[strspn(command_end, WHITESPACE)];
-			int fnlen = strlen(filename);
-
-			if (0 == fnlen)
+			if (filename[0] == '\0')
 			{
 				prt_error("Error: Missing file name argument\n");
 				continue;
 			}
 
-			if ('\n' == filename[fnlen-1]) filename[fnlen-1] = '\0';
 			char *eh_filename = expand_homedir(filename);
 
 			struct stat statbuf;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -814,7 +814,8 @@ int main(int argc, char * argv[])
 		 * otherwise ... */
 		if ('f' == command)
 		{
-			char * filename = &input_string[strcspn(input_string, WHITESPACE)] + 1;
+			char *command_end = &input_string[strcspn(input_string, WHITESPACE)];
+			char *filename = &command_end[strspn(command_end, WHITESPACE)];
 			int fnlen = strlen(filename);
 
 			if (0 == fnlen)

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -828,22 +828,24 @@ int main(int argc, char * argv[])
 			struct stat statbuf;
 			if ((0 == stat(filename, &statbuf)) && statbuf.st_mode & S_IFDIR)
 			{
-				prt_error("Error: Cannot open %s: %s\n",
-				        filename, strerror(EISDIR));
-				continue;
+				errno = EISDIR;
+				goto open_error;
 			}
 
 			input_fh = fopen(filename, "r");
 
 			if (NULL == input_fh)
 			{
-				prt_error("Error: Cannot open %s: %s\n", filename, strerror(errno));
 				input_fh = stdin;
-				continue;
+				goto open_error;
 			}
+
+			continue;
+
+open_error:
+			prt_error("Error: Cannot open %s: %s\n", filename, strerror(errno));
 			continue;
 		}
-
 
 		if (!copts->batch_mode) batch_in_progress = false;
 		if ('\0' != test[0])

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -15,6 +15,8 @@
 
 #include "../link-grammar/link-includes.h"
 
+char *expand_homedir(const char *fn);
+
 #define MAX_INPUT 2048
 
 #ifdef _WIN32


### PR DESCRIPTION
- Bug fixes:
-- lg_readline(): Don't crash due to invalid UTF-8
-- link-parser.c: Discard leading spaces in "!file" argument filename
  This is a very old bug.

- Source code simplifications:
-- link-parser.c: Use idiomatic goto for file open errors
It also simplifies the next fix at that place.
-- link-parser.c: Simplify detection of missing !file argument

-- Feature improvements:
-- Support ~ and ~user expansion (both with and without `libedit`). 
This can be uses to easily access batch files in a home directory. Its partial Windows support is not tested yet *.
-- link-parser: List filename completion possibilities w/o directory name

**[*]** I still need to test all the recently added code on Windows and Mac - better done before 5.7.0 is released (I even don't know if it compiles).
