### PR TITLE
Cleanup t9

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -414,9 +414,10 @@ class DBasicParsingTestCase(unittest.TestCase):
 
     def test_timer_exhausted_exception(self):
         self.assertRaises(LG_TimerExhausted,
-                          self.parse_sent,
-                          "This should take more than one second to parse! " * 20,
-                          ParseOptions(max_parse_time=1))
+                self.parse_sent,
+                "This sentence parses without null words, "
+                "and should take more than one second to parse!" * 14,
+                ParseOptions(max_parse_time=1,short_length=255,disjunct_cost=10.0,linkage_limit=10000))
 
 # The tests here are numbered since their order is important.
 # They depend on the result and state of the previous ones as follows:

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -162,7 +162,7 @@ struct Sentence_s
 	                               This is not the same as num alloced
 	                               because some may be non-canonical. */
 	size_t num_valid_linkages;  /* Number with no pp violations */
-	size_t null_count;          /* Number of null links in linkages */
+	unsigned int null_count;    /* Number of null links in linkages */
 	Linkage        lnkages;     /* Sorted array of valid & invalid linkages */
 	Postprocessor * postprocessor;
 	Postprocessor * constituent_pp;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -516,7 +516,7 @@ int sentence_length(Sentence sent)
 int sentence_null_count(Sentence sent)
 {
 	if (!sent) return 0;
-	return sent->null_count;
+	return (int)sent->null_count;
 }
 
 int sentence_num_linkages_found(Sentence sent)
@@ -621,7 +621,7 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 	if ((verbosity > 0) &&
 	   (PARSE_NUM_OVERFLOW < sent->num_linkages_found))
 	{
-		prt_error("Warning: Combinatorial explosion! nulls=%zu cnt=%d\n"
+		prt_error("Warning: Combinatorial explosion! nulls=%u cnt=%d\n"
 			"Consider retrying the parse with the max allowed disjunct cost set lower.\n"
 			"At the command line, use !cost-max\n",
 			sent->null_count, sent->num_linkages_found);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -467,6 +467,8 @@ int sentence_split(Sentence sent, Parse_Options opts)
 		return -3;
 	}
 
+	if (verbosity >= D_USER_TIMES)
+		prt_error("#### Finished tokenizing (%zu tokens)\n", sent->length);
 	return 0;
 }
 

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -215,7 +215,7 @@ void set_all_condesc_length_limit(Dictionary dict)
 		prt_error("Debug:\n%5s %-6s %3s\n\\", "num", "uc_num", "ll");
 		for (size_t n = 0; n < ct->num_con; n++)
 		{
-			prt_error("%5zu %6d %3d %s\n\\", n, ct->sdesc[n]->uc_num,
+			prt_error("%5zu %6u %3d %s\n\\", n, ct->sdesc[n]->uc_num,
 			       ct->sdesc[n]->length_limit, ct->sdesc[n]->string);
 		}
 		prt_error("\n");

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -448,7 +448,7 @@ static void get_dict_affixes(Dictionary dict, Dict_node * dn,
 	w_len = (NULL == w_sm) ? strlen(w) : (size_t)(w_sm - w);
 	if (w_len > MAX_WORD)
 	{
-		prt_error("Error: word '%s' too long (%zd), program may malfunction\n",
+		prt_error("Error: word '%s' too long (%zu), program may malfunction\n",
 		          w, w_len);
 		w_len = MAX_WORD;
 	}
@@ -675,7 +675,7 @@ bool afdict_init(Dictionary dict)
 		     ac < &afdict->afdict_class[ARRAY_SIZE(afdict_classname)]; ac++)
 		{
 				if (0 == ac->length) continue;
-				lgdebug(+0, "Class %s, %zd items:",
+				lgdebug(+0, "Class %s, %zu items:",
 				        afdict_classname[ac-afdict->afdict_class], ac->length);
 				for (l = 0; l < ac->length; l++)
 					lgdebug(0, " '%s'", ac->string[l]);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -280,7 +280,7 @@ static unsigned int count_clause(Exp *e)
 	}
 	else
 	{
-		assert(false, "Unknown expression type %d", e->type);
+		assert(false, "Unknown expression type %d", (int)e->type);
 	}
 
 	return cnt;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -526,7 +526,7 @@ void print_disjunct_list(Disjunct * dj)
 		if (print_disjunct_address) printf("(%p)", dj);
 		printf(": ");
 
-		if (print_disjunct_ordinal) printf("<%d>", dj->ordinal);
+		if (print_disjunct_ordinal) printf("<%u>", dj->ordinal);
 		printf("[%d](%s) ", i++, cost_stringify(dj->cost));
 
 		print_connector_list(dj->left);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1101,7 +1101,9 @@ static void locate_added_disjuncts(Sentence sent, Tracon_sharing *old_ts)
  *
  * The disjunct and connectors packing in a contiguous memory facilitate a
  * better memory caching for long sentences (a performance gain of a few
- * percents).
+ * percents in the initial implementation, in which this was the sole
+ * purpose of this packing.) In addition, tracon memory sharing
+ * drastically reduces the memory used for connectors.
  *
  * The tracon IDs (if invoked for the parsing step) or tracon lists (if
  * invoked for pruning step) allow for a huge performance boost at these
@@ -1111,9 +1113,8 @@ static void locate_added_disjuncts(Sentence sent, Tracon_sharing *old_ts)
  * In order to save overhead, sentences shorter than
  * sent->min_len_encoding don't undergo encoding - only packing.
  * This can also be used for library tests that totally bypass the use of
- * connector encoding (to validate that the
- * tracon_id/packing/sharing/refcount implementation didn't introduce bugs
- * in the pruning and parsing steps).
+ * connector encoding (to validate that the tracon_id/sharing/refcount
+ * implementation didn't introduce bugs in the pruning and parsing steps).
  * E.g. when using link-parser:
  * - To entirely disable connector encoding:
  * link-parser -test=len-trailing-hash:254
@@ -1191,7 +1192,7 @@ Tracon_sharing *pack_sentence_for_pruning(Sentence sent, unsigned int dcnt,
  * Pack the sentence for parsing.
  * @param old_ts Previous tracon sharing descriptor (if incremental encoding).
  * @param keep_disjuncts Keep for possible parsing w/ increased null count.
- * @return New tracon sharing descriptor or NULL no packing done.
+ * @return New tracon sharing descriptor.
  */
 Tracon_sharing *pack_sentence_for_parsing(Sentence sent, unsigned int dcnt,
                                           unsigned int ccnt,

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -955,8 +955,7 @@ static Tracon_sharing *pack_sentence_init(Sentence sent, unsigned int dcnt,
 		}
 	}
 
-	if (!is_pruning && (NULL != ts) &&
-	    (ts->memblock != sent->dc_memblock))
+	if (!is_pruning && (ts->memblock != sent->dc_memblock))
 	{
 		/* The disjunct & connector content is stored in dc_memblock.
 		 * It will be freed at sentence_delete(). */

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -246,7 +246,7 @@ static const char *error_severity_label(lg_error_severity sev)
 	}
 	else if ((sev < 1) || (sev > lg_None))
 	{
-		snprintf(sevlabel, MAX_SEVERITY_LABEL_SIZE, "Message severity %d", sev);
+		snprintf(sevlabel, MAX_SEVERITY_LABEL_SIZE, "Message severity %d", (int)sev);
 	}
 	else
 	{

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -116,13 +116,5 @@ lg_error_clearall
 lg_error_flush
 lg_exp_stringify
 prt_error
-lg_compute_disjunct_strings
-object_open
-free_disjuncts
-eliminate_duplicate_disjuncts
-catenate_disjuncts
-count_disjuncts
-print_one_disjunct
-build_disjuncts_for_exp
 regex_tokenizer_test
 utf8_strwidth

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -24,7 +24,7 @@
 #include "lisjuncts.h"
 #include "string-set.h"
 
-#ifdef DEBUG
+#ifdef DEBUG_lisjuncts
 #include "print/print-util.h"
 static void assert_same_disjunct(Linkage, WordIdx, const char *);
 #endif /* DEBUG */
@@ -99,7 +99,7 @@ void lg_compute_disjunct_strings(Linkage lkg)
 		if ((len > 0) && (djstr[len-1] == ' ')) len--;
 		djstr[len++] = '\0';
 
-#ifdef DEBUG
+#ifdef DEBUG_lisjuncts
 		assert_same_disjunct(lkg, w, djstr);
 #endif
 
@@ -107,7 +107,8 @@ void lg_compute_disjunct_strings(Linkage lkg)
 	}
 }
 
-#ifdef DEBUG
+#ifdef DEBUG_lisjuncts
+/* Cannot be used when morphology is not suppressed and lexical links exist. */
 static void assert_same_disjunct(Linkage lkg, WordIdx w, const char *djstr)
 {
 	char *cs;

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -94,8 +94,8 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 	}
 	else
 	{
-		lgdebug(D_WPA, "Path position to be replaced (len %zu): %zu\n", n,
-		                wpt - *nwp);
+		lgdebug(D_WPA, "Path position to be replaced (len %zu): %d\n", n,
+		                (int)(wpt - *nwp));
 		n = wpt - *nwp; /* Replace this path. */
 	}
 	(*nwp)[n].word = p;

--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -288,7 +288,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 	Wordgraph_pathpos *wpp;
 	Gword **next; /* next Wordgraph words of the current word */
 	size_t i;
-	size_t null_count_found = 0;
+	unsigned int null_count_found = 0;
 
 	bool match_found = true; /* if all the words are null - it's still a match */
 	Gword **lwg_path;
@@ -372,7 +372,7 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 				if ((null_count_found > lkg->sent->null_count) &&
 				    (lkg->sent->null_count != sent->length-1))
 				{
-					lgdebug(D_SLM, " (Extra, count > %zu)\n", lkg->sent->null_count);
+					lgdebug(D_SLM, " (Extra, count > %u)\n", lkg->sent->null_count);
 					match_found = false;
 					break;
 				}
@@ -447,13 +447,13 @@ bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 	 * count when islands_ok=0. */
 	if (match_found)
 	{
-		size_t count_found =
+		unsigned int count_found =
 			opts->islands_ok ? num_islands(lkg, wpp->path) : null_count_found;
 
 		if ((count_found != lkg->sent->null_count) &&
 		    (lkg->sent->null_count != sent->length-1) && (count_found != sent->length))
 		{
-			lgdebug(D_SLM, "Null count mismatch: Found %zu != null_count %zu\n",
+			lgdebug(D_SLM, "Null count mismatch: Found %u != null_count %u\n",
 					  count_found, lkg->sent->null_count);
 			match_found = false;
 		}

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -750,7 +750,7 @@ static Count_bin do_count(
 			bool Rmatch = d->match_right;
 
 #ifdef VERIFY_MATCH_LIST
-			assert(id == d->match_id, "Modified id (%d!=%d)", id, d->match_id);
+			assert(id == d->match_id, "Modified id (%u!=%u)", id, d->match_id);
 #endif
 
 			for (unsigned int lnull_cnt = lnull_start; lnull_cnt <= lnull_end; lnull_cnt++)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -559,7 +559,7 @@ static Count_bin do_count(
 	Table_connector *t;
 
 	/* TODO: static_assert() that null_count is an unsigned int. */
-	assert (null_count < INT_MAX, "Bad null count %d", null_count);
+	assert (null_count < INT_MAX, "Bad null count %d", (int)null_count);
 
 	t = find_table_pointer(ctxt, lw, rw, le, re, null_count);
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -971,10 +971,8 @@ static Count_bin do_count(
  * used anywhere, and a 3-5% speedup is available if it is avoided.
  * We plan to use this histogram, later ....
  */
-Count_bin do_parse(Sentence sent,
-                   fast_matcher_t *mchxt,
-                   count_context_t *ctxt,
-                   int null_count, Parse_Options opts)
+int do_parse(Sentence sent, fast_matcher_t *mchxt, count_context_t *ctxt,
+             Parse_Options opts)
 {
 	Count_bin hist;
 
@@ -987,7 +985,7 @@ Count_bin do_parse(Sentence sent,
 	/* Cannot reuse since its content is invalid on an increased null_count. */
 	init_table_lrcnt(ctxt, sent);
 
-	hist = do_count(ctxt, -1, sent->length, NULL, NULL, null_count+1);
+	hist = do_count(ctxt, -1, sent->length, NULL, NULL, sent->null_count+1);
 
 	DEBUG_TABLE_STAT(if (verbosity_level(+5)) table_stat(ctxt, sent));
 

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -19,7 +19,7 @@
 typedef struct count_context_s count_context_t;
 
 Count_bin* table_lookup(count_context_t *, int, int, Connector *, Connector *, unsigned int);
-Count_bin do_parse(Sentence, fast_matcher_t*, count_context_t*, int null_count, Parse_Options);
+int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 
 count_context_t* alloc_count_context(Sentence);
 void free_count_context(count_context_t*, Sentence);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -390,12 +390,12 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		total = (total < 0) ? INT_MAX : total;
 
 		sent->num_linkages_found = (int) total;
-		print_time(opts, "Counted parses (%lld w/%zu null%s)", hist_total(&hist),
+		print_time(opts, "Counted parses (%lld w/%u null%s)", hist_total(&hist),
 		           sent->null_count, (sent->null_count != 1) ? "s" : "");
 
 		if (verbosity >= D_USER_INFO)
 		{
-			prt_error("Info: Total count with %zu null links: %lld\n",
+			prt_error("Info: Total count with %u null links: %lld\n",
 			        sent->null_count, total);
 		}
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -379,8 +379,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		if (resources_exhausted(opts->resources)) break;
 		free_linkages(sent);
 
-		sent->num_linkages_found =
-			do_parse(sent, mchxt, ctxt, sent->null_count, opts);
+		sent->num_linkages_found = do_parse(sent, mchxt, ctxt, opts);
 
 		print_time(opts, "Counted parses (%d w/%u null%s)",
 		           sent->num_linkages_found, sent->null_count,

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -326,9 +326,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 	for (unsigned int nl = opts->min_null_count; nl <= max_null_count; nl++)
 	{
-		Count_bin hist;
-		s64 total;
-
 		sent->null_count = nl;
 
 		if (needed_prune_level > current_prune_level)
@@ -382,22 +379,12 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		if (resources_exhausted(opts->resources)) break;
 		free_linkages(sent);
 
-		hist = do_parse(sent, mchxt, ctxt, sent->null_count, opts);
-		total = hist_total(&hist);
+		sent->num_linkages_found =
+			do_parse(sent, mchxt, ctxt, sent->null_count, opts);
 
-		/* total is 64-bit, num_linkages_found is 32-bit. Clamp */
-		total = (total > INT_MAX) ? INT_MAX : total;
-		total = (total < 0) ? INT_MAX : total;
-
-		sent->num_linkages_found = (int) total;
-		print_time(opts, "Counted parses (%lld w/%u null%s)", hist_total(&hist),
-		           sent->null_count, (sent->null_count != 1) ? "s" : "");
-
-		if (verbosity >= D_USER_INFO)
-		{
-			prt_error("Info: Total count with %u null links: %lld\n",
-			        sent->null_count, total);
-		}
+		print_time(opts, "Counted parses (%d w/%u null%s)",
+		           sent->num_linkages_found, sent->null_count,
+		           (sent->null_count != 1) ? "s" : "");
 
 		extractor_t * pex = extractor_new(sent->length, sent->rand_state);
 		bool ovfl = setup_linkages(sent, pex, mchxt, ctxt, opts);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -817,16 +817,15 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 		pc->N_changed = N_deleted[0] = N_deleted[1] = 0;
 	}
 
-	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc->power_cost);
-
 	print_time(opts, "power pruned (for %u null%s)",
 	           pc->null_links, (pc->null_links != 1) ? "s" : "");
 	if (verbosity_level(D_PRUNE))
 	{
 		prt_error("\n\\");
+		prt_error("Debug: Power prune cost: %d\n", pc->power_cost);
 		prt_error("Debug: After power_pruning (for %u null%s, sent->null_count %u):\n\\",
 		          pc->null_links, (pc->null_links != 1) ? "s" : "", pc->sent->null_count);
-		print_disjunct_counts(sent);
+		print_disjunct_counts(pc->sent);
 	}
 
 #ifdef DEBUG

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1337,7 +1337,7 @@ static void get_num_con_uc(Sentence sent,power_table *pt,
  */
 void pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
                         unsigned int null_count, Parse_Options opts,
-                        unsigned int *ncu[])
+                        unsigned int *ncu[2])
 {
 	power_table pt;
 	power_table_init(sent, ts, &pt);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -727,23 +727,17 @@ static bool is_bad(Connector *c)
  *  pass by marking their connectors with the pass number in their
  *  tracon_id field.
  */
-static int power_prune(Sentence sent, power_table *pt,
-                       unsigned int null_count, Parse_Options opts)
+static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 {
-	prune_context pc;
 	int N_deleted[2] = {0}; /* [0] counts first deletions, [1] counts dups. */
 	int total_deleted = 0;
 
-	pc.pt = pt;
-	pc.power_cost = 0;
-	pc.null_links = null_count;
-	pc.N_changed = 1;  /* forces it always to make at least two passes */
-	pc.sent = sent;
-	pc.pass_number = 0;
+	power_table *pt = pc->pt;
+	pc->N_changed = 1;      /* forces it always to make at least two passes */
 
 	while (1)
 	{
-		pc.pass_number++;
+		pc->pass_number++;
 
 		/* left-to-right pass */
 		for (WordIdx w = 0; w < sent->length; w++)
@@ -759,7 +753,7 @@ static int power_prune(Sentence sent, power_table *pt,
 				}
 
 				bool bad = is_bad(d->left);
-				if (bad || left_connector_list_update(&pc, d->left, w, true) < 0)
+				if (bad || left_connector_list_update(pc, d->left, w, true) < 0)
 				{
 					mark_jet_for_dequeue(d->left, true);
 					mark_jet_for_dequeue(d->right, false);
@@ -770,7 +764,7 @@ static int power_prune(Sentence sent, power_table *pt,
 					continue;
 				}
 
-				mark_jet_as_good(d->left, pc.pass_number);
+				mark_jet_as_good(d->left, pc->pass_number);
 				dd = &d->next; /* NEXT */
 			}
 
@@ -779,10 +773,10 @@ static int power_prune(Sentence sent, power_table *pt,
 
 		total_deleted += N_deleted[0] + N_deleted[1];
 		lgdebug(D_PRUNE, "Debug: l->r pass changed %d and deleted %d (%d+%d)\n",
-		        pc.N_changed, N_deleted[0]+N_deleted[1], N_deleted[0], N_deleted[1]);
+		        pc->N_changed, N_deleted[0]+N_deleted[1], N_deleted[0], N_deleted[1]);
 
-		if (pc.N_changed == 0 && N_deleted[0] == 0 && N_deleted[1] == 0) break;
-		pc.N_changed = N_deleted[0] = N_deleted[1] = 0;
+		if (pc->N_changed == 0 && N_deleted[0] == 0 && N_deleted[1] == 0) break;
+		pc->N_changed = N_deleted[0] = N_deleted[1] = 0;
 
 		/* right-to-left pass */
 		for (WordIdx w = sent->length-1; w != (WordIdx) -1; w--)
@@ -797,7 +791,7 @@ static int power_prune(Sentence sent, power_table *pt,
 				}
 
 				bool bad = is_bad(d->right);
-				if (bad || right_connector_list_update(&pc, d->right, w, true) >= sent->length)
+				if (bad || right_connector_list_update(pc, d->right, w, true) >= sent->length)
 				{
 					mark_jet_for_dequeue(d->right, true);
 					mark_jet_for_dequeue(d->left, false);
@@ -808,7 +802,7 @@ static int power_prune(Sentence sent, power_table *pt,
 					continue;
 				}
 
-				mark_jet_as_good(d->right, pc.pass_number);
+				mark_jet_as_good(d->right, pc->pass_number);
 				dd = &d->next; /* NEXT */
 			}
 
@@ -817,21 +811,21 @@ static int power_prune(Sentence sent, power_table *pt,
 
 		total_deleted += N_deleted[0] + N_deleted[1];
 		lgdebug(D_PRUNE, "Debug: r->l pass changed %d and deleted %d (%d+%d)\n",
-		        pc.N_changed, N_deleted[0]+N_deleted[1], N_deleted[0], N_deleted[1]);
+		        pc->N_changed, N_deleted[0]+N_deleted[1], N_deleted[0], N_deleted[1]);
 
-		if (pc.N_changed == 0 && N_deleted[0] == 0 && N_deleted[1] == 0) break;
-		pc.N_changed = N_deleted[0] = N_deleted[1] = 0;
+		if (pc->N_changed == 0 && N_deleted[0] == 0 && N_deleted[1] == 0) break;
+		pc->N_changed = N_deleted[0] = N_deleted[1] = 0;
 	}
 
-	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc.power_cost);
+	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc->power_cost);
 
 	print_time(opts, "power pruned (for %u null%s)",
-	           null_count, (null_count != 1) ? "s" : "");
+	           pc->null_links, (pc->null_links != 1) ? "s" : "");
 	if (verbosity_level(D_PRUNE))
 	{
 		prt_error("\n\\");
 		prt_error("Debug: After power_pruning (for %u null%s, sent->null_count %u):\n\\",
-		          null_count, (null_count != 1) ? "s" : "", pc.sent->null_count);
+		          pc->null_links, (pc->null_links != 1) ? "s" : "", pc->sent->null_count);
 		print_disjunct_counts(sent);
 	}
 
@@ -1340,12 +1334,18 @@ void pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
                         unsigned int null_count, Parse_Options opts,
                         unsigned int *ncu[2])
 {
+	prune_context pc = {0};
 	power_table pt;
+
 	power_table_init(sent, ts, &pt);
 
-	power_prune(sent, &pt, null_count, opts);
+	pc.sent = sent;
+	pc.pt = &pt;
+	pc.null_links = null_count;
+
+	power_prune(sent, &pc, opts);
 	if (pp_prune(sent, ts, opts) > 0)
-		power_prune(sent, &pt, null_count, opts);
+		power_prune(sent, &pc, opts);
 
 	/* No benefit for now to make additional pp_prune() & power_prune() -
 	 * additional deletions are very rare and even then most of the

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -75,13 +75,14 @@ struct multiset_table_s
 typedef struct prune_context_s prune_context;
 struct prune_context_s
 {
-	unsigned int null_links; /* Maximum number of null links. */
-	int power_cost;
-	int N_changed;   /* counts the number of changes
-						   of c->nearest_word fields in a pass */
-	int pass_number;
+	unsigned int null_links; /* maximum number of null links */
+	int pass_number; /* mark tracons for processing only once per pass */
+	int N_changed;   /* counts the changes of c->nearest_word fields in a pass */
+
 	power_table *pt;
 	Sentence sent;
+
+	int power_cost;  /* for debug - shown in the verbose output */
 };
 
 /*

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -727,7 +727,7 @@ static bool is_bad(Connector *c)
  *  tracon_id field.
  */
 static int power_prune(Sentence sent, power_table *pt,
-                       int null_count, Parse_Options opts)
+                       unsigned int null_count, Parse_Options opts)
 {
 	prune_context pc;
 	int N_deleted[2] = {0}; /* [0] counts first deletions, [1] counts dups. */
@@ -824,13 +824,13 @@ static int power_prune(Sentence sent, power_table *pt,
 
 	lgdebug(D_PRUNE, "Debug: power prune cost: %d\n", pc.power_cost);
 
-	print_time(opts, "power pruned (for %d null%s)",
+	print_time(opts, "power pruned (for %u null%s)",
 	           null_count, (null_count != 1) ? "s" : "");
 	if (verbosity_level(D_PRUNE))
 	{
 		prt_error("\n\\");
-		prt_error("Debug: After power_pruning (null_count=%d):\n\\",
-		          opts->min_null_count);
+		prt_error("Debug: After power_pruning (for %u null%s, sent->null_count %u):\n\\",
+		          null_count, (null_count != 1) ? "s" : "", pc.sent->null_count);
 		print_disjunct_counts(sent);
 	}
 

--- a/link-grammar/parse/prune.h
+++ b/link-grammar/parse/prune.h
@@ -17,7 +17,7 @@
 #include "link-includes.h"
 
 void       pp_and_power_prune(Sentence, Tracon_sharing *,  unsigned int,
-                              Parse_Options, unsigned int *[]);
+                              Parse_Options, unsigned int *[2]);
 bool       optional_gap_collapse(Sentence, int, int);
 
 #endif /* _PRUNE_H */

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -1325,7 +1325,7 @@ char * linkage_print_constituent_tree(Linkage linkage, ConstituentDisplayStyle m
 	{
 		return print_flat_constituents(linkage);
 	}
-	prt_error("Warning: Illegal mode %d for printing constituents\n"
+	prt_error("Warning: Illegal mode %u for printing constituents\n"
 	          "Allowed values: %d to %d\n", mode, NO_DISPLAY, MAX_STYLES);
 	return NULL;
 }

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -908,7 +908,7 @@ static void prune_irrelevant_rules(Postprocessor *pp)
 
 	if (verbosity_level(5))
 	{
-		err_msg(lg_Debug, "PP: Saw %zd unique link names in all linkages.\n\\",
+		err_msg(lg_Debug, "PP: Saw %zu unique link names in all linkages.\n\\",
 		       pp_linkset_population(pp->set_of_links_of_sentence));
 		err_msg(lg_Debug, "PP: Using %i 'contains one' rules "
 		                  "and %i 'contains none' rules\n",
@@ -1069,7 +1069,7 @@ static void report_pp_stats(Postprocessor *pp)
 	unused_cnt += report_unused_rule(kno->contains_none_rules);
 	unused_cnt += report_unused_rule(kno->bounded_rules);
 
-	err_msg(lg_Debug, "\nPP stats: %zd of %zd rules unused\n", unused_cnt, rule_cnt);
+	err_msg(lg_Debug, "\nPP stats: %zu of %zu rules unused\n", unused_cnt, rule_cnt);
 }
 
 /**

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -225,7 +225,7 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 	}
 	else
 	{
-		assert(false, "Unknown expression type %d", e->type);
+		assert(false, "Unknown expression type %d", (int)e->type);
 	}
 
 	/* c now points to the list of clauses */

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -563,7 +563,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			}
 
 			if (2*row+2 > max_height-1) {
-				lgdebug(+9, "Extending rows up to %d.\n", (2*row+2)+HEIGHT_INC);
+				lgdebug(+9, "Extending rows up to %u.\n", (2*row+2)+HEIGHT_INC);
 				diagram_alloc_tmpmem(&start, &picture, &xpicture,
 				                     &max_height, (2*row+2)+HEIGHT_INC,
 				                     max_bytes, num_cols);

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -451,7 +451,7 @@ static PER_GWORD_FUNC(gword_by_ordinal_position)
  */
 static PER_GWORD_FUNC(set_word_status)//(Sentence sent, Gword *w, int *arg)
 {
-	int status = *arg;
+	unsigned int status = *arg;
 	switch (status)
 	{
 		case WS_INDICT|WS_REGEX:
@@ -497,7 +497,7 @@ static PER_GWORD_FUNC(set_tokenization_step)
 	w->tokenizing_step = *arg;
 
 	lgdebug(+D_SW, "Word %s: status=%s tokenizing_step=%d\n",
-			  w->subword, gword_status(sent, w), w->tokenizing_step);
+			  w->subword, gword_status(sent, w), (int)w->tokenizing_step);
 
 	return NULL;
 }

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -93,7 +93,7 @@ GNUC_UNUSED const char *gword_morpheme(Sentence sent, const Gword *w)
 			break;
 		default:
 			/* No truncation is expected. */
-			snprintf(buff, sizeof(buff), "MT_%d", w->morpheme_type);
+			snprintf(buff, sizeof(buff), "MT_%d", (int)w->morpheme_type);
 			mt = string_set_add(buff, sent->string_set);
 	}
 

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -87,7 +87,7 @@ void tracon_set_reset(Tracon_set *ss)
 
 	ss->size = s_prime[ss->prime_idx];
 	ss->mod_func = prime_mod_func[ss->prime_idx];
-	memset(ss->table, 0, ss->size*sizeof(clist_slot));
+	memset(ss->table, 0, ss->size * sizeof(clist_slot));
 	ss->ocount = ss->count;
 	ss->count = 0;
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
@@ -101,7 +101,7 @@ Tracon_set *tracon_set_create(void)
 	ss->size = s_prime[ss->prime_idx];
 	ss->mod_func = prime_mod_func[ss->prime_idx];
 	ss->table = (clist_slot *) malloc(ss->size * sizeof(clist_slot));
-	memset(ss->table, 0, ss->size*sizeof(clist_slot));
+	memset(ss->table, 0, ss->size * sizeof(clist_slot));
 	ss->count = ss->ocount = 0;
 	ss->shallow = false;
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
@@ -114,7 +114,7 @@ Tracon_set *tracon_set_create(void)
  */
 static bool connector_equal(const Connector *c1, const Connector *c2)
 {
-	return c1->desc == c2->desc && (c1->multi == c2->multi);
+	return (c1->desc == c2->desc) && (c1->multi == c2->multi);
 }
 
 /** Return TRUE iff the tracon is exactly the same. */
@@ -141,8 +141,8 @@ static void prt_stat(void)
 #define PRT_STAT(...)
 #endif
 
-static bool place_found(const Connector *c, const clist_slot *slot, unsigned int hash,
-                         Tracon_set *ss)
+static bool place_found(const Connector *c, const clist_slot *slot,
+                        unsigned int hash, Tracon_set *ss)
 {
 	if (slot->clist == NULL) return true;
 	if (hash != slot->hash) return false;
@@ -155,7 +155,8 @@ static bool place_found(const Connector *c, const clist_slot *slot, unsigned int
  * lookup the given string in the table.  Return an index
  * to the place it is, or the place where it should be.
  */
-static unsigned int find_place(const Connector *c, unsigned int h, Tracon_set *ss)
+static unsigned int find_place(const Connector *c, unsigned int h,
+                               Tracon_set *ss)
 {
 	PRT_STAT(if (fp_count == 0) atexit(prt_stat); fp_count++;)
 	unsigned int coll_num = 0;

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -242,7 +242,7 @@ static const char *switch_value_string(const Switch *as)
 			break;
 		default:
 			/* Internal error. */
-			snprintf(buf, sizeof(buf), "Unknown type %d\n", as->param_type);
+			snprintf(buf, sizeof(buf), "Unknown type %d\n", (int)as->param_type);
 	}
 
 	return buf;
@@ -825,7 +825,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		else
 		{
 			prt_error("Error: Internal error: Unknown variable type %d\n",
-			          as[j].param_type);
+			          (int)as[j].param_type);
 			return -1;
 		}
 	}


### PR DESCRIPTION
I extracted these commits from my "aggressive power pruning" WIP (a big speedup), which is delayed because I have first to totally reimplement (yet again) the incremental connector encoding.

Fixes here:

"Cosmetic" changes:
- Formatting

Code/comment cleanup:
- Consistently use "unsigned int" for null count
- Fix all format signed/unsigned inconsistencies
- classic_parse(): Don't clamp number of parses here
- do_parse(): Remove the null_count argument
- prune_context_s(): Rearrange member order and improve comments
- disjunct-utils.c: Add/change comments
- pack_sentence_init(): Remove the now unneeded check (NULL != ts)
- Move prune_context allocation to pp_and_power_prune()
 This is needed for the upcoming changes in `pp_and power_prune().`

The unsigned/signed format consistency changes will enable using a stricter compile-time format check (planned for the upcoming "configure" changes).

Debug related:
- assert_same_disjunct(): Enable only on DEBUG_lisjuncts
- Sentence_split(): Add number of tokens in time printing
- pp_and_power_prune(): Add parameter array dimension
- power_prune(): Consolidate terminating debug messages

Bug fixes:
- classic_parse(): Fix setting pruning for linkage_ok=1
The current setting is wrong but it doesn't cause linkage loss in the current corpus batches.

Build stuff:
- link-grammar.def: Remove functions used only by the extinct corpus stuff

For an upcoming speedup:
- tests.py: Increase parse time for parse timer test
The current panic timer test uses a crafted sentence that originally had an "impossible large" parse time. However, with the "aggressive power pruning" WIP it takes less than 1 second to parse so the test fails...
In order that it will take significant time to parse I had to increase its length and use `short_length=255,disjunct_cost=10.0`.

