### PR TITLE
Clang static-analyzer 2

### DIFF
--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -31,10 +31,15 @@ const char * lg_exp_get_string(const Exp* exp)
 void free_Exp(Exp *e)
 {
 	if (NULL == e) return; /* Exp might be null if the user has a bad dict. */
+	Exp *operand_next;
+
 	if (e->type != CONNECTOR_type)
 	{
-		for (Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
+		for (Exp *opd = e->operand_first; opd != NULL; opd = operand_next)
+		{
+			operand_next = opd->operand_next;
 			free_Exp(opd);
+		}
 	}
 	free(e);
 }

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -28,6 +28,8 @@ const char * lg_exp_get_string(const Exp* exp)
 }
 
 /* ======================================================== */
+
+#if 0
 void free_Exp(Exp *e)
 {
 	if (NULL == e) return; /* Exp might be null if the user has a bad dict. */
@@ -43,6 +45,8 @@ void free_Exp(Exp *e)
 	}
 	free(e);
 }
+#endif
+
 /* Exp utilities ... */
 
 /* Returns the number of connectors in the expression e */

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -104,12 +104,13 @@ static bool exp_compare(Exp *e1, Exp *e2)
 	{
 		/* Iterate operands to avoid a deep recursion due to a lot of operands. */
 		for (e1 = e1->operand_first, e2 = e2->operand_first;
-		     e1 != NULL || e2 != NULL;
+		     (e1 != NULL) && (e2 != NULL);
 		     e1 = e1->operand_next, e2 = e2->operand_next)
 		{
 			if (!exp_compare(e1, e2))
 				return false;
 		}
+		return ((e1 == NULL) && (e2 == NULL));
 	}
 	return true;
 }

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -295,7 +295,11 @@ Disjunct *eliminate_duplicate_disjuncts(Disjunct *dw)
 {
 	unsigned int count = 0;
 	disjunct_dup_table *dt;
-	Disjunct *prev = NULL; /* The first disjunct is never eliminated. */
+	/* This initialization is unneeded because the first disjunct is never
+	 * eliminated. However, omitting it generates "uninitialized" compiler
+	 * warning. Setting it to NULL generates clang-analyzer error on
+	 * possible NULL dereference. */
+	Disjunct *prev = dw;
 
 	dt = disjunct_dup_table_new(next_power_of_two_up(2 * count_disjuncts(dw)));
 

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -225,6 +225,8 @@ static void sort_by_nearest_word(Match_node *m, sortbin *sbin, int nearest_word)
 
 fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 {
+	assert(sent->length > 0);
+
 	fast_matcher_t *ctxt;
 
 	ctxt = (fast_matcher_t *) xalloc(sizeof(fast_matcher_t));

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -2092,7 +2092,7 @@ unsigned int pp_and_power_prune(Sentence sent, Tracon_sharing *ts,
 			{
 				if (null_count == 0)
 					cross_mlink_prune(sent, pc.ml);
-				num_deleted = power_prune(sent, &pc, opts);
+				power_prune(sent, &pc, opts);
 			}
 		}
 	}

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3383,6 +3383,7 @@ bool flatten_wordgraph(Sentence sent, Parse_Options opts)
 		}
 
 		free(wp_old);
+		assert(wp_new != NULL, "No new wordgraph path");
 	} while ((NULL != wp_new[1].word) ||
 	         (wp_new[0].word->morpheme_type != MT_INFRASTRUCTURE));
 

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -308,7 +308,7 @@ static unsigned char lg_complete(EditLine *el, int ch)
 				size_t byte_len = wcstombs(NULL, wdirname, 0);
 				if (byte_len == (size_t)-1)
 				{
-					printf("Error: Unable to process UTF8 in directory name.\n");
+					printf("Error: Unable to process non-ASCII in directory name.\n");
 					free(wdirname);
 					return CC_ERROR;
 				}

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -309,6 +309,7 @@ static unsigned char lg_complete(EditLine *el, int ch)
 				if (byte_len == (size_t)-1)
 				{
 					printf("Error: Unable to process UTF8 in directory name.\n");
+					free(wdirname);
 					return CC_ERROR;
 				}
 				char *dirname = malloc(byte_len + 1);


### PR DESCRIPTION
- Fix some FP messages.
There are many other such messages, that eliminating them needs a significant number of assert() calls. Maybe the solution is to make them ifdef'ed on using a static analyzer.

- Fix non-fatal bugs.
The most interesting one is in `free_Exp()` (using stale memory). First I didn't understand how come it hasn't been detected by ASAN. Then I realized this function is not being used any more because expressions are now allocated from memory pools. For now I ifdef'ed it out.