### PR TITLE
Build-disjunct fixes

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -460,18 +460,6 @@ void count_disjuncts_and_connectors(Sentence sent, unsigned int *dca,
 	*cca = ccnt;
 	*dca = dcnt;
 }
-/* ============================================================= */
-
-/**
- * Record the wordgraph word to which the X-node belongs, in each of its
- * disjuncts.
- */
-void word_record_in_disjunct(const Gword * gw, Disjunct * d)
-{
-	for (;d != NULL; d=d->next) {
-		d->originating_gword = (gword_set *)&gw->gword_set_head;
-	}
-}
 
 /* ================ Pack disjuncts and connectors ============== */
 /* Print one connector with all the details.

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -64,7 +64,6 @@ unsigned int count_disjuncts(Disjunct *);
 Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct *);
 char * print_one_disjunct(Disjunct *);
-void word_record_in_disjunct(const Gword *, Disjunct *);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -124,8 +124,8 @@ static void build_sentence_disjuncts(Sentence sent, double cost_cutoff,
 		d = NULL;
 		for (x = sent->word[w].x; x != NULL; x = x->next)
 		{
-			Disjunct *dx = build_disjuncts_for_exp(sent, x->exp, x->string, cost_cutoff, opts);
-			word_record_in_disjunct(x->word, dx);
+			Disjunct *dx = build_disjuncts_for_exp(sent, x->exp, x->string,
+				&x->word->gword_set_head, cost_cutoff, opts);
 			d = catenate_disjuncts(dx, d);
 		}
 		sent->word[w].d = d;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -260,6 +260,8 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 	dis = NULL;
 	for (; cl != NULL; cl = cl->next)
 	{
+		if (NULL == cl->c) continue; /* no connectors */
+
 		if (cl->maxcost <= cost_cutoff)
 		{
 			if (NULL == sent) /* For the SAT-parser, until fixed. */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -252,7 +252,7 @@ static Clause * build_clause(Exp *e, clause_context *ct)
  */
 static Disjunct *
 build_disjunct(Sentence sent, Clause * cl, const char * string,
-               double cost_cutoff, Parse_Options opts)
+               const gword_set *gs, double cost_cutoff, Parse_Options opts)
 {
 	Disjunct *dis, *ndis;
 	Pool_desc *connector_pool = NULL;
@@ -288,6 +288,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 
 			ndis->word_string = string;
 			ndis->cost = cl->cost;
+			ndis->originating_gword = (gword_set*)gs; /* XXX remove constness */
 			ndis->next = dis;
 			dis = ndis;
 		}
@@ -295,8 +296,9 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 	return dis;
 }
 
-Disjunct * build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
-                                   double cost_cutoff, Parse_Options opts)
+Disjunct *build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
+                                  const gword_set *gs, double cost_cutoff,
+                                  Parse_Options opts)
 {
 	Clause *c ;
 	Disjunct * dis;
@@ -313,7 +315,7 @@ Disjunct * build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
 	// printf("%s\n", lg_exp_stringify(exp));
 	c = build_clause(exp, &ct);
 	// print_clause_list(c);
-	dis = build_disjunct(sent, c, word, cost_cutoff, opts);
+	dis = build_disjunct(sent, c, word, gs, cost_cutoff, opts);
 	// print_disjunct_list(dis);
 	pool_delete(ct.Tconnector_pool);
 	pool_delete(ct.Clause_pool);

--- a/link-grammar/prepare/build-disjuncts.h
+++ b/link-grammar/prepare/build-disjuncts.h
@@ -17,7 +17,9 @@
 #include "api-types.h"
 #include "link-includes.h"
 
-Disjunct * build_disjuncts_for_exp(Sentence sent, Exp*, const char*, double cost_cutoff, Parse_Options opts);
+Disjunct *build_disjuncts_for_exp(Sentence sent, Exp *, const char *,
+                                  const gword_set *, double cost_cutoff,
+                                  Parse_Options opts);
 
 #ifdef DEBUG
 void prt_exp(Exp *, int);

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1889,7 +1889,9 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 #else
     cost_cutoff = 1000.0;
 #endif // LIMIT_TOTAL_LINKAGE_COST
-    d = build_disjuncts_for_exp(NULL, de, xnode_word[wi]->string, cost_cutoff, _opts);
+    d = build_disjuncts_for_exp(NULL, de, xnode_word[wi]->string,
+                                &xnode_word[wi]->word->gword_set_head,
+                                cost_cutoff, _opts);
 
     if (d == NULL)
     {
@@ -1900,8 +1902,6 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 #endif
       return false;
     }
-
-    word_record_in_disjunct(xnode_word[wi]->word, d);
 
     /* Recover cost of costly-nulls. */
     const vector<EmptyConnector>& ec = _word_tags[wi].get_empty_connectors();


### PR DESCRIPTION
- build_disjunct(): Skip null disjuncts
This problem always existed, and is harmless beside creating some duplicate linkages, mostly in `islands_ok=true` mode.
- word_record_in_disjunct(): Remove; assign gword_set on disjunct building
Minor speedup.