### PR TITLE
Remove count sharing

### DIFF
--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -38,14 +38,14 @@ struct Disjunct_struct
 	union
 	{
 		Disjunct *dup_table_next; /* Duplicate elimination | before pruning */
-		Disjunct *old;            /* Old disjuncts | before parsing */
+		Disjunct *unused1;        /* Unused now | before parsing */
 	}; /* 8 bytes */
 
 	/* Shared by different steps. For what | when. */
 	union
 	{
 		uint32_t dup_hash;        /* Duplicate elimination | before pruning */
-		uint32_t ordinal;         /* Old disjuncts | before and during parsing */
+		uint32_t unused2;         /* Unused now | before and during parsing */
 	}; /* 4 bytes */
 
 	struct
@@ -71,7 +71,7 @@ int right_connector_count(Disjunct *);
 Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int,
                                           bool);
 Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int,
-                                          Tracon_sharing *, bool);
+                                          bool);
 void free_tracon_sharing(Tracon_sharing *);
 void count_disjuncts_and_connectors(Sentence, unsigned int *, unsigned int *);
 


### PR DESCRIPTION
More and more bugs got found when implementing a more aggressive pruning
(no examples of problematic existing batch sentences in the latest release).
Fixing them increased the overhead and more bugs have discovered.
It seems that the idea is not sound.
It is also hard to understand and maintain.

Its speedup potential is limited (tens of percents), and it prevents
implementing changes that would increase speedup several times more than
that.

**So this idea is dropped until a full-proof way to do that is found.**

**EDIT**: The commit message has more details.

---
I found other ways to speed up parsing, and also to speed up parsing with nulls.
Some of them I already implemented (WIP) and intend to send PRs soon.