### PR TITLE
Fix portability problems detected in the MacOS build

### DIFF
--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -114,13 +114,6 @@ lg_error_formatmsg
 lg_error_printall
 lg_error_clearall
 lg_error_flush
-lg_exp_get_type
-lg_exp_get_dir
-lg_exp_get_multi
-lg_exp_get_string
-lg_exp_get_cost
-lg_exp_operand_first
-lg_exp_operand_next
 lg_exp_stringify
 prt_error
 lg_compute_disjunct_strings

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -85,12 +85,17 @@ void *alloca (size_t);
 #define HAVE_LOCALE_T 1
 #endif /* HAVE_LOCALE_T_IN_LOCALE_H || HAVE_LOCALE_T_IN_XLOCALE_H) */
 
+#ifdef __cplusplus
+/* "restrict" is not a part of ISO C++.
+ * C++ compilers usually know it as __restrict. */
+#define restrict __restrict
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #include <mbctype.h>
 
 /* Compatibility definitions. */
-#define restrict __restrict
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -43,10 +43,13 @@ char *expand_homedir(const char *filename)
 	if (filename[0] != '~') return strdup(filename);
 
 #ifndef _WIN32
-	const char *user = NULL;
+	char *user = NULL;
 	const char *user_end = &filename[strcspn(filename, "/")];
 	if (user_end != &filename[1])
-		user = strndupa(filename + 1, user_end - filename - 1);
+	{
+		user = strdup(filename + 1);
+		user[user_end - filename - 1] = '\0';
+	}
 #endif /* _WIN32 */
 
 #ifdef _WIN32
@@ -74,6 +77,7 @@ char *expand_homedir(const char *filename)
 	{
 		struct passwd *pwd;
 		pwd = getpwnam(user);
+		free(user);
 		if (pwd == NULL) return strdup(filename);
 		home = pwd->pw_dir;
 		filename = user_end;

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -18,17 +18,14 @@
 #include <fcntl.h>
 #include <io.h>
 #include <shellapi.h>                    /* CommandLineToArgvW() */
-#ifdef __MINGW32__
-#include <malloc.h>
-#endif /* __MINGW32__ */
 #include <errno.h>
+#include <malloc.h>
 #else
 #include <stdlib.h>
 #include <sys/types.h>
 #include <pwd.h>
 #endif /* _WIN32 */
 
-#include <malloc.h>
 #include <string.h>
 
 #include "parser-utilities.h"


### PR DESCRIPTION
These are general portability problems - not related specifically to MacOS.

The problem now is that on Mac many linkages are slightly different.
The problem happens on f7945ae24, which is a dic fix. It creates a huge problem on Mac, and absolutely no problem on X86_64.

Running with `-verbosity=9` reveals that the first difference happens in the middle of `expression_prune()`. I guess that this dict change triggers a problem due to some UB (undefined behavior) that happen to be in the code (maybe again something uninitialized).

I intend to single-step at the point of the difference and will update soon.