### PR TITLE
Fix prune comments

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -125,8 +125,12 @@ struct Connector_struct
 		/* For pruning use only */
 		struct
 		{
-			int refcount;      /* Memory-sharing reference count */
-			bool shallow;      /* TRUE if this is a shallow connector */
+			int refcount;   /* Memory-sharing reference count */
+			bool shallow;   /* TRUE if this is a shallow connector.
+			                 * A connectors is shallow if it is the first in
+			                 * its list on its disjunct. (It is deep if it is
+			                 * not the first in its list; it is deepest if it
+			                 * is the last on its list.) */
 		};
 	};
 };

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -129,51 +129,6 @@ struct prune_context_s
 };
 
 /*
-  FIXME: These comments are old and are not relevant in their
-  current form. Convert them to relevant comments.
-
-  The algorithms in this file prune disjuncts from the disjunct list
-  of the sentence that can be eliminated by a simple checks.  The first
-  check works as follows:
-
-  A series of passes are made through the sentence, alternating
-  left-to-right and right-to-left.  Consider the left-to-right pass (the
-  other is symmetric).  A set S of connectors is maintained (initialized
-  to be empty).  Now the disjuncts of the current word are processed.
-  If a given disjunct's left pointing connectors have the property that
-  at least one of them has no connector in S to which it can be matched,
-  then that disjunct is deleted. Now the set S is augmented by the right
-  connectors of the remaining disjuncts of that word.  This completes
-  one word.  The process continues through the words from left to right.
-  Alternate passes are made until no disjunct is deleted.
-
-  It worries me a little that if there are some really huge disjuncts lists,
-  then this process will probably do nothing.  (This fear turns out to be
-  unfounded.)
-
-  Notes:  Power pruning will not work if applied before generating the
-  "and" disjuncts.  This is because certain of it's tricks don't work.
-  Think about this, and finish this note later....
-  Also, currently I use the standard connector match procedure instead
-  of the pruning one, since I know power pruning will not be used before
-  and generation.  Replace this to allow power pruning to work before
-  generating and disjuncts.
-
-  Currently it seems that normal pruning, power pruning, and generation,
-  pruning, and power pruning (after "and" generation) and parsing take
-  about the same amount of time.  This is why doing power pruning before
-  "and" generation might be a very good idea.
-
-  New idea:  Suppose all the disjuncts of a word have a connector of type
-  c pointing to the right.  And further, suppose that there is exactly one
-  word to its right containing that type of connector pointing to the left.
-  Then all the other disjuncts on the latter word can be deleted.
-  (This situation is created by the processing of "either...or", and by
-  the extra disjuncts added to a "," neighboring a conjunction.)
-
-*/
-
-/*
   Here is what you've been waiting for: POWER-PRUNE
 
   The kinds of constraints it checks for are the following:
@@ -222,6 +177,18 @@ struct prune_context_s
    always ensuring that deletable[][] has been defined.  With nothing
    deletable, this is equivalent to RUTHLESS.   --DS, 7/97
 */
+
+/*
+ * From old comments:
+ * It worries me a little that if there are some really huge disjuncts
+ * lists, then this process will probably do nothing.  (This fear turns
+ * out to be unfounded.)
+ *
+ * New idea:  Suppose all the disjuncts of a word have a connector of type
+ * c pointing to the right.  And further, suppose that there is exactly
+ * one word to its right containing that type of connector pointing to the
+ * left.  Then all the other disjuncts on the latter word can be deleted.
+ */
 
 /**
  * free all of the hash tables and C_lists

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -129,57 +129,50 @@ struct prune_context_s
 };
 
 /*
-  Here is what you've been waiting for: POWER-PRUNE
-
-  The kinds of constraints it checks for are the following:
-
-	1) successive connectors on the same disjunct have to go to
-	   nearer and nearer words.
-
-	2) two deep connectors cannot attach to each other
-	   (A connectors is deep if it is not the first in its list; it
-	   is shallow if it is the first in its list; it is deepest if it
-	   is the last on its list.)
-
-	3) on two adjacent words, a pair of connectors can be used
-	   only if they're the deepest ones on their disjuncts
-
-	4) on two non-adjacent words, a pair of connectors can be used only
-	   if not [both of them are the deepest].
-
-   The data structure consists of a pair of hash tables on every word.
-   Each bucket of a hash table has a list of pointers to connectors.
-   These nodes also store if the chosen connector is shallow.
-*/
-/*
-   As with normal pruning, we make alternate left->right and right->left
-   passes.  In the R->L pass, when we're on a word w, we make use of
-   all the left-pointing hash tables on the words to the right of w.
-   After the pruning on this word, we build the left-pointing hash table
-   this word.  This guarantees idempotence of the pass -- after doing an
-   L->R, doing another would change nothing.
-
-   Each connector has an integer c_word field.  This refers to the closest
-   word that it could be connected to.  These are initially determined by
-   how deep the connector is.  For example, a deepest connector can connect
-   to the neighboring word, so its c_word field is w+1 (w-1 if this is a left
-   pointing connector).  It's neighboring shallow connector has a c_word
-   value of w+2, etc.
-
-   The pruning process adjusts these c_word values as it goes along,
-   accumulating information about any way of linking this sentence.
-   The pruning process stops only after no disjunct is deleted and no
-   c_word values change.
-
-   The difference between RUTHLESS and GENTLE power pruning is simply
-   that GENTLE uses the deletable region array, and RUTHLESS does not.
-   So we can get the effect of these two different methods simply by
-   always ensuring that deletable[][] has been defined.  With nothing
-   deletable, this is equivalent to RUTHLESS.   --DS, 7/97
+* Here is what you've been waiting for: POWER-PRUNE
+*
+* The kinds of constraints it checks for are the following:
+*
+*  1) successive connectors on the same disjunct have to go to
+*     nearer and nearer words.
+*
+*  2) two deep connectors cannot attach to each other
+*     (A connectors is deep if it is not the first in its list; it
+*     is shallow if it is the first in its list; it is deepest if it
+*     is the last on its list.)
+*
+*  3) on two adjacent words, a pair of connectors can be used
+*     only if they're the deepest ones on their disjuncts
+*
+*  4) on two non-adjacent words, a pair of connectors can be used only
+*     if not [both of them are the deepest].
+*
+*  The data structure consists of a pair of hash tables on every word.
+*  Each bucket of a hash table has a list of pointers to connectors.
+*
+*  As with expression pruning, we make alternate left->right and
+*  right->left passes.  In the R->L pass, when we're on a word w, we make
+*  use of all the left-pointing hash tables on the words to the right of
+*  w.  After the pruning on this word, we build the left-pointing hash
+*  table this word.  This guarantees idempotence of the pass -- after
+*  doing an L->R, doing another would change nothing.
+*
+*  Each connector has an integer nearest_word field.  This refers to the
+*  closest word that it could be connected to.  These are initially
+*  determined by how deep the connector is.  For example, a deepest
+*  connector can connect to the neighboring word, so its nearest_word
+*  field is w+1 (w-1 if this is a left pointing connector).  It's
+*  neighboring shallow connector has a nearest_word value of w+2, etc.
+*
+*  The pruning process adjusts these nearest_word values as it goes along,
+*  accumulating information about any way of linking this sentence.  The
+*  pruning process stops only after no disjunct is deleted and no
+*  nearest_word values change.
 */
 
 /*
  * From old comments:
+ *
  * It worries me a little that if there are some really huge disjuncts
  * lists, then this process will probably do nothing.  (This fear turns
  * out to be unfounded.)

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -25,7 +25,26 @@
 
 /**
  * Here is expression pruning.  This is done even before the expressions
- * are turned into lists of disjuncts.
+ * are turned into lists of disjuncts. The idea is to make the work of the
+ * next steps (building the disjuncts, removing duplicate disjuncts,
+ * disjunct pruning) lighter by first removing irrelevant connectors.
+ *
+ * The algorithm prunes connectors that can be eliminated by simple checks.
+ *
+ * A series of passes are made through the sentence, alternating
+ * left-to-right and right-to-left.  Consider the left-to-right pass (the
+ * other is symmetric).  A set S of connectors is maintained (initialized
+ * to be empty).  Now the expressions of the current word are processed.
+ * If a given left pointing connector has no connector in S to which it
+ * can be matched, then that connector is deleted. The expression is then
+ * simplified by deleting AND sub-expression with a deleted component
+ * (which may be a connector or a sub-expression), and removing deleted
+ * components from OR sub-expressions (deleting the OR sub-expression upon
+ * deleting of its last component).  Now the set S is augmented by the
+ * right connectors of the remaining disjuncts of that word.  This
+ * completes one word.  The process continues through the words from left
+ * to right.
+ * Alternate passes are made until no connector is deleted.
  */
 
 #define D_EXPRUNE 9

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -45,6 +45,9 @@
  * completes one word.  The process continues through the words from left
  * to right.
  * Alternate passes are made until no connector is deleted.
+ *
+ * FIXME: Mark shallow connectors on dictionary read and enhance the
+ * pruning accordingly.
  */
 
 #define D_EXPRUNE 9


### PR DESCRIPTION
Fix a deep comment rot on the original comments in `prune.c`.
The initial ones now actually describe the expression_prune algo so convert them and move to `exprune.c`.
I also added in `exprune.c` a FIXME that I would like to implement (inspired by the SAT code).
I appended the "shallow, deep, deepest" comment here since PR #1026 has already been applied.