### PR TITLE
Farthest word

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -101,9 +101,16 @@ typedef struct
  * Lets try to keep it that way. */
 struct Connector_struct
 {
-	uint8_t length_limit; /* Can be different than in the descriptor */
-	uint8_t nearest_word;
-	                      /* The nearest word to my left (or right) that
+	union
+	{
+		uint8_t farthest_word;/* The farthest word to my left (or right)
+		                         that this could ever connect to. Computed
+		                         from length_limit by setup_connectors(). */
+		uint8_t length_limit; /* Same purpose as above but relative to the
+		                         current word. This is how it is initially
+		                         set. */
+	};
+	uint8_t nearest_word; /* The nearest word to my left (or right) that
 	                         this could ever connect to.  Initialized by
 	                         setup_connectors(). Final value is found in
 	                         the power pruning. */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -659,6 +659,26 @@ static Count_bin do_count(
 		return t->count;
 	}
 
+	/* The word range (lw, rw) gets split in all tentatively possible ways
+	 * to LHS term and RHS term.
+	 * There can be a total count > 0 only if one of the following
+	 * multiplications results in a value > 0. This in turn is possible
+	 * only if both multiplication terms > 0:
+	 *    LHS term    RHS term
+	 * 1. leftcount x rightcount
+	 * 2. leftcount x l_bnr
+	 * 3. r_bnl     x rightcount
+	 *
+	 * In addition:
+	 * - leftcount > 0   is possible only if there is match_left.
+	 * - rightcount > 0  is possible only if there is match_right.
+	 * - r_bnl > 0       is possible only if le==NULL.
+	 *
+	 * Since the result count is a sum of multiplications of the LHS and
+	 * RHS counts, if one of them is zero, we can skip calculating the
+	 * other one.
+	 */
+
 	if (le == NULL)
 	{
 		start_word = lw+1;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -685,6 +685,7 @@ static Count_bin do_count(
 	}
 	else
 	{
+		/* The following cannot be optimized like end_word due to l_bnr. */
 		start_word = le->nearest_word;
 	}
 
@@ -694,7 +695,13 @@ static Count_bin do_count(
 	}
 	else
 	{
-		end_word = re->nearest_word +1;
+		/* If the LHS count for a word would be zero for a left connector
+		 * due to the distance of this word, we can skip its handling
+		 * entirely. So the checked word interval can be shortened. */
+		if ((le != NULL) && (re->nearest_word > le->farthest_word))
+			end_word = le->farthest_word + 1;
+		else
+			end_word = re->nearest_word + 1;
 	}
 
 	total = zero;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -681,7 +681,8 @@ static Count_bin do_count(
 
 	if (le == NULL)
 	{
-		start_word = lw+1;
+		/* No leftcount, and no rightcount for (w < re->farthest_word). */
+		start_word = MAX(lw+1, re->farthest_word);
 	}
 	else
 	{
@@ -691,7 +692,8 @@ static Count_bin do_count(
 
 	if (re == NULL)
 	{
-		end_word = rw;
+		/* No rightcount, and no leftcount for (w > le->farthest_word). */
+		end_word = MIN(rw, le->farthest_word+1);
 	}
 	else
 	{

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -443,7 +443,10 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 	}
 	else
 	{
-		end_word = re->nearest_word + 1;
+		if ((le != NULL) && (re->nearest_word > le->farthest_word))
+			end_word = le->farthest_word + 1;
+		else
+			end_word = re->nearest_word + 1;
 	}
 
 	/* This condition can never be true here. It is included so GCC

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -430,7 +430,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 
 	if (le == NULL)
 	{
-		start_word = lw + 1;
+		start_word = MAX(lw+1, re->farthest_word);
 	}
 	else
 	{
@@ -439,7 +439,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 
 	if (re == NULL)
 	{
-		end_word = rw;
+		end_word = MIN(rw, le->farthest_word+1);
 	}
 	else
 	{

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -564,17 +564,16 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	gc.same_alternative = false;
 
 	/* Get the lists of candidate matching disjuncts of word w for lc and
-	 * rc.  Consider each of these lists only if the length_limit of lc
-	 * rc and also w, is not greater then the distance between their word
-	 * and the word w. */
-	if ((lc != NULL) && ((w - lw) <= lc->length_limit))
+	 * rc. Consider each of these lists only if the farthest_word of lc/rc
+	 * reaches at least the word w. */
+	if ((lc != NULL) && (w <= lc->farthest_word))
 	{
 		ml = *get_match_table_entry(ctxt->l_table_size[w], ctxt->l_table[w], lc, 0);
 	}
 	if ((lc != NULL) && (ml == NULL)) /* lc optimization */
 		return terminate_match_list(ctxt, -1, front, w, lc, lw, rc, rw);
 
-	if ((rc != NULL) && ((rw - w) <= rc->length_limit))
+	if ((rc != NULL) && (w >= rc->farthest_word))
 	{
 		mr = *get_match_table_entry(ctxt->r_table_size[w], ctxt->r_table[w], rc, 1);
 	}
@@ -602,7 +601,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	for (mx = ml; mx != NULL; mx = mx->next)
 	{
 		if (mx->d->left->nearest_word < lw) break;
-		if ((w - lw) > mx->d->left->length_limit) continue;
+		if (lw < mx->d->left->farthest_word) continue;
 
 		mx->d->match_left = do_match_with_cache(mx->d->left, lc, &mc) &&
 		                    alt_connection_possible(mx->d->left, lc, &gc);
@@ -627,7 +626,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	gc.gword = NULL;
 	for (mx = mr; mx != mr_end; mx = mx->next)
 	{
-		if ((rw - w) > mx->d->right->length_limit) continue;
+		if (rw > mx->d->right->farthest_word) continue;
 
 		if ((lc != NULL) && !mx->d->match_left) continue; /* lc optimization */
 		mx->d->match_right = do_match_with_cache(mx->d->right, rc, &mc) &&

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -565,8 +565,10 @@ form_match_list(fast_matcher_t *ctxt, int w,
 
 	/* Get the lists of candidate matching disjuncts of word w for lc and
 	 * rc. Consider each of these lists only if the farthest_word of lc/rc
-	 * reaches at least the word w. */
-	if ((lc != NULL) && (w <= lc->farthest_word))
+	 * reaches at least the word w.
+	 * Note: The commented out (w <= lc->farthest_word) is checked at the
+	 * callers and is left here for documentation. */
+	if ((lc != NULL) /* && (w <= lc->farthest_word) */)
 	{
 		ml = *get_match_table_entry(ctxt->l_table_size[w], ctxt->l_table[w], lc, 0);
 	}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -29,16 +29,22 @@
 
 /**
  * Set c->nearest_word to the nearest word that this connector could
- * possibly connect to.  The connector *might*, in the end,
- * connect to something more distant, but this is the nearest
- * one that could be connected.
+ * possibly connect to.
+ * The connector *might*, in the end, connect to something more distant,
+ * but this is the nearest one that could be connected.
+ * Also recalculate length_limit to be the farthest word number that could
+ * be connected.
  */
-static int set_dist_fields(Connector * c, size_t w, int delta)
+static int set_dist_fields(Connector * c, size_t w, int delta, int sent_len)
 {
 	int i;
 	if (c == NULL) return (int) w;
-	i = set_dist_fields(c->next, w, delta) + delta;
+	i = set_dist_fields(c->next, w, delta, sent_len) + delta;
 	c->nearest_word = i;
+	int farthest_word = w + (delta * c->length_limit);
+	if (farthest_word < 0) farthest_word = 0;
+	if (farthest_word >= sent_len) farthest_word = sent_len - 1;
+	c->farthest_word = farthest_word;
 	return i;
 }
 
@@ -58,8 +64,9 @@ static void setup_connectors(Sentence sent)
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = xd)
 		{
 			xd = d->next;
-			if ((set_dist_fields(d->left, w, -1) < 0) ||
-			    (set_dist_fields(d->right, w, 1) >= (int) sent->length))
+			if ((set_dist_fields(d->left, w, -1, (int) sent->length) < 0) ||
+			    (set_dist_fields(d->right, w, 1, (int) sent->length) >=
+			     (int) sent->length))
 			{
 				; /* Skip this disjunct. */
 			}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -35,15 +35,15 @@
  * Also recalculate length_limit to be the farthest word number that could
  * be connected.
  */
-static int set_dist_fields(Connector * c, size_t w, int delta, int sent_len)
+static int set_dist_fields(Connector * c, size_t w, int delta, int w_clamp)
 {
 	int i;
 	if (c == NULL) return (int) w;
-	i = set_dist_fields(c->next, w, delta, sent_len) + delta;
+	i = set_dist_fields(c->next, w, delta, w_clamp) + delta;
 	c->nearest_word = i;
 	int farthest_word = w + (delta * c->length_limit);
-	if (farthest_word < 0) farthest_word = 0;
-	if (farthest_word >= sent_len) farthest_word = sent_len - 1;
+	/* Clamp it to the range [0, sent_length). */
+	if (delta * farthest_word > w_clamp) farthest_word = w_clamp;
 	c->farthest_word = farthest_word;
 	return i;
 }
@@ -64,8 +64,8 @@ static void setup_connectors(Sentence sent)
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = xd)
 		{
 			xd = d->next;
-			if ((set_dist_fields(d->left, w, -1, (int) sent->length) < 0) ||
-			    (set_dist_fields(d->right, w, 1, (int) sent->length) >=
+			if ((set_dist_fields(d->left, w, -1, 0) < 0) ||
+			    (set_dist_fields(d->right, w, 1, (int)(sent->length-1)) >=
 			     (int) sent->length))
 			{
 				; /* Skip this disjunct. */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -504,7 +504,7 @@ static bool possible_connection(prune_context *pc,
 		if ((lc->next != NULL) || (rc->next != NULL)) return false;
 	}
 	else
-	if (dist > lc->length_limit || dist > rc->length_limit)
+	if (rword > lc->farthest_word || lword < rc->farthest_word)
 	{
 		return false;
 	}
@@ -611,8 +611,7 @@ left_connector_list_update(prune_context *pc, Connector *c,
 	if (((int) c->nearest_word) < n) n = c->nearest_word;
 
 	/* lb is now the leftmost word we need to check */
-	lb = w - c->length_limit;
-	if (0 > lb) lb = 0;
+	lb = c->farthest_word;
 
 	/* n is now the rightmost word we need to check */
 	for (; n >= lb ; n--)
@@ -656,8 +655,7 @@ right_connector_list_update(prune_context *pc, Connector *c,
 	if (c->nearest_word > n) n = c->nearest_word;
 
 	/* ub is now the rightmost word we need to check */
-	ub = w + c->length_limit;
-	if (ub >= sent_length) ub = sent_length - 1;
+	ub = c->farthest_word;
 
 	/* n is now the leftmost word we need to check */
 	for (; n <= ub ; n++)


### PR DESCRIPTION
Changes here:
- Add comments on the linkage count optimization.
- Convert `length_limit`to word number (`farthest_word`).
- Optimize `start_word`/`end_word`.

Benchmark results on the various batches (speedup multiplier):
`en/basic`/`en/fixes`: ~-1%
`ru`: ~+2%
`en/fix-long`: ~+10%
`en/failures`: ~+18%

The slowness for `en/basic`/`en/fixes` is unfortunate. However, old WIPs contain trimming of `length_limit` (now `farthest_word`) in `power_prune()` and elsewhere, and it is slightly more deficient to trim  `farthest_word` than `length_limit` so hopefully this will get improved when these WIPs are converted to PRs.