### PR TITLE
Test verbosity

### DIFF
--- a/bindings/python-examples/lg_testutils.py
+++ b/bindings/python-examples/lg_testutils.py
@@ -82,9 +82,9 @@ def add_test_option(original_class, test='', debug='', verbosity=0):
         def __init__(self, *args, **kwargs):
             super(ParseOptions_testing, self).__init__(*args, **kwargs)
             if test:
-                self.test=test
+                self.test = test
             if debug:
-                self.debug=debug
+                self.debug = debug
             if verbosity:
-                self.verbosity=verbosity
+                self.verbosity = verbosity
     return ParseOptions_testing

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1097,7 +1097,7 @@ class ZRULangTestCase(unittest.TestCase):
              'облачк.=', '=а.ndnpi',
              '.', 'RIGHT-WALL'])
 
-def linkage_testfile(self, lgdict, popt, desc = ''):
+def linkage_testfile(self, lgdict, popt, desc=''):
     """
     Reads sentences and their corresponding
     linkage diagrams / constituent printings.

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1148,6 +1148,8 @@ def linkage_testfile(self, lgdict, popt, desc = ''):
             diagram = ""
             constituents = ""
             wordpos = ""
+            if popt.verbosity > 1:
+                print('Sentence:', sent)
             linkages = Sentence(sent, lgdict, popt).parse()
             linkage = next(linkages, None)
 

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -675,7 +675,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
     # -- word is/isn't split by suffix splitter
     # -- the one that is in the dict is not the grammatically appropriate word.
     #
-    # Let's is NOT split into two! Its in the dict as one word, lower-case only.
+    # Let's is NOT split into two! It's in the dict as one word, lower-case only.
     def test_f_captilization(self):
         self.assertEqual(list(self.parse_sent('Let\'s eat.')[0].words()),
              ['LEFT-WALL', 'let\'s', 'eat.v', '.', 'RIGHT-WALL'])
@@ -1246,7 +1246,7 @@ class divert_start(object):
 lg_testutils.add_eqcost_linkage_order(Sentence)
 
 # For testing development branches, it may be sometimes useful to use the
-# "test", "debug" and "verbosity" options. The following allows specify them
+# "test", "debug" and "verbosity" options. The following allows to specify them
 # as "tests.py" arguments, interleaved with standard "unittest" arguments.
 
 for i,arg in enumerate(sys.argv):


### PR DESCRIPTION
For some time `tests.py` can be invoked with `[-verbosity=x] [-debug=x] [-test=x]` which set the corresponding parse options and are valuable for debugging (usually with a single test_name argument).

When using with a `*.txt` test file, it is not clear which debug output results from which sentence.
E.g. when this is used:
```
tests.py -verbosity=2 -test=len-multi-pruning:0 IWordPositionTestCase.test_en_word_positions
```

In this PR:
- Add sentence echoing (similar to the `-echo` option of `link-parser`) on -verbosity=2 or more
when processing `*.txt` files. This fix helped me to locate a problem in a WIP.
- In the same occasion 2 cosmetic commits: whitespace and typos.
