### PR TITLE
PP pruning: Ignore cms table connectors marked with BAD_WORD

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1238,6 +1238,8 @@ static bool match_in_cms_table(multiset_table *cmt, const char *pp_link,
 
 	for (Cms *cms = cmt->cms_table[h]; cms != NULL; cms = cms->next)
 	{
+		if (cms->c->nearest_word == BAD_WORD) continue;
+
 		if (can_form_link(pp_link, connector_string(cms->c), subscr))
 		{
 			ppdebug("MATCHED %s\n", connector_string(cms->c));
@@ -1479,6 +1481,7 @@ static int pp_prune(Sentence sent, Tracon_sharing *ts, Parse_Options opts)
 		for (Cms *cms = cmt->cms_table[hash]; cms != NULL; cms = cms->next)
 		{
 			Connector *c = cms->c;
+			if (cms->c->nearest_word == BAD_WORD) continue;
 			if (!post_process_match(selector, connector_string(c))) continue;
 			if (rule->selector_has_wildcard &&
 			    selector_mismatch(selector, c, cmt)) continue;


### PR DESCRIPTION
The pp_prune cms table doesn't support deletions (since trigger connectors are not usually also used for criterion links of other rules). But it is still possible to ignore removed connectors for a slight speedup.


Only one change in the `basic` and `fixes` batches (others not checked
for detailed parses but only for total error count):

`linkparser> it is how big?`

Before this PR:
```
Found 4 linkages (2 had no P.P. violations) at null count 1
	Linkage 1, cost vector = (UNUSED=1 DIS= 0.05 LEN=6)
```
After this PR:
```
Found 2 linkages (2 had no P.P. violations) at null count 1
	Linkage 1, cost vector = (UNUSED=1 DIS= 0.05 LEN=6)
```