### PR TITLE
Improved PP pruning - part 1

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1373,16 +1373,13 @@ static bool mark_bad_connectors(multiset_table *cmt, Connector *c)
 
 static int pp_prune(Sentence sent, Tracon_sharing *ts, Parse_Options opts)
 {
-	pp_knowledge *knowledge;
-	multiset_table *cmt;
-
 	if (sent->postprocessor == NULL) return 0;
 	if (!opts->perform_pp_prune) return 0;
 
-	knowledge = sent->postprocessor->knowledge;
-	cmt = cms_table_new();
-
+	pp_knowledge *knowledge = sent->postprocessor->knowledge;
+	multiset_table *cmt = cms_table_new();
 	Tracon_list *tl = ts->tracon_list;
+
 	if (NULL != tl)
 	{
 		for (int dir = 0; dir < 2; dir++)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -115,49 +115,49 @@ struct prune_context_s
 };
 
 /*
-* Here is what you've been waiting for: POWER-PRUNE
-*
-* The kinds of constraints it checks for are the following:
-*
-*  1) Successive connectors on the same disjunct have to go to
-*     nearer and nearer words.
-*
-*  2) Two deep connectors cannot attach to each other; i.e. a deep
-*     connector can only attache to a shallow one, and a shallow
-*     connector can attache to any connector.
-*     (A connectors is deep if it is not the first in its list; it
-*     is shallow if it is the first in its list; it is deepest if it
-*     is the last on its list.)
-*
-*  3) On two adjacent words, a pair of connectors can be used
-*     only if they're the deepest ones on their disjuncts.
-*
-*  4) On non-adjacent words (with no intervening null-linked words),
-*     a pair of connectors can be used only if at least one of them
-*     is not the deepest.
-*
-*  The data structure consists of a pair of hash tables on every word.
-*  Each bucket of a hash table has a list of pointers to connectors.
-*
-*  As with expression pruning, we make alternate left->right and
-*  right->left passes.  In the R->L pass, when we're on a word w, we make
-*  use of all the left-pointing hash tables on the words to the right of
-*  w.  After the pruning on this word, we build the left-pointing hash
-*  table this word.  This guarantees idempotence of the pass -- after
-*  doing an L->R, doing another would change nothing.
-*
-*  Each connector has an integer nearest_word field.  This refers to the
-*  closest word that it could be connected to.  These are initially
-*  determined by how deep the connector is.  For example, a deepest
-*  connector can connect to the neighboring word, so its nearest_word
-*  field is w+1 (w-1 if this is a left pointing connector).  It's
-*  neighboring shallow connector has a nearest_word value of w+2, etc.
-*
-*  The pruning process adjusts these nearest_word values as it goes along,
-*  accumulating information about any way of linking this sentence.  The
-*  pruning process stops only after no disjunct is deleted and no
-*  nearest_word values change.
-*/
+ * Here is what you've been waiting for: POWER-PRUNE
+ *
+ * The kinds of constraints it checks for are the following:
+ *
+ *  1) Successive connectors on the same disjunct have to go to
+ *     nearer and nearer words.
+ *
+ *  2) Two deep connectors cannot attach to each other; i.e. a deep
+ *     connector can only attache to a shallow one, and a shallow
+ *     connector can attache to any connector.
+ *     (A connectors is deep if it is not the first in its list; it
+ *     is shallow if it is the first in its list; it is deepest if it
+ *     is the last on its list.)
+ *
+ *  3) On two adjacent words, a pair of connectors can be used
+ *     only if they're the deepest ones on their disjuncts.
+ *
+ *  4) On non-adjacent words (with no intervening null-linked words),
+ *     a pair of connectors can be used only if at least one of them
+ *     is not the deepest.
+ *
+ *  The data structure consists of a pair of hash tables on every word.
+ *  Each bucket of a hash table has a list of pointers to connectors.
+ *
+ *  As with expression pruning, we make alternate left->right and
+ *  right->left passes.  In the R->L pass, when we're on a word w, we make
+ *  use of all the left-pointing hash tables on the words to the right of
+ *  w.  After the pruning on this word, we build the left-pointing hash
+ *  table this word.  This guarantees idempotence of the pass -- after
+ *  doing an L->R, doing another would change nothing.
+ *
+ *  Each connector has an integer nearest_word field.  This refers to the
+ *  closest word that it could be connected to.  These are initially
+ *  determined by how deep the connector is.  For example, a deepest
+ *  connector can connect to the neighboring word, so its nearest_word
+ *  field is w+1 (w-1 if this is a left pointing connector).  It's
+ *  neighboring shallow connector has a nearest_word value of w+2, etc.
+ *
+ *  The pruning process adjusts these nearest_word values as it goes along,
+ *  accumulating information about any way of linking this sentence.  The
+ *  pruning process stops only after no disjunct is deleted and no
+ *  nearest_word values change.
+ */
 
 /*
  * From old comments:
@@ -1247,12 +1247,12 @@ static bool match_in_cms_table(multiset_table *cmt, const char *pp_link,
 
 	for (Cms *cms = cmt->cms_table[h]; cms != NULL; cms = cms->next)
 	{
-			if (can_form_link(pp_link, connector_string(cms->c), subscr))
-			{
-				ppdebug("MATCHED %s\n", connector_string(cms->c));
-				return true;
-			}
-			ppdebug("NOT-MATCHED %s \n", connector_string(cms->c));
+		if (can_form_link(pp_link, connector_string(cms->c), subscr))
+		{
+			ppdebug("MATCHED %s\n", connector_string(cms->c));
+			return true;
+		}
+		ppdebug("NOT-MATCHED %s \n", connector_string(cms->c));
 	}
 
 	return false;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1239,17 +1239,19 @@ static bool can_form_link(const char *s, const char *t, const char *e)
 }
 
 /**
- * Returns TRUE iff there is a connector name c in the table
+ * Returns TRUE iff there is a connector name in the sentence
  * that can create a link x such that post_process_match(pp_link, x) is TRUE.
+ * subscr is a pointer into pp_link that indicates the position of the
+ * connector subscr that is tested.
  */
 static bool match_in_cms_table(multiset_table *cmt, const char *pp_link,
-                               const char *c)
+                               const char *subscr)
 {
 	unsigned int h = cms_hash(pp_link);
 
 	for (Cms *cms = cmt->cms_table[h]; cms != NULL; cms = cms->next)
 	{
-			if (can_form_link(pp_link, connector_string(cms->c), c))
+			if (can_form_link(pp_link, connector_string(cms->c), subscr))
 			{
 				ppdebug("MATCHED %s\n", connector_string(cms->c));
 				return true;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -91,7 +91,7 @@ struct cms_struct
 	Connector *c;
 };
 
-#define CMS_SIZE (2<<10)
+#define CMS_SIZE (1<<11)
 typedef struct multiset_table_s multiset_table;
 struct multiset_table_s
 {

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -84,20 +84,6 @@ struct power_table_s
 	Pool_desc *memory_pool;
 };
 
-typedef struct cms_struct Cms;
-struct cms_struct
-{
-	Cms *next;
-	Connector *c;
-};
-
-#define CMS_SIZE (1<<11)
-typedef struct multiset_table_s multiset_table;
-struct multiset_table_s
-{
-	Cms *cms_table[CMS_SIZE];
-};
-
 typedef struct prune_context_s prune_context;
 struct prune_context_s
 {
@@ -1158,6 +1144,20 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 		the need for the last pass.)
 
   */
+
+typedef struct cms_struct Cms;
+struct cms_struct
+{
+	Cms *next;
+	Connector *c;
+};
+
+#define CMS_SIZE (1<<11)
+typedef struct multiset_table_s multiset_table;
+struct multiset_table_s
+{
+	Cms *cms_table[CMS_SIZE];
+};
 
 static multiset_table *cms_table_new(void)
 {


### PR DESCRIPTION
- Clean up code
- Fix a comment rot
- Reduce memory allocation overhead and improve CPU cache behavior

This code uses a kind of hybrid memory allocation sceheme: block allocation, and if exhausted - memory_pool allocation as a fallback.  With the used memory block size (2048 elements) memory pool fallback has never been observed, so I debugged its usage with a temporarily reduced memory block size (256).

The speedup is only %0.5-1.5% (increased with sentence size) but this is also a preparation for a more aggressive PP pruning.

BTW, the new PP pruning code has already code rot.... It is not critical so I will wait with fixing it.
