### PR TITLE
Fix a bug in setting UNLIMITED-CONNECTORS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ Version 5.7.0 (XXX 2019)
  * Incompatible change to the Exp traversal API.
  * Remove the obsolete and unsupported "corpus statistics" code.
  * Major performance improvement (3x-4x) for long sentences. #996
+ * Fix broken build on Windows.
+ * Convert Windows build to Visual Studio 2019.
 
 Version 5.6.2 (24 June 2019)
  * Bug-fix the SQL-backed dictionary.

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Version 5.7.0 (XXX 2019)
  * Major performance improvement (3x-4x) for long sentences. #996
  * Fix broken build on Windows.
  * Convert Windows build to Visual Studio 2019.
+ * Fix a bug that could cause missing linkages on some systems. #1007
 
 Version 5.6.2 (24 June 2019)
  * Bug-fix the SQL-backed dictionary.

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -145,7 +145,7 @@ static void set_condesc_length_limit(Dictionary dict, const Exp *e, int length_l
 		if (en == exp_num_con) break;
 
 		if (econlist[en]->uc_num != sdesc[cn]->uc_num) continue;
-		restart_cn = cn+1;
+		restart_cn = cn;
 
 		const char *wc_str = econlist[en]->string;
 		char *uc_wildcard = strchr(wc_str, LENGTH_LINIT_WILD_TYPE);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -186,7 +186,7 @@ static dyn_str *print_expression_parens(dyn_str *e,
 
 const char *lg_exp_stringify(const Exp *n)
 {
-	static char *e_str;
+	static TLS char *e_str;
 
 	if (e_str != NULL) free(e_str);
 	if (n == NULL)

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -85,12 +85,17 @@ void *alloca (size_t);
 #define HAVE_LOCALE_T 1
 #endif /* HAVE_LOCALE_T_IN_LOCALE_H || HAVE_LOCALE_T_IN_XLOCALE_H) */
 
+#if defined _MSC_VER || defined __cplusplus
+/* "restrict" is not a part of ISO C++.
+ * C++ compilers usually know it as __restrict. */
+#define restrict __restrict
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #include <mbctype.h>
 
 /* Compatibility definitions. */
-#define restrict __restrict
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif


### PR DESCRIPTION
- set_condesc_length_limit(): Fix off-by-1 bug in restart_cn

This is a bad bug when it has an effect. See the commit message for details.
However, it most probably didn't affect Linux systems with the standard libc.
Also, I don't know the probability that this bug will occur on a particular `qsort()` implementation, maybe it is small. In any case, it didn't happen up to now on the systems on which I tested LG, including Windows 8 and 10, Cygwin, FreeBSD, several Linux distributions, MinGW32 and MinGW64 and oldest MacOS systems, and somehow it doesn't happen on 5.6.2 even on the current Mac machine I use (OS version Mojave).

More extensive test suites may detect such bugs. This one could be detected by a test suite that verifies that UNLIMITED-CONNECTORS are set properly (this need some help from the library, in that case there is `link-parser` -v=101` that prints all the connectors and their length limit).

META info:
This PR is intended to be applied after the #1006 (More Windows), because both update the ChangeLog. It also contains 2 commits from #1006 with the same hash and I hope they will get automatically cancelled out. In addition it is not rebased on the current master, but it doesn't suppose top touch affected files.
The ChangeLog in this PR also refers this PR itself (#1007) and I hope I will not create a horrible GitHub loop.

