### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ There are many more papers and references listed on the
 
 See also the
 [C/C++ API documentation](https://www.abisource.com/projects/link-grammar/api/index.html).
-Bindings for other programming languages, including python, python3 and
+Bindings for other programming languages, including python3 and
 java, can be found in the [bindings directory](bindings).
 
 
@@ -311,13 +311,13 @@ the corresponding Python development packages are installed.
 
 These packages are:
 - Linux:
- * Systems using 'rpm' packages: Python2: python-devel; Python3: python3-devel
- * Systems using 'deb' packages: Python2: python-dev; Python3: python3-dev
+ * Systems using 'rpm' packages: python3-devel
+ * Systems using 'deb' packages: python3-dev
 - Windows:
- * Install Python2 and Python3 from https://www.python.org/downloads/windows/ .
+ * Install Python3 from https://www.python.org/downloads/windows/ .
    You also have to install SWIG from http://www.swig.org/download.html .
 - macOS:
- * Install the python and python3 packages using [HomeBrew](http://brew.sh/).
+ * Install python3 using [HomeBrew](http://brew.sh/).
 	Note: With recent Anaconda Python versions, the build process succeeds, but
 	loading the resulted module causes a crash.  Help is needed to resolve that.
 	See the relevant issues in the GitHub repository (search there for
@@ -327,14 +327,12 @@ These packages are:
 NOTE: Before issuing `configure` (see below) you have to validate that
 the required python versions can be invoked using your `PATH`.
 
-The use of the Python bindings is *OPTIONAL*; you do not need these if
-you do not plan to use link-grammar with python.  If you like
-to disable these bindings, use one of:
+The use of the Python bindings is *OPTIONAL*; you do not need these if you
+do not plan to use link-grammar with Python.  If you like to disable
+Python bindings, use:
 
 ```
 ./configure --disable-python-bindings
-./configure --enable-python-bindings=2
-./configure --enable-python-bindings=3
 ```
 
 The linkgrammar.py module provides a high-level interface in Python.
@@ -638,7 +636,7 @@ en/corpus-fixes.batch:     404 errors
 lt/corpus-basic.batch:      15 errors
 ru/corpus-basic.batch:      47 errors
 ```
-The bindings/python directory contains a unit test for the python
+The bindings/python directory contains a unit test for the Python
 bindings. It also performs several basic checks that stress the
 link-grammar libraries.
 

--- a/README.md
+++ b/README.md
@@ -318,8 +318,11 @@ These packages are:
    You also have to install SWIG from http://www.swig.org/download.html .
 - macOS:
  * Install the python and python3 packages using [HomeBrew](http://brew.sh/).
-   Alternatively, install
-[Anaconda](https://conda.io/docs/user-guide/install/download.html).
+	Note: With recent Anaconda Python versions, the build process succeeds, but
+	loading the resulted module causes a crash.  Help is needed to resolve that.
+	See the relevant issues in the GitHub repository (search there for
+	"anaconda").<br>
+	[Anaconda](https://conda.io/docs/user-guide/install/download.html).
 
 NOTE: Before issuing `configure` (see below) you have to validate that
 the required python versions can be invoked using your `PATH`.

--- a/debug/README.md
+++ b/debug/README.md
@@ -86,6 +86,13 @@ following can be done:
 
 `link-parser -test=auto-next-linkage`
 
+`link-parser` warns when tests are enabled. This way it is possible to see in
+the linkage output which tests were enabled. This is particularly important
+when examining output files. However, when doing benchmarks (with and w/o
+tests) this is not desired because these warnings skew the timing.
+If needed, suppress this warnings with the added special tests `@`, as in:
+`-test=@,one-step-parse`.
+
 Useful examples
 ---------------
 

--- a/debug/README.md
+++ b/debug/README.md
@@ -29,13 +29,16 @@ binding.
 1: This is the library default. This is also the default for
 `link-parser`.
 
-2: Display parsing steps time. In case an error/warning gets issued by the library,
-this may help finding out at which step it happened.
+2: Display parsing steps time. In case an error/warning gets issued by the
+library, this may help finding out at which step it happened.
 
-3: Display data file search and locale setup. It can be used to debug
+3: Display some more Info messages:
+- Freeing dictionaries.
+- Number of insane-morphism linkages.
+- A warning when all the linkages have a PP violation.
+
+4: Display data file search and locale setup. It can be used to debug
 problems with the locale setup or in finding the dictionary.
-
-4: Not in use for now.
 
 5-9: Show trace and debug messages regarding sentence handling. Higher
 levels include the messages of the lower ones.
@@ -48,12 +51,14 @@ messages of the lower ones.
 
 100-...: Show only messages exactly at the specified level.
 * 101: Print all the connectors, along with their length limit.
-       A length limit of 0 means the value of the short\_length option is used.
+       A length limit of 0 means the value of the `short_length` option is
+       used.
 
 * 102: Print all disjuncts before pruning.
 
 * 103: Show unsubscripted dictionary words and subscripted ones which share
        the same base word.
+
 * 104: Memory pool statistics.
 
 ### 2) -debug=LOCATIONS (-de=LOCATIONS)
@@ -143,8 +148,8 @@ sed '/^*/d;/^!const/d;/^!batch/d' data/en/corpus-basic.batch | \
 link-parser -test=auto-next-linkage
 ```
 
-(If you cut&paste it to a terminal, remember to escape each of the "**!**" characters
-with a backslash.)
+(If you cut&paste it to a terminal, remember to escape each of the "**!**"
+characters with a backslash.)
 
 This, along with "diff", "grep" etc., can be used in order to validate
 that a change didn't cause undesired effects. Special care should be taken
@@ -157,16 +162,12 @@ classic-parser linkages). In that case the detailed linkages results need
 to be filtered through a script which sorts them according to some
 "canonical order" and also removes duplicates.
 
-4) Display the wordgraph (`!wordgraph=N`) using additional wordgraph-display
-flags:
-
-To use this feature, the library needs to be compiled with
-`--enable-wordgraph-display` (this is done by default).
-
-`link-parser -test=wg:FLAGS`
+4) Display the wordgraph using `-wordgraph=N`, optionally using additional
+wordgraph-display flags with `-test=wg:FLAGS`.
 
 For more examples of how to use the wordgraph-display, see
-[link-grammar/tokenize/README.md](/link-grammar/tokenize/README.md#word-graph-display)
+[link-grammar/tokenize/README.md]
+(/link-grammar/tokenize/README.md#word-graph-display)
 and [msvc/README.md](/msvc/README.md).
 
 5) Test the "trailing connector" hashing for short sentences too (e.g. for
@@ -176,9 +177,9 @@ Or optionally (in order to see relevant debug messages from `preparation.c`):
 `link-parser test=len-trailing-hash:10 -v=5 -debug=preparation.c`
 
 6) -test=<values> for SAT parser debugging:
-linkage-disconnected - Display also solutions which don't have a full linkage.
-sat-stats - Display the number of PP-violations and disconected linkages.
-no-pp_pruning_1 - Disable a partial CONTAINS_NONE_RULES pruning
+`linkage-disconnected` - Display also solutions which don't have a full linkage.
+`sat-stats` - Display the number of PP-violations and disconnected linkages.
+`no-pp_pruning_1` - Disable a partial CONTAINS_NONE_RULES pruning
 
 Debugging and STDIO streams
 ---------------------------
@@ -195,32 +196,48 @@ which messages are printed to `stderr` (see
 "Improved error notification facility"->"C API" in
 [link-grammar/README.md](/link-grammar/README.md)).
 
-Note that when debugging errors during a sentence batch run, it may be useful to
-redirect also `stderr` to the same file (the error facility of the library
+Note that when debugging errors during a sentence batch run, it may be useful
+to redirect also `stderr` to the same file (the error facility of the library
 flushes `stdout` before printing in order to preserve output order).
 
-Configuring for debug
----------------------
-Use:
+Using debugger
+--------------
 
-`configure --enable-debug --enable-wordgraph-display`
+### Configuring for debug
 
-For SAT solver debug:
-`make -DSAT\_DEBUG`
+`configure --enable-debug`
 
-### --enable-debug
-Its sets te DEBUG definitions and removes the optimization flags of the
+Its sets the DEBUG definitions and removes the optimization flags of the
 compiler. The DEBUG definition adds various validity checks, test
 messages, and some debug functions (that can be invoked, for example, from
 the debugger).
 
-### --enable-wordgraph-display
-If something goes wrong, it is often useful to display the wordgraph.
-The wordgraph display function can be invoked from `gdb` using:
 
-`call wordgraph\_show(sent, "")`
+| `gdb` command | Description |
+|---------------|-------------|
+| <pre>call wordgraph_show(sent, "") | If something goes wrong, it is may be useful to display the wordgraph. The second argument can include wordgraph display options.|
+| <pre>call print_all_disjuncts(sent) | Print the disjuncts. |
 
-supposing that "sent" is available (the stack can be rolled down for
-that using the "down" or "frame" `gdb` commands).
 
-The second argument can include wordgraph display options.
+FIXME: Document more debug functions.
+
+Compilation definitions
+-----------------------
+Some debug-related compilation flags can be set using `configure`, to as `make`
+arguments:
+
+| Definition | Description |
+| ---------- |-------------|
+| `NO_SAN_DICT` | Don't use ASAN/UBSAN for dict reading. This cause a vast startup speedup when using ASAN/UBSAN. It is optional because it shouldn't normally be used when debugging the dictionary code. |
+|`POOL_ALLOCATOR=0` | Pool allocator debug facility: A fake pool allocator that uses `malloc()` for each allocation is defined, in order that ASAN or valgrind can be used to find memory usage bugs. |
+|`TRACON_SET_DEBUG` | Print tracon_set stats. |
+|`DEBUG_PP_PRUNE` | PP pruning debug printout. |
+|`DEBUG_TABLE_STAT`| print count table stats. |
+|`DO_COUNT_TRACE` | Detailed trace of do_count. |
+|`DEBUG_X_TABLE` | Print x_table stats. |
+
+### Specific SAT-parser debug
+| Definition | Description |
+| ---------- |-------------|
+| `CONNECTIVITY_DEBUG` |  Debug SAT connectivity . |
+| `SAT_DEBUG`, `VARS` | Debug variables. |

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -862,7 +862,7 @@ open_error:
 		}
 
 		if (!copts->batch_mode) batch_in_progress = false;
-		if ('\0' != test[0])
+		if ('\0' != test[0] && !test_enabled(test, "@"))
 		{
 			/* In batch mode warn only once.
 			 * In auto-next-linkage mode don't warn at all. */


### PR DESCRIPTION
1. In case someone would like to help in the LG library development, here is an update of the debug read readme.
2. In the main readme:
- An update on the problem with Anaconda on Mac.
- Remove most references to python2.
3. In the same occasion add a pseudo-test `@` to suppress the test warning message, in order to prevent the need to comment out this message in `link-parser.c` when running benchmarks on features that are enabled by `-test=`. 