### PR TITLE
Keep and reuse a full size connector table

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -106,7 +106,7 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 		shift = 12;
 	}
 
-	/* Clamp at max 4*(1<<24) == 64 MBytes */
+	/* Clamp at max 8*(1<<24) == 128 MBytes on 64 bit systems. */
 	if (24 < shift) shift = 24;
 	lgdebug(+5, "Connector table size (1<<%u)*%zu\n", shift, sizeof(Table_connector));
 	ctxt->table_size = (1U << shift);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -124,6 +124,10 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 	{
 		if (MAX_LOG2_TABLE_SIZE == shift)
 		{
+			/* The maximum size table has just been allocated. Arrange for
+			 * keeping it allocated until existing, so it can be reused. This
+			 * avoids a big overhead of malloc/free of large memory blocks on
+			 * systems that use mmap/munmap for that (like Linux). */
 			kept_table = ctxt->table;
 			ctxt->keep_table = true;
 			atexit(free_kept_table);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -106,8 +106,9 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 		shift = 12;
 	}
 
-	/* Clamp at max 8*(1<<24) == 128 MBytes on 64 bit systems. */
-	if (24 < shift) shift = 24;
+#define MAX_LOG2_TABLE_SIZE 24
+	/* Clamp at max 8*(1<<MAX_LOG2_TABLE_SIZE)==128 MBytes on 64 bit systems. */
+	if (MAX_LOG2_TABLE_SIZE < shift) shift = MAX_LOG2_TABLE_SIZE;
 	lgdebug(+5, "Connector table size (1<<%u)*%zu\n", shift, sizeof(Table_connector));
 	ctxt->table_size = (1U << shift);
 	/* ctxt->log2_table_size = shift; */
@@ -121,7 +122,7 @@ static void init_table(count_context_t *ctxt, size_t sent_len)
 	}
 	else
 	{
-		if (shift == 24)
+		if (MAX_LOG2_TABLE_SIZE == shift)
 		{
 			kept_table = ctxt->table;
 			ctxt->keep_table = true;


### PR DESCRIPTION
This saves a significant system time on Linux (at least) for long  sentences due to saving of `mmap()`/`munmap()` system calls.
    
See issue #1020 and the discussion at PR #1022.

The patch can be simplified by putting the `static TLS` variable at the file level (instead of function level). I don't know what is cleaner.
