### PR TITLE
Cleanup: Unify Exp functions + more

### DIFF
--- a/bindings/python-examples/parses-pos-en.txt
+++ b/bindings/python-examples/parses-pos-en.txt
@@ -51,6 +51,6 @@ P
 % the word position of these combined splits correctly.
 
 IAs no linkage
-PLEFT-WALL(0, 0) [as](0, 2) no.ij(3, 5) linkage.n-u(6, 13) RIGHT-WALL(13, 13)
-PLEFT-WALL(0, 0) [as](0, 2) no.ij(3, 5) linkage.n-u(6, 13) RIGHT-WALL(13, 13)
+PLEFT-WALL(0, 0) [as](0, 2) no.misc-d(3, 5) linkage.n-u(6, 13) RIGHT-WALL(13, 13)
+PLEFT-WALL(0, 0) [as](0, 2) no.misc-d(3, 5) linkage.n-u(6, 13) RIGHT-WALL(13, 13)
 P

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-""" Note: This only runs with Python3! """
-
 """
+Note: This only runs with Python3!
+
 Demo: Find unlinked or unknown words.
 These demo is extremely simplified.
 It can only work with link-grammar library version >= 5.3.10.
@@ -166,8 +166,6 @@ while True:
                 words_char = []
                 words_byte = []
                 for wi, w in enumerate(words):
-                    if is_python2():
-                        w = w.decode('utf-8')
                     words_char.append(w + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
                     words_byte.append(w + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -144,6 +144,7 @@ struct Dictionary_s
 bool dict_has_word(const Dictionary dict, const char *);
 Exp *Exp_create(Pool_desc *);
 Exp *Exp_create_dup(Pool_desc *, Exp *);
+Exp *make_unary_node(Pool_desc *, Exp *);
 void add_empty_word(Sentence, X_node *);
 
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -142,7 +142,8 @@ struct Dictionary_s
  * probably don't need these. */
 
 bool dict_has_word(const Dictionary dict, const char *);
-Exp * Exp_create(Dictionary);
+Exp *Exp_create(Pool_desc *);
+Exp *Exp_create_dup(Pool_desc *, Exp *);
 void add_empty_word(Sentence, X_node *);
 
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -240,7 +240,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	/* note that the last word of the idiom is first in our list */
 
 	/* ----- this code just sets up the node fields of the dn_list ----*/
-	nc = Exp_create(dict);
+	nc = Exp_create(dict->Exp_pool);
 	nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '-';
 	nc->multi = false;
@@ -248,7 +248,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	nc->operand_next = no;
 	nc->cost = 0;
 
-	n1 = Exp_create(dict);
+	n1 = Exp_create(dict->Exp_pool);
 	n1->operand_first = nc;
 	n1->type = AND_type;
 	n1->operand_next = NULL;
@@ -262,12 +262,12 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	{
 		/* generate the expression for a middle idiom word */
 
-		n1 = Exp_create(dict);
+		n1 = Exp_create(dict->Exp_pool);
 		n1->type = AND_type;
 		n1->operand_next = NULL;
 		n1->cost = 0;
 
-		nc = Exp_create(dict);
+		nc = Exp_create(dict->Exp_pool);
 		nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		nc->dir = '+';
 		nc->multi = false;
@@ -278,7 +278,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 
 		increment_current_name(dict);
 
-		no = Exp_create(dict);
+		no = Exp_create(dict->Exp_pool);
 		no->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 		no->dir = '-';
 		no->multi = false;
@@ -294,7 +294,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
 	}
 	/* now generate the last one */
 
-	nc = Exp_create(dict);
+	nc = Exp_create(dict->Exp_pool);
 	nc->condesc = condesc_add(&dict->contable, generate_id_connector(dict));
 	nc->dir = '+';
 	nc->multi = false;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -831,7 +831,7 @@ static Exp * make_zeroary_node(Pool_desc *mp)
  * This creates a node with one child (namely e).  Initializes
  * the cost to zero.
  */
-static Exp *make_unary_node(Pool_desc *mp, Exp * e)
+Exp *make_unary_node(Pool_desc *mp, Exp * e)
 {
 	Exp * n;
 	n = Exp_create(mp);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -792,9 +792,9 @@ static Dict_node * strict_lookup_list(const Dictionary dict, const char *s)
 /**
  * Allocate a new Exp node.
  */
-Exp *Exp_create(Dictionary dict)
+Exp *Exp_create(Pool_desc *mp)
 {
-	Exp *e = pool_alloc(dict->Exp_pool);
+	Exp *e = pool_alloc(mp);
 	e->tag = NULL;
 	return e;
 }
@@ -804,9 +804,9 @@ Exp *Exp_create(Dictionary dict)
  * This is needed in case it is to be participate more than once in a
  * single expression.
  */
-static Exp *Exp_create_dup(Dictionary dict, Exp *old_e)
+Exp *Exp_create_dup(Pool_desc *mp, Exp *old_e)
 {
-	Exp *new_e = Exp_create(dict);
+	Exp *new_e = Exp_create(mp);
 
 	*new_e = *old_e;
 
@@ -817,9 +817,9 @@ static Exp *Exp_create_dup(Dictionary dict, Exp *old_e)
  * This creates a node with zero children.  Initializes
  * the cost to zero.
  */
-static Exp * make_zeroary_node(Dictionary dict)
+static Exp * make_zeroary_node(Pool_desc *mp)
 {
-	Exp * n = Exp_create(dict);
+	Exp * n = Exp_create(mp);
 	n->type = AND_type;  /* these must be AND types */
 	n->cost = 0.0;
 	n->operand_first = NULL;
@@ -831,10 +831,10 @@ static Exp * make_zeroary_node(Dictionary dict)
  * This creates a node with one child (namely e).  Initializes
  * the cost to zero.
  */
-static Exp * make_unary_node(Dictionary dict, Exp * e)
+static Exp *make_unary_node(Pool_desc *mp, Exp * e)
 {
 	Exp * n;
-	n = Exp_create(dict);
+	n = Exp_create(mp);
 	n->type = AND_type;  /* these must be AND types */
 	n->operand_next = NULL;
 	n->cost = 0.0;
@@ -846,11 +846,11 @@ static Exp * make_unary_node(Dictionary dict, Exp * e)
  * Create an AND_type expression. The expressions nl, nr will be
  * AND-ed together.
  */
-static Exp * make_and_node(Dictionary dict, Exp* nl, Exp* nr)
+static Exp * make_and_node(Pool_desc *mp, Exp* nl, Exp* nr)
 {
 	Exp* n;
 
-	n = Exp_create(dict);
+	n = Exp_create(mp);
 	n->type = AND_type;
 	n->operand_next = NULL;
 	n->cost = 0.0;
@@ -862,9 +862,9 @@ static Exp * make_and_node(Dictionary dict, Exp* nl, Exp* nr)
 	return n;
 }
 
-static Exp *make_op_Exp(Dictionary dict, Exp_type t)
+static Exp *make_op_Exp(Pool_desc *mp, Exp_type t)
 {
-	Exp * n = Exp_create(dict);
+	Exp * n = Exp_create(mp);
 	n->type = t;
 	n->operand_next = NULL;
 	n->cost = 0.0;
@@ -877,11 +877,11 @@ static Exp *make_op_Exp(Dictionary dict, Exp_type t)
  * Create an OR_type expression. The expressions nl, nr will be
  * OR-ed together.
  */
-static Exp * make_or_node(Dictionary dict, Exp* nl, Exp* nr)
+static Exp * make_or_node(Pool_desc *mp, Exp* nl, Exp* nr)
 {
 	Exp* n;
 
-	n = Exp_create(dict);
+	n = Exp_create(mp);
 	n->type = OR_type;
 	n->operand_next = NULL;
 	n->cost = 0.0;
@@ -898,9 +898,9 @@ static Exp * make_or_node(Dictionary dict, Exp* nl, Exp* nr)
  * and the other as zeroary node.  This has the effect of creating
  * what used to be called an optional node.
  */
-static Exp *make_optional_node(Dictionary dict, Exp *e)
+static Exp *make_optional_node(Pool_desc *mp, Exp *e)
 {
-	return make_or_node(dict, make_zeroary_node(dict), e);
+	return make_or_node(mp, make_zeroary_node(mp), e);
 }
 
 /**
@@ -911,7 +911,7 @@ static Exp *make_optional_node(Dictionary dict, Exp *e)
  */
 static Exp * make_dir_connector(Dictionary dict, int i)
 {
-	Exp* n = Exp_create(dict);
+	Exp* n = Exp_create(dict->Exp_pool);
 	char *constring;
 
 	n->dir = dict->token[i];
@@ -971,7 +971,7 @@ static Exp * make_connector(Dictionary dict)
 		}
 
 		/* Wrap it in a unary node as a placeholder for a cost if needed. */
-		n = make_unary_node(dict, dn->exp);
+		n = make_unary_node(dict->Exp_pool, dn->exp);
 
 		file_free_lookup(dn_head);
 	}
@@ -1000,7 +1000,7 @@ static Exp * make_connector(Dictionary dict)
 			min = make_dir_connector(dict, i);
 			if (NULL == min) return NULL;
 
-			n = make_or_node(dict, plu, min);
+			n = make_or_node(dict->Exp_pool, plu, min);
 		}
 		else
 		{
@@ -1019,42 +1019,6 @@ static Exp * make_connector(Dictionary dict)
 
 /* ======================================================================== */
 /* Empty-word handling. */
-
-/** Expression-creating function versions that use the Sentence
- *  expression memory pools.
- *  (FIXME: Unify with the similar functions above.)
- */
-static Exp *make_or_node_from_pool(Sentence sent, Exp *nl, Exp *nr)
-{
-	Exp* n;
-
-	n = pool_alloc(sent->Exp_pool);
-	n->type = OR_type;
-	n->operand_next = NULL;
-	n->cost = 0.0;
-
-	n->operand_first = nl;
-	nl->operand_next = nr;
-	nr->operand_next = NULL;
-
-	return n;
-}
-
-static Exp *make_zeroary_node_from_pool(Sentence sent)
-{
-	Exp * n = pool_alloc(sent->Exp_pool);
-	n->type = AND_type;  /* these must be AND types */
-	n->operand_next = NULL;
-	n->cost = 0.0;
-	n->operand_first = NULL;
-
-	return n;
-}
-
-static Exp *make_optional_node_from_pool(Sentence sent, Exp *e)
-{
-	return make_or_node_from_pool(sent, make_zeroary_node_from_pool(sent), e);
-}
 
 /** Insert ZZZ+ connectors.
  *  This function was mainly used to support using empty-words, a concept
@@ -1079,17 +1043,17 @@ void add_empty_word(Sentence sent, X_node *x)
 		//lgdebug(+0, "Processing '%s'\n", x->string);
 
 		/* zn points at {ZZZ+} */
-		zn = pool_alloc(sent->Exp_pool);
+		zn = Exp_create(sent->Exp_pool);
 		zn->dir = '+';
 		zn->condesc = condesc_add(&sent->dict->contable, ZZZ);
 		zn->multi = false;
 		zn->type = CONNECTOR_type;
 		zn->operand_next = NULL; /* unused, but to be on the safe side */
 		zn->cost = 0.0;
-		zn = make_optional_node_from_pool(sent, zn);
+		zn = make_optional_node(sent->Exp_pool, zn);
 
 		/* an will be {ZZZ+} & (plain-word-exp) */
-		an = pool_alloc(sent->Exp_pool);
+		an = Exp_create(sent->Exp_pool);
 		an->type = AND_type;
 		an->operand_next = NULL;
 		an->cost = 0.0;
@@ -1163,7 +1127,7 @@ static Exp *make_expression(Dictionary dict)
 			if (!link_advance(dict)) {
 				return NULL;
 			}
-			nl = make_optional_node(dict, nl);
+			nl = make_optional_node(dict->Exp_pool, nl);
 		}
 		else if (is_equal(dict, '['))
 		{
@@ -1219,7 +1183,7 @@ static Exp *make_expression(Dictionary dict)
 				}
 				if (nl->tag != NULL)
 				{
-					nl = make_unary_node(dict, nl);
+					nl = make_unary_node(dict->Exp_pool, nl);
 				}
 				nl->tag = exptag_add(dict, dict->token);
 				if (!link_advance(dict)) {
@@ -1241,7 +1205,7 @@ static Exp *make_expression(Dictionary dict)
 		else if (is_equal(dict, ')') || is_equal(dict, ']'))
 		{
 			/* allows "()" or "[]" */
-			nl = make_zeroary_node(dict);
+			nl = make_zeroary_node(dict->Exp_pool);
 		}
 		else
 		{
@@ -1254,13 +1218,13 @@ static Exp *make_expression(Dictionary dict)
 			/* Part 2/2 of SYM_AND processing. */
 
 			/* Expand A ^ B into the expr ((A & B) or (B & A)). */
-			Exp *na = make_and_node(dict,
-			                   Exp_create_dup(dict, e_tail),
-			                   Exp_create_dup(dict, nl));
-			Exp *nb = make_and_node(dict,
-			                   Exp_create_dup(dict, nl),
-			                   Exp_create_dup(dict, e_tail));
-			Exp *or = make_or_node(dict, na, nb);
+			Exp *na = make_and_node(dict->Exp_pool,
+			                   Exp_create_dup(dict->Exp_pool, e_tail),
+			                   Exp_create_dup(dict->Exp_pool, nl));
+			Exp *nb = make_and_node(dict->Exp_pool,
+			                   Exp_create_dup(dict->Exp_pool, nl),
+			                   Exp_create_dup(dict->Exp_pool, e_tail));
+			Exp *or = make_or_node(dict->Exp_pool, na, nb);
 
 			*e_tail = *or; /* SYM_AND result */
 			is_sym_and = false;
@@ -1305,7 +1269,7 @@ static Exp *make_expression(Dictionary dict)
 		 * expression level. */
 		if (e_head == NULL)
 		{
-			e_head = make_op_Exp(dict, op);
+			e_head = make_op_Exp(dict->Exp_pool, op);
 			e_head->operand_first = nl;
 		}
 		else

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -75,7 +75,7 @@ static const char * make_expression(Dictionary dict,
 				"Missing direction character in connector string: %s", con_start);
 
 		/* Create an expression to hold the connector */
-		Exp* e = Exp_create(dict);
+		Exp* e = Exp_create(dict->Exp_pool);
 		e->dir = *p;
 		e->type = CONNECTOR_type;
 		e->operand_next = NULL;
@@ -124,7 +124,7 @@ static const char * make_expression(Dictionary dict,
 	assert(NULL != rest, "Badly formed expression %s", exp_str);
 
 	/* Join it all together. */
-	Exp* join = Exp_create(dict);
+	Exp* join = Exp_create(dict->Exp_pool);
 	join->type = etype;
 	join->operand_next = NULL;
 	join->cost = 0.0;
@@ -191,7 +191,7 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 	/* If the second expression, OR-it with the existing expression. */
 	if (OR_type != bs->exp->type)
 	{
-		Exp* orn = Exp_create(dict);
+		Exp* orn = Exp_create(dict->Exp_pool);
 		orn->type = OR_type;
 		orn->cost = 0.0;
 

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -495,7 +495,7 @@ void SATEncoder::generate_satisfaction_for_expression(int w, int& dfs_position, 
  */
 Exp* SATEncoder::join_alternatives(int w)
 {
-  Exp* exp = Exp_create(_sent);
+  Exp* exp = Exp_create(_sent->Exp_pool);
   exp->type = OR_type;
   exp->cost = 0.0;
 
@@ -503,7 +503,7 @@ Exp* SATEncoder::join_alternatives(int w)
 
   for (X_node* x = _sent->word[w].x; x != NULL; x = x->next)
   {
-    *opdp = Exp_create_dup(_sent, x->exp);
+    *opdp = Exp_create_dup(_sent->Exp_pool, x->exp);
     opdp = &(*opdp)->operand_next;
   }
   *opdp = NULL;
@@ -1779,7 +1779,7 @@ void SATEncoderConjunctionFreeSentences::generate_linked_definitions()
 
 Exp* SATEncoderConjunctionFreeSentences::PositionConnector2exp(const PositionConnector* pc)
 {
-    Exp* e = Exp_create(_sent);
+    Exp* e = Exp_create(_sent->Exp_pool);
     e->type = CONNECTOR_type;
     e->dir = pc->dir;
     e->multi = pc->connector.multi;

--- a/link-grammar/sat-solver/util.cpp
+++ b/link-grammar/sat-solver/util.cpp
@@ -2,6 +2,7 @@
 
 extern "C" {
 #include "api-structures.h"
+#include "dict-common/dict-common.h"
 #include "disjunct-utils.h"
 #include "linkage/linkage.h"
 #include "memory-pool.h"
@@ -51,45 +52,6 @@ Exp* null_exp()
   return &e;
 }
 
-/* FIXME:
- * 1. Remove unused Exp functions when disjuncts are directly built.
- * 2. Unify remaining Exp functions with the similar ones in read-dict.c. */
-
-/**
- * Allocate a new Exp node.
- */
-Exp* Exp_create(Sentence sent)
-{
-  Exp* e = (Exp*)pool_alloc(sent->Exp_pool);
-  return e;
-}
-
-static Exp* make_unary_node(Sentence sent, Exp* e)
-{
-  Exp* n;
-  n = Exp_create(sent);
-  n->type = AND_type;  /* these must be AND types */
-  n->operand_next = NULL;
-  n->cost = 0.0;
-  n->operand_first = e;
-  return n;
-}
-
-/**
- * Duplicate the given Exp node.
- * This is needed in case it is to be participate more than once in an
- * expression (one or more), so its operand_first and operand_next may be
- * different.
- */
-Exp *Exp_create_dup(Sentence sent, Exp *old_e)
-{
-  Exp *new_e = Exp_create(sent);
-
-  *new_e = *old_e;
-
-  return new_e;
-}
-
 /**
  * Prepend the CONNECTOR node addit to the AND node orig.
  * (If orig is NULL, first create an AND node.)
@@ -99,14 +61,14 @@ void add_anded_exp(Sentence sent, Exp*& orig, Exp* addit)
 {
     if (orig == NULL)
     {
-      orig = make_unary_node(sent, Exp_create_dup(sent, addit));
+      orig = make_unary_node(sent->Exp_pool, Exp_create_dup(sent->Exp_pool, addit));
       orig->operand_first->operand_next = NULL;
     }
     else
     {
       // Prepend addit to the existing operands
       Exp *orig_operand_first = orig->operand_first;
-      orig->operand_first = Exp_create_dup(sent, addit);
+      orig->operand_first = Exp_create_dup(sent->Exp_pool, addit);
       orig->operand_first->operand_next = orig_operand_first;
     }
 

--- a/link-grammar/sat-solver/util.hpp
+++ b/link-grammar/sat-solver/util.hpp
@@ -14,7 +14,4 @@ void sat_free_linkages(Sentence, LinkageIdx);
 void sat_free_linkages(Sentence);
 Exp* null_exp();
 void add_anded_exp(Sentence, Exp*&, Exp*);
-Exp* Exp_create(Sentence);
-Exp *Exp_create_dup(Sentence, Exp *old);
-
 #endif


### PR DESCRIPTION
The new Exp tag field and also an additional WIP field there remained uninitialized in ZZZ nodes added by `add_empty_word()`.

Fix that by using there `Exp_create()`.
In the same occasion:
- Unify the sentence Exp function with the dict ones.
- Replace the SAT parser private Exp functions by these unified functions.