### PR TITLE
Portability char

### DIFF
--- a/link-grammar/print/wcwidth.c
+++ b/link-grammar/print/wcwidth.c
@@ -71,7 +71,11 @@ struct interval {
 };
 
 /* auxiliary function for binary search in interval table */
-static bool bisearch(wchar_t ucs, const struct interval *table, int max)
+/* NOTE: The actual parameter is wchar_t, which may be unsigned on
+ * some architectures (e.g. ARM). An (int) formal parameter is used to
+ * prevent a compiler warning in that case (((unsigned int)wchar_t) is
+ * always < INT_MAX) so its value is preserved). */
+static bool bisearch(int ucs, const struct interval *table, int max)
 {
   int min = 0;
   int mid;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -472,7 +472,7 @@ static void batch_process_some_linkages(Label label,
  * If input_string is !command, try to issue it.
  */
 
-static char special_command(char *input_string, Command_Options* copts, Dictionary dict)
+static int special_command(char *input_string, Command_Options* copts, Dictionary dict)
 {
 	if (input_string[0] == COMMENT_CHAR) return 'c';
 	if (input_string[0] == '!')
@@ -818,7 +818,7 @@ int main(int argc, char * argv[])
 		if (strspn(input_string, WHITESPACE) == strlen(input_string))
 			continue;
 
-		char command = special_command(input_string, copts, dict);
+		int command = special_command(input_string, copts, dict);
 		if ('e' == command) break;    /* It was an exit command */
 		if ('c' == command) continue; /* It was another command */
 		if (-1 == command) continue;  /* It was a bad command */


### PR DESCRIPTION
Fixes for cases in which `char` and/or `wchar_t` are unsigned
(e.g. both are unsigned on the `armhf` CPU.)