### PR TITLE
Prune length limit

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -713,7 +713,8 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 				newc = *tracon;
 				if (!ts->is_pruning)
 				{
-					if (o->nearest_word != newc->nearest_word)
+					if ((o->nearest_word != newc->nearest_word) ||
+					    (o->farthest_word != newc->farthest_word))
 					{
 						/* This is a rare case in which a shallow and deep
 						 * connectors don't have the same nearest_word, because
@@ -725,7 +726,8 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 						 * Note:
 						 * In case the parsing ever depends on other Connector
 						 * fields, their will be a need to add a check for them
-						 * here. */
+						 * here.
+						 * Update: farthest_word added. */
 						newc = NULL; /* Don't share it. */
 					}
 				}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1878,7 +1878,9 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 				}
 #endif /* FW */
 
-				shallow_c->farthest_word = MIN(ml[w].nw[1], shallow_c->farthest_word);
+				shallow_c->farthest_word = MAX(w, shallow_c->farthest_word);
+				if (d->right != NULL)
+					d->right->farthest_word = MIN(fw1, d->right->farthest_word);
 			}
 		}
 
@@ -1911,7 +1913,9 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 				}
 #endif /* FW */
 
-				shallow_c->farthest_word = MAX(ml[w].nw[0], shallow_c->farthest_word);
+				shallow_c->farthest_word = MIN(w, shallow_c->farthest_word);
+				if (d->left != NULL)
+					d->left->farthest_word = MAX(fw0, d->left->farthest_word);
 			}
 		}
 	}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1787,7 +1787,7 @@ static mlink_table *build_mlink_table(Sentence sent, mlink_table *ml)
  * this code to have any effect. To be retried when a more aggressive one
  * is implemented.
  */
-static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_table *ml)
+static unsigned int cross_mlink_prune(Sentence sent, mlink_table *ml)
 {
 	int N_deleted[2] = {0};
 	static Connector bad_connector = { .nearest_word = BAD_WORD };
@@ -1996,7 +1996,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 		if (pc.ml != NULL)
 		{
 			if (null_count == 0)
-				cross_mandatory_link_prune(sent, pc.ml);
+				cross_mlink_prune(sent, pc.ml);
 			num_deleted = power_prune(sent, &pc, opts);
 		}
 	}
@@ -2013,7 +2013,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 			if (pc.ml != NULL)
 			{
 				if (null_count == 0)
-					cross_mandatory_link_prune(sent, pc.ml);
+					cross_mlink_prune(sent, pc.ml);
 				num_deleted = power_prune(sent, &pc, opts);
 			}
 		}

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1793,13 +1793,16 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 		if (sent->word[w].optional) continue;
 		if (sent->word[w].d == NULL) continue;
 
-		if ((w > 0) && (ml[w].nw[1] != w))
+		WordIdx_m nw0 = ml[w].nw[0];
+		WordIdx_m nw1 = ml[w].nw[1];
+		WordIdx_m fw0 = ml[w].fw[0];
+		WordIdx_m fw1 = ml[w].fw[1];
+
+		if ((w > 0) && (nw1 != w))
 		{
 			/* Deepest connector constraint l->r. */
-			for (Disjunct *d = sent->word[ml[w].nw[1]].d; d != NULL; d = d->next)
+			for (Disjunct *d = sent->word[nw1].d; d != NULL; d = d->next)
 			{
-				//print_disjunct_list(sent->word[w].d);
-
 				Connector *shallow_c = d->left;
 				if (shallow_c == NULL) continue;
 				if (shallow_c->nearest_word == BAD_WORD)
@@ -1822,10 +1825,10 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 			}
 		}
 
-		if ((w < sent->length-1) && (ml[w].nw[0] != w))
+		if ((w < sent->length-1) && (nw0 != w))
 		{
 			/* Deepest connector constraint r->l. */
-			for (Disjunct *d = sent->word[ml[w].nw[0]].d; d != NULL; d = d->next)
+			for (Disjunct *d = sent->word[nw0].d; d != NULL; d = d->next)
 			{
 				Connector *shallow_c = d->right;
 				if (shallow_c == NULL) continue;
@@ -1850,7 +1853,7 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 		}
 
 		/* Remove disjuncts that are blocked by mandatory l->r links. */
-		for (unsigned int rw = w+1; rw < ml[w].nw[1]; rw++)
+		for (unsigned int rw = w+1; rw < nw1; rw++)
 		{
 			for (Disjunct *d = sent->word[rw].d; d != NULL; d = d->next)
 			{
@@ -1870,7 +1873,7 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 				}
 
 #if FW
-				if (shallow_c->nearest_word > ml[w].fw[1])
+				if (shallow_c->nearest_word > fw1)
 				{
 					shallow_c->nearest_word = BAD_WORD;
 					N_deleted[0]++;
@@ -1885,7 +1888,7 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 		}
 
 		/* Remove disjuncts that are blocked by mandatory r->l links. */
-		for (unsigned int lw = ml[w].nw[0]+1; lw < w; lw++)
+		for (unsigned int lw = nw0+1; lw < w; lw++)
 		{
 			for (Disjunct *d = sent->word[lw].d; d != NULL; d = d->next)
 			{
@@ -1905,12 +1908,13 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 				}
 
 #if FW
-				if (shallow_c->nearest_word < ml[w].fw[0])
+				if (shallow_c->nearest_word < fw0)
 				{
 					shallow_c->nearest_word = BAD_WORD;
 					N_deleted[0]++;
 					continue;
 				}
+
 #endif /* FW */
 
 				shallow_c->farthest_word = MIN(w, shallow_c->farthest_word);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1778,11 +1778,14 @@ static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
  * Since links are not allowed to cross, such disjuncts would create nulls
  * links. So this optimization can only be done when parsing a sentence
  * with null_count==0 (in which null links are not allowed).
- * Possible FIXME:
- * Part of such kind of deletions are also be done in
+ * Possible FIXMEs:
+ * 1. Part of such kind of deletions are also be done in
  * possible_connection(), so there is some overlapping. However,
  * eliminating this overlap (if possible) would not cause a significant
  * speedup because these functions are lightweight.
+ * 2. FW_NOT_NOW: The furthest_word trimming is not aggressive enough for
+ * this code to have any effect. To be retried when a more aggressive one
+ * is implemented.
  */
 static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 {
@@ -1899,14 +1902,14 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 					continue;
 				}
 
-#if FW
+#if FW_NOT_NOW
 				if (shallow_c->nearest_word > fw1)
 				{
 					shallow_c->nearest_word = BAD_WORD;
 					N_deleted[0]++;
 					continue;
 				}
-#endif /* FW */
+#endif /* FW_NOT_NOW */
 
 				shallow_c->farthest_word = MAX(w, shallow_c->farthest_word);
 				if (d->right != NULL)
@@ -1934,7 +1937,7 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 					continue;
 				}
 
-#if FW
+#if FW_NOT_NOW
 				if (shallow_c->nearest_word < fw0)
 				{
 					shallow_c->nearest_word = BAD_WORD;
@@ -1942,7 +1945,7 @@ static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
 					continue;
 				}
 
-#endif /* FW */
+#endif /* FW_NOT_NOW */
 
 				shallow_c->farthest_word = MIN(w, shallow_c->farthest_word);
 				if (d->left != NULL)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1700,7 +1700,7 @@ static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
 			}
 		}
 
-		ml_exists |= ((ml[w].nw[0] != w) || (ml[w].nw[1] != w));
+		ml_exists |= (ml[w].nw[0] != ml[w].nw[1]);
 	}
 
 	if (verbosity_level(+D_PRUNE) && ml_exists)

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -70,7 +70,7 @@ typedef struct
 {
 	WordIdx_m nw[2];   /* minimum link distance */
 	WordIdx_m fw[2];   /* maximum link distance - not implemented yet */
-} mlink_t;
+} mlink_table;
 
 typedef struct c_list_s C_list;
 struct c_list_s
@@ -113,7 +113,7 @@ struct prune_context_s
 	int N_deleted[2];  /* counts deletions: [0]: initial; [1]: by mem. sharing */
 
 	power_table *pt;
-	mlink_t *ml;
+	mlink_table *ml;
 	Sentence sent;
 
 	int power_cost;   /* for debug - shown in the verbose output */
@@ -1639,11 +1639,11 @@ static void get_num_con_uc(Sentence sent,power_table *pt,
 	}
 }
 
-static void mlink_table_init(Sentence sent, mlink_t *ml)
+static void mlink_table_init(Sentence sent, mlink_table *ml)
 {
 	for (WordIdx w = 0; w < sent->length; w++)
 	{
-		ml[w] = (mlink_t)
+		ml[w] = (mlink_table)
 		{
 			.nw[0] = 0, .nw[1] = UNLIMITED_LEN,
 			.fw[0] = UNLIMITED_LEN, .fw[1] = 0,
@@ -1659,7 +1659,7 @@ static void mlink_table_init(Sentence sent, mlink_t *ml)
  * @param ml[out] The table (indexed by word, w/fields indexed by direction).
  * @return \c true iff the table is meaningful.
  */
-static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
+static mlink_table *build_mlink_table(Sentence sent, mlink_table *ml)
 {
 	bool ml_exists = false;
 
@@ -1787,7 +1787,7 @@ static mlink_t *build_mlink_table(Sentence sent, mlink_t *ml)
  * this code to have any effect. To be retried when a more aggressive one
  * is implemented.
  */
-static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_t *ml)
+static unsigned int cross_mandatory_link_prune(Sentence sent, mlink_table *ml)
 {
 	int N_deleted[2] = {0};
 	static Connector bad_connector = { .nearest_word = BAD_WORD };
@@ -1977,7 +1977,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 	power_table_init(sent, ts, &pt);
 
 	bool no_mlink = !!test_enabled("no-mlink");
-	mlink_t *ml = alloca(sent->length * sizeof(*pc.ml));
+	mlink_table *ml = alloca(sent->length * sizeof(*pc.ml));
 
 	pc.always_parse = test_enabled("always-parse");
 	pc.sent = sent;


### PR DESCRIPTION
- Trim `farthest_word` in the power-pruning.
- Add new type of pruning: "must have" links.
- Simplify/improve readability/clarify code.
- Rename `mlink_t` and `cross_mandatory_link_prune()`.
- Add additional "mlink" pruning step.

The speedup is minimal: 1-3% (depending on sentence length).
More work needed on trimming  `farthest_word`. However, it is not clear if it can be improved. This is due to the memory sharing of connectors that is done according to tracons, while the minimal length_limit is according to "leacons".