### PR TITLE
Extended power prune, part 1

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -54,7 +54,7 @@ messages of the lower ones.
        A length limit of 0 means the value of the `short_length` option is
        used.
 
-* 102: Print all disjuncts before pruning.
+* 102: Print all disjuncts before and after pruning.
 
 * 103: Show unsubscripted dictionary words and subscripted ones which share
        the same base word.

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -183,6 +183,18 @@ static inline bool connector_uc_eq(const Connector *c1, const Connector *c2)
 	return (connector_uc_num(c1) == connector_uc_num(c2));
 }
 
+/*
+ * Return the deepest connector in the connector chain starting with \p c.
+ * @param c Any connector
+ * @return The deepest connector (can be modified if needed).
+ */
+static inline Connector *deepest_connector(const Connector *c)
+{
+	for (; c->next != NULL; c = c->next)
+		;
+	return (Connector *)c; /* Note: Constness removed. */
+}
+
 /* Length-limits for how far connectors can reach out. */
 #define UNLIMITED_LEN 255
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -114,6 +114,7 @@ struct Connector_struct
 	                         this could ever connect to.  Initialized by
 	                         setup_connectors(). Final value is found in
 	                         the power pruning. */
+	uint8_t prune_pass;   /* Prune pass number (one bit could be enough) */
 	bool multi;           /* TRUE if this is a multi-connector */
 	int tracon_id;        /* Tracon identifier (see disjunct-utils.c) */
 	const condesc_t *desc;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -1050,6 +1050,12 @@ Tracon_sharing *pack_sentence_for_parsing(Sentence sent, unsigned int dcnt,
 
 	Tracon_sharing *ts = pack_sentence(sent, dcnt, ccnt, false, keep_disjuncts);
 
+	if (verbosity_level(D_SPEC+2))
+	{
+		printf("pack_sentence_for_parsing (null_count %u):\n", sent->null_count);
+		print_all_disjuncts(sent);
+	}
+
 	if (NULL == ts->csid[0])
 	{
 		lgdebug(D_DISJ, "Debug: Encode for parsing (len %zu): None\n",

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -755,7 +755,6 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 			{
 				/* Initialize for the pruning step when no sharing is done yet. */
 				newc->refcount = 1;  /* No sharing yet. */
-				newc->tracon_id = 0; /* Used in power_prune() for pass number. */
 				if (NULL != tl)
 					tl->num_cnctrs_per_word[dir][w]++;
 			}

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -174,5 +174,9 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 
 	setup_connectors(sent);
 
-	if (verbosity_level(D_SPEC+2)) print_all_disjuncts(sent);
+	if (verbosity_level(D_SPEC+2))
+	{
+		printf("prepare_to_parse:\n");
+		print_all_disjuncts(sent);
+	}
 }

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -540,13 +540,15 @@ static bool possible_connection(prune_context *pc,
                                 Connector *lc, Connector *rc,
                                 int lword, int rword)
 {
-	int dist;
+	int dist = rword - lword;
+#ifdef DEBUG
+	assert(0 < dist, "Bad word order in possible connection.");
+#endif
+
 	if (!lc_easy_match(lc->desc, rc->desc)) return false;
 
 	if ((lc->nearest_word > rword) || (rc->nearest_word < lword)) return false;
 
-	dist = rword - lword;
-	// assert(0 < dist, "Bad word order in possible connection.");
 
 	/* Word range constraints */
 	if (1 == dist)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -689,7 +689,7 @@ static bool possible_connection(prune_context *pc,
 
 	if (!lc_easy_match(lc->desc, rc->desc)) return false;
 
-	/* Word range constraints */
+	/* Word range constraints. */
 	if ((lc->nearest_word > rword) || (rc->nearest_word < lword)) return false;
 
 	if (1 == dist)
@@ -956,7 +956,7 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 	{
 		pc->pass_number++;
 
-		/* left-to-right pass */
+		/* Left-to-right pass. */
 		for (WordIdx w = 0; w < sent->length; w++)
 		{
 			for (Disjunct **dd = &sent->word[w].d; *dd != NULL; /* See: NEXT */)
@@ -997,7 +997,7 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 		if (pc->N_changed == 0 && pc->N_deleted[0] == 0 && pc->N_deleted[1] == 0) break;
 		pc->N_changed = pc->N_deleted[0] = pc->N_deleted[1] = pc->N_xlink = 0;
 
-		/* right-to-left pass */
+		/* Right-to-left pass. */
 		for (WordIdx w = sent->length-1; w != (WordIdx) -1; w--)
 		{
 			for (Disjunct **dd = &sent->word[w].d; *dd != NULL; /* See: NEXT */)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -536,6 +536,15 @@ static bool is_cross_mlink(prune_context *pc,
 	Sentence sent = pc->sent;
 	int null_allowed = pc->null_links - pc->null_words;
 
+	if (pc->islands_ok)
+	{
+		if (null_allowed > 0) return false;
+	}
+	else
+	{
+		if (null_allowed > rword - lword - 1) return false;
+	}
+
 	for (int w = lword+1; w < rword; w++)
 	{
 		if (sent->word[w].optional) continue;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -547,10 +547,9 @@ static bool possible_connection(prune_context *pc,
 
 	if (!lc_easy_match(lc->desc, rc->desc)) return false;
 
+	/* Word range constraints */
 	if ((lc->nearest_word > rword) || (rc->nearest_word < lword)) return false;
 
-
-	/* Word range constraints */
 	if (1 == dist)
 	{
 		if ((lc->next != NULL) || (rc->next != NULL)) return false;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -722,6 +722,11 @@ static bool is_bad(Connector *c)
  *  further check. Each tracon is handled only once in the same main loop
  *  pass by marking their connectors with the pass number in their
  *  prune_pass field.
+ *
+ *  Null words (words w/o disjuncts) are detected on the fly (the initial
+ *  ones are detected on the first pass). When the number of the null
+ *  words indicates there will be no parse with the given pc->null_links,
+ *  return -1. Else return the number of discarded disjuncts.
  */
 static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 {

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -711,11 +711,11 @@ static bool is_bad(Connector *c)
  *  sharing, see the comment on them in disjunct-utils.c.
  *
  *  The refcount of each connector serves as its reference count in the
- *  power table. Each time when a connector that cannot match is
+ *  power table. Each time a connector that cannot match is
  *  discovered, its reference count is decreased, and the nearest_word
  *  field of its jet is assigned BAD_WORD. Due to the tracon memory
- *  sharing, each change of the reference count and the assignment of
- *  BAD_WORD affects simultaneously all the identical tracons (and the
+ *  sharing, each change of the reference count and the nearest_word
+ *  field affects simultaneously all the identical tracons (and the
  *  corresponding connectors in the power table). The corresponding
  *  disjuncts are discarded on the fly, and additional disjuncts with jets
  *  so marked with BAD_WORD are discarded when encountered without a
@@ -754,7 +754,7 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 					mark_jet_for_dequeue(d->left, true);
 					mark_jet_for_dequeue(d->right, false);
 
-					/* discard the current disjunct */
+					/* Discard the current disjunct. */
 					*dd = d->next; /* NEXT - set current disjunct to the next one */
 					N_deleted[(int)bad]++;
 					continue;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2004                                                    */
 /* Daniel Sleator, David Temperley, and John Lafferty                    */
 /* Copyright (c) 2009, 2013, 2014 Linas Vepstas                          */
+/* Copyright (c) 2016, 2017, 2018, 2019 Amir Plivatsky                   */
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -876,9 +876,12 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 	}
 	while (!extra_null_word);
 
-	print_time(opts, "power pruned (for %u null%s%s)",
+	char found_nulls[32] = "";
+	if ((verbosity >= D_USER_TIMES) && !extra_null_word && (pc->null_words > 0))
+		snprintf(found_nulls, sizeof(found_nulls), ", found %d", pc->null_words);
+	print_time(opts, "power pruned (for %u null%s%s%s)",
 	           pc->null_links, (pc->null_links != 1) ? "s" : "",
-	           extra_null_word ? ", extra null" : "");
+	           extra_null_word ? ", extra null" : "", found_nulls);
 	if (verbosity_level(D_PRUNE))
 	{
 		prt_error("\n\\");

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -555,7 +555,7 @@ static bool possible_connection(prune_context *pc,
 		if ((lc->next != NULL) || (rc->next != NULL)) return false;
 	}
 	else
-	if (rword > lc->farthest_word || lword < rc->farthest_word)
+	if ((rword > lc->farthest_word) || (lword < rc->farthest_word))
 	{
 		return false;
 	}

--- a/link-grammar/parse/prune.h
+++ b/link-grammar/parse/prune.h
@@ -16,8 +16,8 @@
 #include "api-types.h"                  // Tracon_sharing
 #include "link-includes.h"
 
-void       pp_and_power_prune(Sentence, Tracon_sharing *,  unsigned int,
+unsigned int pp_and_power_prune(Sentence, Tracon_sharing *,  unsigned int,
                               Parse_Options, unsigned int *[2]);
-bool       optional_gap_collapse(Sentence, int, int);
+bool optional_gap_collapse(Sentence, int, int);
 
 #endif /* _PRUNE_H */


### PR DESCRIPTION
This PR implements 2 new ideas:
1. If the pruning indicates that there cannot be a parse with the requested number of nulls, then skip the parse. Without improved pruning, it doesn't cause a speedup because it skips parsing for sentences with a "lightweight" parse anyway. As an slight optimization, the pruning stops when this condition is detected. The sentences that are affected are relatively short. This optimization is disabled with `-test=parse-always`.
2. In power-prune, add a `possible_connection()` step of finding how many nulls will be created due to cross-link considerations.

Speedup batch benchmarks (in parens, increase due to the parse-skipping optimization of (1) above,
found by parallel runnings with and w/o  `-test=parse-always`).
`fix-long`: ~18% (~1%, only 3 short sentences are affected).
`failures`: ~35% (~6.5%)
`pandp-union`: ~15% (~4.5%)

This PR is "part 1". There are 3 additional power-prune extra pruning ideas that are in a WIP stage,
with some promising results but nothing solid to talk about.

A problem with this optimizations is that I fear only I understand them due to not enough documentation (and I may forget the details over time even if now they seem to be obvious). I included the comments from the proof-of-concept code, which uses the ideas in some other manner (hopefully included in the next parts after refined). They include an ASCII diagram. Real diagrams, one for each optimization case, would be much better. However, I don't have any experience in producing such diagrams.

@linas, if some optimization is not clear after reading the comments, please ask me for clarifications, and maybe we will be able to improve the comments.