### PR TITLE
Extended power prune, part 2

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -188,6 +188,11 @@ Or optionally (in order to see relevant debug messages from `preparation.c`):
 `sat-stats` - Display the number of PP-violations and disconnected linkages.
 `no-pp_pruning_1` - Disable a partial CONTAINS_NONE_RULES pruning
 
+7)  -test=<values> for the pruning subsystem:
+`len-multi-pruning:N` - Prune per null_count for more than N-token sentences.
+`always-parse` - Don't use a parse shortcut and always fully prune.
+`no-mlink` - Don't prune using an mlink table,
+
 Debugging and STDIO streams
 ---------------------------
 Messages at severity Info and higher (i.e. also Warning, Error and

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -192,7 +192,7 @@ static inline bool connector_uc_eq(const Connector *c1, const Connector *c2)
  * @param c Any connector
  * @return The deepest connector (can be modified if needed).
  */
-static inline Connector *deepest_connector(const Connector *c)
+static inline Connector *connector_deepest(const Connector *c)
 {
 	for (; c->next != NULL; c = c->next)
 		;

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -335,8 +335,7 @@ static inline unsigned int pair_hash(unsigned int table_size,
  */
 static inline int get_tracon_word_number(Connector *c, int dir)
 {
-	for (; NULL != c->next; c = c->next)
-		;
+	c = connector_deepest(c);
 	return c->nearest_word + ((dir == 0) ? 1 : -1);
 }
 #endif /* _LINK_GRAMMAR_CONNECTORS_H_ */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -494,8 +494,7 @@ void print_one_connector(Connector * e, int dir, int shallow)
 		else
 			printf("<%d>", e->tracon_id);
 	}
-	if ((0 != e->nearest_word) || (0 != e->length_limit))
-		printf("(%d,%d)", e->nearest_word, e->length_limit);
+	printf("(%d,%d)", e->nearest_word, e->length_limit);
 	if (-1 != shallow)
 		printf("%c", (0 == shallow) ? 'd' : 's');
 }

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1573,6 +1573,8 @@ static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
 {
 	bool ml_exists = false;
 
+	mlink_table_init(sent, ml);
+
 	for (unsigned int w = 0; w < sent->length; w++)
 	{
 		if (sent->word[w].optional) continue;
@@ -1724,7 +1726,6 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 	if ((num_deleted > 0) && !no_mlink)
 	{
 		pc.ml = alloca(sent->length * sizeof(*pc.ml));
-		mlink_table_init(sent, pc.ml);
 		pc.ml = build_mlink_table(sent, pc.ml);
 		print_time(opts, "Built_mlink_table%s", pc.ml ? "" : " (empty)");
 		if (pc.ml != NULL)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1569,7 +1569,7 @@ static void mlink_table_init(Sentence sent, mlink_t *ml)
  * @param ml[out] The table (indexed by word, w/fields indexed by direction).
  * @return \c true iff the table is meaningful.
  */
-static bool build_mlink_table(Sentence sent, mlink_t *ml)
+static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
 {
 	bool ml_exists = false;
 
@@ -1644,7 +1644,7 @@ static bool build_mlink_table(Sentence sent, mlink_t *ml)
 		lg_error_flush();
 	}
 
-	return ml_exists;
+	return ml_exists ? ml : NULL;
 }
 
 /**
@@ -1724,12 +1724,10 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 	{
 		pc.ml = alloca(sent->length * sizeof(*pc.ml));
 		mlink_table_init(sent, pc.ml);
-		bool ml_exists = build_mlink_table(sent, pc.ml);
-		print_time(opts, "Built_mlink_table%s", ml_exists ? "" : " (empty)");
-		if (ml_exists)
+		pc.ml = build_mlink_table(sent, pc.ml);
+		print_time(opts, "Built_mlink_table%s", pc.ml ? "" : " (empty)");
+		if (pc.ml != NULL)
 			num_deleted = power_prune(sent, &pc, opts);
-		else
-			pc.ml = NULL;
 	}
 
 	if (num_deleted != -1)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1743,19 +1743,20 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 
 	/* Initialize tentative values. */
 	unsigned int min_nulls = sent->null_count;
-	bool no_parse = false;
+	bool parsing_to_be_done = true;
 
 	if (null_count == MAX_SENTENCE)
 	{
+		/* No prune optimization - this is the last pruning for this sentence. */
 		min_nulls = pc.null_words;
 	}
 	else if ((pc.null_words > sent->null_count) && !pc.always_parse)
 	{
 		min_nulls = sent->null_count + 1;
+		parsing_to_be_done = false;
 	}
 
-	/* If no optimization then it is the last prune, so compute ncu now. */
-	if (!no_parse || (null_count == MAX_SENTENCE))
+	if (parsing_to_be_done)
 		get_num_con_uc(sent, &pt, ncu);
 
 	power_table_delete(&pt);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -913,10 +913,13 @@ static bool pruning_pass_end(prune_context *pc, const char *pass_dir,
 {
 	int total = pc->N_deleted[0] + pc->N_deleted[1];
 
-	lgdebug(D_PRUNE, "Debug: %s pass changed %d and deleted %d (%d+%d)\n",
-	        pass_dir, pc->N_changed, total, pc->N_deleted[0], pc->N_deleted[1]);
-	if (pc->ml != NULL)
-		lgdebug(D_PRUNE, "Debug: xlink: %d\n", pc->N_xlink);
+	char xlink_found[32] = "";
+	if (pc->N_xlink != 0)
+		snprintf(xlink_found, sizeof(xlink_found), ", xlink=%d", pc->N_xlink);
+
+	lgdebug(D_PRUNE, "Debug: %s pass changed %d and deleted %d (%d+%d)%s\n",
+	        pass_dir, pc->N_changed, total, pc->N_deleted[0], pc->N_deleted[1],
+	        xlink_found);
 
 	bool pass_end = ((pc->N_changed == 0) && (total == 0));
 	pc->N_changed = pc->N_deleted[0] = pc->N_deleted[1] = pc->N_xlink = 0;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1710,6 +1710,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 
 	power_table_init(sent, ts, &pt);
 
+	bool no_mlink = !!test_enabled("no-mlink");
 	pc.always_parse = test_enabled("always-parse");
 	pc.sent = sent;
 	pc.pt = &pt;
@@ -1720,7 +1721,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 
 	int num_deleted = power_prune(sent, &pc, opts); /* pc->ml is NULL here. */
 
-	if (num_deleted > 0)
+	if ((num_deleted > 0) && !no_mlink)
 	{
 		pc.ml = alloca(sent->length * sizeof(*pc.ml));
 		mlink_table_init(sent, pc.ml);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -547,7 +547,7 @@ static bool is_cross_mlink(prune_context *pc,
 		if (lword == pc->ml[w].nw[0])
 		{
 			/* w has a link to lword, or it's a null word. */
-			Connector *c = deepest_connector(lc);
+			Connector *c = connector_deepest(lc);
 			if (!c->multi && (c->nearest_word > w) && PR(A)) goto null_word_found;
 		}
 #endif
@@ -555,7 +555,7 @@ static bool is_cross_mlink(prune_context *pc,
 		if (rword == pc->ml[w].nw[1])
 		{
 			/* w has a link to rword, or it's a null word. */
-			Connector *c = deepest_connector(rc);
+			Connector *c = connector_deepest(rc);
 			if (!c->multi && (c->nearest_word < w) && PR(B)) goto null_word_found;
 		}
 #endif

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1029,6 +1029,11 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 		}
 
 		if (pruning_pass_end(pc, "r->l", &total_deleted)) break;
+
+		/* verbosity=5 revealed that the xlink counter is never set after
+		 * the first 2 passes. So neutralize the mlink table here to save a
+		 * slight overhead. */
+		pc->ml = NULL;
 	}
 	while (!extra_null_word || pc->always_parse);
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -64,7 +64,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  * fw[0] (and similarly for the other range).
  *
  * These values are computed by build_mlink_table() after the first
- * power_prune() call, and before each additional call to power_prune(). */
+ * power_prune() call, before invoking an additional power_prune(). */
 typedef struct
 {
 	WordIdx_m nw[2];   /* minimum link distance */
@@ -1685,7 +1685,7 @@ static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
  * connector with (nearest_word < wl) can be discarded.
  *
  * In addition, in all cases, in disjunct which are retained and have so
- * constrained connectors, they length_limit of these connectors can be
+ * constrained connectors, the length_limit of these connectors can be
  * adjusted not to get over w. Note that in the case of (wr - w == 1)
  * the deepest connector is multi, its length_limit cannot be set to 1!
  * This is because it behaves like more that one connector, when the rest
@@ -1721,7 +1721,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 	pc.is_null_word = alloca(sent->length * sizeof(*pc.is_null_word));
 	memset(pc.is_null_word, 0, sent->length * sizeof(*pc.is_null_word));
 
-	int num_deleted = power_prune(sent, &pc, opts); /* pc->ml is NULL here. */
+	int num_deleted = power_prune(sent, &pc, opts); /* pc->ml is NULL here */
 
 	if ((num_deleted > 0) && !no_mlink)
 	{
@@ -1753,7 +1753,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 	}
 	else if ((pc.null_words > sent->null_count) && !pc.always_parse)
 	{
-		min_nulls = sent->null_count + 1;
+		min_nulls = sent->null_count + 1; /* The most that can be inferred */
 		parsing_to_be_done = false;
 	}
 


### PR DESCRIPTION
The main change here, which contributes to most of the speedup:
- prune.c: Add cross-link detection specific to null_count==0

Minor speedup improvements:
- pp_and_power_prune(): Fix efficiency bug - unneeded get_num_con_uc() … ￼…
- power_prune(): Stop using the mlink table after the first 2 passes

Debug related changes:
- Add -test=no_mlink to prune w/o mlink table
**This is important for comparing parsing results to those done with the "classic" pruning**.
The parsing results should be totally identical, but the parse count can be reduced when mlink is used due to better PP pruning that is then possible due to the extra mlink pruning.
- debug/README.md: Document pruning test option values
- print_one_connector(): Always print e->length limit
- pruning_pass_end(): Reduce log cluttering by xlink report on same line

- Code cleanup:
- build_mlink_table(): Change return value to simplify code
- mlink_table_init(): Move to build_mlink_table()
- deepest_connector(): Change it to connector_deepest() ￼…
- get_tracon_word_number(): Use connector_deepest() instead of a loop

**Batch benchmark speedups**:
`fix-long`, `failures`: 11-16% (wild changes in different runs).
`pandp-union.txt`: ~9%.
(A 64-runs benchmark for the short-sentences batches didn't show significant changes but maybe ~1% speedup for the Russian batch, and due to my time constraints I haven't performed the 1000-runs benchmark that is needed for accurate-enough results.)

