### PR TITLE
Dialect code cleanup

### DIFF
--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -303,4 +303,4 @@ Examples:
 
   !dialect=irish
   !dialect=irish,headline
-  !dialect=instructions,bad-spelling=2.2
+  !dialect=instructions,bad-spelling:2.2

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -389,27 +389,9 @@ static void free_dialect_info(dialect_info *dinfo)
 
 	free(dinfo->cost_table);
 	dinfo->cost_table = NULL;
-#ifdef DIALECT_OBJECT
-	free(dinfo->vname);
-	free(dinfo->ccost);
-#else
 	free((void *)dinfo->conf);
-#endif
 }
 
-#ifdef DIALECT_OBJECT
-Dialect_Option parse_options_get_dialect(Parse_Options opts)
-{
-	return opts->dialect;
-}
-
-void parse_options_set_dialect(Parse_Options opts, Dialect_Option dopt)
-{
-	if (0 == strcmp(dconf, opts->dialect.conf)) return;
-	free_dialect_info(opts->dialect);
-	opts->dialect = *dopt;
-}
-#else
 char * parse_options_get_dialect(Parse_Options opts)
 {
 	return opts->dialect.conf;
@@ -421,7 +403,6 @@ void parse_options_set_dialect(Parse_Options opts, const char *dconf)
 	free_dialect_info(&opts->dialect);
 	opts->dialect.conf = strdup(dconf);
 }
-#endif
 /***************************************************************
 *
 * Routines for creating destroying and processing Sentences

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -73,15 +73,6 @@ Exptag *exptag_add(Dictionary dict, const char *tag)
 	return &et->array[tag_index];
 }
 
-#ifdef DIALECT_OBJECT
-Dialect_Option dialect_option_alloc(void)
-{
-	Dialect_Option dialect = malloc(sizeof(*dialect));
-	memset(dialect, 0, sizeof(*dialect));
-	return dialect;
-}
-#endif
-
 /**
  * Set in the cost table the dialect component cost at \p table_index.
  * @retrun \c false iff the component doesn't exist in the dictionary.
@@ -216,13 +207,9 @@ void free_cost_table(Parse_Options opts)
 
 static bool dialect_conf_exists(dialect_info *dinfo)
 {
-#ifdef DIALECT_OBJECT
-	return ((dinfo->vname != NULL) || (dinfo->ccost != NULL);
-#else
 	for (const char *p = dinfo->conf; *p != '\0'; p++)
 		if (!lg_isspace(*p)) return true;
 	return false;
-#endif
 }
 
 const char no_dialect[] = "(unset the dialect option)\n";
@@ -276,10 +263,6 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 
 	if (dialect_conf_exists(dinfo))
 	{
-#ifdef DIALECT_OBJECT
-		prt_error("Error: Dialect setting from Dialect_Option is unsupported.\n");
-		return false;
-#else
 		Dialect user_setup = (Dialect){ 0 };
 		if (!dialect_read_from_one_line_str(dict, &user_setup, dinfo->conf))
 		{
@@ -294,101 +277,9 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 		}
 		free_dialect_table(&user_setup);
 	}
-#endif
 
 	if (verbosity_level(+D_DIALECT+1))
 		print_cost_table(dict, di, dinfo);
 
 	return true;
 }
-
-#ifdef DIALECT_OBJECT
-/* External API. */
-
-/* Initial code. Totally undebugged. */
-
-Dialect_Option lg_dialect_create(void)
-{
-	Dialect_Option dopt = malloc(sizeof(*dopt));
-	memset(dopt, 0, sizeof(*dopt));
-	return dopt;
-}
-
-void lg_dialect_delete(Dialect_Option dopt)
-{
-	if (dopt == NULL) return;
-	free(dopt->cost_table);
-	free(dopt->vname);
-	free(dopt->ccost);
-	free(dopt);
-}
-
-bool lg_dialect_set(Dialect_Option dopt, const char *dialect_name, bool useit)
-{
-	if (dopt == NULL) return false;
-	if (useit)
-	{
-		/* Add dialect. */
-		dopt->vname_sz++;
-		dopt->vname = realloc(dopt->vname, dopt->vname_sz * sizeof(*dopt->vname));
-		dopt->vname[dopt->vname_sz-1] = dialect_name;
-		goto done;
-		return true;
-	}
-	else
-	{
-		/* Remove dialect. */
-		dopt->vname_sz--;
-		for (size_t i = 0; i <= dopt->vname_sz; i++)
-		{
-			if (strcmp(dialect_name, dopt->vname[i]) == 0)
-			{
-				if (i != dopt->vname_sz)
-				{
-					memmove(&dopt->vname[i], &dopt->vname[i+1],
-					        (dopt->vname_sz-i) * sizeof(*dopt->vname));
-				}
-				goto done;
-			}
-		}
-		return false; /* Dialect not found */
-	}
-
-done:
-	if (dopt->cost_table != NULL)
-		free(dopt->cost_table);
-	dopt->cost_table = NULL;
-	return true;
-}
-
-bool lg_dialect_cost(Dialect_Option dopt, const char *dialect_tag_name, double cost)
-{
-	if (!cost_eq(cost, DIALECT_COST_REMOVE))
-	{
-		/* Add dialect component cost. */
-		dopt->ccost_sz++;
-		dopt->ccost = realloc(dopt->ccost, dopt->ccost_sz * sizeof(*dopt->ccost));
-		dopt->ccost[dopt->ccost_sz-1] =
-			(dialect_tag){ .name = dialect_tag_name, .cost = cost };
-		return true;
-	}
-	else
-	{
-		/* Remove dialect component cost. */
-		dopt->ccost_sz--;
-		for (size_t i = 0; i <= dopt->ccost_sz; i++)
-		{
-			if (strcmp(dialect_tag_name, dopt->ccost[i].name) == 0)
-			{
-				if (i != dopt->ccost_sz)
-				{
-					memmove(&dopt->ccost[i], &dopt->ccost[i+1],
-					        (dopt->ccost_sz-i) * sizeof(*dopt->ccost));
-				}
-				return true;
-			}
-		}
-		return false; /* Dialect not found */
-	}
-}
-#endif /* DIALECT_OBJECT */

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -48,8 +48,6 @@ Dialect *dialect_alloc(void)
 
 Exptag *exptag_add(Dictionary dict, const char *tag)
 {
-	if (!valid_dialect_name(tag)) return false;
-
 	expression_tag *et = &dict->tag;
 	unsigned int tag_index = string_id_lookup(tag, et->set);
 

--- a/link-grammar/dict-common/dialect.h
+++ b/link-grammar/dict-common/dialect.h
@@ -20,9 +20,11 @@
 #include "string-id.h"
 
 /* dialect_tag costs with a special meaning. See also link-includes.h. */
-#define DIALECT_COST_MAX        9999.0     /* Less than that is a real cost */
-#define DIALECT_SUB             10002.0    /* Sub-dialect (a vector name) */
-#define DIALECT_SECTION         10003.0    /* Section header (a vector name) */
+#define DIALECT_COST_MAX         9999.0    /* Less than that is a real cost */
+#define DIALECT_COST_DISABLE    10000.0
+#define DIALECT_SUB             10001.0    /* Sub-dialect (a vector name) */
+#define DIALECT_SECTION         10002.0    /* Section header (a vector name) */
+
 
 /* Used for dialect table entries and Dialect_Option component cost array. */
 typedef struct
@@ -59,20 +61,11 @@ struct Dialect_s
 /* Dialect object for parse_options_*_dialect(). */
 struct dialect_option_s
 {
-#ifdef DIALECT_OBJECT
-	char const **vname;            /* Dialect vector names */
-	dialect_tag *ccost;            /* Dialect component cost */
-	unsigned int vname_sz;
-	unsigned int ccost_sz;
-#else
 	char *conf;
-#endif
 	float *cost_table;             /* Indexed by Exptag index field */
 };
 
-#ifndef DIALECT_OBJECT
 typedef struct dialect_option_s dialect_info;
-#endif
 
 Dialect *dialect_alloc(void);
 void free_dialect(Dialect *);
@@ -80,9 +73,6 @@ Exptag *exptag_add(Dictionary, const char *);
 bool setup_dialect(Dictionary, Parse_Options);
 void free_cost_table(Parse_Options opts);
 bool apply_dialect(Dictionary, Dialect *, unsigned int, Dialect *, dialect_info *);
-#ifdef DIALECT_OBJECT
-Dialect_Option dialect_option_alloc(void);
-#endif
 
 static inline bool valid_dialect_name(const char *name)
 {

--- a/link-grammar/dict-common/dialect.h
+++ b/link-grammar/dict-common/dialect.h
@@ -74,14 +74,19 @@ bool setup_dialect(Dictionary, Parse_Options);
 void free_cost_table(Parse_Options opts);
 bool apply_dialect(Dictionary, Dialect *, unsigned int, Dialect *, dialect_info *);
 
-static inline bool valid_dialect_name(const char *name)
+/**
+ * Validate that \p name is a valid dialect tag name.
+ * @name Dialect tag name
+ * @return NULL if valid, else the first offending character.
+ */
+static inline const char *valid_dialect_name(const char *name)
 {
-	if (!isalpha(name[0])) return false;
+	if (!isalpha(name[0])) return name;
 	while (*++name != '\0')
 	{
 		if (!isalnum(name[0]) && name[0] != '_' && name[0] != '-')
-			return false;
+			return name;
 	}
-	return true;
+	return NULL;
 }
 #endif /* _DIALECT_H_ */

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -62,7 +62,7 @@ int size_of_expression(Exp * e)
 	return size;
 }
 
-Exp *copy_Exp(Dictionary dict, Exp *e, Pool_desc *Exp_pool, Parse_Options opts)
+Exp *copy_Exp(Exp *e, Pool_desc *Exp_pool, Parse_Options opts)
 {
 	if (e == NULL) return NULL;
 	Exp *new_e = pool_alloc(Exp_pool);

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -72,9 +72,9 @@ Exp *copy_Exp(Exp *e, Pool_desc *Exp_pool, Parse_Options opts)
 		new_e->cost += opts->dialect.cost_table[new_e->tag->index];
 
 #if 0 /* Not used - left here for documentation. */
-	new_e->operand_next = copy_Exp(dict, e->operand_next, Exp_pool);
+	new_e->operand_next = copy_Exp(e->operand_next, Exp_pool);
 	if (CONNECTOR_type == e->type) return new_e;
-	new_e->operand_first = copy_Exp(dict, e->operand_first, Exp_pool);
+	new_e->operand_first = copy_Exp(e->operand_first, Exp_pool);
 #else
 	if (CONNECTOR_type == e->type) return new_e;
 
@@ -82,7 +82,7 @@ Exp *copy_Exp(Exp *e, Pool_desc *Exp_pool, Parse_Options opts)
 	Exp **tmp_e_a = &new_e->operand_first;
 	for(Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
 	{
-		*tmp_e_a = copy_Exp(dict, opd, Exp_pool, opts);
+		*tmp_e_a = copy_Exp(opd, Exp_pool, opts);
 		tmp_e_a = &(*tmp_e_a)->operand_next;
 	}
 	*tmp_e_a = NULL;

--- a/link-grammar/dict-common/dict-utils.h
+++ b/link-grammar/dict-common/dict-utils.h
@@ -19,7 +19,7 @@
 /* Exp utilities ... */
 void free_Exp(Exp *);
 int  size_of_expression(Exp *);
-Exp * copy_Exp(Dictionary, Exp *, Pool_desc *, Parse_Options);
+Exp * copy_Exp(Exp *, Pool_desc *, Parse_Options);
 bool is_exp_like_empty_word(Dictionary dict, Exp *);
 
 /* X_node utilities ... */

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -165,10 +165,11 @@ static char *get_label(dialect_file_status *dfile)
 		if (!lg_isspace(*p)) break;
 	p[1] = '\0';
 
-	if (!valid_dialect_name(label))
+	const char *bad = valid_dialect_name(label);
+	if (bad != NULL)
 	{
-		prt_error("Error: %s:%s \"%s\": Invalid dialect name.\n",
-		          dfile->fname, suppress_0(dfile->line_number, buf), label);
+		prt_error("Error: %s:%s \"%s\": Invalid character '%c' in dialect name.\n",
+		          dfile->fname, suppress_0(dfile->line_number, buf), label, *bad);
 		return NULL;
 	}
 

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -44,7 +44,7 @@ static void print_dialect_table(Dialect *di)
 	/* First entry unused - tag ID 0 is invalid (for debug). */
 	for (unsigned int i = 0; i < di->num_table_tags; i++)
 	{
-		if (is_dialect_table) prt_error("%3d: ", i);
+		if (is_dialect_table) prt_error("%3u: ", i);
 		prt_error("%-15s %s\n\\",
 		          di->table[i].name, cost_stringify(di->table[i].cost));
 	}
@@ -311,7 +311,7 @@ static bool dialect_read_from_str(Dictionary dict, Dialect *di,
 			{
 				prt_error("Error: %s:%s After \"%s\": Internal error char %02x\n",
 				          dfile->fname, suppress_0(dfile->line_number, buf),
-				          token, *dfile->pin);
+				          token, (unsigned char)*dfile->pin);
 			}
 		}
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1209,9 +1209,12 @@ static Exp *make_expression(Dictionary dict)
 			         (strcmp(dict->token, "and") != 0) &&
 			         isalpha(dict->token[0]))
 			{
-				if (!valid_dialect_name(dict->token))
+				const char *bad = valid_dialect_name(dict->token);
+				if (bad != NULL)
 				{
-					dict_error(dict, "Invalid expression tag name");
+					char badchar[] = { *bad, '\0' };
+					dict_error2(dict, "Invalid character in dialect tag name:",
+					           badchar);
 					return NULL;
 				}
 				if (nl->tag != NULL)

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -210,19 +210,10 @@ link_public_api(bool)
 link_public_api(void)
      parse_options_reset_resources(Parse_Options opts);
 
-#ifdef DIALECT_OBJECT
-typedef struct Dialect_Option_s * Dialect_Option;
-
-link_public_api(Dialect_Option)
-	  parse_options_get_dialect(Parse_Options opts);
-link_public_api(void)
-	  parse_options_set_dialect(Parse_Options opts, Dialect_Option dopt);
-#else
 link_public_api(char *)
 	  parse_options_get_dialect(Parse_Options opts);
 link_public_api(void)
 	  parse_options_set_dialect(Parse_Options opts, const char *dialect);
-#endif
 
 /**********************************************************************
  *
@@ -373,20 +364,6 @@ link_public_api(WordIdx)
      linkage_get_word_char_start(const Linkage linkage, WordIdx w);
 link_public_api(WordIdx)
      linkage_get_word_char_end(const Linkage linkage, WordIdx w);
-
-#define DIALECT_COST_DISABLE    10000.0
-#ifdef DIALECT_OBJECT
-#define DIALECT_COST_REMOVE     10001.0
-
-link_public_api(Dialect_Option)
-     lg_dialect_create(void);
-link_public_api(void)
-     lg_dialect_delete(Dialect_Option dopt);
-link_public_api(bool)
-	  lg_dialect_set(Dialect_Option dopt, const char *dialect, bool useit);
-link_public_api(bool)
-	  lg_dialect_cost(Dialect_Option dopt, const char *component, double cost);
-#endif /* DIALECT_OBJECT */
 
 /**********************************************************************
  *

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2997,7 +2997,7 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w,
 		y = (X_node *) pool_alloc(sent->X_node_pool);
 		y->next = x;
 		x = y;
-		x->exp = copy_Exp(dict, dn->exp, sent->Exp_pool, opts);
+		x->exp = copy_Exp(dn->exp, sent->Exp_pool, opts);
 		if (NULL == s)
 		{
 			x->string = dn->string;


### PR DESCRIPTION
Address review of PR #1060:
- !help dialect: Fix example
- copy_Exp(): Remove redundant Dictionary argument

Also:
- Fix format warnings due to adding `-Wformat-signedness` in PR #1061.
- Provide a clearer error message on invalid dialect name
