### PR TITLE
Reduce timer check rate

### DIFF
--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -151,9 +151,18 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	{
 		sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d);
 
+#if 0
+		/* eliminate_duplicate_disjuncts() is now very efficient and doesn't
+		 * take significant time even for millions of disjuncts. If a very
+		 * large number of disjuncts per word or very large number of words
+		 * per sentence will ever be a problem, then a "checktimer" TLS
+		 * counter can be used there. Old comment and code are retained
+		 * below for documentation. */
+
 		/* Some long Russian sentences can really blow up, here. */
 		if (resources_exhausted(opts->resources))
 			return;
+#endif
 	}
 	print_time(opts, "Eliminated duplicate disjuncts");
 

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -1156,6 +1156,8 @@ void post_process_lkgs(Sentence sent, Parse_Options opts)
 		return;
 	}
 
+#define TCD 512 /* timer checking divisor */
+
 	/* (optional) First pass: just visit the linkages */
 	/* The purpose of the first pass is to make the post-processing
 	 * more efficient.  Because (hopefully) by the time the real work
@@ -1173,7 +1175,7 @@ void post_process_lkgs(Sentence sent, Parse_Options opts)
 
 			post_process_scan_linkage(pp, lkg);
 
-			if ((63 == in%64) && resources_exhausted(opts->resources)) break;
+			if (((TCD-1) == in%TCD) && resources_exhausted(opts->resources)) break;
 		}
 	}
 
@@ -1200,7 +1202,7 @@ void post_process_lkgs(Sentence sent, Parse_Options opts)
 		N_linkages_post_processed++;
 
 		linkage_score(lkg, opts);
-		if ((15 == in%16) && resources_exhausted(opts->resources)) break;
+		if (((TCD-1) == in%TCD) && resources_exhausted(opts->resources)) break;
 	}
 
 	/* If the timer expired, then we never finished post-processing.

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -142,15 +142,18 @@ bool resources_memory_exhausted(Resources r)
 #define RES_COL_WIDTH 40
 
 /** print out the cpu ticks since this was last called */
-static void resources_print_time(int verbosity_opt, Resources r, const char * s)
+GNUC_PRINTF(2,0)
+static void resources_print_time(Resources r, const char *fmt, va_list args)
 {
 	double now;
 	now = current_usage_time();
-	if (verbosity_opt >= D_USER_TIMES)
-	{
-		prt_error("++++ %-*s %7.2f seconds\n",
-		          RES_COL_WIDTH, s, now - r->when_last_called);
-	}
+
+	char s[128] = "";
+	vsnprintf(s, sizeof(s), fmt, args);
+
+	prt_error("++++ %-*s %7.2f seconds\n",
+	          RES_COL_WIDTH, s, now - r->when_last_called);
+
 	r->when_last_called = now;
 }
 
@@ -179,18 +182,12 @@ static void resources_print_total_space(int verbosity_opt, Resources r)
 
 void print_time(Parse_Options opts, const char *fmt, ...)
 {
-	char s[128] = "";
+	if (verbosity < D_USER_TIMES) return;
+	va_list args;
 
-	if (opts->verbosity >= D_USER_TIMES)
-	{
-		va_list args;
-
-		va_start(args, fmt);
-		vsnprintf(s, sizeof(s), fmt, args);
-		va_end(args);
-	}
-
-	resources_print_time(opts->verbosity, opts->resources, s);
+	va_start(args, fmt);
+	resources_print_time(opts->resources, fmt, args);
+	va_end(args);
 }
 
 void parse_options_print_total_time(Parse_Options opts)

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -104,6 +104,15 @@ void resources_reset_space(Resources r)
 
 bool resources_exhausted(Resources r)
 {
+	if (r->timer_expired) return true;
+	if (resources_timer_expired(r)) r->timer_expired = true;
+
+	return r->timer_expired;
+}
+
+#if 0 /* max_memory is not being set any more. */
+bool resources_exhausted(Resources r)
+{
 	if (r->timer_expired || r->memory_exhausted)
 		return true;
 
@@ -115,6 +124,7 @@ bool resources_exhausted(Resources r)
 
 	return (r->timer_expired || r->memory_exhausted);
 }
+#endif
 
 bool resources_timer_expired(Resources r)
 {


### PR DESCRIPTION
This PR is per issue #1020.

The batch benchmark shows speedup of 2-3% for short `en` sentences,
and negligible saving for `ru` and long `en` sentences.

I didn't have a workload (dict + corpus) in which the system time is anything significant to begin with, so I don't know how much the saving is in such a case.