### PR TITLE
Imprve the efficiency of intersect_strings()

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -244,8 +244,11 @@ static bool connector_encode_lc(const char *lc_string, condesc_t *desc)
 
 	for (s = lc_string; '\0' != *s; s++)
 	{
-		lc_value |= (lc_enc_t)(*s & LC_MASK) << ((s-lc_string)*LC_BITS);
-		if (*s != WILD_TYPE) lc_mask |= wildcard;
+		if (*s != WILD_TYPE)
+		{
+			lc_value |= (lc_enc_t)(*s & LC_MASK) << ((s-lc_string)*LC_BITS);
+			lc_mask |= wildcard;
+		}
 		wildcard <<= LC_BITS;
 	};
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -36,10 +36,9 @@
  * is possible to encode up to 9 letters in an uint64_t. */
 #define LC_BITS 7
 #define LC_MASK ((1<<LC_BITS)-1)
+#define MAX_CONNECTOR_LC_LENGTH 9
 
-/* Links are *always* less than 10 chars long . For now. The estimate
- * below is somewhat dangerous .... XXX could be fixed. */
-#define MAX_LINK_NAME_LENGTH 10
+#define MAX_LINK_NAME_LENGTH 12
 
 typedef uint64_t lc_enc_t;
 

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -36,6 +36,11 @@
  * is possible to encode up to 9 letters in an uint64_t. */
 #define LC_BITS 7
 #define LC_MASK ((1<<LC_BITS)-1)
+
+/* Links are *always* less than 10 chars long . For now. The estimate
+ * below is somewhat dangerous .... XXX could be fixed. */
+#define MAX_LINK_NAME_LENGTH 10
+
 typedef uint64_t lc_enc_t;
 
 typedef uint32_t connector_hash_t;

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -3,6 +3,8 @@
 /* Daniel Sleator, David Temperley, and John Lafferty                    */
 /* Copyright (c) 2012, 2014 Linas Vepstas                                */
 /* All rights reserved                                                   */
+/* Copyright (c) 2019 Amir Plivatsky                                     */
+/* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */
 /* license set forth in the LICENSE file included with this software.    */
@@ -23,46 +25,45 @@
  * This returns a string that is the GCD of the two given strings.
  * If the GCD is equal to one of them, a pointer to it is returned.
  * Otherwise a new string for the GCD is put in the string set.
+ *
+ * Note: The head and dependent indicators (lower-case h and d) are
+ * ignored, as the intersection cannot include them.
  */
-static const char * intersect_strings(String_set *sset, const char * s, const char * t)
+static const char *intersect_strings(String_set *sset, const Connector *c1,
+                                     const Connector *c2)
 {
-	int i, j, d;
-	const char *w, *s0;
-	char u0[MAX_LINK_NAME_LENGTH];
-	char *u;
+	const condesc_t *d1 = c1->desc;
+	const condesc_t *d2 = c2->desc;
 
-	/* The head indicator is lower-case h, the dependent indicator is
-	 * lower-case d. If they are present, skip them. The intersection
-	 * cannot include them. */
-	if (islower((int) *s)) s++;
-	if (islower((int) *t)) t++;
+	/* Ignore the head/dependent encoding at bit 0. */
+	lc_enc_t lc1_letters = d1->lc_letters >> 1;
+	lc_enc_t lc2_letters = d2->lc_letters >> 1;
 
-	if (strcmp(s,t) == 0) return s;  /* would work without this */
-	i = strlen(s);
-	j = strlen(t);
-	if (j > i) {
-		w = s; s = t; t = w;
-	}
-	/* s is now the longer (at least not the shorter) string */
-	u = u0;
-	d = 0;
-	s0 = s;
-	while (*t != '\0') {
-		if ((*s == *t) || (*t == '*')) {
-			*u = *s;
-		} else {
-			assert(*s == '*', "Invalid intersection!");
-			d++;
-			*u = *t;
+	lc_enc_t lc_label = lc1_letters | lc2_letters;
+
+	/* This catches ~95% of the cases (it would work without this). */
+	if (lc_label == lc1_letters) return &connector_string(c1)[d1->uc_start];
+	if (lc_label == lc2_letters) return &connector_string(c2)[d2->uc_start];
+
+	char *l = alloca(d1->uc_length + MAX_CONNECTOR_LC_LENGTH + 1);
+	memcpy(l, &connector_string(c1)[d1->uc_start], d1->uc_length);
+
+	for (size_t i = d1->uc_length; /* see note below */; i++)
+	{
+		l[i] = lc_label & LC_MASK;
+		if (l[i] == '\0') l[i] = '*';
+
+		lc_label >>= LC_BITS;
+		if (lc_label == 0)
+		{
+			l[i+1] = '\0';
+			break;
 		}
-		s++; t++; u++;
 	}
-	if (d == 0) {
-		return s0;
-	} else {
-		strcpy(u, s);   /* get the remainder of s */
-		return string_set_add(u0, sset);
-	}
+	/* Note: LC_BITS * MAX_CONNECTOR_LC_LENGTH < sizeof(lc_enc_t).
+	 * So after MAX_CONNECTOR_LC_LENGTH shifts lc_label must be 0. */
+
+	return string_set_add(l, sset);
 }
 
 /**
@@ -77,7 +78,6 @@ void compute_link_names(Linkage lkg, String_set *sset)
 	for (i = 0; i < lkg->num_links; i++)
 	{
 		lkg->link_array[i].link_name = intersect_strings(sset,
-			connector_string(lkg->link_array[i].lc),
-			connector_string(lkg->link_array[i].rc));
+			lkg->link_array[i].lc, lkg->link_array[i].rc);
 	}
 }

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -19,9 +19,6 @@
 #include "linkage.h"
 #include "string-set.h"
 
-/* Links are *always* less than 10 chars long. For now... */
-#define MAX_LINK_NAME_LENGTH 10
-
 /**
  * This returns a string that is the GCD of the two given strings.
  * If the GCD is equal to one of them, a pointer to it is returned.

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -63,6 +63,17 @@ static const char *intersect_strings(String_set *sset, const Connector *c1,
 	/* Note: LC_BITS * MAX_CONNECTOR_LC_LENGTH < sizeof(lc_enc_t).
 	 * So after MAX_CONNECTOR_LC_LENGTH shifts lc_label must be 0. */
 
+#ifdef DEBUG
+	const char *s1 =  &connector_string(c1)[d1->uc_start];
+	const char *s2 =  &connector_string(c1)[d1->uc_start];
+	do
+	{
+		assert(isupper(*s1) == isupper(*s2), "Invalid uppercase part!");
+		assert(*s1 == *s2 || *s1 == '*' || *s2 == '*', "Invalid intersection!");
+	}
+	while ((*s1++ != '0') && (*s2++ != 0));
+#endif
+
 	return string_set_add(l, sset);
 }
 

--- a/link-grammar/linkage/lisjuncts.c
+++ b/link-grammar/linkage/lisjuncts.c
@@ -29,10 +29,6 @@
 static void assert_same_disjunct(Linkage, WordIdx, const char *);
 #endif /* DEBUG */
 
-/* Links are *always* less than 10 chars long . For now. The estimate
- * below is somewhat dangerous .... could be  fixed. */
-#define MAX_LINK_NAME_LENGTH 10
-
 /**
  * lg_compute_disjunct_strings -- Given sentence, compute disjuncts.
  *


### PR DESCRIPTION
Speed up `intersect_strings()` in a factor of about 3, by using connector encoding.

The main speedup is because in absolutely most of the cases  a pointer into the connector strings is returned without entering the label constructing loop, and by avoinf `strlen()`.

Other changes:
- Move MAX_LINK_NAME_LENGTH to `connectors.h`.
- Use a dynamic buffer length for the result.

`MAX_LINK_NAME_LENGTH` is now only used  in `lisjuncts.h`, in which a buffer overflow cannot happen (a truncation would happen instead, but this is not a likely cases due to the big buffer).

The benchmark of `fix-long` and `failures` shows ~2% speedup. It seems it depends on the number of linkages + the linkage limit.

On the `pandp-union.txt` there is no speedup, although the function benchmark still shows ~3x speedup for `intersect_strings()`. It seems this is due to the low `linkage_limit` which is used there (1000) and the mix of sentence length which include a lot of short ones. When I increased it to 10000, I got a speedup of ~2% too.

BTW, my motivation of improving  `intersect_strings()` is to use it for an improved pruning idea in pp_prune() without introducing too much overhead (no results yet).