### PR TITLE
Fix bug in "Don't allow values > 1 for booleans"

### DIFF
--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -787,7 +787,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if ((0 == strcasecmp(y, "true")) || (0 == strcasecmp(y, "t"))) val = 1;
 			if ((0 == strcasecmp(y, "false")) || (0 == strcasecmp(y, "f"))) val = 0;
 
-			if ((val != 0) && (val != 1))
+			if ((as[j].param_type == Bool) && (val != 0) && (val != 1))
 			{
 				prt_error("Error: Invalid value %s for variable \"%s\". %s\n",
 				          y, as[j].string, helpmsg);


### PR DESCRIPTION
I checked that it disallows non-boolean values for booleans, but didn't check that it didn't get broken for other types...

A test suite for `link-parser` is a WIP, and even though it is incomplete I think I can start using it for tests before sending PRs (for now it even doesn't include a relevant test for flag values).