### PR TITLE
#include cleanup

### DIFF
--- a/bindings/ocaml/linkgrammar.c
+++ b/bindings/ocaml/linkgrammar.c
@@ -20,7 +20,7 @@
 /********************************************/
 /* Link Grammar Includes                    */
 /********************************************/
-#include <link-grammar/link-includes.h>
+#include "link-grammar/link-includes.h"
 
 
 #define Po_val(v) (*((Parse_Options *)Data_custom_val(v)))

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -15,7 +15,6 @@
 
 #include "api-structures.h"
 #include "dict-common/dict-utils.h"
-#include "dict-common/dict-api.h"      // for expression_strigify()
 #include "disjunct-utils.h"   // for free_sentence_disjuncts()
 #include "linkage/linkage.h"
 #include "memory-pool.h"
@@ -26,7 +25,6 @@
 #include "string-set.h"
 #include "resources.h"
 #include "sat-solver/sat-encoder.h"
-#include "tokenize/spellcheck.h"
 #include "tokenize/tokenize.h"
 #include "tokenize/word-structures.h" // Needed for Word_struct
 #include "utilities.h"

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -15,18 +15,18 @@
 
 #include "api-structures.h"
 #include "dict-common/dict-utils.h"
-#include "disjunct-utils.h"   // for free_sentence_disjuncts()
+#include "disjunct-utils.h"             // free_sentence_disjuncts
 #include "linkage/linkage.h"
 #include "memory-pool.h"
-#include "parse/histogram.h"  // for PARSE_NUM_OVERFLOW
+#include "parse/histogram.h"            // PARSE_NUM_OVERFLOW
 #include "parse/parse.h"
-#include "post-process/post-process.h" // for post_process_new()
+#include "post-process/post-process.h"  // post_process_new
 #include "prepare/exprune.h"
 #include "string-set.h"
 #include "resources.h"
 #include "sat-solver/sat-encoder.h"
 #include "tokenize/tokenize.h"
-#include "tokenize/word-structures.h" // Needed for Word_struct
+#include "tokenize/word-structures.h"   // Word_struct
 #include "utilities.h"
 
 /* Its OK if this is racey across threads.  Any mild shuffling is enough. */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -14,7 +14,6 @@
 #ifndef _LG_DICT_STRUCTURES_H_
 #define _LG_DICT_STRUCTURES_H_
 
-#include "link-grammar/link-features.h"
 #include "link-includes.h"
 
 LINK_BEGIN_DECLS

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -20,8 +20,8 @@
 #include "dict-common/file-utils.h"
 #include "dict-common/idiom.h"
 #include "error.h"
-#include "print/print.h"
 #include "externs.h"
+#include "print/print.h"
 #include "read-dict.h"
 #include "string-set.h"
 #include "tokenize/tok-structures.h"    // MT_WALL

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -17,6 +17,7 @@
 #include "count.h"
 #include "disjunct-utils.h"             // Disjunct
 #include "extract-links.h"
+#include "fast-match.h"
 #include "utilities.h"                  // Windows rand_r()
 #include "linkage/linkage.h"
 #include "tokenize/word-structures.h"   // Word_Struct

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -24,8 +24,8 @@
 #endif
 #include <signal.h>    /* SIG* */
 
-#include <print/print-util.h> /* for append_string */
-#include <utilities.h> /* for dyn_str functions and UNREACHABLE */
+#include "print/print-util.h" /* for append_string */
+#include "utilities.h" /* for dyn_str functions and UNREACHABLE */
 #endif /* USE_WORDGRAPH_DISPLAY */
 
 #include "api-structures.h"

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -11,11 +11,7 @@
 /*                                                                       */
 /*************************************************************************/
 
-#include "link-grammar/link-includes.h"
-/* If you compile your own program out of the LG source-code tree,
- * include this file as follows in order to pick it up from the
- * LG-package system installation. */
-/* #include <link-grammar/link-includes.h> */
+#include <link-grammar/link-includes.h>
 
 #define COMMENT_CHAR '%'       /* input lines beginning with this are ignored */
 #define WHITESPACE " \t\v\r\n" /* ASCII-only is sufficient here */


### PR DESCRIPTION
In the "dialect" branch (to which I'm now preparing a PR) I made some `#include` file cleanups.
I extracted these commits and added some more cleanups.

While doing that I realize that the `#include <link-grammar/link-includes.h>` in `command-line.h` is fine after all so I reverted the related changes that I once made.