### PR TITLE
Forgotten cleanup commits

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -188,7 +188,7 @@ extractor_t * extractor_new(int nwords, unsigned int ranstat)
 	pex->x_table_size = (1 << log2_table_size);
 
 	DEBUG_X_TABLE(
-		printf("Allocating x_table of size %d (nwords %u)\n",
+		printf("Allocating x_table of size %u (nwords %d)\n",
 		       pex->x_table_size, nwords);
 	)
 	pex->x_table = (Pset_bucket**) xalloc(pex->x_table_size * sizeof(Pset_bucket*));


### PR DESCRIPTION
- Fix format signed/unsigned inconsistency
It looks I mad it after the initial PR push and forgot to force-push it.

- Add `pruning_pass_end()` for common pruning pass ending code
The omission of this one is a mystery - I intended to include it in a cleanup PR, but it got disappeared. Included here is a rewrite...
