### PR TITLE
pack_sentence...() cleanups

### DIFF
--- a/debug/README.md
+++ b/debug/README.md
@@ -179,9 +179,9 @@ and [msvc/README.md](/msvc/README.md).
 
 5) Test the "trailing connector" hashing for short sentences too (e.g. for
 all sentences with more than 10 tokens):
-`link-parser test=len-trailing-hash:10`
+`link-parser test=min-len-encoding:10`
 Or optionally (in order to see relevant debug messages from `preparation.c`):
-`link-parser test=len-trailing-hash:10 -v=5 -debug=preparation.c`
+`link-parser test=min-len-encoding:10 -v=5 -debug=preparation.c`
 
 6) -test=<values> for SAT parser debugging:
 `linkage-disconnected` - Display also solutions which don't have a full linkage.

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -411,7 +411,7 @@ Sentence sentence_create(const char *input_string, Dictionary dict)
 	 * In that case a tracon list is produced for the pruning step,
 	 * and disjunct/connector packing is done too. */
 	sent->min_len_encoding = SENTENCE_MIN_LENGTH_TRAILING_HASH;
-	const char *min_len_encoding = test_enabled("len-trailing-hash");
+	const char *min_len_encoding = test_enabled("min-len-encoding");
 	if (NULL != min_len_encoding)
 		sent->min_len_encoding = atoi(min_len_encoding+1);
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -858,9 +858,9 @@ static Disjunct *pack_disjuncts(Sentence sent, Tracon_sharing *ts,
  * implementation didn't introduce bugs in the pruning and parsing steps).
  * E.g. when using link-parser:
  * - To entirely disable connector encoding:
- * link-parser -test=len-trailing-hash:254
+ * link-parser -test=min-len-encoding:254
  * - To use connector encoding even for short sentences:
- * link-parser -test=len-trailing-hash:0
+ * link-parser -test=min-len-encoding:0
  * Any different result (e.g. number of discarded disjuncts in the pruning
  * step or different parsing results) indicates a bug.
  *

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -867,10 +867,11 @@ static Disjunct *pack_disjuncts(Sentence sent, Tracon_sharing *ts,
  * @param is_pruning TRUE if invoked for pruning, FALSE if invoked for parsing.
  * @return The said context descriptor.
  */
-static Tracon_sharing *pack_sentence_init(Sentence sent, unsigned int dcnt,
-                                          unsigned int ccnt,
-                                          bool is_pruning)
+static Tracon_sharing *pack_sentence_init(Sentence sent, bool is_pruning)
 {
+	unsigned int dcnt = 0, ccnt = 0;
+	count_disjuncts_and_connectors(sent, &dcnt, &ccnt);
+
 	size_t dsize = dcnt * sizeof(Disjunct);
 	if (sizeof(Disjunct) != 64)
 		dsize = ALIGN(dsize, sizeof(Connector));
@@ -969,10 +970,9 @@ void free_tracon_sharing(Tracon_sharing *ts)
  * invoked for pruning step) allow for a huge performance boost at these
  * steps.
  */
-static Tracon_sharing *pack_sentence(Sentence sent, unsigned int dcnt,
-                                     unsigned int ccnt, bool is_pruning)
+static Tracon_sharing *pack_sentence(Sentence sent, bool is_pruning)
 {
-	Tracon_sharing *ts = pack_sentence_init(sent, dcnt, ccnt, is_pruning);
+	Tracon_sharing *ts = pack_sentence_init(sent, is_pruning);
 
 	for (WordIdx w = 0; w < sent->length; w++)
 	{
@@ -986,13 +986,12 @@ static Tracon_sharing *pack_sentence(Sentence sent, unsigned int dcnt,
  * Pack the sentence for pruning.
  * @return New tracon sharing descriptor.
  */
-Tracon_sharing *pack_sentence_for_pruning(Sentence sent, unsigned int dcnt,
-                                          unsigned int ccnt)
+Tracon_sharing *pack_sentence_for_pruning(Sentence sent)
 {
 	unsigned int ccnt_before = 0;
 	if (verbosity_level(D_DISJ)) ccnt_before = count_connectors(sent);
 
-	Tracon_sharing *ts = pack_sentence(sent, dcnt, ccnt, true);
+	Tracon_sharing *ts = pack_sentence(sent, true);
 
 	if (NULL == ts->csid[0])
 	{
@@ -1016,13 +1015,12 @@ Tracon_sharing *pack_sentence_for_pruning(Sentence sent, unsigned int dcnt,
  * Pack the sentence for parsing.
  * @return New tracon sharing descriptor.
  */
-Tracon_sharing *pack_sentence_for_parsing(Sentence sent, unsigned int dcnt,
-                                          unsigned int ccnt)
+Tracon_sharing *pack_sentence_for_parsing(Sentence sent)
 {
 	unsigned int ccnt_before = 0;
 	if (verbosity_level(D_DISJ)) ccnt_before = count_connectors(sent);
 
-	Tracon_sharing *ts = pack_sentence(sent, dcnt, ccnt, false);
+	Tracon_sharing *ts = pack_sentence(sent, false);
 
 	if (verbosity_level(D_SPEC+2))
 	{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -192,58 +192,6 @@ static bool disjuncts_equal(Disjunct * d1, Disjunct * d2)
 }
 #endif
 
-#if 0
-/**
- * Duplicate the given connector chain.
- * If the argument is NULL, return NULL.
- */
-static Connector *connectors_dup(Pool_desc *connector_pool, Connector *origc)
-{
-	Connector head;
-	Connector *prevc = &head;
-	Connector *newc = &head;
-
-	for (Connector *t = origc; t != NULL;  t = t->next)
-	{
-		newc = connector_new(connector_pool, NULL, NULL);
-		*newc = *t;
-
-		prevc->next = newc;
-		prevc = newc;
-	}
-	newc->next = NULL;
-
-	return head.next;
-}
-
-/**
- * Duplicate the given disjunct chain.
- * If the argument is NULL, return NULL.
- */
-static Disjunct *disjuncts_dup(Pool_desc *Disjunct_pool, Pool_desc *Connector_pool,
-                        Disjunct *origd)
-{
-	Disjunct head;
-	Disjunct *prevd = &head;
-	Disjunct *newd = &head;
-
-	for (Disjunct *t = origd; t != NULL; t = t->next)
-	{
-		newd = pool_alloc(Disjunct_pool);
-		newd->word_string = t->word_string;
-		newd->cost = t->cost;
-		newd->left = connectors_dup(Connector_pool, t->left);
-		newd->right = connectors_dup(Connector_pool, t->right);
-		newd->originating_gword = t->originating_gword;
-		prevd->next = newd;
-		prevd = newd;
-	}
-	newd->next = NULL;
-
-	return head.next;
-}
-#endif
-
 static disjunct_dup_table * disjunct_dup_table_new(size_t sz)
 {
 	disjunct_dup_table *dt;

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -67,8 +67,8 @@ char * print_one_disjunct(Disjunct *);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
-Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int);
-Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int);
+Tracon_sharing *pack_sentence_for_pruning(Sentence);
+Tracon_sharing *pack_sentence_for_parsing(Sentence);
 void free_tracon_sharing(Tracon_sharing *);
 void count_disjuncts_and_connectors(Sentence, unsigned int *, unsigned int *);
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -67,10 +67,8 @@ char * print_one_disjunct(Disjunct *);
 int left_connector_count(Disjunct *);
 int right_connector_count(Disjunct *);
 
-Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int,
-                                          bool);
-Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int,
-                                          bool);
+Tracon_sharing *pack_sentence_for_pruning(Sentence, unsigned int, unsigned int);
+Tracon_sharing *pack_sentence_for_parsing(Sentence, unsigned int, unsigned int);
 void free_tracon_sharing(Tracon_sharing *);
 void count_disjuncts_and_connectors(Sentence, unsigned int *, unsigned int *);
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -180,7 +180,7 @@ static void init_table_lrcnt(count_context_t *ctxt, Sentence sent)
 	if (ctxt->table_lrcnt == NULL)
 	{
 		ctxt->table_lrcnt_size =
-			next_power_of_two_up(2048 + sent->num_disjuncts * sent->length / 16);
+			next_power_of_two_up(2048 + sent->num_disjuncts * sent->length / 1.5f);
 		ctxt->table_lrcnt = malloc(ctxt->table_lrcnt_size * sizeof(Table_lrcnt));
 	}
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -306,10 +306,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	prepare_to_parse(sent, opts);
 	if (resources_exhausted(opts->resources)) return;
 
-	unsigned int dcnt = 0, ccnt = 0; /* Allocated number (for memory block). */
-	count_disjuncts_and_connectors(sent, &dcnt, &ccnt);
-
-	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent, dcnt, ccnt);
+	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent);
 	free_sentence_disjuncts(sent);
 
 	if (one_step_parse)
@@ -363,7 +360,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 		if (NULL != ts_pruning)
 		{
-			ts_parsing = pack_sentence_for_parsing(sent, dcnt, ccnt);
+			ts_parsing = pack_sentence_for_parsing(sent);
 			print_time(opts, "Encoded for parsing");
 
 			if (!more_pruning_possible)

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -309,8 +309,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	unsigned int dcnt = 0, ccnt = 0; /* Allocated number (for memory block). */
 	count_disjuncts_and_connectors(sent, &dcnt, &ccnt);
 
-	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent, dcnt, ccnt,
-																			 one_step_parse);
+	Tracon_sharing *ts_pruning = pack_sentence_for_pruning(sent, dcnt, ccnt);
 	free_sentence_disjuncts(sent);
 
 	if (one_step_parse)
@@ -364,8 +363,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 		if (NULL != ts_pruning)
 		{
-			ts_parsing = pack_sentence_for_parsing(sent, dcnt, ccnt,
-			                                       more_pruning_possible);
+			ts_parsing = pack_sentence_for_parsing(sent, dcnt, ccnt);
 			print_time(opts, "Encoded for parsing");
 
 			if (!more_pruning_possible)

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -89,15 +89,13 @@ static void setup_connectors(Sentence sent)
  */
 void gword_record_in_connector(Sentence sent)
 {
-	for (size_t w = 0; w < sent->length; w++)
+	for (Disjunct *d = sent->dc_memblock;
+	     d < &((Disjunct *)sent->dc_memblock)[sent->num_disjuncts]; d++)
 	{
-		for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
-		{
-			for (Connector *c = d->right; NULL != c; c = c->next)
-				c->originating_gword = d->originating_gword;
-			for (Connector *c = d->left; NULL != c; c = c->next)
-				c->originating_gword = d->originating_gword;
-		}
+		for (Connector *c = d->right; NULL != c; c = c->next)
+			c->originating_gword = d->originating_gword;
+		for (Connector *c = d->left; NULL != c; c = c->next)
+			c->originating_gword = d->originating_gword;
 	}
 }
 


### PR DESCRIPTION
The main change here is removing remains of the incremental encoding.
Some more cleanups have been added.
 change the loop over disjuncts in `gword_record_in_connector()` to use the disjunct array.