### PR TITLE
Dialect + general bug fixes / cleanup

### DIFF
--- a/bindings/python-examples/parses-dialect-en.txt
+++ b/bindings/python-examples/parses-dialect-en.txt
@@ -1,0 +1,10 @@
+% Dialect tests
+
+-dialect='headline'
+IThieves rob bank
+O
+O    +------->WV------>+
+O    +--->Wd---+---Sp--+--Os--+
+O    |         |       |      |
+OLEFT-WALL thieves.n rob.v bank.n
+O

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1088,6 +1088,12 @@ class ZRULangTestCase(unittest.TestCase):
              'облачк.=', '=а.ndnpi',
              '.', 'RIGHT-WALL'])
 
+class ZXDictDialectTestCase(unittest.TestCase):
+    def test_dialect(self):
+        linkage_testfile(self, Dictionary(lang='en'), ParseOptions(dialect='headline'), 'dialect')
+
+#############################################################################
+
 def linkage_testfile(self, lgdict, popt, desc=''):
     """
     Reads sentences and their corresponding

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -44,6 +44,7 @@ class ParseOptions(object):
                  repeatable_rand=True,
                  test='',
                  debug='',
+                 dialect='',
                  ):
 
         self._obj = clg.parse_options_create()
@@ -62,6 +63,7 @@ class ParseOptions(object):
         self.repeatable_rand = repeatable_rand
         self.test = test
         self.debug = debug
+        self.dialect = dialect
 
     # Allow only the attribute names listed below.
     def __setattr__(self, name, value):
@@ -92,8 +94,18 @@ class ParseOptions(object):
     @debug.setter
     def debug(self, value):
         if not isinstance(value, str):
-            raise TypeError("debug must be set to a string")
+            raise TypeError("dialect must be set to a string")
         return clg.parse_options_set_debug(self._obj, value)
+
+    @property
+    def dialect(self):
+        return clg.parse_options_get_dialect(self._obj)
+
+    @debug.setter
+    def dialect(self, value):
+        if not isinstance(value, str):
+            raise TypeError("dialect must be set to a string")
+        return clg.parse_options_set_dialect(self._obj, value)
 
     @property
     def verbosity(self):

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -82,7 +82,7 @@ class ParseOptions(object):
     @test.setter
     def test(self, value):
         if not isinstance(value, str):
-            raise TypeError("islands_ok must be set to a string")
+            raise TypeError("test must be set to a string")
         return clg.parse_options_set_test(self._obj, value)
 
     @property
@@ -92,7 +92,7 @@ class ParseOptions(object):
     @debug.setter
     def debug(self, value):
         if not isinstance(value, str):
-            raise TypeError("islands_ok must be set to a string")
+            raise TypeError("debug must be set to a string")
         return clg.parse_options_set_debug(self._obj, value)
 
     @property
@@ -106,7 +106,7 @@ class ParseOptions(object):
     @verbosity.setter
     def verbosity(self, value):
         if not isinstance(value, int):
-            raise TypeError("Verbosity must be set to an integer")
+            raise TypeError("verbosity must be set to an integer")
         if value not in range(0,120):
             raise ValueError("Verbosity levels can be any integer between 0 and 120 inclusive")
         clg.parse_options_set_verbosity(self._obj, value)
@@ -125,9 +125,9 @@ class ParseOptions(object):
     @linkage_limit.setter
     def linkage_limit(self, value):
         if not isinstance(value, int):
-            raise TypeError("Linkage Limit must be set to an integer")
+            raise TypeError("linkage_limit must be set to an integer")
         if value < 0:
-            raise ValueError("Linkage Limit must be positive")
+            raise ValueError("linkage_limit must be positive")
         clg.parse_options_set_linkage_limit(self._obj, value)
 
     @property
@@ -142,7 +142,7 @@ class ParseOptions(object):
     @disjunct_cost.setter
     def disjunct_cost(self, value):
         if not isinstance(value, float):
-            raise TypeError("Distjunct cost must be set to a float")
+            raise TypeError("disjunct_cost must be set to a float")
         clg.parse_options_set_disjunct_cost(self._obj, value)
 
     @property

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -292,6 +292,7 @@ components.
 
 The value of this variable consists of comma-separated names, with an
 optional cost value after a ":" delimiter (which can be empty).
+White space is not allowed.
 
 Names without a cost value are dialect names from the "4.0.dialect" file,
 and the dialect components are assigned costs as defined there.

--- a/link-grammar/api-types.h
+++ b/link-grammar/api-types.h
@@ -27,7 +27,6 @@ typedef struct Postprocessor_s Postprocessor;
 typedef struct Resources_s * Resources;
 
 /* Some of the more obscure typedefs */
-typedef struct Connector_set_s Connector_set;
 typedef struct Disjunct_struct Disjunct;
 typedef struct Link_s Link;
 typedef struct String_set_s String_set;

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -84,7 +84,7 @@ static bool apply_component(Dictionary dict, Dialect *di,
 
 	if (cost_index == SI_NOTFOUND)
 	{
-		prt_error("Error: Dialect component \"%s\" is not in the dictionary\n",
+		prt_error("Error: Dialect component \"%s\" is not in the dictionary.\n",
 			di->table[table_index].name);
 		return false;
 	}
@@ -134,7 +134,7 @@ static bool apply_table_entry(Dictionary dict, Dialect *from,
 			if (encountered[sub_index])
 			{
 				prt_error("Error: Loop detected at sub-dialect \"%s\" "
-				          "(of dialect \"%s\")\n",
+				          "(of dialect \"%s\").\n",
 				          to->table[i].name, to->table[table_index].name);
 				return false;
 			}
@@ -175,14 +175,14 @@ static void print_cost_table(Dictionary dict, Dialect *di, dialect_info *dinfo)
 
 	if (et->num == 0)
 	{
-		assert(dinfo->cost_table == NULL, "Unexpected cost table");
-		prt_error("Debug: No dialect cost table (no tags in the dict)\n");
+		assert(dinfo->cost_table == NULL, "Unexpected cost table.");
+		prt_error("Debug: No dialect cost table (no tags in the dict).\n");
 		return;
 	}
 
 	if (dinfo->cost_table == NULL)
 	{
-		prt_error("Debug: No dialect cost table\n");
+		prt_error("Debug: No dialect cost table.\n");
 		return;
 	}
 
@@ -229,7 +229,7 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 	{
 		if (!dialect_conf_exists(dinfo)) return true;
 		prt_error("Error: Dialect setup failed: No dialects in the \"%s\" "
-					 "dictionary %s\n", dict->lang, no_dialect);
+					 "dictionary %s.\n", dict->lang, no_dialect);
 		return false;
 	}
 

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -201,6 +201,7 @@ static void print_cost_table(Dictionary dict, Dialect *di, dialect_info *dinfo)
 void free_cost_table(Parse_Options opts)
 {
 	free(opts->dialect.cost_table);
+	opts->dialect.cost_table = NULL;
 }
 
 static bool dialect_conf_exists(dialect_info *dinfo)

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -64,14 +64,14 @@ Dictionary dictionary_create_default_lang(void)
 		lang[strcspn(lang, "_-")] = '\0';
 		dictionary = dictionary_create_lang(lang);
 	}
-	free(lang);
 
 	/* Fall back to English if no default locale or no matching dict. */
-	if (NULL == dictionary)
+	if ((NULL == dictionary) && ((lang == NULL) || (0 != strcmp(lang, "en"))))
 	{
 		dictionary = dictionary_create_lang("en");
 	}
 
+	free(lang);
 	return dictionary;
 }
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -118,7 +118,6 @@ struct Dictionary_s
 
 	pp_knowledge  * base_knowledge;    /* Core post-processing rules */
 	pp_knowledge  * hpsg_knowledge;    /* Head-Phrase Structure rules */
-	Connector_set * unlimited_connector_set; /* NULL=everything is unlimited */
 	String_set *    string_set;        /* Set of link names in the dictionary */
 	Word_file *     word_file_header;
 	ConTable        contable;

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -168,8 +168,17 @@ static char *get_label(dialect_file_status *dfile)
 	const char *bad = valid_dialect_name(label);
 	if (bad != NULL)
 	{
-		prt_error("Error: %s:%s \"%s\": Invalid character '%c' in dialect name.\n",
-		          dfile->fname, suppress_0(dfile->line_number, buf), label, *bad);
+		if (bad[0] == '\0')
+		{
+			prt_error("Error: %s:%s \"%s\": Missing name before a delimiter.\n",
+		             dfile->fname, suppress_0(dfile->line_number, buf), label);
+		}
+		else
+		{
+			prt_error("Error: %s:%s \"%s\": Invalid character '%c' in dialect name.\n",
+			          dfile->fname, suppress_0(dfile->line_number, buf), label,
+			          bad[0]);
+		}
 		return NULL;
 	}
 

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -191,7 +191,7 @@ static bool require_delimiter(dialect_file_status *dfile, char *s, char *buf)
 {
 	if (strchr(dfile->delims, *s) == NULL)
 	{
-		prt_error("Error: %s:%s Before \"%s\": Missing delimiter\n",
+		prt_error("Error: %s:%s Before \"%s\": Missing delimiter.\n",
 		          dfile->fname, suppress_0(dfile->line_number, buf), s);
 		return false;
 	}
@@ -319,7 +319,7 @@ static bool dialect_read_from_str(Dictionary dict, Dialect *di,
 			}
 			else
 			{
-				prt_error("Error: %s:%s After \"%s\": Internal error char %02x\n",
+				prt_error("Error: %s:%s After \"%s\": Internal error char %02x.\n",
 				          dfile->fname, suppress_0(dfile->line_number, buf),
 				          token, (unsigned char)*dfile->pin);
 			}
@@ -346,7 +346,7 @@ static bool dialect_read_from_str(Dictionary dict, Dialect *di,
 
 				if (end == NULL)
 				{
-					prt_error("Error: %s:%s Missing newline at end of file\n",
+					prt_error("Error: %s:%s Missing newline at end of file.\n",
 					          dfile->fname, suppress_0(dfile->line_number, buf));
 					return false;
 				}

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -187,12 +187,19 @@ static char *get_label(dialect_file_status *dfile)
 	return label;
 }
 
+static char *isolate_line(char *s)
+{
+	s[strcspn(s, "\n")] = '\0';
+	return s;
+}
+
 static bool require_delimiter(dialect_file_status *dfile, char *s, char *buf)
 {
 	if (strchr(dfile->delims, *s) == NULL)
 	{
 		prt_error("Error: %s:%s Before \"%s\": Missing delimiter.\n",
-		          dfile->fname, suppress_0(dfile->line_number, buf), s);
+		          dfile->fname, suppress_0(dfile->line_number, buf),
+		          isolate_line(s));
 		return false;
 	}
 	return true;

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -467,6 +467,9 @@ bool dialect_file_read(Dictionary dict, const char *fname)
 	return true;
 }
 
+/* Denote link-parser's dialect variable or Parse_Options dialect option. */
+#define DIALECT_OPTION "dialect option"
+
 /**
  * Decode the !dialect user variable.
  */
@@ -479,12 +482,12 @@ bool dialect_read_from_one_line_str(Dictionary dict, Dialect *di,
 		if (*c == '[')
 		{
 			/* Section header specification is not allowed. */
-			prt_error("Error: dialect variable: Invalid character \"[\".\n");
+			prt_error("Error: "DIALECT_OPTION": Invalid character \"[\".\n");
 			return false;
 		}
 		else if (*c == '\n')
 		{
-			prt_error("Error: dialect variable: Newlines are not allowed.\n");
+			prt_error("Error: "DIALECT_OPTION": Newlines are not allowed.\n");
 			return false;
 		}
 	}
@@ -493,7 +496,7 @@ bool dialect_read_from_one_line_str(Dictionary dict, Dialect *di,
 
 	dialect_file_status dfile =
 	{
-		.fname = "User setup",
+		.fname = DIALECT_OPTION,
 		.pin = di->kept_input,
 		.line_number = 0, /* 0 denotes reading from a string. */
 		.delims = delims_string,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -588,7 +588,7 @@ static Count_bin do_count(int lineno, count_context_t *ctxt,
 		snprintf(m_result, sizeof(m_result), "(M=%lld)", hist_total(&t->count));
 
 	level++;
-	prt_error("%*sdo_count%s:%d lw=%d rw=%d le=%s(%d) re=%s(%d) null_count=%d\n\\",
+	prt_error("%*sdo_count%s:%d lw=%d rw=%d le=%s(%d) re=%s(%d) null_count=%u\n\\",
 		level*2, "", m_result, lineno, lw, rw, V(le),ID(le,lw), V(re),ID(re,rw), null_count);
 	Count_bin r = do_count1(lineno, ctxt, lw, rw, le, re, null_count);
 	prt_error("%*sreturn%.*s:%d=%lld\n",

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -377,7 +377,8 @@ static const char *stringify_Exp_type(Exp_type type)
 	}
 	else
 	{
-		snprintf(unknown_type, sizeof(unknown_type)-1, "unknown_type-%d", type);
+		snprintf(unknown_type, sizeof(unknown_type)-1, "unknown_type-%d",
+		         (int)(type));
 		type_str = unknown_type;
 	}
 


### PR DESCRIPTION
Bug fixes:
- free_cost_table(): Nullify cost_table to designate no caching
It causes a double-free crash.
- dictionary_create_default_lang(): Don't open "en" a second time
It causes double error messages if the 'en' dict contains an error.

- get_label(): Fix a bad and truncated error message if a name is missing
- require_delimiter(): Don't print the whole file after the point of error

Python / tests suite:
- Python binding ParseOptions(): Add parse_options_*_dialect()
- Python binding ParseOptions(): Notify real variable names on errors
- tests.py: Add a dialect test

Cleanup:
- Define DIALECT_OPTION: The name of the dialect option in error messages
- Dictionary_s: Remove unused field "Connector_set"
- !help dialect: Document a current limitation in user variable values
- DEBUG mode: Fix format warnings due to -Wformat-signedness
- Dialect code: Add '.' at end of error messages
I now think that messages must end with a period. I started with the recent ones.