### PR TITLE
Fixes for Windows

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -179,7 +179,7 @@ extractor_t * extractor_new(int nwords, unsigned int ranstat)
 	} else if (nwords >= 10) {
 		log2_table_size = 14 + nwords / 24;
 	} else if (nwords >= 4) {
-		log2_table_size = 1 + 1.5 * nwords;
+		log2_table_size = 1 + nwords + nwords / 2;
 	} else {
 		log2_table_size = 5;
 	}

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -19,6 +19,9 @@
 #include "api-types.h"
 #include "const-prime.h"
 #include "lg_assert.h"
+#ifdef _WIN32
+#include "utilities.h"                  // ssize_t
+#endif
 
 #define STR_POOL
 #define MEM_POOL_INIT (8*1024)

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -49,7 +49,8 @@
 #ifdef _WIN32
 void lg_strerror(int err_no, char *buf, size_t len)
 {
-	return strerror_s(buf, len, err_no);
+	if (strerror_s(buf, len, err_no) != 0)
+		strerror_s(buf, len, errno); /* errno got set by previous strerror_s() */
 }
 #else
 #if HAVE_STRERROR_R

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -457,7 +457,7 @@ void downcase_utf8_str(char *to, const char * from, size_t usize, locale_t);
 void upcase_utf8_str(char *to, const char * from, size_t usize, locale_t);
 #endif
 
-size_t lg_strlcpy(char * dest, const char *src, size_t size);
+size_t lg_strlcpy(char * restrict dst, const char * restrict src, size_t dsize);
 void safe_strcat(char *u, const char *v, size_t usize);
 char *safe_strdup(const char *u);
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -90,6 +90,7 @@ void *alloca (size_t);
 #include <mbctype.h>
 
 /* Compatibility definitions. */
+#define restrict __restrict
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -52,16 +52,19 @@ char *expand_homedir(const char *filename)
 		user = strndupa(filename + 1, user_end - filename - 1);
 #endif /* _WIN32 */
 
-	const char *home;
 #ifdef _WIN32
+	char *home;
+
 	const char *homepath = getenv("HOMEPATH");
 	if ((homepath == NULL) || (homepath[0] == '\0')) return strdup(filename);
-	const char *homedrive = getenv("HOMEPATH");
+	const char *homedrive = getenv("HOMEDRIVE");
 
 	home = malloc(strlen(homepath) + strlen(homedrive) + 1);
 	strcpy(home, homedrive);
 	strcat(home, homepath);
 #else
+	const char *home;
+
 	if (user == NULL)
 	{
 		home = getenv("HOME");

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -58,10 +58,12 @@ char *expand_homedir(const char *filename)
 	const char *homepath = getenv("HOMEPATH");
 	if ((homepath == NULL) || (homepath[0] == '\0')) return strdup(filename);
 	const char *homedrive = getenv("HOMEDRIVE");
+	if (homedrive == NULL) homedrive = "";
 
 	home = malloc(strlen(homepath) + strlen(homedrive) + 1);
 	strcpy(home, homedrive);
 	strcat(home, homepath);
+	filename++;
 #else
 	const char *home;
 

--- a/msvc/LinkGrammar.vcxproj
+++ b/msvc/LinkGrammar.vcxproj
@@ -22,24 +22,24 @@
     <ProjectGuid>{0A6C539A-3140-48BD-865C-05F45637B93B}</ProjectGuid>
     <RootNamespace>LinkGrammar</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">

--- a/msvc/LinkGrammar.vcxproj
+++ b/msvc/LinkGrammar.vcxproj
@@ -286,6 +286,7 @@
     <ClInclude Include="..\link-grammar\tokenize\tokenize.h" />
     <ClInclude Include="..\link-grammar\tokenize\word-structures.h" />
     <ClInclude Include="..\link-grammar\tokenize\wordgraph.h" />
+    <ClInclude Include="..\link-grammar\tracon-set.h" />
     <ClInclude Include="..\link-grammar\utilities.h" />
     <ClInclude Include="link-grammar\link-features.h" />
   </ItemGroup>
@@ -338,6 +339,7 @@
     <ClCompile Include="..\link-grammar\tokenize\tokenize.c" />
     <ClCompile Include="..\link-grammar\tokenize\wg-display.c" />
     <ClCompile Include="..\link-grammar\tokenize\wordgraph.c" />
+    <ClCompile Include="..\link-grammar\tracon-set.c" />
     <ClCompile Include="..\link-grammar\utilities.c" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/LinkGrammar.vcxproj.filters
+++ b/msvc/LinkGrammar.vcxproj.filters
@@ -162,6 +162,9 @@
     <ClCompile Include="..\link-grammar\memory-pool.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\link-grammar\tracon-set.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\link-grammar\api-structures.h">
@@ -330,6 +333,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="link-grammar\link-features.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\tracon-set.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/LinkGrammarExe.vcxproj
+++ b/msvc/LinkGrammarExe.vcxproj
@@ -33,26 +33,26 @@
     <ProjectGuid>{532EFF4D-758A-4705-91EE-9A4AC72C017B}</ProjectGuid>
     <RootNamespace>LinkGrammarExe</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/msvc/LinkGrammarJava.vcxproj
+++ b/msvc/LinkGrammarJava.vcxproj
@@ -21,24 +21,24 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D74DF531-C18E-4988-8A8C-4F23556DEC1B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/msvc/Python2.vcxproj
+++ b/msvc/Python2.vcxproj
@@ -108,29 +108,29 @@ swig.exe -python -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar 
     <ProjectGuid>{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Python2</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/msvc/Python3.vcxproj
+++ b/msvc/Python3.vcxproj
@@ -107,29 +107,29 @@ swig.exe -python -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar 
     <ProjectGuid>{B3AF571B-F80D-4A9C-A8C4-29026316A000}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Python3</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
My fixes and additions in the previous release broke several things in the Windows build.
Here I fixed all of them.
I also fixed some warnings that we don't enable on GCC (or maybe GCC doesn't care, like missing "restrict" in function declaration).
In addition I fixed the Windows "~" support that I recently added.
I validated that it passes the Python tests.
I didn't test the others because there is no build/run system to do that yet.

I still need to test on Mac and will update on that soon (with a PR if needed).
Reference: PR #1000.

