### PR TITLE
Dict: Flag an empty word list in as an error

### DIFF
--- a/data/ru/stem.dict
+++ b/data/ru/stem.dict
@@ -55,11 +55,11 @@
 пирит.= тис.= чон.= :
   LLAAQ+ or LLDXR+;
 
-абаз.ndmsv дем.ndmsv кондом.ndmsv лимб.ndmsv одр.ndmsv орт.ndmsv 
-пирит.ndmsv тис.ndmsv чон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 абаз.ndmsi дем.ndmsi кондом.ndmsi лимб.ndmsi одр.ndmsi орт.ndmsi 
 пирит.ndmsi тис.ndmsi чон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+абаз.ndmsv дем.ndmsv кондом.ndmsv лимб.ndmsv одр.ndmsv орт.ndmsv 
+пирит.ndmsv тис.ndmsv чон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 абазин.= балкар.= имеретин.= :
   LLACX+ or LLAYI+ or LLBRO+;
@@ -98,11 +98,11 @@
 аблогин.= :
   LLFJJ+ or LLFJT+;
 
-аблогин.nlfpg :  <morph-С,жр,од,мн,рд>;
+аблогин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 аблогин.nlmsi :  <morph-С,мр,од,ед,им>;
 
-аблогин.nlfpv :  <morph-С,жр,од,мн,вн>;
+аблогин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 абонент.= :
   LLACI+ or LLBRO+ or LLBZF+;
@@ -140,9 +140,9 @@
 абрин.= :
   LLFQF+ or LLFID+;
 
-абрин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 абрин.nlmsi :  <morph-С,мр,од,ед,им>;
+
+абрин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 абхаз.= авар.= бургунд.= духобор.= кюрин.= себялюб.= 
 сердцевед.= старовер.= тевтон.= челядин.= швейцар.= :
@@ -248,9 +248,9 @@
 автотранспорт.= :
   LLAAU+;
 
-автотранспорт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 автотранспорт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+автотранспорт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 автошоу.= айова.= альберто.= битлз.= джорджия.= директстар.= 
 доминго.= дурново.= коммерсантъ.= лэп.= :
@@ -264,9 +264,9 @@
 агам.= амеб.= :
   LLAGT+ or LLBZE+;
 
-агам.nlfpg амеб.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 агам.nlfpv амеб.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+агам.nlfpg амеб.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 агами.= :
   LLADG+ or LLDQL+;
@@ -281,9 +281,9 @@
 агат.= :
   LLAAQ+ or LLFKR+ or LLBZF+ or LLFHR+;
 
-агат.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 агат.ndmsi :  <morph-С,мр,но,ед,им>;
+
+агат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.2:
   LLFQF+ or LLFJN+;
@@ -323,9 +323,9 @@
 адамов.= :
   LLFJG+ or LLFUO+;
 
-адамов.amsi :  <morph-П,мр,ед,им>;
-
 адамов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+адамов.amsi :  <morph-П,мр,ед,им>;
 
 адамов.admsv :  <morph-П,мр,ед,вн,но>;
 
@@ -346,18 +346,18 @@
 аделин.= :
   LLFJC+ or LLFJT+;
 
-аделин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 аделин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+аделин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 адов.= иродов.= :
   LLFUO+ or LLDKP+;
 
-адов.amsi иродов.amsi :  <morph-П,мр,ед,им>;
-
 адов.amss иродов.amss :  <morph-П,мр,ед,кр>;
 
 адов.admsv иродов.admsv :  <morph-П,мр,ед,вн,но>;
+
+адов.amsi иродов.amsi :  <morph-П,мр,ед,им>;
 
 адрес.= :
   LLABN+ or LLBYU+ or LLCCZ+ or LLFWB+ or LLCGW+ or LLFWD+ or LLCJW+;
@@ -379,11 +379,11 @@
 азарин.= :
   LLAAQ+ or LLFQF+;
 
+азарин.ndmsi :  <morph-С,мр,но,ед,им>;
+
 азарин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 азарин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-азарин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 азиатско-тихоокеанск.= мошенническ.= программистск.= :
   LLBEO+;
@@ -435,11 +435,11 @@
 луцк.= пинск.= черногорск.= югорск.= южно-сахалинск.= :
   LLDWW+ or LLGRQ+;
 
-акмолинск.ndmsv бердянск.ndmsv днепродзержинск.ndmsv зеленогорск.ndmsv иртышск.ndmsv краматорск.ndmsv 
-луцк.ndmsv пинск.ndmsv черногорск.ndmsv югорск.ndmsv южно-сахалинск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 акмолинск.ndmsi бердянск.ndmsi днепродзержинск.ndmsi зеленогорск.ndmsi иртышск.ndmsi краматорск.ndmsi 
 луцк.ndmsi пинск.ndmsi черногорск.ndmsi югорск.ndmsi южно-сахалинск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+акмолинск.ndmsv бердянск.ndmsv днепродзержинск.ndmsv зеленогорск.ndmsv иртышск.ndmsv краматорск.ndmsv 
+луцк.ndmsv пинск.ndmsv черногорск.ndmsv югорск.ndmsv южно-сахалинск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 активир.= :
   LLCFY+ or LLELG+ or LLFNS+;
@@ -460,16 +460,16 @@
 акул.= стрекоз.= человекообезьян.= :
   LLAGT+ or LLBFF+;
 
-акул.nlfpg стрекоз.nlfpg человекообезьян.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 акул.nlfpv стрекоз.nlfpv человекообезьян.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+акул.nlfpg стрекоз.nlfpg человекообезьян.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 акцепт.= пунктир.= :
   LLAAQ+ or LLBYU+ or LLFRE+;
 
-акцепт.ndmsv пунктир.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 акцепт.ndmsi пунктир.ndmsi :  <morph-С,мр,но,ед,им>;
+
+акцепт.ndmsv пунктир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ал.= :
   LLBRQ+ or LLDKF+;
@@ -497,9 +497,9 @@
 александров.= киров.= :
   LLDWW+ or LLFQF+ or LLFOU+ or LLDZR+;
 
-александров.nlmsi киров.nlmsi :  <morph-С,мр,од,ед,им>;
-
 александров.ndmsv киров.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+александров.nlmsi киров.nlmsi :  <morph-С,мр,од,ед,им>;
 
 александров.ndmsi киров.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -523,9 +523,9 @@
 алеш.= :
   LLFNE+;
 
-алеш.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 алеш.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+алеш.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 али.= :
   LLFJB+ or LLFHW+ or LLFKT+;
@@ -549,50 +549,6 @@
 
 /ru/words/words.6:
   LLAAQ+ or LLBYZ+;
-
-азям.ndmsv акафист.ndmsv акциз.ndmsv алмаз.ndmsv амилоид.ndmsv анион.ndmsv 
-анод.ndmsv арбуз.ndmsv архив.ndmsv асфальт.ndmsv атом.ndmsv аукцион.ndmsv 
-байрам.ndmsv бакштов.ndmsv баланс.ndmsv балкон.ndmsv баллон.ndmsv бальзам.ndmsv 
-баркас.ndmsv барьер.ndmsv басон.ndmsv бастион.ndmsv баян.ndmsv безмен.ndmsv 
-бидон.ndmsv билет.ndmsv биллон.ndmsv бильярд.ndmsv биоген.ndmsv битум.ndmsv 
-бордюр.ndmsv брандер.ndmsv буран.ndmsv бушлат.ndmsv вакуум.ndmsv ватер.ndmsv 
-ввод.ndmsv вектор.ndmsv взвод.ndmsv виссон.ndmsv водомет.ndmsv водопад.ndmsv 
-водород.ndmsv газон.ndmsv галоген.ndmsv галоид.ndmsv галун.ndmsv ганоид.ndmsv 
-гарем.ndmsv гейзер.ndmsv гипюр.ndmsv глетчер.ndmsv глицин.ndmsv глобус.ndmsv 
-гобелен.ndmsv гонорар.ndmsv грейдер.ndmsv грейфер.ndmsv гудрон.ndmsv демпфер.ndmsv 
-диван.ndmsv диез.ndmsv диплом.ndmsv доступ.ndmsv дуэт.ndmsv жетон.ndmsv 
-зипун.ndmsv извоз.ndmsv инфаркт.ndmsv ион.ndmsv исход.ndmsv камин.ndmsv 
-канун.ndmsv капкан.ndmsv караван.ndmsv карбид.ndmsv кардан.ndmsv карниз.ndmsv 
-картуз.ndmsv каскад.ndmsv катод.ndmsv каупер.ndmsv кафтан.ndmsv кессон.ndmsv 
-клапан.ndmsv клистир.ndmsv кокон.ndmsv коллоид.ndmsv колхоз.ndmsv колчан.ndmsv 
-комод.ndmsv компас.ndmsv коридор.ndmsv костюм.ndmsv котонин.ndmsv кретон.ndmsv 
-купон.ndmsv курсор.ndmsv лабаз.ndmsv ледоход.ndmsv лесовоз.ndmsv ликвид.ndmsv 
-лиман.ndmsv линотип.ndmsv ломбер.ndmsv майорат.ndmsv макет.ndmsv маникюр.ndmsv 
-метеор.ndmsv микрон.ndmsv миномет.ndmsv моляр.ndmsv монотип.ndmsv наган.ndmsv 
-нажим.ndmsv нарыв.ndmsv нейтрон.ndmsv обгон.ndmsv обиход.ndmsv обоз.ndmsv 
-обряд.ndmsv обход.ndmsv овин.ndmsv опиум.ndmsv орган.ndmsv отряд.ndmsv 
-пакгауз.ndmsv пансион.ndmsv парашют.ndmsv паровоз.ndmsv паром.ndmsv пароход.ndmsv 
-пасьянс.ndmsv патефон.ndmsv педикюр.ndmsv пенсион.ndmsv переезд.ndmsv переход.ndmsv 
-перрон.ndmsv пирофор.ndmsv пистон.ndmsv пищевод.ndmsv плаун.ndmsv плафон.ndmsv 
-плеврит.ndmsv пленэр.ndmsv плинтус.ndmsv плод.ndmsv плунжер.ndmsv плывун.ndmsv 
-поем.ndmsv покер.ndmsv покров.ndmsv полигон.ndmsv помидор.ndmsv понтон.ndmsv 
-призыв.ndmsv приказ.ndmsv приплод.ndmsv провес.ndmsv проем.ndmsv протез.ndmsv 
-пулемет.ndmsv радар.ndmsv разжим.ndmsv размен.ndmsv разъем.ndmsv район.ndmsv 
-рангоут.ndmsv рацион.ndmsv реактор.ndmsv рекорд.ndmsv реостат.ndmsv реферат.ndmsv 
-рефулер.ndmsv ромбоид.ndmsv ротатор.ndmsv ротор.ndmsv рубин.ndmsv рулон.ndmsv 
-рыбоход.ndmsv салоп.ndmsv саман.ndmsv самолет.ndmsv самолов.ndmsv сарафан.ndmsv 
-сейнер.ndmsv сервиз.ndmsv серозем.ndmsv сифон.ndmsv скаляр.ndmsv скрепер.ndmsv 
-слалом.ndmsv снаряд.ndmsv совхоз.ndmsv стадион.ndmsv стакан.ndmsv стеноз.ndmsv 
-стокер.ndmsv сульфид.ndmsv сустав.ndmsv сфероид.ndmsv табор.ndmsv талон.ndmsv 
-тамбур.ndmsv тангир.ndmsv танкер.ndmsv телефон.ndmsv тендер.ndmsv термос.ndmsv 
-тимпан.ndmsv тифоид.ndmsv топаз.ndmsv трактир.ndmsv тромбон.ndmsv тротуар.ndmsv 
-труп.ndmsv трюм.ndmsv тулуп.ndmsv турнир.ndmsv тюльпан.ndmsv углевод.ndmsv 
-углерод.ndmsv угломер.ndmsv уезд.ndmsv улус.ndmsv унос.ndmsv фасад.ndmsv 
-фикус.ndmsv финноз.ndmsv флакон.ndmsv флюид.ndmsv фонтан.ndmsv фосген.ndmsv 
-фрегат.ndmsv фронтон.ndmsv фужер.ndmsv фургон.ndmsv футляр.ndmsv хоровод.ndmsv 
-циклон.ndmsv чемодан.ndmsv чулан.ndmsv шантан.ndmsv шарнир.ndmsv швеллер.ndmsv 
-шеврон.ndmsv шифон.ndmsv штоф.ndmsv шуруп.ndmsv экран.ndmsv эскарп.ndmsv 
-эстамп.ndmsv этап.ndmsv этюд.ndmsv эшелон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 азям.ndmsi акафист.ndmsi акциз.ndmsi алмаз.ndmsi амилоид.ndmsi анион.ndmsi 
 анод.ndmsi арбуз.ndmsi архив.ndmsi асфальт.ndmsi атом.ndmsi аукцион.ndmsi 
@@ -637,6 +593,50 @@
 циклон.ndmsi чемодан.ndmsi чулан.ndmsi шантан.ndmsi шарнир.ndmsi швеллер.ndmsi 
 шеврон.ndmsi шифон.ndmsi штоф.ndmsi шуруп.ndmsi экран.ndmsi эскарп.ndmsi 
 эстамп.ndmsi этап.ndmsi этюд.ndmsi эшелон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+азям.ndmsv акафист.ndmsv акциз.ndmsv алмаз.ndmsv амилоид.ndmsv анион.ndmsv 
+анод.ndmsv арбуз.ndmsv архив.ndmsv асфальт.ndmsv атом.ndmsv аукцион.ndmsv 
+байрам.ndmsv бакштов.ndmsv баланс.ndmsv балкон.ndmsv баллон.ndmsv бальзам.ndmsv 
+баркас.ndmsv барьер.ndmsv басон.ndmsv бастион.ndmsv баян.ndmsv безмен.ndmsv 
+бидон.ndmsv билет.ndmsv биллон.ndmsv бильярд.ndmsv биоген.ndmsv битум.ndmsv 
+бордюр.ndmsv брандер.ndmsv буран.ndmsv бушлат.ndmsv вакуум.ndmsv ватер.ndmsv 
+ввод.ndmsv вектор.ndmsv взвод.ndmsv виссон.ndmsv водомет.ndmsv водопад.ndmsv 
+водород.ndmsv газон.ndmsv галоген.ndmsv галоид.ndmsv галун.ndmsv ганоид.ndmsv 
+гарем.ndmsv гейзер.ndmsv гипюр.ndmsv глетчер.ndmsv глицин.ndmsv глобус.ndmsv 
+гобелен.ndmsv гонорар.ndmsv грейдер.ndmsv грейфер.ndmsv гудрон.ndmsv демпфер.ndmsv 
+диван.ndmsv диез.ndmsv диплом.ndmsv доступ.ndmsv дуэт.ndmsv жетон.ndmsv 
+зипун.ndmsv извоз.ndmsv инфаркт.ndmsv ион.ndmsv исход.ndmsv камин.ndmsv 
+канун.ndmsv капкан.ndmsv караван.ndmsv карбид.ndmsv кардан.ndmsv карниз.ndmsv 
+картуз.ndmsv каскад.ndmsv катод.ndmsv каупер.ndmsv кафтан.ndmsv кессон.ndmsv 
+клапан.ndmsv клистир.ndmsv кокон.ndmsv коллоид.ndmsv колхоз.ndmsv колчан.ndmsv 
+комод.ndmsv компас.ndmsv коридор.ndmsv костюм.ndmsv котонин.ndmsv кретон.ndmsv 
+купон.ndmsv курсор.ndmsv лабаз.ndmsv ледоход.ndmsv лесовоз.ndmsv ликвид.ndmsv 
+лиман.ndmsv линотип.ndmsv ломбер.ndmsv майорат.ndmsv макет.ndmsv маникюр.ndmsv 
+метеор.ndmsv микрон.ndmsv миномет.ndmsv моляр.ndmsv монотип.ndmsv наган.ndmsv 
+нажим.ndmsv нарыв.ndmsv нейтрон.ndmsv обгон.ndmsv обиход.ndmsv обоз.ndmsv 
+обряд.ndmsv обход.ndmsv овин.ndmsv опиум.ndmsv орган.ndmsv отряд.ndmsv 
+пакгауз.ndmsv пансион.ndmsv парашют.ndmsv паровоз.ndmsv паром.ndmsv пароход.ndmsv 
+пасьянс.ndmsv патефон.ndmsv педикюр.ndmsv пенсион.ndmsv переезд.ndmsv переход.ndmsv 
+перрон.ndmsv пирофор.ndmsv пистон.ndmsv пищевод.ndmsv плаун.ndmsv плафон.ndmsv 
+плеврит.ndmsv пленэр.ndmsv плинтус.ndmsv плод.ndmsv плунжер.ndmsv плывун.ndmsv 
+поем.ndmsv покер.ndmsv покров.ndmsv полигон.ndmsv помидор.ndmsv понтон.ndmsv 
+призыв.ndmsv приказ.ndmsv приплод.ndmsv провес.ndmsv проем.ndmsv протез.ndmsv 
+пулемет.ndmsv радар.ndmsv разжим.ndmsv размен.ndmsv разъем.ndmsv район.ndmsv 
+рангоут.ndmsv рацион.ndmsv реактор.ndmsv рекорд.ndmsv реостат.ndmsv реферат.ndmsv 
+рефулер.ndmsv ромбоид.ndmsv ротатор.ndmsv ротор.ndmsv рубин.ndmsv рулон.ndmsv 
+рыбоход.ndmsv салоп.ndmsv саман.ndmsv самолет.ndmsv самолов.ndmsv сарафан.ndmsv 
+сейнер.ndmsv сервиз.ndmsv серозем.ndmsv сифон.ndmsv скаляр.ndmsv скрепер.ndmsv 
+слалом.ndmsv снаряд.ndmsv совхоз.ndmsv стадион.ndmsv стакан.ndmsv стеноз.ndmsv 
+стокер.ndmsv сульфид.ndmsv сустав.ndmsv сфероид.ndmsv табор.ndmsv талон.ndmsv 
+тамбур.ndmsv тангир.ndmsv танкер.ndmsv телефон.ndmsv тендер.ndmsv термос.ndmsv 
+тимпан.ndmsv тифоид.ndmsv топаз.ndmsv трактир.ndmsv тромбон.ndmsv тротуар.ndmsv 
+труп.ndmsv трюм.ndmsv тулуп.ndmsv турнир.ndmsv тюльпан.ndmsv углевод.ndmsv 
+углерод.ndmsv угломер.ndmsv уезд.ndmsv улус.ndmsv унос.ndmsv фасад.ndmsv 
+фикус.ndmsv финноз.ndmsv флакон.ndmsv флюид.ndmsv фонтан.ndmsv фосген.ndmsv 
+фрегат.ndmsv фронтон.ndmsv фужер.ndmsv фургон.ndmsv футляр.ndmsv хоровод.ndmsv 
+циклон.ndmsv чемодан.ndmsv чулан.ndmsv шантан.ndmsv шарнир.ndmsv швеллер.ndmsv 
+шеврон.ndmsv шифон.ndmsv штоф.ndmsv шуруп.ndmsv экран.ndmsv эскарп.ndmsv 
+эстамп.ndmsv этап.ndmsv этюд.ndmsv эшелон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.7:
   LLFKO+ or LLFIH+;
@@ -715,18 +715,18 @@
 алтын.= :
   LLABU+ or LLEHC+;
 
-алтын.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 алтын.ndmsi :  <morph-С,мр,но,ед,им>;
+
+алтын.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 алтын.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 алунит.= :
   LLAAQ+ or LLFIH+;
 
-алунит.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 алунит.ndmsi :  <morph-С,мр,но,ед,им>;
+
+алунит.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 алфе.= бартоломе.= баты.= варфоломе.= евстигне.= елисе.= 
 ереме.= ермола.= ерофе.= иса.= моисе.= орфе.= 
@@ -746,11 +746,11 @@
 кристин.= матрен.= :
   LLFIN+;
 
-альбин.nlfpg ангелин.nlfpg анжелин.nlfpg жозефин.nlfpg исидор.nlfpg карин.nlfpg 
-кристин.nlfpg матрен.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 альбин.nlfpv ангелин.nlfpv анжелин.nlfpv жозефин.nlfpv исидор.nlfpv карин.nlfpv 
 кристин.nlfpv матрен.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+альбин.nlfpg ангелин.nlfpg анжелин.nlfpg жозефин.nlfpg исидор.nlfpg карин.nlfpg 
+кристин.nlfpg матрен.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 /ru/words/words.8:
   LLEBJ+;
@@ -869,18 +869,18 @@
 аман.= :
   LLFJM+ or LLFJL+;
 
-аман.nlmsi :  <morph-С,мр,од,ед,им>;
-
 аман.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+аман.nlmsi :  <morph-С,мр,од,ед,им>;
 
 аман.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 альбом.= альков.= амбар.= :
   LLAAQ+ or LLEHC+;
 
-альбом.ndmsv альков.ndmsv амбар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 альбом.ndmsi альков.ndmsi амбар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+альбом.ndmsv альков.ndmsv амбар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.9:
   LLFQF+ or LLFJT+;
@@ -937,9 +937,9 @@
 амин.= :
   LLAAQ+ or LLFHJ+;
 
-амин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 амин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+амин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 аммони.= :
   LLBPP+ or LLBQK+;
@@ -950,18 +950,18 @@
 ампер.= :
   LLABW+ or LLBYZ+;
 
-ампер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ампер.ndmsi :  <morph-С,мр,но,ед,им>;
 
 ампер.ndmpg :  <morph-С,мр,но,мн,рд>;
 
+ампер.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 амур.= :
   LLACI+ or LLDWW+ or LLBNU+ or LLBYU+;
 
-амур.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 амур.nlmsi :  <morph-С,мр,од,ед,им>;
+
+амур.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 амур.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -971,11 +971,11 @@
 ан.= :
   LLDTM+ or LLAFX+ or LLFLJ+;
 
-ан.i :  <morph-СОЮЗ,0>;
+ан.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 ан.p :  <morph-ЧАСТ,0>;
 
-ан.ndfpg :  <morph-С,жр,но,мн,рд>;
+ан.i :  <morph-СОЮЗ,0>;
 
 анализир.= :
   LLELI+ or LLCGS+;
@@ -992,9 +992,9 @@
 анастасиин.= :
   LLFUR+;
 
-анастасиин.amsi :  <morph-П,мр,ед,им>;
-
 анастасиин.admsv :  <morph-П,мр,ед,вн,но>;
+
+анастасиин.amsi :  <morph-П,мр,ед,им>;
 
 алекси.= анатоли.= васили.= витали.= геннади.= георги.= 
 григори.= дмитри.= :
@@ -1054,11 +1054,11 @@
 антипод.= :
   LLAAQ+ or LLACI+ or LLBZE+;
 
+антипод.ndmsi :  <morph-С,мр,но,ед,им>;
+
 антипод.nlmsi :  <morph-С,мр,од,ед,им>;
 
 антипод.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-антипод.ndmsi :  <morph-С,мр,но,ед,им>;
 
 антон.= :
   LLFKO+ or LLFIH+ or LLEDG+;
@@ -1082,11 +1082,11 @@
 тотем.= тяжеловес.= :
   LLAAQ+ or LLACI+ or LLBYU+;
 
-анчоус.nlmsi гибрид.nlmsi живот.nlmsi полип.nlmsi субъект.nlmsi термит.nlmsi 
-тотем.nlmsi тяжеловес.nlmsi :  <morph-С,мр,од,ед,им>;
-
 анчоус.ndmsv гибрид.ndmsv живот.ndmsv полип.ndmsv субъект.ndmsv термит.ndmsv 
 тотем.ndmsv тяжеловес.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+анчоус.nlmsi гибрид.nlmsi живот.nlmsi полип.nlmsi субъект.nlmsi термит.nlmsi 
+тотем.nlmsi тяжеловес.nlmsi :  <morph-С,мр,од,ед,им>;
 
 анчоус.ndmsi гибрид.ndmsi живот.ndmsi полип.ndmsi субъект.ndmsi термит.ndmsi 
 тотем.ndmsi тяжеловес.ndmsi :  <morph-С,мр,но,ед,им>;
@@ -1146,11 +1146,11 @@
 аргун.= :
   LLDWW+ or LLEBJ+ or LLEAU+;
 
+аргун.ndmsi :  <morph-С,мр,но,ед,им>;
+
 аргун.nlmsi :  <morph-С,мр,од,ед,им>;
 
 аргун.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-аргун.ndmsi :  <morph-С,мр,но,ед,им>;
 
 аренд.= :
   LLAFX+ or LLBYZ+ or LLCCZ+ or LLFWB+ or LLCGW+;
@@ -1160,9 +1160,9 @@
 арест.= :
   LLAAQ+ or LLBYU+ or LLFWB+;
 
-арест.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 арест.ndmsi :  <morph-С,мр,но,ед,им>;
+
+арест.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 арестантск.= камаринск.= корректорск.= кухмистерск.= ординаторск.= парикмахерск.= 
 покойницк.= прозекторск.= :
@@ -1201,9 +1201,9 @@
 артемовск.= :
   LLDWW+ or LLDYP+ or LLBEP+ or LLDYV+;
 
-артемовск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 артемовск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+артемовск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.15:
   LLACG+;
@@ -1694,11 +1694,11 @@
 аршин.= :
   LLABU+ or LLBYZ+;
 
-аршин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 аршин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 аршин.ndmpg :  <morph-С,мр,но,мн,рд>;
+
+аршин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 асланиди.= бачило.= гастелло.= гуцало.= довгялло.= догадайло.= 
 забейворота.= косых.= красных.= мавроди.= пашенных.= пашуто.= 
@@ -1753,1454 +1753,6 @@
 
 /ru/words/words.16:
   LLAAQ+;
-
-абандон.ndmsv абдомен.ndmsv абдуктор.ndmsv абелит.ndmsv абиетин.ndmsv аблятив.ndmsv 
-абляут.ndmsv абонемент.ndmsv аборт.ndmsv абрикотин.ndmsv абсент.ndmsv абсентеизм.ndmsv 
-абсолютизм.ndmsv абсорбент.ndmsv абсорбер.ndmsv абсорбциометр.ndmsv абсцесс.ndmsv авангард.ndmsv 
-аванзал.ndmsv аванпорт.ndmsv аванпост.ndmsv аванс.ndmsv авантюризм.ndmsv авантюрин.ndmsv 
-авгит.ndmsv август.ndmsv аверс.ndmsv авиаагрегат.ndmsv авиабензин.ndmsv авиабилет.ndmsv 
-авиагоризонт.ndmsv авиагруз.ndmsv авиадесант.ndmsv авиазавод.ndmsv авиакомпас.ndmsv авиалайнер.ndmsv 
-авиамаршрут.ndmsv авиамотор.ndmsv авиаотряд.ndmsv авиапорт.ndmsv авиаприбор.ndmsv авиапулемет.ndmsv 
-авиарейс.ndmsv авиасалон.ndmsv авиасев.ndmsv авиатехникум.ndmsv авиафонд.ndmsv авитаминоз.ndmsv 
-авлос.ndmsv авост.ndmsv авран.ndmsv автоаларм.ndmsv автобатальон.ndmsv автобензин.ndmsv 
-автобетоновоз.ndmsv автовагон.ndmsv автовоз.ndmsv автовокзал.ndmsv автогенез.ndmsv автогенератор.ndmsv 
-автогипноз.ndmsv автограф.ndmsv автогрейд.ndmsv автогрейдер.ndmsv автогудронатор.ndmsv автодин.ndmsv 
-автодиспетчер.ndmsv автодром.ndmsv автожир.ndmsv автокартограф.ndmsv автокатализ.ndmsv автоклав.ndmsv 
-автоклуб.ndmsv автокод.ndmsv автоколлиматор.ndmsv автокомбинат.ndmsv автокомпенсатор.ndmsv автокомпрессор.ndmsv 
-автоконтакт.ndmsv автокоррелятор.ndmsv автокран.ndmsv автокросс.ndmsv автол.ndmsv автолесовоз.ndmsv 
-автолиз.ndmsv автолист.ndmsv автомагазин.ndmsv автоматизм.ndmsv автомашинист.ndmsv автомонитор.ndmsv 
-автоморфизм.ndmsv автомотоклуб.ndmsv автоним.ndmsv автооператор.ndmsv автоответ.ndmsv автоотряд.ndmsv 
-автопавильон.ndmsv автопансионат.ndmsv автопереход.ndmsv автопилот.ndmsv автоповтор.ndmsv автополимер.ndmsv 
-автопортрет.ndmsv автоприцеп.ndmsv автопровод.ndmsv авторегулятор.ndmsv автореферат.ndmsv авторефрижератор.ndmsv 
-авторитаризм.ndmsv автосалон.ndmsv автосамосвал.ndmsv автосин.ndmsv автоспорт.ndmsv автостоп.ndmsv 
-автотаймер.ndmsv автотормоз.ndmsv автотрансформатор.ndmsv автотуризм.ndmsv автофильтр.ndmsv автофургон.ndmsv 
-автохром.ndmsv автоцементовоз.ndmsv автоцентр.ndmsv автоштурман.ndmsv агал.ndmsv агалит.ndmsv 
-агальматолит.ndmsv агафит.ndmsv агглютинин.ndmsv агенс.ndmsv агитпроп.ndmsv агитпункт.ndmsv 
-агломерат.ndmsv агломератовоз.ndmsv агломератопенобетон.ndmsv агон.ndmsv аграмант.ndmsv аграмматизм.ndmsv 
-аграф.ndmsv агреман.ndmsv агробиоценоз.ndmsv агрокомбинат.ndmsv агрокомплекс.ndmsv агрометр.ndmsv 
-агроприем.ndmsv агропункт.ndmsv адалин.ndmsv адамант.ndmsv адамсит.ndmsv адаптер.ndmsv 
-адаптометр.ndmsv адат.ndmsv аддендум.ndmsv аддуктор.ndmsv аденин.ndmsv аденит.ndmsv 
-аденовирус.ndmsv адермин.ndmsv адиантум.ndmsv адонизид.ndmsv адонилен.ndmsv адонис.ndmsv 
-адреналин.ndmsv адрон.ndmsv адсорбат.ndmsv адсорбент.ndmsv адсорбер.ndmsv адстрат.ndmsv 
-адуляр.ndmsv адюльтер.ndmsv ажгон.ndmsv азан.ndmsv азид.ndmsv азин.ndmsv 
-азиридинамид.ndmsv азобензол.ndmsv азотобактерин.ndmsv азотоген.ndmsv азотфиксатор.ndmsv азур.ndmsv 
-азурит.ndmsv аил.ndmsv айлант.ndmsv аймар.ndmsv айран.ndmsv айрол.ndmsv 
-академизм.ndmsv акант.ndmsv аканф.ndmsv акарицид.ndmsv аквавит.ndmsv аквамарин.ndmsv 
-акваплан.ndmsv акваполивольфрамат.ndmsv аквариум.ndmsv аквилон.ndmsv аккомпанемент.ndmsv аккордеон.ndmsv 
-аккредитив.ndmsv аккузатив.ndmsv аккумулятор.ndmsv акмеизм.ndmsv аколит.ndmsv аком.ndmsv 
-аконит.ndmsv аконитин.ndmsv акр.ndmsv акридин.ndmsv акрихин.ndmsv акробатизм.ndmsv 
-акролеин.ndmsv акроним.ndmsv акрофут.ndmsv акс.ndmsv акселератор.ndmsv акселерометр.ndmsv 
-аксельбант.ndmsv аксерофтол.ndmsv аксессуар.ndmsv аксиометр.ndmsv аксминстер.ndmsv аксон.ndmsv 
-акт.ndmsv актант.ndmsv активатор.ndmsv актин.ndmsv актинометр.ndmsv актиномикоз.ndmsv 
-актинон.ndmsv актограф.ndmsv актомиозин.ndmsv актор.ndmsv акут.ndmsv акцептор.ndmsv 
-акцидент.ndmsv аланин.ndmsv алас.ndmsv алгезис.ndmsv алгол.ndmsv алгометр.ndmsv 
-алгоритм.ndmsv алебастр.ndmsv алеврит.ndmsv алевролит.ndmsv алейрометр.ndmsv алейрон.ndmsv 
-александрит.ndmsv алеф.ndmsv ализарин.ndmsv аликзандер.ndmsv алинеатор.ndmsv алинит.ndmsv 
-алкагест.ndmsv алкалоз.ndmsv алкалоид.ndmsv алкил.ndmsv алкоголизм.ndmsv алкоголят.ndmsv 
-алкоран.ndmsv аллатив.ndmsv аллегоризм.ndmsv аллеломорф.ndmsv аллерген.ndmsv аллил.ndmsv 
-аллицин.ndmsv аллограф.ndmsv аллод.ndmsv алломон.ndmsv аллоним.ndmsv аллополиплоид.ndmsv 
-аллоскоп.ndmsv аллотип.ndmsv аллотрансплантат.ndmsv аллофан.ndmsv аллофон.ndmsv аллюр.ndmsv 
-алогизм.ndmsv алтаит.ndmsv алуноген.ndmsv альбакор.ndmsv альбедометр.ndmsv альбидум.ndmsv 
-альбинизм.ndmsv альбион.ndmsv альбит.ndmsv альбумин.ndmsv альбуминат.ndmsv альбуминоид.ndmsv 
-альбуцид.ndmsv альгин.ndmsv альгицид.ndmsv альдегид.ndmsv альдокортин.ndmsv альдостерон.ndmsv 
-алькасар.ndmsv альмандин.ndmsv альмукантарат.ndmsv альпинизм.ndmsv альт.ndmsv альтазимут.ndmsv 
-альтгорн.ndmsv альтернант.ndmsv альтернат.ndmsv альтернатор.ndmsv альтернион.ndmsv альтиграф.ndmsv 
-альтиметр.ndmsv альтруизм.ndmsv альфатрон.ndmsv альянс.ndmsv алюминат.ndmsv алюминон.ndmsv 
-амавроз.ndmsv амазонит.ndmsv амальгаматор.ndmsv амандин.ndmsv амарант.ndmsv амариллис.ndmsv 
-амбоцептор.ndmsv амбушюр.ndmsv амвон.ndmsv амебиаз.ndmsv амебоцит.ndmsv амейоз.ndmsv 
-аметист.ndmsv амиант.ndmsv амигдалин.ndmsv амид.ndmsv амидол.ndmsv амидопирин.ndmsv 
-амикрон.ndmsv амил.ndmsv амилацетат.ndmsv амилен.ndmsv амилоидоз.ndmsv аминопирин.ndmsv 
-аминопласт.ndmsv аминоспирт.ndmsv аминофенол.ndmsv амирис.ndmsv амитоз.ndmsv аммиакат.ndmsv 
-аммонал.ndmsv аммофос.ndmsv амнион.ndmsv аморализм.ndmsv аморит.ndmsv амортизатор.ndmsv 
-аморфизм.ndmsv амофор.ndmsv ампер-час.ndmsv ампервольтваттметр.ndmsv ампервольтметр.ndmsv амперметр.ndmsv 
-амплидин.ndmsv амулет.ndmsv амфетамин.ndmsv амфибол.ndmsv амфиболит.ndmsv амфидиплоид.ndmsv 
-амфимакр.ndmsv амфимиксис.ndmsv амфион.ndmsv амфитеатр.ndmsv анабазин.ndmsv анабаптизм.ndmsv 
-анабасис.ndmsv анабиоз.ndmsv анаболизм.ndmsv анаглиф.ndmsv анадиплосис.ndmsv анакард.ndmsv 
-анаколуф.ndmsv анализ.ndmsv анализатор.ndmsv анальцим.ndmsv анамнез.ndmsv анаморфизм.ndmsv 
-анаморфоз.ndmsv ананим.ndmsv анапест.ndmsv анаплазмоз.ndmsv анапофиз.ndmsv анаптиксис.ndmsv 
-анархизм.ndmsv анастамоз.ndmsv анастигмат.ndmsv анастомоз.ndmsv анатаз.ndmsv анатоксин.ndmsv 
-анатоцизм.ndmsv анафорез.ndmsv анахронизм.ndmsv анаэробиоз.ndmsv ангажемент.ndmsv ангидрид.ndmsv 
-ангидрит.ndmsv ангиит.ndmsv ангиоспазм.ndmsv ангиотензин.ndmsv англез.ndmsv англезит.ndmsv 
-англицизм.ndmsv англофон.ndmsv ангоб.ndmsv ангстрем.ndmsv андалузит.ndmsv андезин.ndmsv 
-андезит.ndmsv андерграунд.ndmsv андеррайтер.ndmsv андроген.ndmsv андрон.ndmsv андростерон.ndmsv 
-аневрин.ndmsv анемограф.ndmsv анемометр.ndmsv анеморумбограф.ndmsv анемоскоп.ndmsv анемохор.ndmsv 
-анестезин.ndmsv анетол.ndmsv анзерин.ndmsv анид.ndmsv анизол.ndmsv анилин.ndmsv 
-анимализм.ndmsv анимизм.ndmsv анионит.ndmsv анис.ndmsv анкас.ndmsv анкерит.ndmsv 
-анкилоз.ndmsv анкилостомоз.ndmsv анклав.ndmsv аннекс.ndmsv аннит.ndmsv аннуитет.ndmsv 
-аннулятор.ndmsv анонс.ndmsv анортит.ndmsv анортозит.ndmsv анортоскоп.ndmsv анофтальм.ndmsv 
-антаблемент.ndmsv антабус.ndmsv антагонизм.ndmsv антерозоид.ndmsv антефикс.ndmsv антецедент.ndmsv 
-антиаллерген.ndmsv антиапекс.ndmsv антиатом.ndmsv антибиоз.ndmsv антивибратор.ndmsv антивирус.ndmsv 
-антигиперон.ndmsv антидепрессант.ndmsv антидетонатор.ndmsv антидот.ndmsv антикатализатор.ndmsv антикатод.ndmsv 
-антиквариат.ndmsv антиклимакс.ndmsv антикоагулянт.ndmsv антилогарифм.ndmsv антиминс.ndmsv антимир.ndmsv 
-антимонат.ndmsv антимонит.ndmsv антимуссон.ndmsv антимутаген.ndmsv антинакипин.ndmsv антинейтрон.ndmsv 
-антинуклон.ndmsv антиоксидант.ndmsv антипассат.ndmsv антипирин.ndmsv антиполлютант.ndmsv антипротон.ndmsv 
-антиптозис.ndmsv антироман.ndmsv антисемитизм.ndmsv антиспаст.ndmsv антистимул.ndmsv антитеатр.ndmsv 
-антитезис.ndmsv антитоксин.ndmsv антифебрин.ndmsv антифермент.ndmsv антиферромагнетизм.ndmsv антифон.ndmsv 
-антифраз.ndmsv антифриз.ndmsv антифунгин.ndmsv антихлор.ndmsv антициклон.ndmsv античарм.ndmsv 
-антиэлектрон.ndmsv антоним.ndmsv антофиллит.ndmsv антракноз.ndmsv антракоз.ndmsv антракосиликоз.ndmsv 
-антракс.ndmsv антрацен.ndmsv антрацит.ndmsv антрекот.ndmsv антропоген.ndmsv антрополит.ndmsv 
-антропометр.ndmsv антропоним.ndmsv антуриум.ndmsv анус.ndmsv анфракс.ndmsv анхузин.ndmsv 
-анчар.ndmsv аншлюс.ndmsv анэструс.ndmsv аорист.ndmsv аортит.ndmsv апартамент.ndmsv 
-апартеид.ndmsv апекс.ndmsv апельсин.ndmsv аперитив.ndmsv апертометр.ndmsv апиоид.ndmsv 
-апитоксин.ndmsv апланат.ndmsv апланатизм.ndmsv апломб.ndmsv апоастр.ndmsv аподозис.ndmsv 
-апозиопезис.ndmsv апокалипсис.ndmsv апоконин.ndmsv апокриф.ndmsv аполид.ndmsv аполитизм.ndmsv 
-аполлоникон.ndmsv апомиксис.ndmsv апомикт.ndmsv апоневроз.ndmsv апостат.ndmsv апостроф.ndmsv 
-апофеоз.ndmsv апохромат.ndmsv апоцентр.ndmsv аппендикс.ndmsv аппендицит.ndmsv апперкот.ndmsv 
-апплет.ndmsv аппликатор.ndmsv аппрет.ndmsv априоризм.ndmsv арабизм.ndmsv арагонит.ndmsv 
-арахис.ndmsv арахноидит.ndmsv арборицид.ndmsv арбутин.ndmsv аргал.ndmsv аргентит.ndmsv 
-аргиллит.ndmsv аргинин.ndmsv аргироид.ndmsv аргон.ndmsv арготизм.ndmsv аргумент.ndmsv 
-ардометр.ndmsv ареал.ndmsv ареоид.ndmsv ареометр.ndmsv ариллоид.ndmsv ариллус.ndmsv 
-аристон.ndmsv арифмограф.ndmsv арифмометр.ndmsv аркбутан.ndmsv арккосеканс.ndmsv арккосинус.ndmsv 
-арккотангенс.ndmsv аркоз.ndmsv арксеканс.ndmsv арксинус.ndmsv арктангенс.ndmsv армагеддон.ndmsv 
-армальколит.ndmsv армозин.ndmsv армоцемент.ndmsv армюр.ndmsv ароматизатор.ndmsv арпан.ndmsv 
-арпанет.ndmsv аррасен.ndmsv арретир.ndmsv аррорут.ndmsv арсенал.ndmsv арсенат.ndmsv 
-арсенид.ndmsv арсенит.ndmsv арсенолит.ndmsv арсенопирит.ndmsv арсис.ndmsv арталин.ndmsv 
-артдивизион.ndmsv артериит.ndmsv артериосклероз.ndmsv артефакт.ndmsv артикул.ndmsv артистизм.ndmsv 
-артобстрел.ndmsv артос.ndmsv артроз.ndmsv артроскоп.ndmsv архаизм.ndmsv архетип.ndmsv 
-архибентос.ndmsv архиватор.ndmsv архитрав.ndmsv арьергард.ndmsv асбест.ndmsv асбестит.ndmsv 
-асбестобетон.ndmsv асбестоз.ndmsv асбестонит.ndmsv асболан.ndmsv асболит.ndmsv асбоцемент.ndmsv 
-асидерит.ndmsv асидетон.ndmsv асидол.ndmsv асиндетон.ndmsv асканит.ndmsv аскаридоз.ndmsv 
-аскетизм.ndmsv аспарагин.ndmsv аспарагус.ndmsv аспидиум.ndmsv аспиратор.ndmsv асс.ndmsv 
-ассемблер.ndmsv ассонанс.ndmsv ассортимент.ndmsv астатизм.ndmsv астеризм.ndmsv астероид.ndmsv 
-астигмат.ndmsv астигматизатор.ndmsv астрагал.ndmsv астралин.ndmsv астралит.ndmsv астрограф.ndmsv 
-астрокомпас.ndmsv астрокупол.ndmsv астрон.ndmsv астропеленгатор.ndmsv астроскоп.ndmsv астрофотометр.ndmsv 
-асфальтит.ndmsv асцит.ndmsv атавизм.ndmsv атаксит.ndmsv атеизм.ndmsv ателектаз.ndmsv 
-атероматоз.ndmsv атетоз.ndmsv атлетизм.ndmsv атмометр.ndmsv атмосфериум.ndmsv атолл.ndmsv 
-атомизатор.ndmsv атомизм.ndmsv атомоход.ndmsv атофан.ndmsv атрибут.ndmsv атриум.ndmsv 
-атропин.ndmsv аттентат.ndmsv аттенюатор.ndmsv аттестат.ndmsv аттитюд.ndmsv аттрактант.ndmsv 
-аттрактор.ndmsv аттракцион.ndmsv аттрибут.ndmsv аттрит.ndmsv аудиенц-зал.ndmsv аудиограф.ndmsv 
-аудиоматериал.ndmsv аудиометр.ndmsv аудион.ndmsv аудиоскоп.ndmsv аудиофон.ndmsv аудифон.ndmsv 
-ауксанограф.ndmsv ауксанометр.ndmsv ауксин.ndmsv аурамин.ndmsv аурат.ndmsv ауреомицин.ndmsv 
-аурипигмент.ndmsv аурихальцит.ndmsv аустенит.ndmsv аут.ndmsv ауткросс.ndmsv аутогипноз.ndmsv 
-аутотрансплантат.ndmsv аутригер.ndmsv афанит.ndmsv аферезис.ndmsv афицид.ndmsv афоризм.ndmsv 
-афронт.ndmsv аффект.ndmsv аффидевит.ndmsv аффикс.ndmsv аффинор.ndmsv ахондрит.ndmsv 
-ахромат.ndmsv ахроматизм.ndmsv ахроматин.ndmsv ацетальдегид.ndmsv ацетанилид.ndmsv ацетилен.ndmsv 
-ацетилхолин.ndmsv ацетометр.ndmsv ацидоз.ndmsv ацроптилон.ndmsv аэратор.ndmsv аэроаллерген.ndmsv 
-аэробиоз.ndmsv аэробус.ndmsv аэровокзал.ndmsv аэрогаммарадиометр.ndmsv аэрограф.ndmsv аэродром.ndmsv 
-аэроклуб.ndmsv аэролит.ndmsv аэролифт.ndmsv аэрометеорограф.ndmsv аэрометр.ndmsv аэрон.ndmsv 
-аэроневроз.ndmsv аэроплан.ndmsv аэросев.ndmsv аэросидерит.ndmsv аэросолоскоп.ndmsv аэростат.ndmsv 
-аэротаксис.ndmsv аэротермометр.ndmsv аэрофильтр.ndmsv аэрофит.ndmsv аэрофлот.ndmsv аэрофон.ndmsv 
-аэрофор.ndmsv аэрофототрансформатор.ndmsv бабувизм.ndmsv багер.ndmsv багрец.ndmsv бадан.ndmsv 
-бадминтон.ndmsv бадьян.ndmsv база-магазин.ndmsv базальт.ndmsv базамент.ndmsv базилект.ndmsv 
-байкалит.ndmsv байонет.ndmsv байпас.ndmsv байронизм.ndmsv байт-код.ndmsv бакан.ndmsv 
-бакаут.ndmsv бакборт.ndmsv бакелит.ndmsv баклажан.ndmsv бакпорт.ndmsv бакт.ndmsv 
-бактериоз.ndmsv бактериолиз.ndmsv бактериолизин.ndmsv бактериородопсин.ndmsv бактериостат.ndmsv бактерицид.ndmsv 
-бакштейн.ndmsv бал-маскарад.ndmsv балдахин.ndmsv балластер.ndmsv баллер.ndmsv баллистит.ndmsv 
-баллистокардиограф.ndmsv баллонет.ndmsv балмакан.ndmsv бальзамин.ndmsv бампер.ndmsv банан.ndmsv 
-бандитизм.ndmsv баннер.ndmsv баннерет.ndmsv бант.ndmsv баньян.ndmsv баобаб.ndmsv 
-баптизм.ndmsv барбакан.ndmsv барбарис.ndmsv барбет.ndmsv барбитал.ndmsv барбитурат.ndmsv 
-барботер.ndmsv барботин.ndmsv баргоут.ndmsv барельеф.ndmsv бареттер.ndmsv барион.ndmsv 
-барит.ndmsv барицентр.ndmsv баркан.ndmsv барн.ndmsv барограф.ndmsv барометр.ndmsv 
-барорецептор.ndmsv бароскоп.ndmsv баростат.ndmsv баротермометр.ndmsv барристер.ndmsv барстер.ndmsv 
-бартер.ndmsv бархоут.ndmsv баскетбол.ndmsv бассетгорн.ndmsv бастр.ndmsv батальон.ndmsv 
-батан.ndmsv батат.ndmsv батипитометр.ndmsv батиплан.ndmsv батискаф.ndmsv батитермограф.ndmsv 
-батман.ndmsv батокс.ndmsv батолит.ndmsv батометр.ndmsv батон.ndmsv батопорт.ndmsv 
-батуд.ndmsv батут.ndmsv баул.ndmsv баштан.ndmsv беватрон.ndmsv бедекер.ndmsv 
-бедлам.ndmsv бедленд.ndmsv бейдевинд.ndmsv бейлер.ndmsv бейсбол.ndmsv бейт.ndmsv 
-бейфут.ndmsv бейшлот.ndmsv бекар.ndmsv беккерельметр.ndmsv беккросс.ndmsv бекхенд.ndmsv 
-белозор.ndmsv белоус.ndmsv бельведер.ndmsv бельмес.ndmsv бельморез.ndmsv бельфлер.ndmsv 
-бензедрин.ndmsv бензиномер.ndmsv бензовоз.ndmsv бензоин.ndmsv бензол.ndmsv бензомер.ndmsv 
-бензонасос.ndmsv бензонафтол.ndmsv бензопровод.ndmsv бензорез.ndmsv бензофильтр.ndmsv бентонит.ndmsv 
-бентос.ndmsv бенуар.ndmsv бергамот.ndmsv бересклет.ndmsv берет.ndmsv берилл.ndmsv 
-бериллиоз.ndmsv берсез.ndmsv бест.ndmsv бестселлер.ndmsv бета-радиометр.ndmsv бетаин.ndmsv 
-бетатрон.ndmsv бетонит.ndmsv бетоновоз.ndmsv бетонолом.ndmsv бетононасос.ndmsv бетонэлемент.ndmsv 
-бефстроганов.ndmsv бешмет.ndmsv биатлон.ndmsv биб.ndmsv бибколлектор.ndmsv библиобус.ndmsv 
-бивалент.ndmsv бивектор.ndmsv бивертин.ndmsv бигус.ndmsv бигхед.ndmsv бизнес.ndmsv 
-бизнес-инкубатор.ndmsv бизнес-план.ndmsv бизнес-проект.ndmsv бикарбид.ndmsv бикарбонат.ndmsv биквадрат.ndmsv 
-бикомпакт.ndmsv бикс.ndmsv бикхед.ndmsv билирубин.ndmsv билирубинометр.ndmsv биллет.ndmsv 
-биллион.ndmsv бильгарциоз.ndmsv бильдаппарат.ndmsv биметалл.ndmsv бимс.ndmsv бинейтрон.ndmsv 
-бином.ndmsv биогенез.ndmsv биогеоценоз.ndmsv биогерм.ndmsv биоиндикатор.ndmsv биокатализатор.ndmsv 
-биолант.ndmsv биолизис.ndmsv биолит.ndmsv биологизм.ndmsv биоматериал.ndmsv биомицин.ndmsv 
-бионт.ndmsv биоорганизм.ndmsv биополимер.ndmsv биопотенциал.ndmsv биопрепарат.ndmsv биореактор.ndmsv 
-биорегулятор.ndmsv биоритм.ndmsv биосинтез.ndmsv биоскоп.ndmsv биостимулятор.ndmsv биостром.ndmsv 
-биотип.ndmsv биотит.ndmsv биотоп.ndmsv биотрон.ndmsv биотуалет.ndmsv биофильтр.ndmsv 
-биофильтратор.ndmsv биоценоз.ndmsv биоцикл.ndmsv биоэффект.ndmsv биплан.ndmsv бисмалит.ndmsv 
-биссиноз.ndmsv бистр.ndmsv бисульфат.ndmsv бисульфит.ndmsv битер.ndmsv битмап.ndmsv 
-битмэп.ndmsv битумовоз.ndmsv бифитер.ndmsv бифунктор.ndmsv бифштекс.ndmsv бихромат.ndmsv 
-бицепс.ndmsv бицилиндр.ndmsv благовест.ndmsv бланк-заказ.ndmsv бланкизм.ndmsv бланфикс.ndmsv 
-бласт.ndmsv бластомер.ndmsv блат.ndmsv блезир.ndmsv блейвейс.ndmsv блейзер.ndmsv 
-блейштейн.ndmsv бленкер.ndmsv блефарит.ndmsv блинд.ndmsv блинкер.ndmsv блистер.ndmsv 
-блистр.ndmsv блицтурнир.ndmsv блок-аппарат.ndmsv блок-комплект.ndmsv блок-контейнер.ndmsv блок-пакет.ndmsv 
-блок-полис.ndmsv блок-сигнал.ndmsv блок-тормоз.ndmsv блокатор.ndmsv блокгауз.ndmsv блокиратор.ndmsv 
-блокпост.ndmsv блокшив.ndmsv блузон.ndmsv блюз.ndmsv блюм.ndmsv блюмс.ndmsv 
-бод.ndmsv боезапас.ndmsv боезаряд.ndmsv боекомплект.ndmsv боеприпас.ndmsv бозон.ndmsv 
-бойкот.ndmsv бойлер.ndmsv бокал.ndmsv бокс.ndmsv боксит.ndmsv болиголов.ndmsv 
-болид.ndmsv болограф.ndmsv болометр.ndmsv болт.ndmsv большевизм.ndmsv болюс.ndmsv 
-бомбазин.ndmsv бомбардон.ndmsv бомбовоз.ndmsv бомбомет.ndmsv бомонд.ndmsv бонитет.ndmsv 
-боннет.ndmsv боп.ndmsv боразон.ndmsv борат.ndmsv борацит.ndmsv боргес.ndmsv 
-борд.ndmsv бордерленд.ndmsv борид.ndmsv борн.ndmsv борнит.ndmsv бороментол.ndmsv 
-боросиликат.ndmsv бороскоп.ndmsv бортприпас.ndmsv боскет.ndmsv ботворез.ndmsv ботулизм.ndmsv 
-брадзот.ndmsv брадион.ndmsv брайлофон.ndmsv бракет.ndmsv браманизм.ndmsv брамин.ndmsv 
-брандмауэр.ndmsv брандспойт.ndmsv брас.ndmsv брасс.ndmsv браузер.ndmsv брахманизм.ndmsv 
-бревис.ndmsv бревномер.ndmsv брегет.ndmsv брезент.ndmsv брейд-вымпел.ndmsv брекватер.ndmsv 
-бриз.ndmsv бриллиант.ndmsv бриллиантин.ndmsv брильянт.ndmsv бриолин.ndmsv брогам.ndmsv 
-брокат.ndmsv бромат.ndmsv бромацетон.ndmsv бромид.ndmsv бромоводород.ndmsv бромпортрет.ndmsv 
-бромурал.ndmsv бронежилет.ndmsv бронетранспортер.ndmsv бронхит.ndmsv бронхоаденит.ndmsv бронхоскоп.ndmsv 
-брудер.ndmsv брудергауз.ndmsv брудершафт.ndmsv брукит.ndmsv брульон.ndmsv бруцеллез.ndmsv 
-брэнд.ndmsv брюмер.ndmsv бтр.ndmsv буддизм.ndmsv бузун.ndmsv буклет.ndmsv 
-буксус.ndmsv буланжерит.ndmsv бульдозер.ndmsv бум.ndmsv бунд.ndmsv бундесвер.ndmsv 
-бундесрат.ndmsv бурат.ndmsv бурдон.ndmsv буревал.ndmsv буркун.ndmsv бурнонит.ndmsv 
-бурозем.ndmsv буронос.ndmsv буррет.ndmsv бурсит.ndmsv бурхан.ndmsv бустер.ndmsv 
-бут.ndmsv бутадиен.ndmsv бутерброд.ndmsv бутил.ndmsv бутилен.ndmsv бутирометр.ndmsv 
-бутобетон.ndmsv бутон.ndmsv бутстрап.ndmsv буцентавр.ndmsv бушприт.ndmsv бытовизм.ndmsv 
-бьеф.ndmsv бэкус.ndmsv бэр.ndmsv бювет.ndmsv бюст.ndmsv в-блокатор.ndmsv 
-ваап.ndmsv вагинизм.ndmsv вагинит.ndmsv вагонооборот.ndmsv вадемекум.ndmsv вазомотор.ndmsv 
-вазон.ndmsv вакуум-аппарат.ndmsv вакуум-компрессор.ndmsv вакуум-насос.ndmsv вакуум-пресс.ndmsv вакуум-фильтр.ndmsv 
-вакуум-щит.ndmsv вакуумметр.ndmsv валер.ndmsv вализер.ndmsv валокордин.ndmsv вальс.ndmsv 
-вальтрап.ndmsv вальян.ndmsv вампум.ndmsv ванадат.ndmsv ванадинит.ndmsv вандализм.ndmsv 
-вандемьер.ndmsv вандрут.ndmsv вантоз.ndmsv ванчес.ndmsv вапориметр.ndmsv варактор.ndmsv 
-варваризм.ndmsv вариатор.ndmsv вариетет.ndmsv вариолит.ndmsv вариометр.ndmsv вариофон.ndmsv 
-варитрон.ndmsv варметр.ndmsv варрант.ndmsv васкулит.ndmsv вассалитет.ndmsv ватервейс.ndmsv 
-ватержакет.ndmsv ватерклозет.ndmsv ватерпас.ndmsv ватерштаг.ndmsv ватман.ndmsv ватт-час.ndmsv 
-ваттметр.ndmsv вахтпарад.ndmsv вашгерд.ndmsv вгиб.ndmsv вебсайт.ndmsv вегетоневроз.ndmsv 
-ведаизм.ndmsv ведизм.ndmsv вездеход.ndmsv везикулит.ndmsv везувиан.ndmsv вейсманизм.ndmsv 
-векторметр.ndmsv велд.ndmsv велодром.ndmsv велозавод.ndmsv велокросс.ndmsv велосипед.ndmsv 
-велосит.ndmsv велоспорт.ndmsv велотренажер.ndmsv велоэргометр.ndmsv вельбот.ndmsv вельветин.ndmsv 
-вельветон.ndmsv вельд.ndmsv вельс.ndmsv велюр.ndmsv вендиспансер.ndmsv веннер.ndmsv 
-вентилятор.ndmsv вераскоп.ndmsv верджинел.ndmsv вердикт.ndmsv веризм.ndmsv верификатор.ndmsv 
-верлибр.ndmsv вермахт.ndmsv вермикулит.ndmsv вермильон.ndmsv верньер.ndmsv веронал.ndmsv 
-верп.ndmsv вертоград.ndmsv вертодром.ndmsv вертолет.ndmsv вестерн.ndmsv ветнадзор.ndmsv 
-ветпрепарат.ndmsv ветпункт.ndmsv ветровал.ndmsv ветролом.ndmsv ветромер.ndmsv ветрочет.ndmsv 
-взаимозачет.ndmsv взвоз.ndmsv взгляд.ndmsv взлом.ndmsv взмет.ndmsv взмыв.ndmsv 
-взнос.ndmsv взор.ndmsv взрез.ndmsv взрыв.ndmsv взъезд.ndmsv вибратор.ndmsv 
-вибрафон.ndmsv виброграф.ndmsv виброгрохот.ndmsv виброзонд.ndmsv виброметр.ndmsv вибромолот.ndmsv 
-виброскоп.ndmsv вибротрон.ndmsv виброфон.ndmsv виброшум.ndmsv вивианит.ndmsv вигамор.ndmsv 
-вигвам.ndmsv видеоадаптер.ndmsv видеоархив.ndmsv видеодокумент.ndmsv видеозал.ndmsv видеоимпульс.ndmsv 
-видеоканал.ndmsv видеоклип.ndmsv видеомагнитофон.ndmsv видеоматериал.ndmsv видеомонитор.ndmsv видеоплейер.ndmsv 
-видеопоказ.ndmsv видеопродукт.ndmsv видеопроектор.ndmsv видеорежим.ndmsv видеоряд.ndmsv видеосалон.ndmsv 
-видеосигнал.ndmsv видеосюжет.ndmsv видеотекс.ndmsv видеотекст.ndmsv видеотелефон.ndmsv видеотерминал.ndmsv 
-видеотюнер.ndmsv видеофильм.ndmsv видеоэкран.ndmsv видикон.ndmsv византин.ndmsv визионизм.ndmsv 
-визуализатор.ndmsv викариат.ndmsv викиап.ndmsv виксатин.ndmsv вилайет.ndmsv виллис.ndmsv 
-вильтон.ndmsv винград.ndmsv виндротор.ndmsv виндроуэр.ndmsv виндсерфер.ndmsv винзавод.ndmsv 
-винил.ndmsv винилит.ndmsv винипласт.ndmsv виноматериал.ndmsv виномер.ndmsv винопровод.ndmsv 
-винсент.ndmsv винторез.ndmsv винчестер.ndmsv виппер.ndmsv вирилизм.ndmsv вирт.ndmsv 
-вискозиметр.ndmsv вискозин.ndmsv висмутин.ndmsv висмутит.ndmsv висцин.ndmsv витализм.ndmsv 
-вителлин.ndmsv витерит.ndmsv вицмундир.ndmsv влагомер.ndmsv влагооборот.ndmsv водовод.ndmsv 
-водоворот.ndmsv водогнет.ndmsv водозабор.ndmsv водоканал.ndmsv водоотвод.ndmsv водоотлив.ndmsv 
-водоподъем.ndmsv водопровод.ndmsv водораздел.ndmsv водорез.ndmsv водосбор.ndmsv водосброс.ndmsv 
-водоскат.ndmsv водослив.ndmsv военкомат.ndmsv вождизм.ndmsv возглас.ndmsv воздуховод.ndmsv 
-воздухомер.ndmsv воздухообмен.ndmsv воздухопровод.ndmsv воздухофильтр.ndmsv возраст.ndmsv вокализм.ndmsv 
-вокатив.ndmsv вокодер.ndmsv волан.ndmsv волейбол.ndmsv волитив.ndmsv волластонит.ndmsv 
-волновод.ndmsv волнограф.ndmsv волнолет.ndmsv волнолом.ndmsv волномер.ndmsv волноотвод.ndmsv 
-волноплан.ndmsv волнорез.ndmsv волован.ndmsv волокнит.ndmsv воломит.ndmsv вольвокс.ndmsv 
-вольтаметр.ndmsv вольтамперметр.ndmsv вольтметр.ndmsv вольтомметр.ndmsv вольтоммиллиамперметр.ndmsv вольфрам.ndmsv 
-вольфрамат.ndmsv вольфрамит.ndmsv волюменометр.ndmsv волюметр.ndmsv волюминометр.ndmsv волюнтатив.ndmsv 
-воробьевит.ndmsv ворсит.ndmsv воскопресс.ndmsv восход.ndmsv вотум.ndmsv вронскиан.ndmsv 
-всас.ndmsv всхлип.ndmsv всхрап.ndmsv вуз.ndmsv вулкан.ndmsv вулканизм.ndmsv 
-вулканит.ndmsv вульгаризм.ndmsv вульпинит.ndmsv вульфенит.ndmsv вход.ndmsv въезд.ndmsv 
-выверт.ndmsv выгиб.ndmsv выжереб.ndmsv вызов.ndmsv выкос.ndmsv выкус.ndmsv 
-вылет.ndmsv вымпелком.ndmsv вымпелфал.ndmsv выпад.ndmsv выпот.ndmsv высвист.ndmsv 
-высов.ndmsv высотомер.ndmsv выхват.ndmsv выхлоп.ndmsv вычет.ndmsv вюрцит.ndmsv 
-габион.ndmsv габитус.ndmsv гавот.ndmsv гагат.ndmsv гадолинит.ndmsv газават.ndmsv 
-газатор.ndmsv газгольдер.ndmsv газлифт.ndmsv газоанализатор.ndmsv газоаппарат.ndmsv газобаллон.ndmsv 
-газобетон.ndmsv газовоз.ndmsv газоген.ndmsv газогенератор.ndmsv газоконденсат.ndmsv газолин.ndmsv 
-газомер.ndmsv газомет.ndmsv газометр.ndmsv газомотор.ndmsv газообмен.ndmsv газоотвод.ndmsv 
-газоотсос.ndmsv газопровод.ndmsv газопроводоотвод.ndmsv газосигнализатор.ndmsv газотрон.ndmsv газотурбовоз.ndmsv 
-газотурбогенератор.ndmsv газотурбоход.ndmsv газоход.ndmsv газошлакозолобетон.ndmsv гайдроп.ndmsv гайковерт.ndmsv 
-гайморит.ndmsv гайтан.ndmsv гакаборт.ndmsv галактометр.ndmsv галалит.ndmsv галантир.ndmsv 
-галеас.ndmsv галенит.ndmsv галеон.ndmsv галиот.ndmsv галипот.ndmsv галлицизм.ndmsv 
-галлон.ndmsv галлуазит.ndmsv галогенид.ndmsv галогенуглеводород.ndmsv галон.ndmsv галоп.ndmsv 
-галотан.ndmsv галп.ndmsv галс.ndmsv галфвинд.ndmsv гальванизм.ndmsv гальванометр.ndmsv 
-гальваноскоп.ndmsv гальваностереотип.ndmsv гальванотаксис.ndmsv гальюн.ndmsv гамамелис.ndmsv гамбургер.ndmsv 
-гамелан.ndmsv гаметофит.ndmsv гамильтониан.ndmsv гамлетизм.ndmsv гамма-плотномер.ndmsv гандбол.ndmsv 
-гандизм.ndmsv гандикап.ndmsv ганистер.ndmsv ганит.ndmsv гаолян.ndmsv гаплозис.ndmsv 
-гаптен.ndmsv гаптоглобин.ndmsv гарвард.ndmsv гардероб.ndmsv гарлем.ndmsv гармонизатор.ndmsv 
-гармонограф.ndmsv гарниерит.ndmsv гарнизон.ndmsv гарпиус.ndmsv гарт.ndmsv гастрит.ndmsv 
-гастроскоп.ndmsv гастрофилез.ndmsv гастроэнтерит.ndmsv гаулейтер.ndmsv гаусс.ndmsv гбайт.ndmsv 
-гваякол.ndmsv гвоздодер.ndmsv гебраизм.ndmsv гедонизм.ndmsv гейзерит.ndmsv гейландит.ndmsv 
-гейм.ndmsv геймбол.ndmsv гекельфон.ndmsv гекзаметр.ndmsv гексахлоран.ndmsv гексахорд.ndmsv 
-гексаэдр.ndmsv гексод.ndmsv гектар.ndmsv гектограмм.ndmsv гектограф.ndmsv гектолитр.ndmsv 
-гектометр.ndmsv гелигнит.ndmsv геликоид.ndmsv геликон.ndmsv геликоптер.ndmsv гелиограф.ndmsv 
-гелиодор.ndmsv гелиометр.ndmsv гелиоскоп.ndmsv гелиостат.ndmsv гелиотаксис.ndmsv гелиотроп.ndmsv 
-гелиотропин.ndmsv гелофит.ndmsv гельвет.ndmsv гельминтоз.ndmsv гельмпорт.ndmsv гем.ndmsv 
-гематин.ndmsv гематит.ndmsv гематобласт.ndmsv гематоген.ndmsv гематокрит.ndmsv гемоглобин.ndmsv 
-гемопоэз.ndmsv гемоторакс.ndmsv гемоцитометр.ndmsv генезис.ndmsv генерал-бас.ndmsv генералитет.ndmsv 
-генератор.ndmsv генетив.ndmsv генитив.ndmsv генобласт.ndmsv генотип.ndmsv генофонд.ndmsv 
-геноцид.ndmsv генриметр.ndmsv генштаб.ndmsv геоид.ndmsv геообъект.ndmsv геопроцесс.ndmsv 
-геоскоп.ndmsv геотаксис.ndmsv геотрон.ndmsv геотропизм.ndmsv геофон.ndmsv гепатит.ndmsv 
-гепатопротектор.ndmsv гептаметр.ndmsv гептан.ndmsv гептахорд.ndmsv гептаэдр.ndmsv гептод.ndmsv 
-герб.ndmsv германизм.ndmsv герминатор.ndmsv гермицид.ndmsv гермошлем.ndmsv героизм.ndmsv 
-герпес.ndmsv герундив.ndmsv герцметр.ndmsv гессиан.ndmsv гест.ndmsv гестаген.ndmsv 
-гетеризм.ndmsv гетеродин.ndmsv гетерозис.ndmsv гетероморфоз.ndmsv гетеротрансплантат.ndmsv гетит.ndmsv 
-геттер.ndmsv гешефт.ndmsv гештальт.ndmsv гиалин.ndmsv гиалит.ndmsv гиалоген.ndmsv 
-гиаломер.ndmsv гиацинт.ndmsv гиббереллин.ndmsv гиббсит.ndmsv гибискус.ndmsv гибридер.ndmsv 
-гигабайт.ndmsv гигантизм.ndmsv гигрин.ndmsv гигрограф.ndmsv гигрометр.ndmsv гигроскоп.ndmsv 
-гигростат.ndmsv гигрофит.ndmsv гидантоин.ndmsv гидденит.ndmsv гидразин.ndmsv гидрамнион.ndmsv 
-гидрант.ndmsv гидрартроз.ndmsv гидрастин.ndmsv гидрастинин.ndmsv гидрат.ndmsv гидрид.ndmsv 
-гидроавтомат.ndmsv гидроагрегат.ndmsv гидроаэродром.ndmsv гидроаэроионизатор.ndmsv гидробур.ndmsv гидрогенератор.ndmsv 
-гидродамал.ndmsv гидроканал.ndmsv гидроклав.ndmsv гидрокс.ndmsv гидроксил.ndmsv гидролит.ndmsv 
-гидролокатор.ndmsv гидрометеор.ndmsv гидромеханизм.ndmsv гидромонитор.ndmsv гидромотор.ndmsv гидронасос.ndmsv 
-гидронефроз.ndmsv гидроним.ndmsv гидроплан.ndmsv гидропланер.ndmsv гидропресс.ndmsv гидропривод.ndmsv 
-гидропульт.ndmsv гидроразрыв.ndmsv гидросамолет.ndmsv гидросепаратор.ndmsv гидроскоп.ndmsv гидростат.ndmsv 
-гидросульфат.ndmsv гидросульфит.ndmsv гидротаксис.ndmsv гидроторакс.ndmsv гидротормоз.ndmsv гидроторф.ndmsv 
-гидротрансформатор.ndmsv гидротроп.ndmsv гидротрубопровод.ndmsv гидротурбогенератор.ndmsv гидрофан.ndmsv гидрофит.ndmsv 
-гидрофон.ndmsv гидрофор.ndmsv гидрохинон.ndmsv гидроцилиндр.ndmsv гильберт.ndmsv гимен.ndmsv 
-гимн.ndmsv гинофор.ndmsv гипербатон.ndmsv гиперболоид.ndmsv гипервитаминоз.ndmsv гиперзаряд.ndmsv 
-гиперизм.ndmsv гиперкератоз.ndmsv гиперкинез.ndmsv гиперкосмос.ndmsv гиперон.ndmsv гиперостоз.ndmsv 
-гиперсол.ndmsv гиперстен.ndmsv гипертекст.ndmsv гипертензин.ndmsv гипертиреоз.ndmsv гипершар.ndmsv 
-гипноз.ndmsv гипнотизм.ndmsv гипобласт.ndmsv гиповитаминоз.ndmsv гипокауст.ndmsv гипоксантин.ndmsv 
-гиполимнион.ndmsv гипопаратиреоз.ndmsv гипопион.ndmsv гипостаз.ndmsv гипостасис.ndmsv гипостом.ndmsv 
-гипосульфит.ndmsv гипотаксис.ndmsv гипоталамус.ndmsv гипоталлус.ndmsv гипофаринкс.ndmsv гипофиз.ndmsv 
-гипоцентр.ndmsv гиппокамп.ndmsv гипсобетон.ndmsv гипсолит.ndmsv гипсометр.ndmsv гипсотермометр.ndmsv 
-гиратор.ndmsv гиробус.ndmsv гирогоризонт.ndmsv гирокомпас.ndmsv гиролит.ndmsv гирополукомпас.ndmsv 
-гироскоп.ndmsv гиростабилизатор.ndmsv гиростат.ndmsv гирудин.ndmsv гистамин.ndmsv гистерезис.ndmsv 
-гистерометр.ndmsv гистероскоп.ndmsv гистидин.ndmsv гистобласт.ndmsv гистогенез.ndmsv гит.ndmsv 
-гитерс.ndmsv гитлеризм.ndmsv гитов.ndmsv гладиолус.ndmsv глазомер.ndmsv глайд.ndmsv 
-гласис.ndmsv глауберит.ndmsv глауконит.ndmsv глаукофан.ndmsv глезер.ndmsv глейкометр.ndmsv 
-глет.ndmsv гликоген.ndmsv гликозид.ndmsv глинит.ndmsv глинобетон.ndmsv глинозем.ndmsv 
-глипт.ndmsv глиптодонт.ndmsv глистогон.ndmsv глиф.ndmsv глицерид.ndmsv глицерофосфат.ndmsv 
-глобин.ndmsv глобоид.ndmsv глобулин.ndmsv глобулит.ndmsv глоссит.ndmsv глубиномер.ndmsv 
-глубомер.ndmsv глутамат.ndmsv глутамин.ndmsv глыбодроб.ndmsv глюкагон.ndmsv глюкокортикоид.ndmsv 
-глюон.ndmsv глютен.ndmsv глютин.ndmsv гмелинит.ndmsv гнатонемус.ndmsv гнейс.ndmsv 
-гнет.ndmsv гномон.ndmsv гностицизм.ndmsv го-сотерн.ndmsv гоацин.ndmsv гоббл.ndmsv 
-говлит.ndmsv годограф.ndmsv голландер.ndmsv голлендер.ndmsv голливуд.ndmsv голотип.ndmsv 
-голофан.ndmsv голоцен.ndmsv голоэдр.ndmsv гоматропин.ndmsv гомеоморфизм.ndmsv гомеостазис.ndmsv 
-гомеостат.ndmsv гомерид.ndmsv гоминдан.ndmsv гоминьдан.ndmsv гомогенизатор.ndmsv гомоеозис.ndmsv 
-гомоморфизм.ndmsv гомополимер.ndmsv гомстед.ndmsv гонадотропин.ndmsv гониометр.ndmsv гонт.ndmsv 
-гопкалит.ndmsv гоппер-фидер.ndmsv горводоканал.ndmsv горельеф.ndmsv горжилхоз.ndmsv горизонт.ndmsv 
-горисполком.ndmsv горицвет.ndmsv горком.ndmsv горкомхоз.ndmsv гороптер.ndmsv гороскоп.ndmsv 
-горсовет.ndmsv госбюджет.ndmsv госдеп.ndmsv госдепартамент.ndmsv госзаказ.ndmsv госкомитет.ndmsv 
-госконцерн.ndmsv госкредит.ndmsv госпакет.ndmsv госпромхоз.ndmsv госпротокол.ndmsv госсипин.ndmsv 
-госуниверситет.ndmsv госхоз.ndmsv госцентр.ndmsv госэкзамен.ndmsv грабен.ndmsv гравилат.ndmsv 
-гравиметр.ndmsv гравитометр.ndmsv гравитон.ndmsv градиент.ndmsv грамицидин.ndmsv грамм.ndmsv 
-грамм-атом.ndmsv грамм-эквивалент.ndmsv граммофон.ndmsv гранатомет.ndmsv гранитоид.ndmsv гранолит.ndmsv 
-гранофир.ndmsv гранпасьянс.ndmsv грант.ndmsv гранулит.ndmsv гранулоцит.ndmsv гранулятор.ndmsv 
-граптолит.ndmsv грат.ndmsv граунд.ndmsv графитопласт.ndmsv графкомбинат.ndmsv графометр.ndmsv 
-грейпфрут.ndmsv грецизм.ndmsv гречиховод.ndmsv гридистор.ndmsv гриль-бар.ndmsv грим.ndmsv 
-гриот.ndmsv гриффон.ndmsv грозводоканал.ndmsv громоотвод.ndmsv гросс.ndmsv гросс-чартер.ndmsv 
-гросфатер.ndmsv грот.ndmsv гроулер.ndmsv груббер.ndmsv грузомакет.ndmsv грунтобетон.ndmsv 
-грунтозацеп.ndmsv грунтонос.ndmsv грунтопровод.ndmsv группоид.ndmsv грэмит.ndmsv грэхемит.ndmsv 
-гуанин.ndmsv гудронатор.ndmsv гужон.ndmsv гукер.ndmsv гульден.ndmsv гуманизм.ndmsv 
-гумин.ndmsv гумит.ndmsv гуммигут.ndmsv гуммикопал.ndmsv гуммит.ndmsv гумус.ndmsv 
-гурд.ndmsv гурт.ndmsv гуссит.ndmsv гуэмал.ndmsv гэз.ndmsv гюйс.ndmsv 
-дагерротип.ndmsv дадаизм.ndmsv дазар.ndmsv дайджест.ndmsv дайм.ndmsv дайон.ndmsv 
-дакриоаденит.ndmsv дакриоцистит.ndmsv дакрон.ndmsv дальномер.ndmsv дальтон.ndmsv дальтон-план.ndmsv 
-дальтонизм.ndmsv дамаст.ndmsv даменит.ndmsv дамп.ndmsv даосизм.ndmsv дарвинизм.ndmsv 
-датолит.ndmsv даукарин.ndmsv даусонит.ndmsv дацан.ndmsv дацит.ndmsv двоетес.ndmsv 
-двурост.ndmsv двутавр.ndmsv двучлен.ndmsv деаэратор.ndmsv дебаркадер.ndmsv дебит.ndmsv 
-девиатор.ndmsv девясил.ndmsv дегерминатор.ndmsv дедвейт.ndmsv дезагрегант.ndmsv дезигнат.ndmsv 
-дезинтегратор.ndmsv дезинфектор.ndmsv дезодорант.ndmsv дезодоратор.ndmsv дезоксирибонуклеотид.ndmsv деизм.ndmsv 
-деисус.ndmsv дейдвуд.ndmsv дейтафон.ndmsv дейтерид.ndmsv дейтрон.ndmsv декабризм.ndmsv 
-декагон.ndmsv декаграмм.ndmsv декаданс.ndmsv декалин.ndmsv декалитр.ndmsv декаметр.ndmsv 
-деканат.ndmsv декапод.ndmsv декастер.ndmsv декаэдр.ndmsv деклинатор.ndmsv деклинограф.ndmsv 
-деклинометр.ndmsv декодер.ndmsv декокт.ndmsv декомпрессор.ndmsv декор.ndmsv декорт.ndmsv 
-декортикатор.ndmsv декорум.ndmsv декремент.ndmsv декстрин.ndmsv декстринизатор.ndmsv декуплет.ndmsv 
-деликатес.ndmsv деликт.ndmsv делинквент.ndmsv делириум.ndmsv дельтаплан.ndmsv дельтоид.ndmsv 
-дельтоэдр.ndmsv дельфиниум.ndmsv демерол.ndmsv демикотон.ndmsv демимонд.ndmsv демодулятор.ndmsv 
-демонизм.ndmsv демос.ndmsv демультипликатор.ndmsv денатурат.ndmsv дендроид.ndmsv дендрометр.ndmsv 
-дендрон.ndmsv денотат.ndmsv денсиметр.ndmsv денситометр.ndmsv дентин.ndmsv деодорант.ndmsv 
-департамент.ndmsv депилятор.ndmsv деполяризатор.ndmsv депорт.ndmsv депрессант.ndmsv депрессор.ndmsv 
-дер.ndmsv дератизатор.ndmsv деревобетон.ndmsv дерен.ndmsv дерепрессор.ndmsv дериват.ndmsv 
-дермантин.ndmsv дерматин.ndmsv дерматит.ndmsv дерматоген.ndmsv дерматоз.ndmsv дерматоид.ndmsv 
-дерматофит.ndmsv дермоид.ndmsv дернорез.ndmsv дерносним.ndmsv деррик-кран.ndmsv десигнат.ndmsv 
-десикант.ndmsv десикатор.ndmsv дескриптор.ndmsv деспотизм.ndmsv деструктор.ndmsv десублиматор.ndmsv 
-детандер.ndmsv детектафон.ndmsv детектор.ndmsv детергент.ndmsv детерминатив.ndmsv детонатор.ndmsv 
-детонометр.ndmsv детранслятор.ndmsv детрит.ndmsv дефектоскоп.ndmsv деферент.ndmsv дефибратор.ndmsv 
-дефибрер.ndmsv дефибриллятор.ndmsv дефинитив.ndmsv дефис.ndmsv дефлегматор.ndmsv дефлектор.ndmsv 
-дефлятор.ndmsv дефолиант.ndmsv дефростер.ndmsv децемвират.ndmsv децибел.ndmsv децибелметр.ndmsv 
-дециграмм.ndmsv децилитр.ndmsv дециллион.ndmsv дециметр.ndmsv дешифратор.ndmsv деэмульгатор.ndmsv 
-деэмульсатор.ndmsv джаз.ndmsv джаз-банд.ndmsv джаз-оркестр.ndmsv джаз-центр.ndmsv джайв.ndmsv 
-джайнизм.ndmsv джампан.ndmsv джекфрут.ndmsv джемпринт.ndmsv джемсонит.ndmsv джеспилит.ndmsv 
-джиггер.ndmsv джингоизм.ndmsv джип.ndmsv джулеп.ndmsv джут.ndmsv дзерен.ndmsv 
-дзот.ndmsv диабаз.ndmsv диабет.ndmsv диагенез.ndmsv диагноз.ndmsv диаграф.ndmsv 
-диазин.ndmsv диазоматериал.ndmsv диазоэфир.ndmsv диаклаз.ndmsv диалектизм.ndmsv диализ.ndmsv 
-диализат.ndmsv диализатор.ndmsv диамант.ndmsv диамат.ndmsv диаметр.ndmsv диамид.ndmsv 
-диамин.ndmsv диапазон.ndmsv диапозитив.ndmsv диапроектор.ndmsv диартроз.ndmsv диаскоп.ndmsv 
-диастаз.ndmsv диастер.ndmsv диатез.ndmsv диатермокоагулятор.ndmsv диатомин.ndmsv диатомит.ndmsv 
-диафан.ndmsv диафанометр.ndmsv диафаноскоп.ndmsv диафиз.ndmsv диафильм.ndmsv диафон.ndmsv 
-дибазол.ndmsv дивертикул.ndmsv дивертисмент.ndmsv дивертор.ndmsv дивиденд.ndmsv дивидент.ndmsv 
-дивизион.ndmsv дивизор.ndmsv дивинил.ndmsv дигален.ndmsv дигидрат.ndmsv дигитайзер.ndmsv 
-дигиталис.ndmsv диглиф.ndmsv диграф.ndmsv дидактизм.ndmsv дидодекаэдр.ndmsv диен.ndmsv 
-диетпродукт.ndmsv дизайн.ndmsv дизассемблер.ndmsv дизель-мотор.ndmsv дизельэлектроход.ndmsv дизохол.ndmsv 
-дизъюнкт.ndmsv диксиленд.ndmsv диктант.ndmsv диктат.ndmsv диктограф.ndmsv диктофон.ndmsv 
-диктум.ndmsv дилатограф.ndmsv дилатометр.ndmsv дилижанс.ndmsv дилятатор.ndmsv димайз-чартер.ndmsv 
-димер.ndmsv диметилфталат.ndmsv диметр.ndmsv диморфизм.ndmsv димюон.ndmsv динаметр.ndmsv 
-динамизм.ndmsv динамобаллистокардиограф.ndmsv динамограф.ndmsv динамометр.ndmsv динамоскоп.ndmsv динамотор.ndmsv 
-динаполис.ndmsv динар.ndmsv динас.ndmsv динатрон.ndmsv динейтрон.ndmsv динорнис.ndmsv 
-диод.ndmsv дионин.ndmsv диопсид.ndmsv диоптаз.ndmsv диоптограф.ndmsv диоптр.ndmsv 
-диорит.ndmsv диплекс.ndmsv диплот.ndmsv дипротодон.ndmsv диргем.ndmsv директорат.ndmsv 
-дирхем.ndmsv дисбаланс.ndmsv дискант.ndmsv дисклимакс.ndmsv дисконтинуум.ndmsv дискос.ndmsv 
-дискриминант.ndmsv дискриминатор.ndmsv дискурс.ndmsv диспансер.ndmsv диспашер.ndmsv диспергатор.ndmsv 
-диспут.ndmsv диссектор.ndmsv диссонанс.ndmsv дистиллер.ndmsv дистиллят.ndmsv дистиллятор.ndmsv 
-дистресс.ndmsv дистрикт.ndmsv дисульфан.ndmsv дисульфат.ndmsv дисульфид.ndmsv дисульфонат.ndmsv 
-дитриглиф.ndmsv диурез.ndmsv диуретин.ndmsv дифенил.ndmsv дифениламин.ndmsv дифирамб.ndmsv 
-дифосген.ndmsv дифтерит.ndmsv дифтонгоид.ndmsv диффаматор.ndmsv диффеоморфизм.ndmsv дифферент.ndmsv 
-дифферентометр.ndmsv дифференциал.ndmsv дифференциатор.ndmsv диффузат.ndmsv дихлорофос.ndmsv дихлофос.ndmsv 
-дихроизм.ndmsv дихромат.ndmsv дицинодонт.ndmsv диэдр.ndmsv диэлектрофорез.ndmsv диэнцефалон.ndmsv 
-диэтил.ndmsv диэтиламид.ndmsv добор.ndmsv доворот.ndmsv доггер.ndmsv догкарт.ndmsv 
-догляд.ndmsv догмат.ndmsv догматизм.ndmsv додекаэдр.ndmsv дождемер.ndmsv дозатор.ndmsv 
-дозиметр.ndmsv доклад.ndmsv докторат.ndmsv документ.ndmsv документоооборот.ndmsv долерит.ndmsv 
-долиман.ndmsv доллар.ndmsv доломан.ndmsv дольмен.ndmsv домен.ndmsv доминиген.ndmsv 
-доминион.ndmsv домком.ndmsv домкрат.ndmsv домовоз.ndmsv домол.ndmsv донжон.ndmsv 
-донос.ndmsv доппель-центнер.ndmsv допризыв.ndmsv дормез.ndmsv дорн.ndmsv дортуар.ndmsv 
-достархан.ndmsv драглайн.ndmsv драгметалл.ndmsv драгстер.ndmsv драйв.ndmsv драматизм.ndmsv 
-драмтеатр.ndmsv драндулет.ndmsv дредноут.ndmsv дренчер.ndmsv дрифт.ndmsv дрифтер.ndmsv 
-дромгед.ndmsv дросс.ndmsv дрот.ndmsv друидизм.ndmsv дуализм.ndmsv дубликат.ndmsv 
-дублон.ndmsv дубль-бекар.ndmsv дубль-диез.ndmsv дубль-негатив.ndmsv дубль-позитив.ndmsv дукат.ndmsv 
-дульцин.ndmsv думпкар.ndmsv дунит.ndmsv дуоденит.ndmsv дуоплазмотрон.ndmsv дуплекс-процесс.ndmsv 
-дуплет.ndmsv дупликатор.ndmsv дутар.ndmsv дуумвират.ndmsv духан.ndmsv дымоанализатор.ndmsv 
-дымокур.ndmsv дымоотвод.ndmsv дымопровод.ndmsv дымоход.ndmsv дырокол.ndmsv дюйм.ndmsv 
-дюкер.ndmsv дюпрен.ndmsv дюрол.ndmsv дюрометр.ndmsv дюшес.ndmsv евродоллар.ndmsv 
-европеизм.ndmsv евросоюз.ndmsv емшан.ndmsv епископат.ndmsv ертаул.ndmsv ефод.ndmsv 
-жадеит.ndmsv жакан.ndmsv жакт.ndmsv жанр.ndmsv жанризм.ndmsv жаргонизм.ndmsv 
-жарт.ndmsv жбан.ndmsv жгут.ndmsv жезл.ndmsv железобетон.ndmsv железографит.ndmsv 
-желтозем.ndmsv желтоцвет.ndmsv женотдел.ndmsv женсовет.ndmsv жиклер.ndmsv жилкомхоз.ndmsv 
-жилотдел.ndmsv жилфонд.ndmsv жиркомбинат.ndmsv жирнозем.ndmsv жирокомбинат.ndmsv жирооборот.ndmsv 
-жиропот.ndmsv жироприказ.ndmsv жирорасчет.ndmsv жокей-клуб.ndmsv жом.ndmsv жор.ndmsv 
-жордан.ndmsv жостер.ndmsv жульен.ndmsv жупел.ndmsv журнализм.ndmsv журфикс.ndmsv 
-завком.ndmsv заворот.ndmsv заглот.ndmsv заготпункт.ndmsv загранаппарат.ndmsv заграндокумент.ndmsv 
-загс.ndmsv загул.ndmsv закидон.ndmsv законопроект.ndmsv залп.ndmsv зальбанд.ndmsv 
-замес.ndmsv заплот.ndmsv заплыв.ndmsv заратит.ndmsv зарез.ndmsv зарод.ndmsv 
-засев.ndmsv засов.ndmsv затл.ndmsv захлеб.ndmsv звездолет.ndmsv звездопад.ndmsv 
-зверосовхоз.ndmsv звздолет.ndmsv звуколокатор.ndmsv звукообраз.ndmsv звукопровод.ndmsv звукоряд.ndmsv 
-здравотдел.ndmsv здравпункт.ndmsv зеин.ndmsv землевоз.ndmsv землеотвод.ndmsv землесос.ndmsv 
-земснаряд.ndmsv земфонд.ndmsv зеолит.ndmsv зеркалит.ndmsv зерноаспиратор.ndmsv зернокомбайн.ndmsv 
-зернопровод.ndmsv зернопульт.ndmsv зерносклад.ndmsv зерносовхоз.ndmsv зерноэлеватор.ndmsv зет.ndmsv 
-зиггурат.ndmsv зиккурат.ndmsv зимоген.ndmsv зитцкриг.ndmsv златоцвет.ndmsv знакогенератор.ndmsv 
-зов.ndmsv золоотвал.ndmsv зонд.ndmsv зонт.ndmsv зоолит.ndmsv зоомагазин.ndmsv 
-зооморфизм.ndmsv зооноз.ndmsv зоопланктон.ndmsv зоосад.ndmsv зооценоз.ndmsv зооцентр.ndmsv 
-зумпф.ndmsv зыбун.ndmsv зюйд.ndmsv иглофильтр.ndmsv игнитрон.ndmsv идеализм.ndmsv 
-идентификатор.ndmsv идефикс.ndmsv идиобласт.ndmsv идиолект.ndmsv идиоматизм.ndmsv идиотизм.ndmsv 
-идиофон.ndmsv идокраз.ndmsv иезуитизм.ndmsv иероглиф.ndmsv изатин.ndmsv изафенин.ndmsv 
-изафет.ndmsv избирком.ndmsv извет.ndmsv извив.ndmsv извод.ndmsv изворот.ndmsv 
-изгиб.ndmsv излет.ndmsv измолот.ndmsv износ.ndmsv изоамилацетат.ndmsv изобутан.ndmsv 
-изобутилен.ndmsv изодиморфизм.ndmsv изоколон.ndmsv изолюкс.ndmsv изолятор.ndmsv изоморфизм.ndmsv 
-изопрен.ndmsv изоспин.ndmsv изотон.ndmsv изофермент.ndmsv изохолестерин.ndmsv изохронизм.ndmsv 
-изоцентр.ndmsv икарус.ndmsv иконоскоп.ndmsv иконостас.ndmsv икос.ndmsv икосаэдр.ndmsv 
-икромет.ndmsv икс.ndmsv икт.ndmsv иктус.ndmsv илеит.ndmsv иллиризм.ndmsv 
-иллюзион.ndmsv ильм.ndmsv ильменит.ndmsv имажинизм.ndmsv имамат.ndmsv имарет.ndmsv 
-именослов.ndmsv имидазол.ndmsv иммельман.ndmsv иммитанс.ndmsv имморализм.ndmsv иммунитет.ndmsv 
-иммуноглобулин.ndmsv иммунодепрессант.ndmsv иммунокорректор.ndmsv иммунопрепарат.ndmsv иммуностимулятор.ndmsv иммунотоксин.ndmsv 
-иммуноцит.ndmsv импеллер.ndmsv императив.ndmsv империал.ndmsv имперфект.ndmsv импичмент.ndmsv 
-импост.ndmsv инактиватор.ndmsv инвар.ndmsv инверсор.ndmsv инвертин.ndmsv инвертор.ndmsv 
-ингалятор.ndmsv ингибитор.ndmsv ингредиент.ndmsv ингридиент.ndmsv индамин.ndmsv индемнитет.ndmsv 
-индент.ndmsv индикан.ndmsv индикатив.ndmsv индикатор.ndmsv индикт.ndmsv индоксил.ndmsv 
-индол.ndmsv индоссамент.ndmsv индофенол.ndmsv индуизм.ndmsv индуктор.ndmsv инжектор.ndmsv 
-инклинатор.ndmsv инклинометр.ndmsv инклюзив.ndmsv инкремент.ndmsv инкубатор.ndmsv инозин.ndmsv 
-инозит.ndmsv инсайт.ndmsv инсектофунгицид.ndmsv инсорит.ndmsv инспекторат.ndmsv инсталлятор.ndmsv 
-инстинкт.ndmsv инсулин.ndmsv инсульт.ndmsv интеграл.ndmsv интегратор.ndmsv интеграф.ndmsv 
-интеллект.ndmsv интенсиметр.ndmsv интенсификатор.ndmsv интервал.ndmsv интердикт.ndmsv интеркомпрессор.ndmsv 
-интернат.ndmsv интернет.ndmsv интерполятор.ndmsv интерфакс.ndmsv интерфейс.ndmsv интерферометр.ndmsv 
-интерфикс.ndmsv интерцептор.ndmsv интерьер.ndmsv интроскоп.ndmsv интуиционизм.ndmsv инулин.ndmsv 
-инфикс.ndmsv инфильтрат.ndmsv инфинитив.ndmsv инфлятор.ndmsv информпатент.ndmsv информприбор.ndmsv 
-инфорсмент.ndmsv инцидент.ndmsv инъюнктив.ndmsv иоганнес.ndmsv иод.ndmsv иодид.ndmsv 
-иол.ndmsv ионизатор.ndmsv ионит.ndmsv ионоген.ndmsv иономер.ndmsv ионофорез.ndmsv 
-ионтофорез.ndmsv ипподром.ndmsv ипсилон.ndmsv иранизм.ndmsv иргизит.ndmsv ирмос.ndmsv 
-ислам.ndmsv исламизм.ndmsv испанизм.ndmsv испод.ndmsv исполком.ndmsv иссоп.ndmsv 
-истеблишмент.ndmsv истмат.ndmsv истод.ndmsv историзм.ndmsv истэблишмент.ndmsv итальянизм.ndmsv 
-итератор.ndmsv иудаизм.ndmsv ихтиоз.ndmsv ихтиокол.ndmsv ихтиол.ndmsv ихтиолит.ndmsv 
-ишиас.ndmsv йогурт.ndmsv йодат.ndmsv йодид.ndmsv йодоформ.ndmsv кабелепровод.ndmsv 
-кабель-кран.ndmsv кабестан.ndmsv кабошон.ndmsv кабриолет.ndmsv кавальер.ndmsv каверномер.ndmsv 
-каверпойнт.ndmsv кагал.ndmsv каганат.ndmsv кагат.ndmsv кадаверин.ndmsv кадавр.ndmsv 
-каданс.ndmsv кадастр.ndmsv казакин.ndmsv казеин.ndmsv казеиноген.ndmsv казимир.ndmsv 
-казинет.ndmsv каинит.ndmsv кайнозит.ndmsv кактоид.ndmsv кактус.ndmsv кала-азар.ndmsv 
-калам.ndmsv каламин.ndmsv каламит.ndmsv каландр.ndmsv калган.ndmsv калейдоскоп.ndmsv 
-калейдофон.ndmsv калиаппарат.ndmsv калибромер.ndmsv калиброметр.ndmsv калифат.ndmsv каллаит.ndmsv 
-каллус.ndmsv калоризатор.ndmsv калориметр.ndmsv калорифер.ndmsv калуфер.ndmsv калым.ndmsv 
-кальвадос.ndmsv кальвинизм.ndmsv калькулятор.ndmsv кальцекс.ndmsv кальцит.ndmsv кальциферол.ndmsv 
-кальян.ndmsv калюмет.ndmsv калютрон.ndmsv камбуз.ndmsv камербанд.ndmsv камерон.ndmsv 
-камертон.ndmsv камлот.ndmsv камнемет.ndmsv камнепад.ndmsv камуфлет.ndmsv камышит.ndmsv 
-канаус.ndmsv канделябр.ndmsv кандибобер.ndmsv кандиль-синап.ndmsv кандым.ndmsv канкан.ndmsv 
-канкроид.ndmsv канон.ndmsv кантаридин.ndmsv кантарус.ndmsv канторис.ndmsv канцеляризм.ndmsv 
-канцелярит.ndmsv канцер.ndmsv канцероген.ndmsv каньон.ndmsv каолин.ndmsv каолинит.ndmsv 
-каон.ndmsv каперс.ndmsv капилляр.ndmsv капитализм.ndmsv капитул.ndmsv капонир.ndmsv 
-капор.ndmsv капот.ndmsv капремонт.ndmsv каприс.ndmsv капролактам.ndmsv капрон.ndmsv 
-капсид.ndmsv каптал.ndmsv капут.ndmsv капюшон.ndmsv карабин.ndmsv карантин.ndmsv 
-карат.ndmsv карачун.ndmsv карбазол.ndmsv карбас.ndmsv карбинол.ndmsv карбоксил.ndmsv 
-карболеин.ndmsv карболен.ndmsv карболинеум.ndmsv карболит.ndmsv карбон.ndmsv карбонат.ndmsv 
-карбонил.ndmsv карбонит.ndmsv карборан.ndmsv карборунд.ndmsv карбункул.ndmsv карбункулез.ndmsv 
-карбюратор.ndmsv карбюризатор.ndmsv кардиган.ndmsv кардиограф.ndmsv кардиосклероз.ndmsv кардиостимулятор.ndmsv 
-кардит.ndmsv кардиф.ndmsv кариес.ndmsv карильон.ndmsv кариогенез.ndmsv кариотип.ndmsv 
-карленгс.ndmsv кармазин.ndmsv карнавал.ndmsv карналлит.ndmsv карнеол.ndmsv карнотит.ndmsv 
-каротин.ndmsv карраген.ndmsv карст.ndmsv картер.ndmsv карцер.ndmsv карьеризм.ndmsv 
-касса-реал.ndmsv кассир-автомат.ndmsv касситерит.ndmsv кассореал.ndmsv кастет.ndmsv катаболизм.ndmsv 
-катаклизм.ndmsv каталексис.ndmsv катализ.ndmsv катализатор.ndmsv катамаран.ndmsv катарсис.ndmsv 
-катастат.ndmsv кататермометр.ndmsv катафорез.ndmsv катафот.ndmsv катафронт.ndmsv катенан.ndmsv 
-катеноид.ndmsv катет.ndmsv катетер.ndmsv катетометр.ndmsv катехизатор.ndmsv катехизис.ndmsv 
-катехоламин.ndmsv катион.ndmsv катлинит.ndmsv католит.ndmsv католицизм.ndmsv катрен.ndmsv 
-каудекс.ndmsv каузатив.ndmsv каучуконос.ndmsv каф.ndmsv кафешантан.ndmsv кашемир.ndmsv 
-каштан.ndmsv кбайт.ndmsv кбит.ndmsv кбод.ndmsv квадрант.ndmsv квадриллион.ndmsv 
-квадрильон.ndmsv квадрумвират.ndmsv квадруплекс.ndmsv квадруплет.ndmsv квазар.ndmsv квазиатом.ndmsv 
-квазиделикт.ndmsv квазиимпульс.ndmsv квалификатор.ndmsv квантизатор.ndmsv квантификатор.ndmsv квантометр.ndmsv 
-квантор.ndmsv квартал.ndmsv квартер.ndmsv кварцит.ndmsv кватернион.ndmsv кверцит.ndmsv 
-кверцитрон.ndmsv квиетизм.ndmsv квикстеп.ndmsv квинтал.ndmsv квинтет.ndmsv квинтиллион.ndmsv 
-квинтильон.ndmsv кворум.ndmsv кеб.ndmsv кеватрон.ndmsv кегельбан.ndmsv кедр.ndmsv 
-кейбер.ndmsv кейс.ndmsv кекс.ndmsv келоид.ndmsv кельвин.ndmsv кенаф.ndmsv 
-кенотаф.ndmsv кенотрон.ndmsv керамзит.ndmsv керамит.ndmsv кераргирит.ndmsv кератин.ndmsv 
-кератит.ndmsv кератоз.ndmsv кератофир.ndmsv кермезит.ndmsv керн.ndmsv кернер.ndmsv 
-керогаз.ndmsv керонафт.ndmsv керосинопровод.ndmsv керосинорез.ndmsv керсантит.ndmsv керченит.ndmsv 
-кетгут.ndmsv кетчуп.ndmsv кианит.ndmsv кивот.ndmsv киддерминстер.ndmsv кизельгур.ndmsv 
-кизерит.ndmsv килдеркин.ndmsv килектор.ndmsv килим.ndmsv килоампер.ndmsv килобайт.ndmsv 
-килобар.ndmsv киловатт-час.ndmsv киловольтметр.ndmsv килограмм.ndmsv килограммометр.ndmsv килолитр.ndmsv 
-километр.ndmsv килоом.ndmsv килопонд.ndmsv килоэлектронвольт.ndmsv килт.ndmsv кильватер.ndmsv 
-кильсон.ndmsv кимберлит.ndmsv кимвал.ndmsv кимограф.ndmsv кингстон.ndmsv кинематограф.ndmsv 
-кинеограф.ndmsv кинескоп.ndmsv кинетеодолит.ndmsv кинетоскоп.ndmsv киноаппарат.ndmsv киноархив.ndmsv 
-кинобилет.ndmsv киновидеоматериал.ndmsv киновидеопоказ.ndmsv киновидеофильм.ndmsv киновидеофотодокумент.ndmsv кинодокумент.ndmsv 
-киножурнал.ndmsv кинозал.ndmsv киноизм.ndmsv кинокадр.ndmsv кинокомплект.ndmsv киноконцерн.ndmsv 
-киноконцерт.ndmsv киноматериал.ndmsv кинообъектив.ndmsv кинопавильон.ndmsv киноплакат.ndmsv кинопоказ.ndmsv 
-кинопроектор.ndmsv кинопрожектор.ndmsv кинопрокат.ndmsv кинопросмотр.ndmsv кинопулемет.ndmsv киносеанс.ndmsv 
-киносериал.ndmsv кинотеатр.ndmsv кинотеодолит.ndmsv кинотехникум.ndmsv кинофакультет.ndmsv кинофильм.ndmsv 
-кинофотодокумент.ndmsv кинофотоматериал.ndmsv кинофоторентгеноматериал.ndmsv кинофотофонодокумент.ndmsv кинофотофономатериал.ndmsv киноцентр.ndmsv 
-киноэкран.ndmsv киноэкскурс.ndmsv киот.ndmsv кипп.ndmsv кирказон.ndmsv киршвассер.ndmsv 
-кислород.ndmsv кислотомер.ndmsv китаизм.ndmsv кифоз.ndmsv клавесин.ndmsv клавилюкс.ndmsv 
-клавир.ndmsv клавицимбал.ndmsv клаксон.ndmsv кламмер.ndmsv клан.ndmsv клап.ndmsv 
-клапштос.ndmsv кларен.ndmsv кларендон.ndmsv кларенс.ndmsv кларнет.ndmsv классицизм.ndmsv 
-кластер.ndmsv клатрат.ndmsv клаусталит.ndmsv клевант.ndmsv клевеит.ndmsv клеймор.ndmsv 
-клерет.ndmsv клидонограф.ndmsv климакс.ndmsv климат.ndmsv климатрон.ndmsv клинекс.ndmsv 
-клинометр.ndmsv клиностат.ndmsv клинчер.ndmsv клир.ndmsv клиренс.ndmsv клирос.ndmsv 
-клистрон.ndmsv клитор.ndmsv клов.ndmsv клонус.ndmsv клопомор.ndmsv клопфер.ndmsv 
-клот.ndmsv клуатр.ndmsv клупп.ndmsv клюв.ndmsv клюз.ndmsv клюфт.ndmsv 
-клямс.ndmsv кляп.ndmsv кляссер.ndmsv кнастер.ndmsv кнессет.ndmsv кнехт.ndmsv 
-книгообмен.ndmsv книксен.ndmsv кнут.ndmsv коагулянт.ndmsv коагулят.ndmsv коагулятор.ndmsv 
-коацерват.ndmsv кобалтин.ndmsv кобальт.ndmsv кобальтин.ndmsv кобблер.ndmsv кобол.ndmsv 
-когерер.ndmsv кодасил.ndmsv кодекс.ndmsv кодер.ndmsv кодон.ndmsv кожтовар.ndmsv 
-кожуун.ndmsv козлетон.ndmsv коитус.ndmsv кок-сагыз.ndmsv кокаин.ndmsv кокаинизм.ndmsv 
-кокос.ndmsv кокпит.ndmsv коксит.ndmsv коксобензол.ndmsv коксоцерит.ndmsv кокцидиоз.ndmsv 
-коленвал.ndmsv колет.ndmsv колит.ndmsv коллаген.ndmsv коллайдер.ndmsv коллапс.ndmsv 
-коллапсар.ndmsv колларгол.ndmsv коллект.ndmsv коллектив.ndmsv коллетериум.ndmsv коллиматор.ndmsv 
-коллодиум.ndmsv коллоквиум.ndmsv коллоксилин.ndmsv коловорот.ndmsv колоквинт.ndmsv колонат.ndmsv 
-колоноскоп.ndmsv колонтитул.ndmsv колор.ndmsv колориметр.ndmsv колофон.ndmsv колтун.ndmsv 
-колумбит.ndmsv колун.ndmsv колхицин.ndmsv колчедан.ndmsv кольдкрем.ndmsv кольт.ndmsv 
-кольтер.ndmsv колюр.ndmsv комбайн.ndmsv комбед.ndmsv комбижир.ndmsv комбинат.ndmsv 
-комбинезон.ndmsv комизм.ndmsv комикс.ndmsv комингс.ndmsv комиссариат.ndmsv комитат.ndmsv 
-комитет.ndmsv коммунизм.ndmsv коммуникатор.ndmsv коммутатор.ndmsv компандер.ndmsv компаратор.ndmsv 
-компаунд.ndmsv компендиум.ndmsv компенсатор.ndmsv компиллятор.ndmsv комплекс.ndmsv комплексон.ndmsv 
-комплемент.ndmsv комплимент.ndmsv комплот.ndmsv композер.ndmsv композит.ndmsv компостер.ndmsv 
-компресс.ndmsv компрессор.ndmsv комптометр.ndmsv комптонит.ndmsv компьютер.ndmsv комсостав.ndmsv 
-конвейер.ndmsv конвектор.ndmsv конвент.ndmsv конвертер.ndmsv конвертоплан.ndmsv конвертор.ndmsv 
-конгломерат.ndmsv конгрев.ndmsv конгресс.ndmsv конгресс-холл.ndmsv конденсат.ndmsv конденсатор.ndmsv 
-конденсор.ndmsv кондиционер.ndmsv кондоминиум.ndmsv кондуктометр.ndmsv конезавод.ndmsv конесовхоз.ndmsv 
-кониметр.ndmsv конклав.ndmsv конкорданс.ndmsv конкордат.ndmsv конкремент.ndmsv конкубинат.ndmsv 
-конкур.ndmsv коннектор.ndmsv коноид.ndmsv коносамент.ndmsv консенсус.ndmsv консервант.ndmsv 
-консилиум.ndmsv консистометр.ndmsv консолет.ndmsv консонанс.ndmsv консонант.ndmsv консорциум.ndmsv 
-конспект.ndmsv константан.ndmsv констриктор.ndmsv конструкт.ndmsv консулат.ndmsv консумент.ndmsv 
-контактор.ndmsv контаминант.ndmsv контейнер.ndmsv контейнеровоз.ndmsv контингент.ndmsv континент.ndmsv 
-континуум.ndmsv контоид.ndmsv контокоррент.ndmsv контрабас.ndmsv контраданс.ndmsv контражур.ndmsv 
-контрапост.ndmsv контраргумент.ndmsv контратип.ndmsv контрафагот.ndmsv контрафорс.ndmsv контрацептив.ndmsv 
-контрбанкет.ndmsv контрбрас.ndmsv контргамбит.ndmsv контргрейфер.ndmsv контргруз.ndmsv контрданс.ndmsv 
-контрдовод.ndmsv контрейлер.ndmsv контрзаговор.ndmsv контркалибр.ndmsv контрклин.ndmsv контркривошип.ndmsv 
-контрманевр.ndmsv контрнегатив.ndmsv контроллер.ndmsv контрольприбор.ndmsv контрответ.ndmsv контрпривод.ndmsv 
-контрприем.ndmsv контрприказ.ndmsv контрпроект.ndmsv контррезервуар.ndmsv контррельс.ndmsv контртитул.ndmsv 
-контрудар.ndmsv контрфорс.ndmsv контрштамп.ndmsv контрэскарп.ndmsv конфайнмент.ndmsv конфекцион.ndmsv 
-конферанс.ndmsv конференц-зал.ndmsv конфигуратор.ndmsv конфикс.ndmsv конформизм.ndmsv конфузор.ndmsv 
-концентр.ndmsv концентрат.ndmsv концентратор.ndmsv концепт.ndmsv концепт-план.ndmsv концерн.ndmsv 
-конъюнкт.ndmsv конъюнктив.ndmsv конъюнктивит.ndmsv кооператив.ndmsv координатограф.ndmsv копирайт.ndmsv 
-копиручет.ndmsv копновоз.ndmsv копролит.ndmsv коракл.ndmsv коралл.ndmsv кораллит.ndmsv 
-коран.ndmsv корвет.ndmsv корволант.ndmsv кордебалет.ndmsv кордиамин.ndmsv кордиерит.ndmsv 
-кордит.ndmsv кореопсис.ndmsv кориандр.ndmsv корибант.ndmsv кориум.ndmsv кормофит.ndmsv 
-корн.ndmsv корнеед.ndmsv корнеплод.ndmsv корнер.ndmsv корнет-а-пистон.ndmsv корнит.ndmsv 
-корнишон.ndmsv корнпапир.ndmsv коронавирус.ndmsv коронаротромбоз.ndmsv коронограф.ndmsv коротрон.ndmsv 
-корпункт.ndmsv коррелометр.ndmsv коррелят.ndmsv коррелятор.ndmsv корригент.ndmsv коррпункт.ndmsv 
-корт.ndmsv кортизон.ndmsv кортикостероид.ndmsv корунд.ndmsv косеканс.ndmsv косинус.ndmsv 
-космограф.ndmsv космодром.ndmsv космолет.ndmsv космоплан.ndmsv космос.ndmsv космотрон.ndmsv 
-косоур.ndmsv косс.ndmsv кострец.ndmsv котангенс.ndmsv котиледон.ndmsv котильон.ndmsv 
-котлоагрегат.ndmsv котлован.ndmsv котонизатор.ndmsv коулсонит.ndmsv кофактор.ndmsv кофермент.ndmsv 
-кофр.ndmsv коффердам.ndmsv кохинор.ndmsv кочкорез.ndmsv кошт.ndmsv коэффициент.ndmsv 
-краз.ndmsv крайисполком.ndmsv крайком.ndmsv крайоблгорисполком.ndmsv краковян.ndmsv крамбол.ndmsv 
-краниопаг.ndmsv крапп.ndmsv краскопульт.ndmsv краснозем.ndmsv краснотал.ndmsv красоднев.ndmsv 
-кратер.ndmsv кратир.ndmsv кратоген.ndmsv кратон.ndmsv крафт.ndmsv крахмалопродукт.ndmsv 
-креатин.ndmsv кредитанштальт.ndmsv кредитив.ndmsv крезол.ndmsv крейт.ndmsv крейцер.ndmsv 
-крейцкопф.ndmsv крекер.ndmsv крекинг-процесс.ndmsv кремневодород.ndmsv кремнезем.ndmsv кремнеуглеводород.ndmsv 
-кренгельс.ndmsv креномер.ndmsv кренометр.ndmsv креозол.ndmsv креозот.ndmsv креолин.ndmsv 
-креометр.ndmsv креон.ndmsv креп-жаккард.ndmsv креп-марокен.ndmsv креп-шифон.ndmsv кресс-салат.ndmsv 
-кретинизм.ndmsv крешер.ndmsv кривошип.ndmsv криз.ndmsv крикет.ndmsv кринолин.ndmsv 
-кринум.ndmsv криогидрат.ndmsv криозонд.ndmsv криолит.ndmsv криометр.ndmsv криопротектор.ndmsv 
-криостат.ndmsv криотрон.ndmsv криптобиоз.ndmsv криптограф.ndmsv криптон.ndmsv криптофит.ndmsv 
-кристадин.ndmsv кристалл.ndmsv кристаллизатор.ndmsv кристаллит.ndmsv кристаллогидрат.ndmsv кристаллоид.ndmsv 
-кристобалит.ndmsv критицизм.ndmsv крокер.ndmsv крокус.ndmsv кронглас.ndmsv кронштейн.ndmsv 
-крор.ndmsv кросс.ndmsv кросс-курс.ndmsv кроссворд.ndmsv кроссинговер.ndmsv кроссовер.ndmsv 
-кротон.ndmsv круговорот.ndmsv кругозор.ndmsv кругооборот.ndmsv круиз.ndmsv крупозавод.ndmsv 
-крупон.ndmsv крутогор.ndmsv крутояр.ndmsv крым-сагыз.ndmsv крюгерранд.ndmsv крюйсов.ndmsv 
-крюммер.ndmsv ксантин.ndmsv ксантофилл.ndmsv ксенолит.ndmsv ксенон.ndmsv ксенотрансплантат.ndmsv 
-ксероз.ndmsv ксерокс.ndmsv ксерофит.ndmsv ксероформ.ndmsv ксилол.ndmsv ксилолит.ndmsv 
-ксилометр.ndmsv ксилофон.ndmsv ку-клукс-клан.ndmsv кубизм.ndmsv кубит.ndmsv кубоид.ndmsv 
-кубометр.ndmsv кубооктаэдр.ndmsv куверт.ndmsv кукан.ndmsv кукельван.ndmsv кукерсит.ndmsv 
-куламон.ndmsv кулон.ndmsv кулонометр.ndmsv кульверт.ndmsv кульм.ndmsv кульман.ndmsv 
-культиватор.ndmsv культпоход.ndmsv культуризм.ndmsv культфонд.ndmsv кумарин.ndmsv кумпол.ndmsv 
-кунгас.ndmsv куприт.ndmsv купферштейн.ndmsv курбан-байрам.ndmsv курбет.ndmsv курвиметр.ndmsv 
-курзал.ndmsv курослеп.ndmsv курсограф.ndmsv кусторез.ndmsv кутас.ndmsv кьят.ndmsv 
-кэш-файл.ndmsv кяриз.ndmsv лабардан.ndmsv лабиринт.ndmsv лабиринтодонт.ndmsv лабиум.ndmsv 
-лабрадорит.ndmsv лабрум.ndmsv лавсан.ndmsv ладдетрон.ndmsv лазер.ndmsv лазулит.ndmsv 
-лазурит.ndmsv лайм.ndmsv лайнер.ndmsv лакколит.ndmsv лакмус.ndmsv лаконизм.ndmsv 
-лакриматор.ndmsv лактарин.ndmsv лактобутирометр.ndmsv лактокрит.ndmsv лактометр.ndmsv лактон.ndmsv 
-лактоскоп.ndmsv лактофлавин.ndmsv лал.ndmsv ламаизм.ndmsv ламаркизм.ndmsv ламберт.ndmsv 
-ламбрадор.ndmsv ламбрекен.ndmsv ламинит.ndmsv лампион.ndmsv лампрофир.ndmsv лангет.ndmsv 
-лангустин.ndmsv ландвер.ndmsv ландолет.ndmsv ландрин.ndmsv ландшафт.ndmsv ландштурм.ndmsv 
-ланкорд.ndmsv ланолин.ndmsv лантан.ndmsv лантанид.ndmsv лантаноид.ndmsv лапароскоп.ndmsv 
-лапласиан.ndmsv лаптоп.ndmsv ларингит.ndmsv ларингоскоп.ndmsv ларингоспазм.ndmsv ларингофон.ndmsv 
-латекс.ndmsv латерит.ndmsv латинизм.ndmsv лацкан.ndmsv лацпорт.ndmsv левеллер.ndmsv 
-левират.ndmsv левкас.ndmsv легализм.ndmsv леггемоглобин.ndmsv легион.ndmsv легитимизм.ndmsv 
-легумин.ndmsv ледебурит.ndmsv ледерин.ndmsv ледогенератор.ndmsv ледокол.ndmsv ледолом.ndmsv 
-ледопад.ndmsv ледорез.ndmsv ледоруб.ndmsv ледосброс.ndmsv ледостав.ndmsv лейас.ndmsv 
-лейборизм.ndmsv лейкоз.ndmsv лейкопласт.ndmsv лейкопоэз.ndmsv лейкотроп.ndmsv лейкоцит.ndmsv 
-лейкоцитоз.ndmsv лейнафос.ndmsv лейтмотив.ndmsv лейцин.ndmsv лейцит.ndmsv лейцитит.ndmsv 
-лейчестер.ndmsv лекиф.ndmsv лексикон.ndmsv ленд-лиз.ndmsv ленинизм.ndmsv леонтиазис.ndmsv 
-леотард.ndmsv лепидодендрон.ndmsv лепидолит.ndmsv лептоспироз.ndmsv лесозавод.ndmsv лесокомбайн.ndmsv 
-лесокомбинат.ndmsv лесоматериал.ndmsv лесоповал.ndmsv лесопункт.ndmsv лесосклад.ndmsv леспромхоз.ndmsv 
-лесс.ndmsv лесстройматериал.ndmsv лесхоз.ndmsv лецитин.ndmsv лецитис.ndmsv лжеплод.ndmsv 
-лиард.ndmsv либерализм.ndmsv ливнеотвод.ndmsv ливнесброс.ndmsv ливр.ndmsv лиганд.ndmsv 
-лигнин.ndmsv лигнит.ndmsv лигностон.ndmsv лигроин.ndmsv лидар.ndmsv лиддит.ndmsv 
-лизат.ndmsv лизгольдер.ndmsv лизиметр.ndmsv лизин.ndmsv лизис.ndmsv лизоклин.ndmsv 
-лизол.ndmsv лизоформ.ndmsv лизоцим.ndmsv ликбез.ndmsv ликвидитет.ndmsv ликвидус.ndmsv 
-ликтрос.ndmsv лимитер.ndmsv лимитроф.ndmsv лимниграф.ndmsv лимонит.ndmsv лимузин.ndmsv 
-лимфаденит.ndmsv лимфангит.ndmsv лимфангоит.ndmsv лимфогранулематоз.ndmsv лимфоцит.ndmsv лингафон.ndmsv 
-линеаризм.ndmsv линимент.ndmsv линин.ndmsv линкер.ndmsv линкольн.ndmsv линкор.ndmsv 
-линкруст.ndmsv линнеит.ndmsv линобатист.ndmsv линоксин.ndmsv линолеат.ndmsv линолеум.ndmsv 
-линтер.ndmsv лионез.ndmsv липарит.ndmsv липоид.ndmsv липопротеин.ndmsv липотропин.ndmsv 
-липофусцин.ndmsv лиризм.ndmsv лириодендрон.ndmsv лисохвост.ndmsv лисп.ndmsv листер.ndmsv 
-литакиноскоп.ndmsv литаскоп.ndmsv литерал.ndmsv литогенез.ndmsv литопон.ndmsv литотес.ndmsv 
-литофит.ndmsv литофон.ndmsv литр.ndmsv литфонд.ndmsv лиф.ndmsv лифт.ndmsv 
-лифтер.ndmsv лихнис.ndmsv лихтеровоз.ndmsv логарифм.ndmsv логицизм.ndmsv логогриф.ndmsv 
-логометр.ndmsv логос.ndmsv логотип.ndmsv ложемент.ndmsv локатив.ndmsv локатор.ndmsv 
-локаут.ndmsv локдаун.ndmsv локер.ndmsv локнит.ndmsv локомотив.ndmsv локон.ndmsv 
-локус.ndmsv ломонос.ndmsv ломоносовит.ndmsv лонгет.ndmsv лонгулит.ndmsv лонгхорн.ndmsv 
-лонгшез.ndmsv лонжерон.ndmsv лордоз.ndmsv лотос.ndmsv лоуд.ndmsv лофт.ndmsv 
-лубрикатор.ndmsv лугорез.ndmsv луидор.ndmsv лунатизм.ndmsv луноход.ndmsv лупанар.ndmsv 
-лупулин.ndmsv льдоаккумулятор.ndmsv льдогенератор.ndmsv льнозавод.ndmsv льнокомбайн.ndmsv льнокомбинат.ndmsv 
-льноматериал.ndmsv льносовхоз.ndmsv люверс.ndmsv люггер.ndmsv люизит.ndmsv люксметр.ndmsv 
-люксон.ndmsv люля-кебаб.ndmsv люмен.ndmsv люменотроп.ndmsv люменофорэкран.ndmsv люминал.ndmsv 
-люминограф.ndmsv люминофор.ndmsv люмпен-пролетариат.ndmsv люнет.ndmsv люнкерит.ndmsv люпин.ndmsv 
-люпус.ndmsv люстрин.ndmsv люфт.ndmsv люэс.ndmsv ляд.ndmsv лян.ndmsv 
-ляп.ndmsv ляпсус.ndmsv лярд.ndmsv магизм.ndmsv магистрат.ndmsv магнезит.ndmsv 
-магнетизм.ndmsv магнетит.ndmsv магнетометр.ndmsv магнетон.ndmsv магнетрон.ndmsv магнитограф.ndmsv 
-магнитокардиограф.ndmsv магнитометр.ndmsv магнитоплан.ndmsv магнитопровод.ndmsv магнитоскоп.ndmsv магнитотаксис.ndmsv 
-магнитофон.ndmsv магнификат.ndmsv магнолит.ndmsv магнон.ndmsv мадригал.ndmsv маздаизм.ndmsv 
-маздеизм.ndmsv мазер.ndmsv мазохизм.ndmsv маис.ndmsv майлар.ndmsv майоран.ndmsv 
-макадам.ndmsv макаронизм.ndmsv маквис.ndmsv макогон.ndmsv макроагрегат.ndmsv макроанализ.ndmsv 
-макрогенератор.ndmsv макроклимат.ndmsv макрокосм.ndmsv макролит.ndmsv макромир.ndmsv макрон.ndmsv 
-макрообъект.ndmsv макроорганизм.ndmsv макропроцесс.ndmsv макропроцессор.ndmsv макрорадикал.ndmsv макрорельеф.ndmsv 
-макрорус.ndmsv макрос.ndmsv макрошлиф.ndmsv макроэлемент.ndmsv максвелл.ndmsv максимакс.ndmsv 
-максимин.ndmsv максимон.ndmsv максимум.ndmsv малахит.ndmsv маллеин.ndmsv мальм.ndmsv 
-мальпост.ndmsv мангал.ndmsv манганат.ndmsv манганин.ndmsv манганит.ndmsv мангольд.ndmsv 
-мангостан.ndmsv манизм.ndmsv манифест.ndmsv манихеизм.ndmsv манометр.ndmsv манор.ndmsv 
-маностат.ndmsv маноцитин.ndmsv мантелет.ndmsv мануал.ndmsv манускрипт.ndmsv маншон.ndmsv 
-маньеризм.ndmsv маразм.ndmsv маракас.ndmsv мараскин.ndmsv мареограф.ndmsv марзан.ndmsv 
-маринизм.ndmsv марказит.ndmsv марксизм.ndmsv мармит.ndmsv марокен.ndmsv марс.ndmsv 
-марсоход.ndmsv март.ndmsv мартен.ndmsv мартенсит.ndmsv мартин-штаг.ndmsv мартингал.ndmsv 
-мартинизм.ndmsv марципан.ndmsv марш-маневр.ndmsv марш-парад.ndmsv маршрутизатор.ndmsv маседуан.ndmsv 
-маскарад.ndmsv маскарон.ndmsv маскот.ndmsv маскхалат.ndmsv маслозавод.ndmsv масломер.ndmsv 
-маслопровод.ndmsv маслорадиатор.ndmsv маслосырзавод.ndmsv маслофильтр.ndmsv масс-спектр.ndmsv масс-спектрограф.ndmsv 
-масс-спектрометр.ndmsv массикот.ndmsv массоперенос.ndmsv мастикатор.ndmsv мастихин.ndmsv мастоидит.ndmsv 
-матанализ.ndmsv мателот.ndmsv матлот.ndmsv матриархат.ndmsv матрикул.ndmsv матч-турнир.ndmsv 
-маузер.ndmsv мауэрлат.ndmsv махизм.ndmsv махметр.ndmsv мачжан.ndmsv машино-час.ndmsv 
-маюскул.ndmsv мбайт.ndmsv мгд-генератор.ndmsv меандр.ndmsv мегабар.ndmsv мегабит.ndmsv 
-мегавольт.ndmsv мегалит.ndmsv мегалополис.ndmsv мегампер.ndmsv меганит.ndmsv мегаполис.ndmsv 
-мегасейм.ndmsv мегаскоп.ndmsv мегатрон.ndmsv мегафайл.ndmsv мегафон.ndmsv меггер.ndmsv 
-мегом.ndmsv мегометр.ndmsv мегомметр.ndmsv медальон.ndmsv меджлис.ndmsv медиатор.ndmsv 
-медикамент.ndmsv мединститут.ndmsv мединструмент.ndmsv медиумизм.ndmsv медосбор.ndmsv медосмотр.ndmsv 
-медпрепарат.ndmsv медпункт.ndmsv медрадиопрепарат.ndmsv медсанбат.ndmsv межпарламент.ndmsv мезальянс.ndmsv 
-мезоатом.ndmsv мезолит.ndmsv мезон.ndmsv мезонин.ndmsv мезорельеф.ndmsv мезоскаф.ndmsv 
-мезотрон.ndmsv мезофилл.ndmsv мезофит.ndmsv мейоз.ndmsv мейозис.ndmsv мелаконит.ndmsv 
-меламин.ndmsv меланжер.ndmsv меланин.ndmsv меланоз.ndmsv мелантерит.ndmsv мелизм.ndmsv 
-мелинит.ndmsv мелиорант.ndmsv мелис.ndmsv мелкозем.ndmsv мелодион.ndmsv мелонит.ndmsv 
-мелос.ndmsv мелофон.ndmsv мелькомбинат.ndmsv мельтон.ndmsv мельхиор.ndmsv мембранофон.ndmsv 
-меморандум.ndmsv мемориал.ndmsv менгир.ndmsv менделеевит.ndmsv менделизм.ndmsv менингит.ndmsv 
-менталитет.ndmsv ментициррус.ndmsv ментол.ndmsv менуэт.ndmsv меньшевизм.ndmsv меридиан.ndmsv 
-меркаптан.ndmsv меркаптид.ndmsv мерседес.ndmsv мескалин.ndmsv месмеризм.ndmsv мессенджер.ndmsv 
-мессианизм.ndmsv мессидор.ndmsv местком.ndmsv месяцеслов.ndmsv метабазис.ndmsv метабиоз.ndmsv 
-метаболизм.ndmsv метаболит.ndmsv метагенез.ndmsv метакрилат.ndmsv метакристалл.ndmsv металл.ndmsv 
-металлозавод.ndmsv металлоид.ndmsv металлокомбинат.ndmsv металлолом.ndmsv металлофермент.ndmsv металлофон.ndmsv 
-метан.ndmsv метанол.ndmsv метанопродуцент.ndmsv метасиликат.ndmsv метасоматоз.ndmsv метастаз.ndmsv 
-метафайл.ndmsv метафосфат.ndmsv метацентр.ndmsv метгемоглобин.ndmsv метемпсихоз.ndmsv метеозонд.ndmsv 
-метеоприбор.ndmsv метеорадиолокатор.ndmsv метеоризм.ndmsv метеорит.ndmsv метеорограф.ndmsv метеоролит.ndmsv 
-метил.ndmsv метиламин.ndmsv метилат.ndmsv метилбутадиен.ndmsv метилен.ndmsv метиленхлорид.ndmsv 
-метионин.ndmsv методизм.ndmsv метол.ndmsv метоп.ndmsv метрит.ndmsv метромост.ndmsv 
-метроном.ndmsv метрополитен.ndmsv механизм.ndmsv механицизм.ndmsv механорецептор.ndmsv мехзавод.ndmsv 
-мехкарьер.ndmsv мехмат.ndmsv мигматит.ndmsv мид.ndmsv мидриаз.ndmsv миелин.ndmsv 
-миелит.ndmsv микалекс.ndmsv миканит.ndmsv микоз.ndmsv микроавтобус.ndmsv микроамперметр.ndmsv 
-микроанализ.ndmsv микроанализатор.ndmsv микробар.ndmsv микробарограф.ndmsv микробарометр.ndmsv микроваттметр.ndmsv 
-микровзрыв.ndmsv микровизор.ndmsv микрограф.ndmsv микроинтерферометр.ndmsv микроинфаркт.ndmsv микрокалориметр.ndmsv 
-микрокалькулятор.ndmsv микроклимат.ndmsv микрокод.ndmsv микроколориметр.ndmsv микрокомпьютер.ndmsv микроконтинент.ndmsv 
-микроконтроллер.ndmsv микрокосм.ndmsv микрокосмос.ndmsv микрокристалл.ndmsv микрокулон.ndmsv микролит.ndmsv 
-микром.ndmsv микроманипулятор.ndmsv микроманометр.ndmsv микромер.ndmsv микрометеор.ndmsv микрометр.ndmsv 
-микромиллиметр.ndmsv микромир.ndmsv микронивелир.ndmsv микрообъект.ndmsv микрообъем.ndmsv микроом.ndmsv 
-микроомметр.ndmsv микроорганизм.ndmsv микропирометр.ndmsv микроприбор.ndmsv микропринт.ndmsv микропроектор.ndmsv 
-микропроцессор.ndmsv микрорадиоавтограф.ndmsv микрорайон.ndmsv микрорельеф.ndmsv микросейсм.ndmsv микросейсмометр.ndmsv 
-микроскоп.ndmsv микроспектрофотометр.ndmsv микросрез.ndmsv микротекст.ndmsv микротелевизор.ndmsv микротелефон.ndmsv 
-микротом.ndmsv микротранзистор.ndmsv микротрон.ndmsv микротуман.ndmsv микрофильм.ndmsv микрофильтр.ndmsv 
-микрофон.ndmsv микрофотометр.ndmsv микроэлектрод.ndmsv микроэлектрон.ndmsv миксер.ndmsv миксограф.ndmsv 
-миксоматоз.ndmsv микшер.ndmsv милитаризм.ndmsv милиум.ndmsv миллерит.ndmsv миллиамперметр.ndmsv 
-миллибар.ndmsv милливольтамперметр.ndmsv милливольтметр.ndmsv миллиграмм.ndmsv миллилитр.ndmsv миллиметр.ndmsv 
-миллирадиан.ndmsv миллирентген.ndmsv мильрейс.ndmsv миманс.ndmsv мимеограф.ndmsv миметизм.ndmsv 
-минарет.ndmsv минерал.ndmsv минерализатор.ndmsv минералит.ndmsv минералопровод.ndmsv мини-завод.ndmsv 
-мини-контейнер.ndmsv мини-пивзавод.ndmsv миникомпьютер.ndmsv минимакс.ndmsv минимализм.ndmsv миниметр.ndmsv 
-минимум.ndmsv минорат.ndmsv минускул.ndmsv миньон.ndmsv миоглобин.ndmsv миограф.ndmsv 
-миозин.ndmsv миозис.ndmsv миозит.ndmsv миокард.ndmsv миокардит.ndmsv миоцен.ndmsv 
-мирабилит.ndmsv миробалан.ndmsv миррор.ndmsv мирт.ndmsv мистицизм.ndmsv митоз.ndmsv 
-миф.ndmsv млат.ndmsv мнемометр.ndmsv мнемон.ndmsv многоплан.ndmsv многочлен.ndmsv 
-мобайл.ndmsv могар.ndmsv моделизм.ndmsv модем.ndmsv модератор.ndmsv модернизм.ndmsv 
-модильон.ndmsv модификатор.ndmsv модулянт.ndmsv модулятор.ndmsv модус.ndmsv мозолин.ndmsv 
-мокрец.ndmsv молескин.ndmsv молибден.ndmsv молибденит.ndmsv молитвослов.ndmsv моллюскоцид.ndmsv 
-молниеотвод.ndmsv молокозавод.ndmsv молокомер.ndmsv молокоотсос.ndmsv молокопровод.ndmsv молотоглав.ndmsv 
-мольберт.ndmsv момент.ndmsv монархизм.ndmsv монацит.ndmsv монгольфьер.ndmsv монд.ndmsv 
-монизм.ndmsv монитор.ndmsv моноаллергоид.ndmsv моноанализатор.ndmsv моногенизм.ndmsv моногидрат.ndmsv 
-моноид.ndmsv моноканал.ndmsv монокомпаратор.ndmsv монокристалл.ndmsv монокуляр.ndmsv моном.ndmsv 
-мононуклеоз.ndmsv моноплан.ndmsv монополизм.ndmsv монорельс.ndmsv монорим.ndmsv монотеизм.ndmsv 
-монофизит.ndmsv монохорд.ndmsv монохром.ndmsv моноцит.ndmsv монтесинос.ndmsv монтмориллонит.ndmsv 
-монумент.ndmsv мопед.ndmsv морализм.ndmsv морганизм.ndmsv морген.ndmsv мордент.ndmsv 
-морион.ndmsv морфин.ndmsv морфинизм.ndmsv морфоз.ndmsv мосгорсуд.ndmsv мотет.ndmsv 
-мотив.ndmsv мотобол.ndmsv мотобот.ndmsv мотовелосипед.ndmsv мотовоз.ndmsv мотодельтаплан.ndmsv 
-мотодром.ndmsv мотозавод.ndmsv мотокросс.ndmsv мотокультиватор.ndmsv мотопункт.ndmsv мотороллер.ndmsv 
-мотоспорт.ndmsv мотоцикл.ndmsv мотошлем.ndmsv мохер.ndmsv моцион.ndmsv муар.ndmsv 
-муидор.ndmsv муллит.ndmsv мультивибратор.ndmsv мультиплексор.ndmsv мультиплет.ndmsv мультициклон.ndmsv 
-мультфильм.ndmsv мусковит.ndmsv мусоровоз.ndmsv мусоропровод.ndmsv мусоросброс.ndmsv мусс.ndmsv 
-муссон.ndmsv муст.ndmsv мутаген.ndmsv мутатор.ndmsv мутон.ndmsv мутуализм.ndmsv 
-мухаррем.ndmsv мухомор.ndmsv мухояр.ndmsv мухур.ndmsv муцин.ndmsv мушкет.ndmsv 
-мушкетон.ndmsv мылонафт.ndmsv мэйнфрейм.ndmsv мюзет.ndmsv мюзетт.ndmsv мюзик-холл.ndmsv 
-мюзикл.ndmsv мюон.ndmsv мюридизм.ndmsv мясоед.ndmsv мясокомбинат.ndmsv мясоптицекомбинат.ndmsv 
-мясопуст.ndmsv мясосовхоз.ndmsv набла-оператор.ndmsv навет.ndmsv навицерт.ndmsv нагиб.ndmsv 
-нагнет.ndmsv нагрев.ndmsv надвиг.ndmsv наддув.ndmsv надир.ndmsv надкласс.ndmsv 
-надкус.ndmsv надотряд.ndmsv надсмотр.ndmsv нажин.ndmsv нажор.ndmsv найл.ndmsv 
-найм.ndmsv наказ.ndmsv наклев.ndmsv наклономер.ndmsv накос.ndmsv накрап.ndmsv 
-нактоуз.ndmsv намолот.ndmsv намост.ndmsv нанизм.ndmsv наноатом.ndmsv наос.ndmsv 
-напалм.ndmsv наплыв.ndmsv наполеон.ndmsv наполеондор.ndmsv напрокат.ndmsv наркомат.ndmsv 
-наркотин.ndmsv нарост.ndmsv нарсуд.ndmsv нартекс.ndmsv нарцеин.ndmsv нарцисс.ndmsv 
-нативизм.ndmsv натр.ndmsv натролит.ndmsv натурализм.ndmsv натюрморт.ndmsv наукоград.ndmsv 
-наутофон.ndmsv нафтен.ndmsv нафтол.ndmsv нахрап.ndmsv нахшлаг.ndmsv нацизм.ndmsv 
-национализм.ndmsv начет.ndmsv начсостав.ndmsv нгултрум.ndmsv неакцепт.ndmsv небаланс.ndmsv 
-небосвод.ndmsv небосклон.ndmsv небоскреб.ndmsv невзнос.ndmsv невзрыв.ndmsv неврит.ndmsv 
-невродиспансер.ndmsv невроз.ndmsv неврофиброматоз.ndmsv невус.ndmsv невыезд.ndmsv невыход.ndmsv 
-невычет.ndmsv негабарит.ndmsv негативизм.ndmsv негатрон.ndmsv недобор.ndmsv недогляд.ndmsv 
-недожин.ndmsv недокал.ndmsv недокомплект.ndmsv недокорм.ndmsv недолив.ndmsv недолов.ndmsv 
-недомес.ndmsv недомол.ndmsv недомолот.ndmsv недорасход.ndmsv недород.ndmsv недосев.ndmsv 
-недоучет.ndmsv недочет.ndmsv незачет.ndmsv нейзильбер.ndmsv нейл.ndmsv нейлон.ndmsv 
-нейрин.ndmsv нейристор.ndmsv нейрит.ndmsv нейрокомпьютер.ndmsv нейромодулятор.ndmsv нейрон.ndmsv 
-нейрорегулятор.ndmsv нейротоксикант.ndmsv нейтрализатор.ndmsv нейтрализм.ndmsv нейтралитет.ndmsv нейтродин.ndmsv 
-нейтрофил.ndmsv неклен.ndmsv некробиоз.ndmsv некроз.ndmsv нексус.ndmsv нектар.ndmsv 
-нектарин.ndmsv нектаронос.ndmsv нектон.ndmsv нектофор.ndmsv нематоцид.ndmsv нематоцист.ndmsv 
-неметалл.ndmsv неоген.ndmsv неолит.ndmsv неологизм.ndmsv неон.ndmsv неонацизм.ndmsv 
-неопрен.ndmsv неореализм.ndmsv неотип.ndmsv неофашизм.ndmsv неоцен.ndmsv непентес.ndmsv 
-непотизм.ndmsv непровар.ndmsv нептунизм.ndmsv нервизм.ndmsv нерол.ndmsv несговор.ndmsv 
-несессер.ndmsv нетбол.ndmsv нетоскоп.ndmsv неуд.ndmsv неучет.ndmsv неф.ndmsv 
-нефелинит.ndmsv нефелометр.ndmsv нефоскоп.ndmsv нефрит.ndmsv нефроз.ndmsv нефтевоз.ndmsv 
-нефтедоллар.ndmsv нефтезавод.ndmsv нефтекараван.ndmsv нефтепровод.ndmsv нефтепродуктопровод.ndmsv нефтерайон.ndmsv 
-нефтесклад.ndmsv нивоз.ndmsv нигилизм.ndmsv нигрозин.ndmsv нигрол.ndmsv никелин.ndmsv 
-никколит.ndmsv нимб.ndmsv нисан.ndmsv ниссан.ndmsv нистагм.ndmsv нитевод.ndmsv 
-нитон.ndmsv нитрагин.ndmsv нитрид.ndmsv нитрил.ndmsv нитрит.ndmsv нитробензол.ndmsv 
-нитроглицерин.ndmsv нитрометр.ndmsv нитрон.ndmsv нитропластификатор.ndmsv нитротолуол.ndmsv нитрофенол.ndmsv 
-нихром.ndmsv нобилитет.ndmsv новакулит.ndmsv новокаин.ndmsv новотел.ndmsv новояз.ndmsv 
-нозематоз.ndmsv нокаут.ndmsv нокдаун.ndmsv ноктовизор.ndmsv ноктюрн.ndmsv номадизм.ndmsv 
-номен.ndmsv номинал.ndmsv номинализм.ndmsv номинат.ndmsv номогенез.ndmsv номоканон.ndmsv 
-нонет.ndmsv нониллион.ndmsv нониус.ndmsv нонсенс.ndmsv норд.ndmsv норимон.ndmsv 
-нормобласт.ndmsv норсульфазол.ndmsv нотариат.ndmsv нотис.ndmsv ноумен.ndmsv нуклеин.ndmsv 
-нуклеопротеид.ndmsv нуклеотид.ndmsv нуклеус.ndmsv нуклид.ndmsv нуклон.ndmsv нумератор.ndmsv 
-нуммулит.ndmsv нут.ndmsv нутромер.ndmsv нуцеллус.ndmsv ньюмаркет.ndmsv ньютон.ndmsv 
-нэп.ndmsv нюанс.ndmsv обапол.ndmsv обвес.ndmsv обвоз.ndmsv обертон.ndmsv 
-обет.ndmsv обзавод.ndmsv обзол.ndmsv обком.ndmsv облакомер.ndmsv облет.ndmsv 
-облизбирком.ndmsv облисполком.ndmsv обмол.ndmsv обмолот.ndmsv обогрев.ndmsv обсидиан.ndmsv 
-обстрел.ndmsv обсчет.ndmsv обтуратор.ndmsv обтюратор.ndmsv обхват.ndmsv оверарм.ndmsv 
-овердрафт.ndmsv овогенез.ndmsv овоскоп.ndmsv овсец.ndmsv овцесовхоз.ndmsv огнепровод.ndmsv 
-огнецвет.ndmsv одеон.ndmsv однотес.ndmsv одноцвет.ndmsv одночлен.ndmsv одограф.ndmsv 
-одометр.ndmsv одонтобласт.ndmsv одонтограф.ndmsv одонтокласт.ndmsv одонтолит.ndmsv одоратор.ndmsv 
-оз.ndmsv озокерит.ndmsv озон.ndmsv озонатор.ndmsv озонид.ndmsv озонометр.ndmsv 
-оидиум.ndmsv окат.ndmsv океан.ndmsv океанариум.ndmsv окенит.ndmsv оккультизм.ndmsv 
-оклад.ndmsv окоем.ndmsv окот.ndmsv окрол.ndmsv окружком.ndmsv оксалат.ndmsv 
-оксигемоглобин.ndmsv оксигемометр.ndmsv оксигенатор.ndmsv оксид.ndmsv оксиликвит.ndmsv оксиморон.ndmsv 
-окситоцин.ndmsv оксюморон.ndmsv октакорд.ndmsv октаметр.ndmsv октан.ndmsv октант.ndmsv 
-октаэдр.ndmsv октаэдрит.ndmsv октет.ndmsv октил.ndmsv октильон.ndmsv октод.ndmsv 
-олеандр.ndmsv олеат.ndmsv олеин.ndmsv олеонафт.ndmsv олефин.ndmsv оливенит.ndmsv 
-оливин.ndmsv олигоклаз.ndmsv олигонуклеотид.ndmsv олигоцен.ndmsv ольстер.ndmsv омброметр.ndmsv 
-омегатрон.ndmsv омет.ndmsv омикрон.ndmsv омлет.ndmsv омметр.ndmsv омнибус.ndmsv 
-омограф.ndmsv омоморф.ndmsv омоним.ndmsv омофон.ndmsv омофор.ndmsv омфалит.ndmsv 
-омфацит.ndmsv онанизм.ndmsv ондограф.ndmsv ондулятор.ndmsv онер.ndmsv оникс.ndmsv 
-онкоген.ndmsv онкорнавирус.ndmsv онтогенез.ndmsv оолит.ndmsv опалин.ndmsv операнд.ndmsv 
-опиат.ndmsv опистограф.ndmsv оплот.ndmsv оплыв.ndmsv опопанакс.ndmsv опорос.ndmsv 
-опсонин.ndmsv опт.ndmsv оптиметр.ndmsv оптимизатор.ndmsv оптимизм.ndmsv оптимум.ndmsv 
-оптофон.ndmsv оптрон.ndmsv опус.ndmsv опцион.ndmsv оранжад.ndmsv оргазм.ndmsv 
-организм.ndmsv органоген.ndmsv органоид.ndmsv органон.ndmsv органопрепарат.ndmsv органофосфат.ndmsv 
-органум.ndmsv оргкомитет.ndmsv орготдел.ndmsv оргплан.ndmsv орграф.ndmsv ордонанс.ndmsv 
-ореол.ndmsv оригинал-дубликат.ndmsv оригинал-макет.ndmsv оркестрион.ndmsv орлец.ndmsv орлоп.ndmsv 
-орнитоз.ndmsv орнитоптер.ndmsv орогенез.ndmsv орогенезис.ndmsv орс.ndmsv орсин.ndmsv 
-ортикон.ndmsv ортит.ndmsv ортоводород.ndmsv ортогенез.ndmsv ортоклаз.ndmsv ортопантомограф.ndmsv 
-ортоферрит.ndmsv ортоцентр.ndmsv ортштейн.ndmsv орфарион.ndmsv орфеорион.ndmsv орфизм.ndmsv 
-орхит.ndmsv оршад.ndmsv ослоп.ndmsv осмометр.ndmsv осмос.ndmsv осот.ndmsv 
-оссеин.ndmsv остеит.ndmsv остеоартрит.ndmsv остеобласт.ndmsv остеокласт.ndmsv остеомиелит.ndmsv 
-остеон.ndmsv остеопороз.ndmsv остеосклероз.ndmsv остеофит.ndmsv остеохондрит.ndmsv остеохондроз.ndmsv 
-остит.ndmsv остракизм.ndmsv остракон.ndmsv острец.ndmsv остропестр.ndmsv осциллограф.ndmsv 
-осциллоскоп.ndmsv осциллятор.ndmsv отгиб.ndmsv отзовизм.ndmsv отзыв.ndmsv отит.ndmsv 
-отказ.ndmsv откус.ndmsv отмин.ndmsv отогрев.ndmsv отолит.ndmsv отосклероз.ndmsv 
-отоскоп.ndmsv отофон.ndmsv отоцист.ndmsv отпад.ndmsv отсвет.ndmsv отсчет.ndmsv 
-оттрелит.ndmsv отунит.ndmsv отъезд.ndmsv оуэнизм.ndmsv офикальцит.ndmsv офиклеид.ndmsv 
-офиолит.ndmsv офис.ndmsv офис-клаб.ndmsv офит.ndmsv офорт.ndmsv офсайд.ndmsv 
-офтальмоскоп.ndmsv охотнадзор.ndmsv очерет.ndmsv очкур.ndmsv паб.ndmsv павильон.ndmsv 
-павинол.ndmsv пагамент.ndmsv паганизм.ndmsv пагодит.ndmsv падеграс.ndmsv падекатр.ndmsv 
-падепатинер.ndmsv падуб.ndmsv падун.ndmsv пайп.ndmsv пакер.ndmsv пакетбот.ndmsv 
-паккард.ndmsv паккер.ndmsv паклен.ndmsv пакт.ndmsv палагонит.ndmsv паланкин.ndmsv 
-палантин.ndmsv палас.ndmsv палатинат.ndmsv палафит.ndmsv палеоген.ndmsv палеолит.ndmsv 
-палеоцен.ndmsv паликар.ndmsv палимпсест.ndmsv палингенез.ndmsv палиндром.ndmsv палисад.ndmsv 
-палисандр.ndmsv палладиум.ndmsv палласит.ndmsv паллет.ndmsv паллиатив.ndmsv паллограф.ndmsv 
-пальмитин.ndmsv пальстаб.ndmsv палюс.ndmsv памперс.ndmsv панарабизм.ndmsv панбархат.ndmsv 
-панген.ndmsv пангенезис.ndmsv пандан.ndmsv панданус.ndmsv пандус.ndmsv панелевоз.ndmsv 
-панкреас.ndmsv панкреатин.ndmsv панкреатит.ndmsv панлогизм.ndmsv паннус.ndmsv паноптикум.ndmsv 
-панпсихизм.ndmsv пансионат.ndmsv панславизм.ndmsv пантеизм.ndmsv пантеон.ndmsv пантограф.ndmsv 
-пантокрин.ndmsv пантометр.ndmsv пантопон.ndmsv пантоскоп.ndmsv пантостат.ndmsv пантюркизм.ndmsv 
-панчбол.ndmsv панчингбол.ndmsv папаверин.ndmsv папаин.ndmsv папайотин.ndmsv папизм.ndmsv 
-паповавирус.ndmsv паппус.ndmsv парабеллум.ndmsv парабиоз.ndmsv параболоид.ndmsv параван.ndmsv 
-парагнейс.ndmsv парагон.ndmsv парагонит.ndmsv параграф.ndmsv парадокс.ndmsv паразитизм.ndmsv 
-паразитоз.ndmsv параизомер.ndmsv параклет.ndmsv параклит.ndmsv парализатор.ndmsv паралипоменон.ndmsv 
-параллакс.ndmsv параллелепипед.ndmsv параллелизм.ndmsv параллелограмм.ndmsv паралогизм.ndmsv параметр.ndmsv 
-параметрит.ndmsv параметрон.ndmsv парангон.ndmsv паранефрит.ndmsv парантез.ndmsv парапарез.ndmsv 
-параплан.ndmsv парапротеин.ndmsv парапроцесс.ndmsv парасинапсис.ndmsv паратаксис.ndmsv паратиф.ndmsv 
-паратонзиллит.ndmsv параф.ndmsv парафимоз.ndmsv парацетамол.ndmsv парашютизм.ndmsv паргасит.ndmsv 
-парез.ndmsv паризит.ndmsv парламент.ndmsv пармезан.ndmsv парогенератор.ndmsv парод.ndmsv 
-пародонтоз.ndmsv пародос.ndmsv пароксизм.ndmsv паромер.ndmsv паромотор.ndmsv пароним.ndmsv 
-паронит.ndmsv паропровод.ndmsv паростоз.ndmsv паротит.ndmsv паротурбогенератор.ndmsv парсизм.ndmsv 
-партактив.ndmsv партбилет.ndmsv партком.ndmsv партнерс.ndmsv партон.ndmsv партсъезд.ndmsv 
-паслен.ndmsv пассажиро-груз.ndmsv пассаметр.ndmsv пассеизм.ndmsv пассиватор.ndmsv пастеризатор.ndmsv 
-пастис.ndmsv пасторат.ndmsv патерностер.ndmsv патиссон.ndmsv патогенез.ndmsv патриархат.ndmsv 
-патриотизм.ndmsv патрициат.ndmsv патронат.ndmsv патроним.ndmsv паттерн.ndmsv паужин.ndmsv 
-пауперизм.ndmsv пахит.ndmsv пацифизм.ndmsv пеан.ndmsv пегамоид.ndmsv пегматит.ndmsv 
-педантизм.ndmsv педвуз.ndmsv педикулез.ndmsv педогенез.ndmsv педометр.ndmsv педсовет.ndmsv 
-педсостав.ndmsv пейджер.ndmsv пейсмекер.ndmsv пекан.ndmsv пекогон.ndmsv пектин.ndmsv 
-пектолит.ndmsv пелагит.ndmsv пеленгатор.ndmsv пелетрон.ndmsv пелит.ndmsv пелорус.ndmsv 
-пелькомпас.ndmsv пельтаст.ndmsv пемзобетон.ndmsv пеммикан.ndmsv пемфигус.ndmsv пен-клуб.ndmsv 
-пенал.ndmsv пендрагон.ndmsv пенеплен.ndmsv пенетрометр.ndmsv пенис.ndmsv пеницилл.ndmsv 
-пенициллин.ndmsv пеннивейт.ndmsv пенобетон.ndmsv пеногипс.ndmsv пеноматериал.ndmsv пенопласт.ndmsv 
-пенополиизоцианурат.ndmsv пенополистирол.ndmsv пеносиликат.ndmsv пенс.ndmsv пентагрид.ndmsv пентадом.ndmsv 
-пентаметр.ndmsv пентан.ndmsv пентасульфид.ndmsv пентахорд.ndmsv пентаэдр.ndmsv пентеконтор.ndmsv 
-пентекостис.ndmsv пентландит.ndmsv пентод.ndmsv пентоксид.ndmsv пентолит.ndmsv пентрит.ndmsv 
-пентхауз.ndmsv пентхаус.ndmsv пенчингбол.ndmsv пеньюар.ndmsv пеплобетон.ndmsv пеплум.ndmsv 
-пепсин.ndmsv пептон.ndmsv перборат.ndmsv первообраз.ndmsv первоцвет.ndmsv первоэлемент.ndmsv 
-пергамен.ndmsv пергамин.ndmsv перевод.ndmsv переворот.ndmsv перегиб.ndmsv перегляд.ndmsv 
-перегрев.ndmsv перегуд.ndmsv передир.ndmsv передопрос.ndmsv переем.ndmsv пережим.ndmsv 
-перекос.ndmsv перелаз.ndmsv переливт.ndmsv перемол.ndmsv перемолот.ndmsv перепад.ndmsv 
-перепев.ndmsv переплет.ndmsv перепляс.ndmsv переприем.ndmsv перерасчет.ndmsv перерод.ndmsv 
-перерыв.ndmsv пересвист.ndmsv пересев.ndmsv пересказ.ndmsv переспрос.ndmsv пересчет.ndmsv 
-переучет.ndmsv перечет.ndmsv периаденит.ndmsv перибласт.ndmsv перигастрит.ndmsv перидот.ndmsv 
-перидотит.ndmsv перикард.ndmsv перикардит.ndmsv периклаз.ndmsv периметр.ndmsv периметрит.ndmsv 
-периневрит.ndmsv период.ndmsv периодат.ndmsv периодонт.ndmsv периодонтит.ndmsv периост.ndmsv 
-периостит.ndmsv перипласт.ndmsv периптер.ndmsv перископ.ndmsv перисперм.ndmsv перистом.ndmsv 
-перитифлит.ndmsv перитонит.ndmsv перицентр.ndmsv перицит.ndmsv перкалин.ndmsv перколятор.ndmsv 
-перламутр.ndmsv перлвейс.ndmsv перлон.ndmsv перманганат.ndmsv пермансив.ndmsv пермеаметр.ndmsv 
-пермутатор.ndmsv пермутит.ndmsv перовскит.ndmsv перозис.ndmsv пероксид.ndmsv перрадиус.ndmsv 
-персистор.ndmsv персонал.ndmsv персульфат.ndmsv пертит.ndmsv перфект.ndmsv перфоввод.ndmsv 
-перфоратор.ndmsv перхлорат.ndmsv перхлорвинил.ndmsv перцептрон.ndmsv песколюб.ndmsv пескомет.ndmsv 
-пессимизм.ndmsv пессимум.ndmsv пестицид.ndmsv петаз.ndmsv петалит.ndmsv петрогенезис.ndmsv 
-петроглиф.ndmsv петродоллар.ndmsv петролатум.ndmsv петролеум.ndmsv петросилекс.ndmsv петцит.ndmsv 
-пещур.ndmsv пи-мезон.ndmsv пиан.ndmsv пианизм.ndmsv пиар.ndmsv пиастр.ndmsv 
-пивбар.ndmsv пивзавод.ndmsv пигус.ndmsv пиелит.ndmsv пиелонефрит.ndmsv пиетет.ndmsv 
-пиетизм.ndmsv пижонит.ndmsv пизолит.ndmsv пикап.ndmsv пикер.ndmsv пикет.ndmsv 
-пикноз.ndmsv пикнометр.ndmsv пикограмм.ndmsv пикокулон.ndmsv пиколин.ndmsv пикон.ndmsv 
-пикорнавирус.ndmsv пикрат.ndmsv пикрин.ndmsv пикрит.ndmsv пикрол.ndmsv пикротоксин.ndmsv 
-пиксафон.ndmsv пиксидиум.ndmsv пилав.ndmsv пиллерс.ndmsv пилокарпин.ndmsv пилокарпус.ndmsv 
-пилон.ndmsv пилорус.ndmsv пилум.ndmsv пимент.ndmsv пинакоид.ndmsv пинбол.ndmsv 
-пинцет.ndmsv пиодерматоз.ndmsv пиодермит.ndmsv пиоз.ndmsv пион.ndmsv пионеротряд.ndmsv 
-пионефрит.ndmsv пионефроз.ndmsv пиоскоп.ndmsv пиоторакс.ndmsv пиперазин.ndmsv пиперидин.ndmsv 
-пиперин.ndmsv пипермент.ndmsv пиперонал.ndmsv пиразин.ndmsv пиразол.ndmsv пиранометр.ndmsv 
-пираргирит.ndmsv пиргелиометр.ndmsv пиргеометр.ndmsv пиргом.ndmsv пирекс.ndmsv пиреноид.ndmsv 
-пиретрум.ndmsv пиридин.ndmsv пиридоксин.ndmsv пиримидин.ndmsv пиробензол.ndmsv пирогаллол.ndmsv 
-пирозапал.ndmsv пирокатехин.ndmsv пироксен.ndmsv пироксилин.ndmsv пиролиз.ndmsv пиролюзит.ndmsv 
-пирометр.ndmsv пироморфит.ndmsv пирон.ndmsv пиронафт.ndmsv пироп.ndmsv пиропатрон.ndmsv 
-пироплазмоз.ndmsv пироскаф.ndmsv пироскоп.ndmsv пиросмалит.ndmsv пиростат.ndmsv пиросульфат.ndmsv 
-пирофиллит.ndmsv пирофотометр.ndmsv пирошнур.ndmsv пироэффект.ndmsv пиррол.ndmsv пирролидин.ndmsv 
-пирротин.ndmsv пирротит.ndmsv пирс.ndmsv пируэт.ndmsv писсуар.ndmsv пистацит.ndmsv 
-пистолет.ndmsv питербот.ndmsv питириаз.ndmsv питометр.ndmsv питономорф.ndmsv питоцин.ndmsv 
-питтицит.ndmsv питуитрин.ndmsv пифос.ndmsv пищекомбинат.ndmsv пищеконцентрат.ndmsv плавзавод.ndmsv 
-плавсостав.ndmsv плагиат.ndmsv плагиоклаз.ndmsv плаз.ndmsv плазматрон.ndmsv плазмин.ndmsv 
-плазмоген.ndmsv плазмоид.ndmsv плазмолиз.ndmsv плазмон.ndmsv плазмотип.ndmsv плазмотрон.ndmsv 
-плазмохин.ndmsv плазмоцид.ndmsv планеризм.ndmsv планеродром.ndmsv планетоид.ndmsv планетолет.ndmsv 
-планетоход.ndmsv планиметр.ndmsv планктер.ndmsv планктон.ndmsv планометр.ndmsv пластбетон.ndmsv 
-пластеин.ndmsv пластикат.ndmsv пластикатор.ndmsv пластификатор.ndmsv пластобетон.ndmsv пластометр.ndmsv 
-пластрон.ndmsv платан.ndmsv платинат.ndmsv платинит.ndmsv платиноид.ndmsv платинотрон.ndmsv 
-платонизм.ndmsv плац-парад.ndmsv плацдарм.ndmsv плашкоут.ndmsv плебисцит.ndmsv плебс.ndmsv 
-плевел.ndmsv плед.ndmsv плейас.ndmsv плейер.ndmsv плейстон.ndmsv плейстоцен.ndmsv 
-плексиглас.ndmsv плексит.ndmsv плектр.ndmsv племзавод.ndmsv племколхоз.ndmsv племконзавод.ndmsv 
-племотдел.ndmsv племптицерепродуктор.ndmsv племптицесовхоз.ndmsv племрепродуктор.ndmsv племсовхоз.ndmsv племхоз.ndmsv 
-пленум.ndmsv плеоназм.ndmsv плеонаст.ndmsv плеопод.ndmsv плеохроизм.ndmsv плес.ndmsv 
-плессиметр.ndmsv плетизмограф.ndmsv плиофильм.ndmsv плиоцен.ndmsv плис.ndmsv плодосбор.ndmsv 
-плодосмен.ndmsv плодосовхоз.ndmsv плодосъем.ndmsv плоскорез.ndmsv плотномер.ndmsv плотокараван.ndmsv 
-плотоход.ndmsv плумбат.ndmsv плумбит.ndmsv плутеус.ndmsv плутонизм.ndmsv плювиограф.ndmsv 
-плювиоз.ndmsv плювиометр.ndmsv плюр.ndmsv плюрализм.ndmsv плюсквамперфект.ndmsv пневматолиз.ndmsv 
-пневматолит.ndmsv пневматофор.ndmsv пневмеркатор.ndmsv пневмограф.ndmsv пневмоинструмент.ndmsv пневмокониоз.ndmsv 
-пневмонит.ndmsv пневмоскоп.ndmsv пневмостартер.ndmsv пневмостом.ndmsv пневмоторакс.ndmsv пневмотормоз.ndmsv 
-пневмоход.ndmsv победит.ndmsv подвид.ndmsv подгнет.ndmsv подграф.ndmsv поддомен.ndmsv 
-поджим.ndmsv подзавод.ndmsv подзаряд.ndmsv подзыв.ndmsv подиум.ndmsv подканал.ndmsv 
-подкатод.ndmsv подкласс.ndmsv подкомитет.ndmsv подлет.ndmsv подмыв.ndmsv поднаряд.ndmsv 
-подобъект.ndmsv подогрев.ndmsv подоператор.ndmsv подотдел.ndmsv подотряд.ndmsv подофил.ndmsv 
-подпар.ndmsv подпараграф.ndmsv подпараметр.ndmsv подпредел.ndmsv подпроект.ndmsv подпункт.ndmsv 
-подрайон.ndmsv подрод.ndmsv подрыв.ndmsv подсвист.ndmsv подсед.ndmsv подсчет.ndmsv 
-подтекст.ndmsv подтип.ndmsv подхват.ndmsv подцед.ndmsv подцентр.ndmsv позитивизм.ndmsv 
-позитрон.ndmsv позумент.ndmsv позыв.ndmsv пойнт.ndmsv показ.ndmsv полиамид.ndmsv 
-полианит.ndmsv полиартрит.ndmsv полибазит.ndmsv поливитамин.ndmsv полигалит.ndmsv полигенизм.ndmsv 
-полиграф.ndmsv полиизопрен.ndmsv поликарбонат.ndmsv поликристалл.ndmsv поликсен.ndmsv полимент.ndmsv 
-полимерконтейнер.ndmsv полимерраствор.ndmsv полиметалл.ndmsv полиневрит.ndmsv полином.ndmsv полиоэнцефалит.ndmsv 
-полипептид.ndmsv полиплоид.ndmsv полипоз.ndmsv полисахарид.ndmsv полисерозит.ndmsv полиспаст.ndmsv 
-полистирол.ndmsv полисульфид.ndmsv политеизм.ndmsv политес.ndmsv политехникум.ndmsv политкомикс.ndmsv 
-политотдел.ndmsv политпросвет.ndmsv политсостав.ndmsv полифонизм.ndmsv полиформальдегид.ndmsv полифосфат.ndmsv 
-полихлорвинил.ndmsv полихлорид.ndmsv полихронид.ndmsv полицилиндр.ndmsv полиэдр.ndmsv полиэкран.ndmsv 
-полиэстер.ndmsv полиэтилен.ndmsv полиэтилентерефталат.ndmsv полиэфир.ndmsv полиэфиримид.ndmsv поллиноз.ndmsv 
-поллютант.ndmsv полонез.ndmsv полонизм.ndmsv полтергейст.ndmsv полуавтомат.ndmsv полуантрацит.ndmsv 
-полубаркас.ndmsv полубархат.ndmsv полубимс.ndmsv полубокс.ndmsv полуборт.ndmsv полувагон.ndmsv 
-полувал.ndmsv полуватман.ndmsv полувзвод.ndmsv полувольт.ndmsv полугар.ndmsv полугидрат.ndmsv 
-полудиаметр.ndmsv полуимпериал.ndmsv полуинвариант.ndmsv полуинтервал.ndmsv полукадр.ndmsv полуклюз.ndmsv 
-полукокс.ndmsv полуколлоид.ndmsv полукомплект.ndmsv полукупол.ndmsv полулист.ndmsv полуметалл.ndmsv 
-полумир.ndmsv полумост.ndmsv полуоборот.ndmsv полуовал.ndmsv полуопал.ndmsv полупериод.ndmsv 
-полупилон.ndmsv полуповорот.ndmsv полуподвал.ndmsv полупоклон.ndmsv полуприсед.ndmsv полуприцеп.ndmsv 
-полуразъем.ndmsv полураскос.ndmsv полураспад.ndmsv полусвет.ndmsv полусвод.ndmsv полусумматор.ndmsv 
-полутакт.ndmsv полуустав.ndmsv полуфабрикат.ndmsv полуфинал.ndmsv полуцикл.ndmsv полуцилиндр.ndmsv 
-полушепот.ndmsv полуштоф.ndmsv полуэскадрон.ndmsv полуют.ndmsv польдер.ndmsv поляризатор.ndmsv 
-поляриметр.ndmsv полярископ.ndmsv поляристробометр.ndmsv полярограф.ndmsv поляроид.ndmsv полярон.ndmsv 
-помдамур.ndmsv помост.ndmsv помпельмус.ndmsv помпон.ndmsv понор.ndmsv понтификат.ndmsv 
-поп-арт.ndmsv поролон.ndmsv портатив.ndmsv портбукет.ndmsv портланд.ndmsv портландцемент.ndmsv 
-портплед.ndmsv портсигар.ndmsv портшез.ndmsv порфирин.ndmsv порфирит.ndmsv порфироид.ndmsv 
-порыв.ndmsv посвист.ndmsv посев.ndmsv послеимпульс.ndmsv постамент.ndmsv постикум.ndmsv 
-постпакет.ndmsv постплиоцен.ndmsv постскриптум.ndmsv постулат.ndmsv постфикс.ndmsv потенциал.ndmsv 
-потенциометр.ndmsv потир.ndmsv почтамт.ndmsv пошепт.ndmsv пошиб.ndmsv прагматизм.ndmsv 
-празем.ndmsv празеодим.ndmsv прайд.ndmsv прайс-лист.ndmsv пракрит.ndmsv практикум.ndmsv 
-практицизм.ndmsv прапор.ndmsv преанимизм.ndmsv превентор.ndmsv предиктор.ndmsv преднизолон.ndmsv 
-предпарламент.ndmsv предпроцессор.ndmsv презерватив.ndmsv президиум.ndmsv прейскурант.ndmsv прелюд.ndmsv 
-премикс.ndmsv премоляр.ndmsv преон.ndmsv препарат.ndmsv препринт.ndmsv препроцессор.ndmsv 
-преселектор.ndmsv пресс-автомат.ndmsv пресс-конвейер.ndmsv пресс-материал.ndmsv пресс-релиз.ndmsv пресс-тайм.ndmsv 
-пресс-центр.ndmsv прессшпан.ndmsv престол.ndmsv претерит.ndmsv преферанс.ndmsv префикс.ndmsv 
-префиксоид.ndmsv преформизм.ndmsv прецедент.ndmsv преципитат.ndmsv привкус.ndmsv привнос.ndmsv 
-приворот.ndmsv пригород.ndmsv пригрев.ndmsv пригруз.ndmsv приезд.ndmsv призматоид.ndmsv 
-призмоид.ndmsv призор.ndmsv приливомер.ndmsv прилов.ndmsv принос.ndmsv принтер.ndmsv 
-принцип.ndmsv принципат.ndmsv приорат.ndmsv приплав.ndmsv приплыв.ndmsv припляс.ndmsv 
-присвист.ndmsv присев.ndmsv присед.ndmsv присест.ndmsv присчет.ndmsv приуз.ndmsv 
-прификс.ndmsv прихлеб.ndmsv прихлоп.ndmsv причет.ndmsv причт.ndmsv проброс.ndmsv 
-провиант.ndmsv провинциализм.ndmsv провирус.ndmsv провитамин.ndmsv проволокобетон.ndmsv проворот.ndmsv 
-прогар.ndmsv прогестерон.ndmsv прогестин.ndmsv прогестоген.ndmsv прогиб.ndmsv прогнатизм.ndmsv 
-прогноз.ndmsv программатор.ndmsv прогрев.ndmsv прогресс.ndmsv продир.ndmsv продотряд.ndmsv 
-продпункт.ndmsv продром.ndmsv продукт.ndmsv продуктообмен.ndmsv продуктопровод.ndmsv проектор.ndmsv 
-прожект.ndmsv прозаизм.ndmsv прозенцефалон.ndmsv прозор.ndmsv прозэнцефалон.ndmsv прокариот.ndmsv 
-проквестор.ndmsv прокос.ndmsv проктит.ndmsv проктодеум.ndmsv прокус.ndmsv пролактин.ndmsv 
-проламин.ndmsv пролепсис.ndmsv пролеткульт.ndmsv пролифератион.ndmsv промен.ndmsv променад.ndmsv 
-промикропс.ndmsv промискуитет.ndmsv промотор.ndmsv промстройпроект.ndmsv пронаос.ndmsv пронатор.ndmsv 
-пронефрос.ndmsv прононс.ndmsv пронотум.ndmsv пронуклеус.ndmsv пропан.ndmsv пропанол.ndmsv 
-пропарокситон.ndmsv пропеллер.ndmsv пропердин.ndmsv пропилен.ndmsv проплыв.ndmsv прополис.ndmsv 
-проприоцептор.ndmsv пропс.ndmsv проран.ndmsv просвет.ndmsv просеминар.ndmsv проскениум.ndmsv 
-прософт.ndmsv проспект.ndmsv простагландин.ndmsv простатит.ndmsv просцениум.ndmsv просчет.ndmsv 
-протагон.ndmsv протазан.ndmsv протазис.ndmsv проталлиум.ndmsv протамин.ndmsv протаргол.ndmsv 
-протеид.ndmsv протеин.ndmsv протекторат.ndmsv протеус.ndmsv противовес.ndmsv противогаз.ndmsv 
-противоугон.ndmsv протобласт.ndmsv протовирус.ndmsv протогин.ndmsv протограф.ndmsv протозооз.ndmsv 
-протокол.ndmsv протоконтинент.ndmsv протон.ndmsv протонотариат.ndmsv протопектин.ndmsv протопласт.ndmsv 
-протоподит.ndmsv проторакс.ndmsv проторенессанс.ndmsv протрактор.ndmsv протромбин.ndmsv протуберанц-спектроскоп.ndmsv 
-профбилет.ndmsv профермент.ndmsv профибринолизин.ndmsv профилограф.ndmsv профилометр.ndmsv профит.ndmsv 
-профицит.ndmsv профком.ndmsv профконсультант.ndmsv профотбор.ndmsv профсоюз.ndmsv профцентр.ndmsv 
-процесс.ndmsv процессор.ndmsv прочет.ndmsv проэструс.ndmsv прудонизм.ndmsv прустит.ndmsv 
-псалтерион.ndmsv псаммит.ndmsv псаммофит.ndmsv псевдоапокриф.ndmsv псевдовектор.ndmsv псевдокод.ndmsv 
-псевдокристалл.ndmsv псевдоним.ndmsv псевдопереход.ndmsv псевдораствор.ndmsv псевдоскаляр.ndmsv псевдофольклор.ndmsv 
-псевтерминал.ndmsv псилоз.ndmsv псион.ndmsv пситтакоз.ndmsv психизм.ndmsv психоанализ.ndmsv 
-психогальванометр.ndmsv психогенез.ndmsv психогериат.ndmsv психоз.ndmsv психометр.ndmsv психон.ndmsv 
-психоневроз.ndmsv психостимулятор.ndmsv психрограф.ndmsv психрометр.ndmsv псориаз.ndmsv птеридосперм.ndmsv 
-птиалин.ndmsv птифур.ndmsv птоз.ndmsv птомаин.ndmsv пуаз.ndmsv пуант.ndmsv 
-пуантилизм.ndmsv пудрет.ndmsv пуловер.ndmsv пульверизатор.ndmsv пульман.ndmsv пульмонит.ndmsv 
-пульпер.ndmsv пульпит.ndmsv пульповод.ndmsv пульпомер.ndmsv пульпомет.ndmsv пульпопровод.ndmsv 
-пульс.ndmsv пульсар.ndmsv пульсатор.ndmsv пульсиметр.ndmsv пульсометр.ndmsv пульт.ndmsv 
-пункт.ndmsv пунсон.ndmsv пунцон.ndmsv пургатив.ndmsv пурген.ndmsv пуризм.ndmsv 
-пурин.ndmsv пуританизм.ndmsv пурпурин.ndmsv путемер.ndmsv путепровод.ndmsv путчизм.ndmsv 
-пуф.ndmsv пуццолан.ndmsv пушкинизм.ndmsv пчелосовхоз.ndmsv пшат.ndmsv пылемер.ndmsv 
-пыльцевход.ndmsv пьедестал.ndmsv пьезокристалл.ndmsv пьезометр.ndmsv пьемонтит.ndmsv пьютер.ndmsv 
-пэдлбол.ndmsv пюпитр.ndmsv пяртнерс.ndmsv рабдит.ndmsv рабдом.ndmsv раввинат.ndmsv 
-равелин.ndmsv радиан.ndmsv радиант.ndmsv радиатор.ndmsv радикализм.ndmsv радикулит.ndmsv 
-радиоавтограф.ndmsv радиоальтиметр.ndmsv радиоаппарат.ndmsv радиоветромер.ndmsv радиовизор.ndmsv радиоволновод.ndmsv 
-радиовысотомер.ndmsv радиогониометр.ndmsv радиогоризонт.ndmsv радиодальномер.ndmsv радиодиапазон.ndmsv радиозавод.ndmsv 
-радиозонд.ndmsv радиоизотоп.ndmsv радиоимпульс.ndmsv радиоинженер.ndmsv радиоинтерферометр.ndmsv радиоканал.ndmsv 
-радиокаскад.ndmsv радиоклип.ndmsv радиокомбайн.ndmsv радиокомитет.ndmsv радиокомпаратор.ndmsv радиокомпас.ndmsv 
-радиокомплекс.ndmsv радиокомпонент.ndmsv радиоконцерт.ndmsv радиолит.ndmsv радиолокатор.ndmsv радиолот.ndmsv 
-радиолярит.ndmsv радиомаркер.ndmsv радиоматериал.ndmsv радиометеорограф.ndmsv радиометр.ndmsv радиомодем.ndmsv 
-радионавигатор.ndmsv радионуклеид.ndmsv радионуклид.ndmsv радиообмен.ndmsv радиопеленгатор.ndmsv радиоперехват.ndmsv 
-радиоприем.ndmsv радиопродукт.ndmsv радиопротектор.ndmsv радиопульсар.ndmsv радиорепродуктор.ndmsv радиорупор.ndmsv 
-радиосигнал.ndmsv радиоспектрометр.ndmsv радиоспектроскоп.ndmsv радиотелеграф.ndmsv радиотелескоп.ndmsv радиотелефон.ndmsv 
-радиотовар.ndmsv радиоуглерод.ndmsv радиоуровнемер.ndmsv радиоцентр.ndmsv радиоцикл.ndmsv радиошум.ndmsv 
-радиоэлектрон.ndmsv радиоэлемент.ndmsv радиус-вектор.ndmsv радон.ndmsv радонометр.ndmsv разбаланс.ndmsv 
-разброд.ndmsv разворот.ndmsv разгар.ndmsv разгиб.ndmsv раздор.ndmsv раздув.ndmsv 
-разер.ndmsv разлад.ndmsv разлет.ndmsv размол.ndmsv разогрев.ndmsv разъезд.ndmsv 
-райграс.ndmsv райком.ndmsv райпищекомбинат.ndmsv райсовет.ndmsv райфикешт.ndmsv райцентр.ndmsv 
-ракетодром.ndmsv ракетоплан.ndmsv ракурс.ndmsv рамадан.ndmsv рамблер.ndmsv раммельсбергит.ndmsv 
-рамс.ndmsv рамуляриоз.ndmsv ранверсман.ndmsv ранд.ndmsv рант.ndmsv рапид.ndmsv 
-раппорт.ndmsv рапс.ndmsv раритет.ndmsv расизм.ndmsv расогенез.ndmsv распатор.ndmsv 
-расплод.ndmsv расплыв.ndmsv рассвет.ndmsv рассев.ndmsv расстрел.ndmsv расходомер.ndmsv 
-раунд.ndmsv раут.ndmsv рахат-лукум.ndmsv рахис.ndmsv рахит.ndmsv рахитизм.ndmsv 
-рацемат.ndmsv рашкет.ndmsv рашпер.ndmsv рдест.ndmsv реагент.ndmsv реактанс.ndmsv 
-реактант.ndmsv реактопласт.ndmsv реализм.ndmsv реальгар.ndmsv ребус.ndmsv ревант.ndmsv 
-реваншизм.ndmsv реввоенсовет.ndmsv реверанс.ndmsv ревербератор.ndmsv реверберометр.ndmsv реверс.ndmsv 
-реверсор.ndmsv ревертант.ndmsv ревком.ndmsv ревматизм.ndmsv ревмокардит.ndmsv револьвер.ndmsv 
-ревтрибунал.ndmsv регенерат.ndmsv регенератор.ndmsv регион.ndmsv регистр.ndmsv регламент.ndmsv 
-реглет.ndmsv реголит.ndmsv регресс.ndmsv регулятор.ndmsv редан.ndmsv редингот.ndmsv 
-редуктор.ndmsv редут.ndmsv редюит.ndmsv реестр.ndmsv резен.ndmsv резерват.ndmsv 
-резервуар.ndmsv резерпин.ndmsv резинат.ndmsv резинит.ndmsv резинозис.ndmsv резинол.ndmsv 
-резист.ndmsv резистанс.ndmsv резистин.ndmsv резистор.ndmsv резит.ndmsv резнатрон.ndmsv 
-резол.ndmsv резонанс.ndmsv резонатор.ndmsv резонон.ndmsv резорцин.ndmsv результант.ndmsv 
-результат.ndmsv резус-фактор.ndmsv резьбомер.ndmsv реимпорт.ndmsv рейд.ndmsv рейдер.ndmsv 
-рейс.ndmsv рейсмас.ndmsv рейсмус.ndmsv рейсфедер.ndmsv рейхсвер.ndmsv рейхсрат.ndmsv 
-реквием.ndmsv реквизит.ndmsv рекордер.ndmsv рекордизм.ndmsv рекостав.ndmsv рекредитив.ndmsv 
-рексит.ndmsv ректификат.ndmsv ректификатор.ndmsv ректон.ndmsv ректорат.ndmsv ректороманоскоп.ndmsv 
-ректоскоп.ndmsv рекуперат.ndmsv рекуператор.ndmsv релаксатор.ndmsv релаксин.ndmsv реликт.ndmsv 
-релин.ndmsv релит.ndmsv рельсотранспортер.ndmsv релятивизм.ndmsv ремедиум.ndmsv ремингтон.ndmsv 
-ремкомплект.ndmsv ремонстрант.ndmsv ремонтуар.ndmsv рен.ndmsv ренессанс.ndmsv ренет.ndmsv 
-ренин.ndmsv ренклод.ndmsv ренонс.ndmsv рентген.ndmsv рентгенметр.ndmsv рентгенолаборант.ndmsv 
-реовирус.ndmsv реокардиограф.ndmsv реометр.ndmsv реотаксис.ndmsv реотан.ndmsv реотропизм.ndmsv 
-реофит.ndmsv реохорд.ndmsv репеллент.ndmsv репеллер.ndmsv репер.ndmsv репертуар.ndmsv 
-реперфоратор.ndmsv реперфотрансмиттер.ndmsv репитер.ndmsv репликар.ndmsv репликон.ndmsv репорт.ndmsv 
-репрессор.ndmsv реприманд.ndmsv репринт.ndmsv репродуктор.ndmsv репродуцент.ndmsv репшнур.ndmsv 
-ресивер.ndmsv рескрипт.ndmsv респект.ndmsv респиратор.ndmsv респирометр.ndmsv рестарт.ndmsv 
-ресторан.ndmsv рестрикт.ndmsv ретикулин.ndmsv ретинен.ndmsv ретинит.ndmsv ретинол.ndmsv 
-ретранслятор.ndmsv ретраншемент.ndmsv ретровирус.ndmsv ретрорефлектор.ndmsv реум.ndmsv референдум.ndmsv 
-рефлектометр.ndmsv рефлектор.ndmsv рефлотрон.ndmsv рефлюкс.ndmsv реформизм.ndmsv рефрактометр.ndmsv 
-рефрактор.ndmsv рефрен.ndmsv рефрижератор.ndmsv рецепт.ndmsv рецептер.ndmsv рецептор.ndmsv 
-рецидивизм.ndmsv рецикл.ndmsv речитатив.ndmsv реэкспорт.ndmsv риаколит.ndmsv риал.ndmsv 
-рибонуклеотид.ndmsv рибофлавин.ndmsv риванол.ndmsv ригодон.ndmsv ригоризм.ndmsv ризалит.ndmsv 
-ризопод.ndmsv риккетсиоз.ndmsv риксдалер.ndmsv ринит.ndmsv риновирус.ndmsv риноскоп.ndmsv 
-риокан.ndmsv риолит.ndmsv риометр.ndmsv риппер.ndmsv рисс.ndmsv ритм.ndmsv 
-риторизм.ndmsv ритуализм.ndmsv риф.ndmsv рифмоплет.ndmsv рифт.ndmsv рицин.ndmsv 
-рицинин.ndmsv роббер.ndmsv роброн.ndmsv робурит.ndmsv ровер.ndmsv рогоз.ndmsv 
-родамин.ndmsv роданид.ndmsv родентицид.ndmsv роджер.ndmsv рододендрон.ndmsv родонит.ndmsv 
-родопсин.ndmsv родохрозит.ndmsv родстер.ndmsv рожнец.ndmsv розанилин.ndmsv розеин.ndmsv 
-розмарин.ndmsv рок-н-ролл.ndmsv ролл.ndmsv роллер.ndmsv рольмопс.ndmsv романизм.ndmsv 
-романтизм.ndmsv ромб.ndmsv ромбододекаэдр.ndmsv ромбоэдр.ndmsv ромштекс.ndmsv ронгалит.ndmsv 
-росомер.ndmsv ростбиф.ndmsv ростер.ndmsv ростерит.ndmsv ростомер.ndmsv ротаметр.ndmsv 
-ротапринт.ndmsv ротацизм.ndmsv ротон.ndmsv роуд.ndmsv роульс.ndmsv роштейн.ndmsv 
-роялизм.ndmsv рубеллит.ndmsv рубероид.ndmsv рубрикатор.ndmsv рудерпост.ndmsv рудимент.ndmsv 
-рудовоз.ndmsv русиа-петролиум.ndmsv русизм.ndmsv руссоизм.ndmsv рутил.ndmsv рыбозавод.ndmsv 
-рыбокомбинат.ndmsv рыбонасос.ndmsv рыбоподъем.ndmsv рыбхоз.ndmsv рыдван.ndmsv рым.ndmsv 
-рэгтайм.ndmsv рэкет.ndmsv рэл.ndmsv рэн.ndmsv ряст.ndmsv сабайон.ndmsv 
-сабан.ndmsv сабеизм.ndmsv сабур.ndmsv саван.ndmsv саган.ndmsv садизм.ndmsv 
-саз.ndmsv сайзер.ndmsv сайодин.ndmsv сайт.ndmsv саккос.ndmsv сакман.ndmsv 
-саксаул.ndmsv саксгорн.ndmsv саксофон.ndmsv салипирин.ndmsv салицин.ndmsv салол.ndmsv 
-салолин.ndmsv саломас.ndmsv салун.ndmsv сальварсан.ndmsv сальмонеллез.ndmsv сальпингит.ndmsv 
-самарскит.ndmsv саммит.ndmsv самоанализ.ndmsv самовозврат.ndmsv самогипноз.ndmsv самоклад.ndmsv 
-самолето-рейс.ndmsv самолетовылет.ndmsv самонаклад.ndmsv самообман.ndmsv самооговор.ndmsv самоостанов.ndmsv 
-самоотвод.ndmsv самоотчет.ndmsv самопал.ndmsv самопресс.ndmsv саморазрыв.ndmsv самораспад.ndmsv 
-самосвал.ndmsv самосин.ndmsv самосплав.ndmsv самостил.ndmsv самосуд.ndmsv самотряс.ndmsv 
-самоцвет.ndmsv сампан.ndmsv самум.ndmsv самшит.ndmsv санбат.ndmsv сангвинизм.ndmsv 
-санидин.ndmsv санктус.ndmsv санпросвет.ndmsv санскрит.ndmsv сантибар.ndmsv сантиграмм.ndmsv 
-сантилитр.ndmsv сантим.ndmsv сантиметр.ndmsv сантипуаз.ndmsv сантистокс.ndmsv сантонин.ndmsv 
-сапонат.ndmsv сапонин.ndmsv сапонит.ndmsv сапр.ndmsv сапролит.ndmsv сапропелит.ndmsv 
-сапрофит.ndmsv сапун.ndmsv сардер.ndmsv сардоникс.ndmsv сарказм.ndmsv саркоид.ndmsv 
-сарос.ndmsv сассафрас.ndmsv сатанизм.ndmsv сателлоид.ndmsv сатинер.ndmsv сатинет.ndmsv 
-сатириаз.ndmsv сатириазис.ndmsv сатуратор.ndmsv сатурнизм.ndmsv сауэр.ndmsv сафлор.ndmsv 
-сафранин.ndmsv сафрол.ndmsv сахарат.ndmsv сахарид.ndmsv сахариметр.ndmsv сахарозавод.ndmsv 
-сахарометр.ndmsv сахаромицет.ndmsv сахаронос.ndmsv сбыт.ndmsv свеклокомбайн.ndmsv свеклосовхоз.ndmsv 
-сверхбаллон.ndmsv сверхгигант.ndmsv сверхдредноут.ndmsv сверхкомплект.ndmsv сверхорганизм.ndmsv свес.ndmsv 
-световод.ndmsv светодиод.ndmsv светолюб.ndmsv светопровод.ndmsv светорегулятор.ndmsv светосигнал.ndmsv 
-светофильтр.ndmsv светофор.ndmsv свингометр.ndmsv свиносовхоз.ndmsv своп.ndmsv сворот.ndmsv 
-сглаз.ndmsv сдув.ndmsv сеанс.ndmsv севооборот.ndmsv севосмен.ndmsv севр.ndmsv 
-сегунат.ndmsv сезам.ndmsv сейм.ndmsv сейсмоаппарат.ndmsv сейсмограф.ndmsv сейсмометр.ndmsv 
-сейсмоскоп.ndmsv сейф.ndmsv секанс.ndmsv секатор.ndmsv секретариат.ndmsv секретер.ndmsv 
-секретин.ndmsv секс.ndmsv секстаккорд.ndmsv секстан.ndmsv секстант.ndmsv секстет.ndmsv 
-секстиллион.ndmsv секстильон.ndmsv сексуализм.ndmsv секундомер.ndmsv селектор.ndmsv селенид.ndmsv 
-селесброс.ndmsv сельсин.ndmsv сельсовет.ndmsv сельфактор.ndmsv семеномер.ndmsv семестр.ndmsv 
-семиинвариант.ndmsv семинар.ndmsv семитизм.ndmsv семфонд.ndmsv семявход.ndmsv семяпровод.ndmsv 
-сенармонтит.ndmsv сенат.ndmsv сеновал.ndmsv сенсибилизатор.ndmsv сенситометр.ndmsv сенсуализм.ndmsv 
-сентипуаз.ndmsv сеньорат.ndmsv сеньорен-конвент.ndmsv сепаратизм.ndmsv сепаратор.ndmsv сепиолит.ndmsv 
-сепсис.ndmsv септаккорд.ndmsv септемвират.ndmsv септет.ndmsv септиллион.ndmsv септильон.ndmsv 
-сервант.ndmsv сервелат.ndmsv сервилизм.ndmsv сервис.ndmsv сервис-период.ndmsv сервитут.ndmsv 
-сервоклапан.ndmsv сервокомпенсатор.ndmsv сервомеханизм.ndmsv сервомотор.ndmsv сервопривод.ndmsv сериал.ndmsv 
-серин.ndmsv сериф.ndmsv серицин.ndmsv серицит.ndmsv серкес.ndmsv серотонин.ndmsv 
-серп.ndmsv серпантин.ndmsv серпент.ndmsv серпентинит.ndmsv сертификат.ndmsv серум.ndmsv 
-серфер.ndmsv сестон.ndmsv сеттльмент.ndmsv сжим.ndmsv сибилянт.ndmsv сигнализатор.ndmsv 
-сидерат.ndmsv сидерит.ndmsv сидероз.ndmsv сидеролит.ndmsv сидеростат.ndmsv сиенит.ndmsv 
-сикамор.ndmsv сиккатив.ndmsv сикоз.ndmsv сикомор.ndmsv сикурс.ndmsv силан.ndmsv 
-силикальцит.ndmsv силикоз.ndmsv силикон.ndmsv силикофосфат.ndmsv силицид.ndmsv силлабизм.ndmsv 
-силлиманит.ndmsv силлогизм.ndmsv силоксан.ndmsv силоксид.ndmsv силомер.ndmsv силон.ndmsv 
-силумин.ndmsv силуминит.ndmsv силур.ndmsv сильванит.ndmsv сильвин.ndmsv сильвинит.ndmsv 
-сильфон.ndmsv симбиоз.ndmsv символизм.ndmsv симплекс.ndmsv симпозиум.ndmsv симптом.ndmsv 
-симфиз.ndmsv симфонизм.ndmsv синап.ndmsv синапс.ndmsv синапсис.ndmsv синглет.ndmsv 
-синдесмоз.ndmsv синдетикон.ndmsv синдикат.ndmsv синдолор.ndmsv синдром.ndmsv синедрион.ndmsv 
-синемаскоп.ndmsv синематограф.ndmsv синерезис.ndmsv синерод.ndmsv синестрол.ndmsv синклит.ndmsv 
-синкретизм.ndmsv синод.ndmsv синоним.ndmsv синопсис.ndmsv синостоз.ndmsv синтаксис.ndmsv 
-синтез.ndmsv синтезатор.ndmsv синтекс.ndmsv синтоизм.ndmsv синтомицин.ndmsv синусит.ndmsv 
-синхондроз.ndmsv синхроимпульс.ndmsv синхроконтакт.ndmsv синхронизатор.ndmsv синхронизм.ndmsv синхроноскоп.ndmsv 
-синхросигнал.ndmsv синхроскоп.ndmsv синхротрон.ndmsv синхрофазотрон.ndmsv синхроциклотрон.ndmsv синьоритет.ndmsv 
-сионизм.ndmsv сиринкс.ndmsv систр.ndmsv ситар.ndmsv сифилис.ndmsv скайсуипер.ndmsv 
-скаленоэдр.ndmsv скальол.ndmsv скальп.ndmsv сканер.ndmsv скаполит.ndmsv скарб.ndmsv 
-скарификатор.ndmsv скарн.ndmsv скатол.ndmsv скаутизм.ndmsv скафандр.ndmsv сквид.ndmsv 
-скейт.ndmsv скейтборд.ndmsv скелетон.ndmsv скеннер.ndmsv скепсис.ndmsv скептицизм.ndmsv 
-скипетр.ndmsv скирдовоз.ndmsv скифл.ndmsv склерит.ndmsv склерометр.ndmsv склерон.ndmsv 
-склероскоп.ndmsv сколиоз.ndmsv скольдер.ndmsv скополамин.ndmsv скородит.ndmsv скоростемер.ndmsv 
-скотопрогон.ndmsv скрап.ndmsv скрининг-тест.ndmsv скрипт.ndmsv скрофулез.ndmsv скруббер.ndmsv 
-скрупул.ndmsv славянизм.ndmsv слад.ndmsv слайд.ndmsv слайдер.ndmsv слиперс.ndmsv 
-словораздел.ndmsv слогораздел.ndmsv слот.ndmsv слюдинит.ndmsv слюногон.ndmsv сляб.ndmsv 
-смарагд.ndmsv смарагдит.ndmsv смилакс.ndmsv смитсонит.ndmsv снеговал.ndmsv снегозанос.ndmsv 
-снеголом.ndmsv снегомер.ndmsv снегопад.ndmsv снегоступ.ndmsv снеготранспортер.ndmsv снегоход.ndmsv 
-снобизм.ndmsv снобол.ndmsv сноп.ndmsv собес.ndmsv совдеп.ndmsv соверен.ndmsv 
-совмин.ndmsv совнарком.ndmsv совнархоз.ndmsv согрев.ndmsv содалит.ndmsv содар.ndmsv 
-содоклад.ndmsv созыв.ndmsv сокет.ndmsv соланин.ndmsv солемер.ndmsv соленоид.ndmsv 
-солерет.ndmsv солерод.ndmsv солерос.ndmsv солесос.ndmsv солецизм.ndmsv солидат.ndmsv 
-солидол.ndmsv солидус.ndmsv солипсизм.ndmsv солиситор.ndmsv солитон.ndmsv соллюкс.ndmsv 
-солнцеворот.ndmsv солнцецвет.ndmsv соломер.ndmsv соломит.ndmsv соломовяз.ndmsv соломотряс.ndmsv 
-сольвент.ndmsv соляриум.ndmsv соматотропин.ndmsv сомит.ndmsv сонант.ndmsv сонар.ndmsv 
-сонм.ndmsv сонометр.ndmsv сополимер.ndmsv сопор.ndmsv сопромат.ndmsv сопроцессор.ndmsv 
-сорбат.ndmsv сорбент.ndmsv сорбит.ndmsv сорегент.ndmsv сорит.ndmsv соробан.ndmsv 
-сорокоуст.ndmsv сорорат.ndmsv сортамент.ndmsv сортимент.ndmsv сорус.ndmsv соскоб.ndmsv 
-соссюрит.ndmsv сосуд.ndmsv сотерн.ndmsv соул.ndmsv софизм.ndmsv софит.ndmsv 
-софт.ndmsv софтбол.ndmsv социал-демократ.ndmsv социализм.ndmsv социум.ndmsv спад.ndmsv 
-спайдер.ndmsv спандекс.ndmsv спейсер.ndmsv спекл.ndmsv спектр.ndmsv спектрогелиограф.ndmsv 
-спектрогелиометр.ndmsv спектрограф.ndmsv спектрометр.ndmsv спектрорадиометр.ndmsv спектросенситометр.ndmsv спектроскоп.ndmsv 
-спектрофотометр.ndmsv спекулярит.ndmsv спеллер.ndmsv спен.ndmsv спенкер.ndmsv сперматозоид.ndmsv 
-сперматоцид.ndmsv спермацет.ndmsv спермин.ndmsv спецаукцион.ndmsv спецвагон.ndmsv спецгруз.ndmsv 
-спецжелезобетон.ndmsv спецзаказ.ndmsv специнструмент.ndmsv спецкласс.ndmsv спецкомплект.ndmsv спецконтингент.ndmsv 
-спецкурс.ndmsv спецобъект.ndmsv спецотдел.ndmsv спецподъезд.ndmsv спецрадиоматериал.ndmsv спецрейс.ndmsv 
-спецсамолет.ndmsv спецсеминар.ndmsv спецсимвол.ndmsv спецстройматериал.ndmsv спецэкспортер.ndmsv спецэффект.ndmsv 
-спидбол.ndmsv спидометр.ndmsv спидстер.ndmsv спинакер.ndmsv спинар.ndmsv спинет.ndmsv 
-спинор.ndmsv спинтарископ.ndmsv спиритизм.ndmsv спирограф.ndmsv спирометр.ndmsv спиртомер.ndmsv 
-спиртометр.ndmsv сплайн.ndmsv спленит.ndmsv сплин.ndmsv сподумен.ndmsv спойлер.ndmsv 
-спонгин.ndmsv спонгит.ndmsv спондилит.ndmsv спорофилл.ndmsv спорофит.ndmsv спорт.ndmsv 
-спортзал.ndmsv спортклуб.ndmsv спот.ndmsv спрайт.ndmsv спредер.ndmsv спринклер.ndmsv 
-спринт.ndmsv сприт.ndmsv спрос.ndmsv спуд.ndmsv спул.ndmsv спурт.ndmsv 
-срыв.ndmsv ссыппункт.ndmsv стабилизатор.ndmsv стабилитрон.ndmsv ставролит.ndmsv стагирит.ndmsv 
-стадиал.ndmsv стаз.ndmsv стакер.ndmsv сталагмит.ndmsv сталагмометр.ndmsv сталактит.ndmsv 
-сталебетон.ndmsv сталинит.ndmsv стальбетон.ndmsv станнат.ndmsv станнит.ndmsv станс.ndmsv 
-станционер.ndmsv стаплер.ndmsv старн.ndmsv старнпост.ndmsv старнсон.ndmsv старославянизм.ndmsv 
-статер.ndmsv статир.ndmsv статолит.ndmsv статор.ndmsv статоскоп.ndmsv статотчет.ndmsv 
-статоцист.ndmsv стаут.ndmsv стачком.ndmsv стеарат.ndmsv стеатит.ndmsv стеблеплод.ndmsv 
-стейкбургер.ndmsv стеклограф.ndmsv стеклопакет.ndmsv стеклопласт.ndmsv стеклоприбор.ndmsv стеклотекстолит.ndmsv 
-стеклохолст.ndmsv стеклярус.ndmsv стелларатор.ndmsv стеллит.ndmsv стем.ndmsv стемпид.ndmsv 
-стенд.ndmsv стендер.ndmsv стенолом.ndmsv стеноп.ndmsv стенотип.ndmsv степотип.ndmsv 
-степс.ndmsv стер.ndmsv стерадиан.ndmsv стереоавтограф.ndmsv стереобат.ndmsv стереограф.ndmsv 
-стереодиапозитив.ndmsv стереоизомер.ndmsv стереокартограф.ndmsv стереокомпаратор.ndmsv стереомагнитофон.ndmsv стереометр.ndmsv 
-стереомикроскоп.ndmsv стереопроектор.ndmsv стереоскоп.ndmsv стереотаксис.ndmsv стереофильм.ndmsv стереоэкран.ndmsv 
-стереоэффект.ndmsv стерилизатор.ndmsv стерин.ndmsv стернит.ndmsv стероид.ndmsv стетоскоп.ndmsv 
-стетсон.ndmsv стефанит.ndmsv стибин.ndmsv стибнит.ndmsv стивер.ndmsv стигмат.ndmsv 
-стигматизм.ndmsv стилет.ndmsv стилобат.ndmsv стилограф.ndmsv стилолит.ndmsv стилометр.ndmsv 
-стильб.ndmsv стильбит.ndmsv стимер.ndmsv стимул.ndmsv стимулянт.ndmsv стимулятор.ndmsv 
-стипль-чез.ndmsv стиптицин.ndmsv стиракс.ndmsv стишовит.ndmsv стоговоз.ndmsv стожар.ndmsv 
-стоицизм.ndmsv стокс.ndmsv столон.ndmsv стоматит.ndmsv стоматоскоп.ndmsv стомп.ndmsv 
-стоп-кран.ndmsv стоп-овер.ndmsv стоп-сигнал.ndmsv стопин.ndmsv стоун.ndmsv стоцвет.ndmsv 
-страбизм.ndmsv страдивариус.ndmsv страз.ndmsv страстоцвет.ndmsv стратоплан.ndmsv стратостат.ndmsv 
-страхфонд.ndmsv стрекун.ndmsv стрелолист.ndmsv стренер.ndmsv стрептомицин.ndmsv стресс.ndmsv 
-стресс-детектор.ndmsv стрессор.ndmsv стример.ndmsv стриммер.ndmsv стрип.ndmsv стриппер.ndmsv 
-стриптиз.ndmsv стрихнин.ndmsv строанцианит.ndmsv строб.ndmsv стробил.ndmsv стробилус.ndmsv 
-стробимпульс.ndmsv стробоскоп.ndmsv стройбат.ndmsv стройотряд.ndmsv строматолит.ndmsv стронцианит.ndmsv 
-стропконтейнер.ndmsv строфант.ndmsv строфулус.ndmsv струнобетон.ndmsv студебеккер.ndmsv ступор.ndmsv 
-субимпульс.ndmsv субконтинент.ndmsv субконтракт.ndmsv сублимат.ndmsv субмикрон.ndmsv субподряд.ndmsv 
-субпродукт.ndmsv субрегион.ndmsv субстрат.ndmsv субстратостат.ndmsv субсчет.ndmsv субтитр.ndmsv 
-субфебрилитет.ndmsv субштамм.ndmsv суверенитет.ndmsv сугроб.ndmsv судооборот.ndmsv судоподъем.ndmsv 
-судоремонт.ndmsv сузафон.ndmsv сукцинит.ndmsv султанат.ndmsv сульгин.ndmsv сульфазол.ndmsv 
-сульфамид.ndmsv сульфаниламид.ndmsv сульфгидрат.ndmsv сульфидин.ndmsv сульфонал.ndmsv сумет.ndmsv 
-сумматор.ndmsv суннизм.ndmsv суперген.ndmsv супергетеродин.ndmsv суперкар.ndmsv суперкомпьютер.ndmsv 
-суперкремникон.ndmsv суперлайнер.ndmsv супермапипезиметр.ndmsv супермарафон.ndmsv супермаркет.ndmsv суперортикон.ndmsv 
-суперпарамагнетизм.ndmsv суперпластификатор.ndmsv суперсплав.ndmsv суперстрат.ndmsv суперсульфат.ndmsv супертанкер.ndmsv 
-супертоксикант.ndmsv супертоксин.ndmsv суперфильм.ndmsv суперфосфат.ndmsv суперэкотоксикант.ndmsv суперэкслибрис.ndmsv 
-супин.ndmsv супинатор.ndmsv суррогат.ndmsv сурфактант.ndmsv суслон.ndmsv суспензор.ndmsv 
-суфизм.ndmsv суфляр.ndmsv суфражизм.ndmsv суффикс.ndmsv сухогруз.ndmsv суходол.ndmsv 
-сухолом.ndmsv сухолюб.ndmsv сухоцвет.ndmsv сучкорез.ndmsv сфагнум.ndmsv сфалерит.ndmsv 
-сфен.ndmsv сфеноид.ndmsv сферокристалл.ndmsv сферолит.ndmsv сферометр.ndmsv сферопласт.ndmsv 
-сферосидерит.ndmsv сфигмограф.ndmsv сфигмоманометр.ndmsv сфигмометр.ndmsv сфинктер.ndmsv схематизм.ndmsv 
-сценизм.ndmsv сцинтиллометр.ndmsv сцинтиллоскоп.ndmsv сцинтиллятор.ndmsv съезд.ndmsv сыропуст.ndmsv 
-сэбин.ndmsv сюзеренитет.ndmsv сюрвейер.ndmsv сюрреализм.ndmsv сямисэн.ndmsv табес.ndmsv 
-табльдот.ndmsv табулятор.ndmsv тазиметр.ndmsv тайгеркэт.ndmsv тайм.ndmsv тайм-аут.ndmsv 
-тайм-чартер.ndmsv таймаут.ndmsv таймер.ndmsv таймограф.ndmsv таймун.ndmsv таймшит.ndmsv 
-тайфун.ndmsv таконит.ndmsv таксиметр.ndmsv таксис.ndmsv таксит.ndmsv таксометр.ndmsv 
-таксомотор.ndmsv таксон.ndmsv таксофон.ndmsv такт.ndmsv тактометр.ndmsv такыр.ndmsv 
-таламус.ndmsv талант.ndmsv талер.ndmsv талес.ndmsv талион.ndmsv талипот.ndmsv 
-талис.ndmsv талисман.ndmsv таллом.ndmsv талмуд.ndmsv талмудизм.ndmsv талькомагнезит.ndmsv 
-тамаринд.ndmsv тамбур-шлюз.ndmsv тамбурин.ndmsv тампон.ndmsv тамтам.ndmsv танатоценоз.ndmsv 
-танбур.ndmsv тангенс.ndmsv тангор.ndmsv тандем.ndmsv тандер.ndmsv танид.ndmsv 
-танин.ndmsv танкодром.ndmsv таннат.ndmsv таннин.ndmsv тантал.ndmsv танталат.ndmsv 
-танталит.ndmsv танцзал.ndmsv танцкласс.ndmsv тарантас.ndmsv тарарам.ndmsv тардион.ndmsv 
-тардон.ndmsv тарлатан.ndmsv тартар.ndmsv тартразин.ndmsv тартрат.ndmsv тархун.ndmsv 
-тасманит.ndmsv тау-сагыз.ndmsv таутохронизм.ndmsv тахеометр.ndmsv тахилит.ndmsv тахиметр.ndmsv 
-тахиол.ndmsv тахион.ndmsv тахограф.ndmsv тахометр.ndmsv тацет.ndmsv твердозем.ndmsv 
-твердомер.ndmsv твил.ndmsv твин.ndmsv твист.ndmsv твэл.ndmsv театр.ndmsv 
-тегмен.ndmsv тезаурус.ndmsv тезис.ndmsv теизм.ndmsv теин.ndmsv тейлоризм.ndmsv 
-текс.ndmsv тексроп.ndmsv текст.ndmsv текст-процессор.ndmsv текстовинит.ndmsv текстолит.ndmsv 
-тектит.ndmsv теламон.ndmsv телеавтограф.ndmsv телевизор.ndmsv телеграф.ndmsv телеканал.ndmsv 
-телекиноматериал.ndmsv телекинопроектор.ndmsv телекласс.ndmsv телекомплекс.ndmsv телекоптер.ndmsv телекс.ndmsv 
-телемарафон.ndmsv телематериал.ndmsv телеметр.ndmsv телемонитор.ndmsv телемост.ndmsv теленейрон.ndmsv 
-телеобъектив.ndmsv телепорт.ndmsv телерадиокомплекс.ndmsv телерадиоцентр.ndmsv телеран.ndmsv телеросс.ndmsv 
-телесейсм.ndmsv телесериал.ndmsv телескоп.ndmsv телеспектроскоп.ndmsv телесюжет.ndmsv телетайп.ndmsv 
-телетекст.ndmsv телетермометр.ndmsv телефакс.ndmsv телефильм.ndmsv телефотометр.ndmsv телецентр.ndmsv 
-телеэкран.ndmsv теллур.ndmsv теллурат.ndmsv теллурид.ndmsv теллурит.ndmsv теллурометр.ndmsv 
-теломер.ndmsv телорез.ndmsv тельсон.ndmsv тельфер.ndmsv тембр.ndmsv темп.ndmsv 
-темпл.ndmsv темпон.ndmsv тенар.ndmsv тенардит.ndmsv тендерометр.ndmsv тенезм.ndmsv 
-тенелюб.ndmsv тенериф.ndmsv тензиометр.ndmsv тензометр.ndmsv тензор.ndmsv теннантит.ndmsv 
-тенорит.ndmsv тент.ndmsv тенториум.ndmsv теобромин.ndmsv теодолит.ndmsv теорикон.ndmsv 
-теофиллин.ndmsv тепловизор.ndmsv тепловоз.ndmsv теплоизолятор.ndmsv тепломер.ndmsv теплообмен.ndmsv 
-теплоотвод.ndmsv теплопеленгатор.ndmsv теплоперенос.ndmsv теплоприбор.ndmsv теплород.ndmsv теплофильтр.ndmsv 
-теплоход.ndmsv теплурометр.ndmsv терабайт.ndmsv терабит.ndmsv теракт.ndmsv тератоген.ndmsv 
-терблиг.ndmsv тергит.ndmsv терилен.ndmsv термидор.ndmsv термин.ndmsv терминал.ndmsv 
-терминатор.ndmsv терминизм.ndmsv термистор.ndmsv термоантрацит.ndmsv термобарометр.ndmsv термобиметалл.ndmsv 
-термогазоанализатор.ndmsv термогенератор.ndmsv термограф.ndmsv термозит.ndmsv термоиндикатор.ndmsv термокаутер.ndmsv 
-термоконтейнер.ndmsv термометр.ndmsv термоперенос.ndmsv термопериод.ndmsv термопласт.ndmsv термопрен.ndmsv 
-термопсис.ndmsv терморегулятор.ndmsv терморезистор.ndmsv терморецептор.ndmsv термосифон.ndmsv термоскоп.ndmsv 
-термостат.ndmsv термотаксис.ndmsv термотрон.ndmsv термофосфат.ndmsv термоэлектрогенератор.ndmsv термоэлектрон.ndmsv 
-термоэлемент.ndmsv терн.ndmsv терпентин.ndmsv терпинол.ndmsv терразит.ndmsv террамицин.ndmsv 
-террариум.ndmsv терренкур.ndmsv террикон.ndmsv террор.ndmsv терроризм.ndmsv терцет.ndmsv 
-тессаракт.ndmsv тест-акт.ndmsv тестер.ndmsv тестон.ndmsv тетанус.ndmsv тетраборат.ndmsv 
-тетрагидрофуран.ndmsv тетрадимит.ndmsv тетраметр.ndmsv тетраморф.ndmsv тетрапод.ndmsv тетрафтор.ndmsv 
-тетрафторбромпропан.ndmsv тетрафторбромэтан.ndmsv тетрафтордибромпропан.ndmsv тетрафтордихлорпропан.ndmsv тетрафтордихлорэтан.ndmsv тетрафтортетрахлорпропан.ndmsv 
-тетрафтортрихлор.ndmsv тетрафторхлорпропан.ndmsv тетрафторхлорэтан.ndmsv тетрахлорметан.ndmsv тетрахорд.ndmsv тетраэдр.ndmsv 
-тетраэдрит.ndmsv тетраэтилен.ndmsv тетраэтиленпентамин.ndmsv тетраэтилентамин.ndmsv тетрил.ndmsv тетробол.ndmsv 
-тетрод.ndmsv тетродотоксин.ndmsv тетроксид.ndmsv тетрофторид.ndmsv тефилин.ndmsv тефлон.ndmsv 
-тефрит.ndmsv тефроит.ndmsv техминимум.ndmsv технадзор.ndmsv техникум.ndmsv техницизм.ndmsv 
-технотрон.ndmsv техосмотр.ndmsv техотдел.ndmsv техперсонал.ndmsv техуглерод.ndmsv техцентр.ndmsv 
-тиазин.ndmsv тиазол.ndmsv тиамин.ndmsv тикер.ndmsv тиккер.ndmsv тиллит.ndmsv 
-тимберс.ndmsv тимин.ndmsv тимол.ndmsv тимпанит.ndmsv тимус.ndmsv тимьян.ndmsv 
-тинкал.ndmsv тиоальдегид.ndmsv тиокол.ndmsv тиол.ndmsv тионил.ndmsv тионилхлорид.ndmsv 
-тиосульфат.ndmsv тиоурацил.ndmsv тиофос.ndmsv тиоцианат.ndmsv тиоэфир.ndmsv типикон.ndmsv 
-типометр.ndmsv типоразмер.ndmsv типун.ndmsv тиратрон.ndmsv тиреоидин.ndmsv тиристор.ndmsv 
-тирит.ndmsv тирозин.ndmsv тироксин.ndmsv тирольен.ndmsv тирс.ndmsv титанат.ndmsv 
-титанит.ndmsv тиф.ndmsv тифлит.ndmsv тиходол.ndmsv тобогган.ndmsv товарообмен.ndmsv 
-товарооборот.ndmsv токопровод.ndmsv токосъем.ndmsv токоферол.ndmsv токсикант.ndmsv токсикоз.ndmsv 
-токсин.ndmsv токсоплазм.ndmsv токсоплазмоз.ndmsv толкун.ndmsv толобат.ndmsv толуол.ndmsv 
-томограф.ndmsv томсенолит.ndmsv томсонит.ndmsv тонар.ndmsv тонарм.ndmsv тонвал.ndmsv 
-тонер.ndmsv тонзиллит.ndmsv тонно-километр.ndmsv тонометр.ndmsv тонус.ndmsv тонфильм.ndmsv 
-топазолит.ndmsv топенант.ndmsv топинамбур.ndmsv топливомер.ndmsv топливопровод.ndmsv топоним.ndmsv 
-топотип.ndmsv топтимберс.ndmsv топчан.ndmsv топшур.ndmsv торакс.ndmsv торбан.ndmsv 
-торбанит.ndmsv торбернит.ndmsv торгпред.ndmsv торгсин.ndmsv торианит.ndmsv торизм.ndmsv 
-торит.ndmsv торкрет.ndmsv торкретбетон.ndmsv торн.ndmsv тороид.ndmsv торон.ndmsv 
-торос.ndmsv торс.ndmsv торт.ndmsv торус.ndmsv торфобетон.ndmsv торфобрикет.ndmsv 
-торфокомпост.ndmsv торфонасос.ndmsv торфорез.ndmsv торфосос.ndmsv торшер.ndmsv торшон.ndmsv 
-тост.ndmsv тостер.ndmsv тотализатор.ndmsv тотемизм.ndmsv тофус.ndmsv траверз.ndmsv 
-травертин.ndmsv травматизм.ndmsv травмопункт.ndmsv травокос.ndmsv трагакант.ndmsv трагант.ndmsv 
-трагизм.ndmsv трайлер.ndmsv трактат.ndmsv трамблер.ndmsv трамп.ndmsv трамплин.ndmsv 
-трамтарарам.ndmsv транажер.ndmsv транзиент.ndmsv транзистор.ndmsv транквилизатор.ndmsv транс.ndmsv 
-трансбордер.ndmsv трансвертер.ndmsv трансдуктор.ndmsv трансепт.ndmsv транскодер.ndmsv транскриптор.ndmsv 
-транслятор.ndmsv трансмиттер.ndmsv транспарант.ndmsv трансплантат.ndmsv транспозон.ndmsv транспорт.ndmsv 
-транспортер.ndmsv транспьютер.ndmsv транссудат.ndmsv трансуран.ndmsv трансфер.ndmsv трансферт.ndmsv 
-трансфикс.ndmsv трансфокатор.ndmsv трансформ.ndmsv трансформатор.ndmsv трап.ndmsv трапецоид.ndmsv 
-трапецоэдр.ndmsv трапп.ndmsv трас.ndmsv трассер.ndmsv траст.ndmsv траст-актив.ndmsv 
-траст-отдел.ndmsv траст-фонд.ndmsv траулер.ndmsv трахеит.ndmsv трахит.ndmsv тред-юнион.ndmsv 
-трейлер.ndmsv тремблер.ndmsv тремолит.ndmsv тремор.ndmsv трен.ndmsv тренажер.ndmsv 
-треншальтер.ndmsv треонин.ndmsv трепел.ndmsv трехчлен.ndmsv трешкоут.ndmsv триазин.ndmsv 
-триаминотринитробензол.ndmsv триамциналон.ndmsv триас.ndmsv триацетат.ndmsv трибометр.ndmsv трибунал.ndmsv 
-трибунат.ndmsv трибутилфосфат.ndmsv тривектор.ndmsv тривиум.ndmsv тригидрат.ndmsv триглиф.ndmsv 
-триглицерин.ndmsv триграф.ndmsv тридимит.ndmsv тризм.ndmsv трикальцийфосфат.ndmsv триколор.ndmsv 
-трикотин.ndmsv триллер.ndmsv тримаран.ndmsv тримезол.ndmsv тример.ndmsv триместр.ndmsv 
-триметилолэтантринитрат.ndmsv триметилоэтантринитрат.ndmsv триметилфосфит.ndmsv триметр.ndmsv триммер.ndmsv тримюон.ndmsv 
-тринископ.ndmsv тринитробензол.ndmsv тринитроксилол.ndmsv тринитротолуол.ndmsv тринитрофенол.ndmsv трином.ndmsv 
-триоксид.ndmsv триолет.ndmsv трип.ndmsv трипанозомоз.ndmsv трипаносомоз.ndmsv триплан.ndmsv 
-триплекс.ndmsv триплет.ndmsv триплит.ndmsv триполифосфат.ndmsv триппер.ndmsv трипс.ndmsv 
-трипсин.ndmsv трипсиноген.ndmsv триптан.ndmsv триптофан.ndmsv тритикал.ndmsv триумвират.ndmsv 
-триумф.ndmsv трифан.ndmsv трифенил.ndmsv трифенилен.ndmsv трифлорум.ndmsv трифторбромметан.ndmsv 
-трифторбромпропан.ndmsv трифторбромэтан.ndmsv трифтордибромпропан.ndmsv трифтордибромэтан.ndmsv трифтордихлорпропан.ndmsv трифтордихлорэтан.ndmsv 
-трифторид.ndmsv трифторпентахлорпропан.ndmsv трифтортетрахлор.ndmsv трифтортрибромпропан.ndmsv трифтортрихлорпропан.ndmsv трифтортрихлорэтан.ndmsv 
-трифторхлорметан.ndmsv трифторхлорпропан.ndmsv трифторхлорэтан.ndmsv трихиаз.ndmsv трихинеллез.ndmsv трихиноз.ndmsv 
-трихит.ndmsv трихлорнитрометан.ndmsv трихлорэтан.ndmsv трихлорэтилен.ndmsv трихом.ndmsv трихомоноз.ndmsv 
-трихоцефалез.ndmsv трицепс.ndmsv триэдр.ndmsv триэтаноламин.ndmsv триэтаноламиногидрохлорид.ndmsv триэтилфосфит.ndmsv 
-троакар.ndmsv троетес.ndmsv троилит.ndmsv троллейбус.ndmsv троллейвоз.ndmsv троллейкар.ndmsv 
-тромб.ndmsv тромбин.ndmsv тромбоген.ndmsv тромбоз.ndmsv тромбопластин.ndmsv тромбофлебит.ndmsv 
-тромбоцит.ndmsv тромп.ndmsv тропизм.ndmsv тропот.ndmsv трос.ndmsv трот.ndmsv 
-тротил.ndmsv трофобиоз.ndmsv трофоневроз.ndmsv трохантин.ndmsv трохотрон.ndmsv троцкизм.ndmsv 
-труакар.ndmsv трубопровод.ndmsv труборез.ndmsv трубоцвет.ndmsv трудфронт.ndmsv трюизм.ndmsv 
-туаз.ndmsv туальденор.ndmsv туан.ndmsv тубафон.ndmsv тубдиспансер.ndmsv туберкулез.ndmsv 
-туберкулин.ndmsv тубус.ndmsv туманограф.ndmsv тумблер.ndmsv тумор.ndmsv турбоагрегат.ndmsv 
-турбобур.ndmsv турбовентилятор.ndmsv турбовоз.ndmsv турбогенератор.ndmsv турбодетандер.ndmsv турбокомпрессор.ndmsv 
-турбонасос.ndmsv турбопровод.ndmsv турбоход.ndmsv турбоэлектроход.ndmsv туризм.ndmsv турион.ndmsv 
-турмалин.ndmsv турнепс.ndmsv турникет.ndmsv турнюр.ndmsv туроператор.ndmsv турпоход.ndmsv 
-турф.ndmsv тустеп.ndmsv туфобетон.ndmsv тюнер.ndmsv тюрбан.ndmsv тюрингит.ndmsv 
-тюркизм.ndmsv тютюн.ndmsv тягомер.ndmsv тягун.ndmsv уаз.ndmsv уайт-спирит.ndmsv 
-уанстеп.ndmsv убиквист.ndmsv убрус.ndmsv увоз.ndmsv увулит.ndmsv углеводород.ndmsv 
-углегипс.ndmsv углепровод.ndmsv углесос.ndmsv узус.ndmsv узуфрукт.ndmsv уик-энд.ndmsv 
-уклонизм.ndmsv уклономер.ndmsv украинизм.ndmsv укус.ndmsv улет.ndmsv ульманит.ndmsv 
-ульмин.ndmsv ультиматум.ndmsv ультрамарин.ndmsv ультрамикрометр.ndmsv ультрамикроскоп.ndmsv ультрамонтан.ndmsv 
-ультрафильтр.ndmsv ультрафиолет.ndmsv умет.ndmsv умлаут.ndmsv умляут.ndmsv умформер.ndmsv 
-унанимизм.ndmsv универсам.ndmsv университет.ndmsv универсум.ndmsv унионизм.ndmsv унитаз.ndmsv 
-унитаризм.ndmsv ункус.ndmsv унтертон.ndmsv уорд.ndmsv уралит.ndmsv уран.ndmsv 
-уранат.ndmsv уранил.ndmsv уранилдинитрат.ndmsv уранилкарбонат.ndmsv уранинит.ndmsv уранит.ndmsv 
-ураноскоп.ndmsv урат.ndmsv урацил.ndmsv урбанизм.ndmsv уретан.ndmsv уретрит.ndmsv 
-уретроренофиброскоп.ndmsv уретроскоп.ndmsv уринал.ndmsv урман.ndmsv уробилин.ndmsv уровнемер.ndmsv 
-уродан.ndmsv урометр.ndmsv уротропин.ndmsv уряд.ndmsv утильзавод.ndmsv утопизм.ndmsv 
-ухаб.ndmsv уход.ndmsv учес.ndmsv фабком.ndmsv фабрикат.ndmsv фавор.ndmsv 
-фаворитизм.ndmsv фагоцит.ndmsv фагоцитоз.ndmsv фазер.ndmsv фазис.ndmsv фазитрон.ndmsv 
-фазоинвертор.ndmsv фазоиндикатор.ndmsv фазокомпенсатор.ndmsv фазометр.ndmsv фазорегулятор.ndmsv фазотрон.ndmsv 
-файербол.ndmsv файл.ndmsv факолит.ndmsv факс.ndmsv факт.ndmsv фактис.ndmsv 
-фактор.ndmsv факториал.ndmsv факультатив.ndmsv факультет.ndmsv фаланстер.ndmsv фалл.ndmsv 
-фаллос.ndmsv фалреп.ndmsv фальбанд.ndmsv фалькон.ndmsv фальконет.ndmsv фальсификат.ndmsv 
-фальстарт.ndmsv фальстем.ndmsv фальцаппарат.ndmsv фальцбейн.ndmsv фальцет.ndmsv фальшборт.ndmsv 
-фальшфейер.ndmsv фаматинит.ndmsv фамулус.ndmsv фанатизм.ndmsv фаншон.ndmsv фарватер.ndmsv 
-фарингит.ndmsv фаринотом.ndmsv фармаколит.ndmsv фармакосидерит.ndmsv фарс.ndmsv фарфор.ndmsv 
-фассаит.ndmsv фатализм.ndmsv фатум.ndmsv фаустпатрон.ndmsv фацет.ndmsv фашизм.ndmsv 
-фаэтон.ndmsv фаялит.ndmsv фаянс.ndmsv федерализм.ndmsv фельетон.ndmsv фельзит.ndmsv 
-феминизм.ndmsv фен.ndmsv фенакит.ndmsv фенацетин.ndmsv фенил.ndmsv фенилаланин.ndmsv 
-фенилен.ndmsv фенокристалл.ndmsv фенол.ndmsv фенолит.ndmsv фенолоспирт.ndmsv фенолспирт.ndmsv 
-фенолформальдегид.ndmsv фенолфталеин.ndmsv фенолят.ndmsv феномен.ndmsv фенотип.ndmsv феод.ndmsv 
-феодализм.ndmsv феракрил.ndmsv ферберит.ndmsv ферментоанализатор.ndmsv фермион.ndmsv фермуар.ndmsv 
-феромон.ndmsv феррат.ndmsv феррит.ndmsv ферровольфрам.ndmsv ферропсевдобрукит.ndmsv феррорезонанс.ndmsv 
-ферросиликон.ndmsv ферросиликохром.ndmsv ферросплав.ndmsv феррохром.ndmsv фетишизм.ndmsv фетоскоп.ndmsv 
-фетр.ndmsv фефер.ndmsv фиакр.ndmsv фиат.ndmsv фибрин.ndmsv фибринбиопласт.ndmsv 
-фибриноген.ndmsv фибробласт.ndmsv фибробронхоскоп.ndmsv фиброгастродуоденоскоп.ndmsv фиброгастроскоп.ndmsv фиброид.ndmsv 
-фиброин.ndmsv фиброколоноскоп.ndmsv фибролит.ndmsv фиброскоп.ndmsv фиброцит.ndmsv фидеизм.ndmsv 
-фидеикомисс.ndmsv фидер.ndmsv фиельд.ndmsv физалис.ndmsv физмат.ndmsv фикс.ndmsv 
-фиксатив.ndmsv фиксатуар.ndmsv филателизм.ndmsv филипс.ndmsv филлипсит.ndmsv филлит.ndmsv 
-филлокактус.ndmsv филогенез.ndmsv филодендрон.ndmsv филон.ndmsv фильдекос.ndmsv фильдеперс.ndmsv 
-фильм.ndmsv фильмокомбинат.ndmsv фильмоскоп.ndmsv фильмостат.ndmsv фильмофон.ndmsv фильмофонд.ndmsv 
-фильтрат.ndmsv филэллин.ndmsv филюм.ndmsv фимиам.ndmsv фимоз.ndmsv фингал.ndmsv 
-фингер.ndmsv финиметр.ndmsv финишер.ndmsv финмаркет.ndmsv финотдел.ndmsv финт.ndmsv 
-фиорд.ndmsv фирман.ndmsv фирмацит.ndmsv фирн.ndmsv фитин.ndmsv фитогормон.ndmsv 
-фитопланктон.ndmsv фитотоксин.ndmsv фитотрон.ndmsv фитоценоз.ndmsv флавин.ndmsv фламин.ndmsv 
-фланелет.ndmsv флат.ndmsv флаттер.ndmsv флебит.ndmsv флеболит.ndmsv флеботом.ndmsv 
-флегматизм.ndmsv флежолет.ndmsv флексагон.ndmsv флексатон.ndmsv флексор.ndmsv флексорайтер.ndmsv 
-флер.ndmsv флерон.ndmsv флинт.ndmsv флинтглас.ndmsv флип.ndmsv флиппер.ndmsv 
-флицид.ndmsv флобафен.ndmsv флогистон.ndmsv флогопит.ndmsv флоккул.ndmsv флоккулус.ndmsv 
-флоккулятор.ndmsv флокс.ndmsv флокулянт.ndmsv фломастер.ndmsv флоридин.ndmsv флортимберс.ndmsv 
-флотоконцентрат.ndmsv флювиометр.ndmsv флюксоид.ndmsv флюорит.ndmsv флюороскоп.ndmsv флютбет.ndmsv 
-фляер.ndmsv фокометр.ndmsv фокстрот.ndmsv фокус-покус.ndmsv фол.ndmsv фолдер.ndmsv 
-фолиант.ndmsv фолликул.ndmsv фолликулин.ndmsv фолликулит.ndmsv фольклор.ndmsv фолькмот.ndmsv 
-фольксваген.ndmsv фон.ndmsv фонавтограф.ndmsv фонд.ndmsv фонендоскоп.ndmsv фонограф.ndmsv 
-фонодокумент.ndmsv фонокардиограф.ndmsv фонолит.ndmsv фонометр.ndmsv фонон.ndmsv фонопор.ndmsv 
-фоноскоп.ndmsv фонт.ndmsv форамен.ndmsv форвакуум.ndmsv форд.ndmsv фордевинд.ndmsv 
-фордизм.ndmsv фордун.ndmsv форез.ndmsv форинт.ndmsv форлянд.ndmsv форм-фактор.ndmsv 
-формализм.ndmsv формальдегид.ndmsv форматер.ndmsv форматив.ndmsv формил.ndmsv формуляр.ndmsv 
-фороракос.ndmsv форстерит.ndmsv фортран.ndmsv форум.ndmsv форхенд.ndmsv форцепс.ndmsv 
-форштадт.ndmsv форштос.ndmsv фосфид.ndmsv фосфин.ndmsv фосфит.ndmsv фосфоазот.ndmsv 
-фосфорит.ndmsv фосфороскоп.ndmsv фот.ndmsv фото-робот.ndmsv фотоавтомат.ndmsv фотоальбом.ndmsv 
-фотоаппарат.ndmsv фотоархив.ndmsv фотогелиограф.ndmsv фотоген.ndmsv фотодетектор.ndmsv фотодиод.ndmsv 
-фотодокумент.ndmsv фотодубликат.ndmsv фотозал.ndmsv фотоинжектор.ndmsv фотокадр.ndmsv фотокартограф.ndmsv 
-фотокатализатор.ndmsv фотокатод.ndmsv фотоколориметр.ndmsv фотоконкурс.ndmsv фотолиз.ndmsv фотоматериал.ndmsv 
-фотометр.ndmsv фотон.ndmsv фотонабор.ndmsv фотонейтрон.ndmsv фотообъектив.ndmsv фотоофсет.ndmsv 
-фотопериод.ndmsv фотоплан.ndmsv фотополимер.ndmsv фотополяриметр.ndmsv фотопортрет.ndmsv фотопроцесс.ndmsv 
-фотопулемет.ndmsv фотореактив.ndmsv фоторезист.ndmsv фоторезистор.ndmsv фоторецептор.ndmsv фотосинтез.ndmsv 
-фотоскоп.ndmsv фотостат.ndmsv фототаймер.ndmsv фототаксис.ndmsv фототелеграф.ndmsv фототелескоп.ndmsv 
-фототеодолит.ndmsv фототранзистор.ndmsv фототрансформатор.ndmsv фототрафарет.ndmsv фототриангулятор.ndmsv фотофон.ndmsv 
-фотофорез.ndmsv фотохромизм.ndmsv фотохронограф.ndmsv фотоцинкограф.ndmsv фотошаблон.ndmsv фотоэкспонометр.ndmsv 
-фотоэлектрокалориметр.ndmsv фотоэлектрон.ndmsv фотоэлемент.ndmsv фотоэтюд.ndmsv фотоэффект.ndmsv фразеологизм.ndmsv 
-франклин.ndmsv франклинит.ndmsv франко-вагон.ndmsv франко-завод.ndmsv франко-лихтер.ndmsv франко-порт.ndmsv 
-франко-резервуар.ndmsv франко-склад.ndmsv фратрицид.ndmsv фрейдизм.ndmsv фрейм.ndmsv фреон.ndmsv 
-фридмон.ndmsv фризер.ndmsv фрикцион.ndmsv фример.ndmsv фристайл.ndmsv фритюр.ndmsv 
-фронт.ndmsv фронтир.ndmsv фронтиспис.ndmsv фронтит.ndmsv фрюктидор.ndmsv фталазол.ndmsv 
-фталеин.ndmsv фтириаз.ndmsv фтор.ndmsv фторбромметан.ndmsv фторбромпропан.ndmsv фторбромэтан.ndmsv 
-фторгептахлорпропан.ndmsv фтордибромметан.ndmsv фтордибромпропан.ndmsv фтордибромэтан.ndmsv фтордихлорметан.ndmsv фтордихлорпропан.ndmsv 
-фтордихлорэтан.ndmsv фторид.ndmsv фтороалюминат.ndmsv фторопласт.ndmsv фторосиликат.ndmsv фтороуглерод.ndmsv 
-фторпентабромпропан.ndmsv фторпентахлорпропан.ndmsv фторпентахлорэтан.ndmsv фторполимер.ndmsv фторсекстабромпропан.ndmsv фторсекстахлорпропан.ndmsv 
-фтортетрабромпропан.ndmsv фтортетрабромэтан.ndmsv фтортетрахлорпропан.ndmsv фтортетрахлорэтан.ndmsv фтортрибромпропан.ndmsv фтортрибромэтан.ndmsv 
-фтортрихлорметан.ndmsv фтортрихлорпропан.ndmsv фтортрихлорэтан.ndmsv фторуглерод.ndmsv фторфосфат.ndmsv фторхлорметан.ndmsv 
-фторхлорпропан.ndmsv фторхлорэтан.ndmsv фторэластомер.ndmsv фукс.ndmsv фуксин.ndmsv фуксит.ndmsv 
-фукус.ndmsv фульгурит.ndmsv фульминат.ndmsv фуляр.ndmsv фумигант.ndmsv фумигатор.ndmsv 
-фунгицид.ndmsv фундамент.ndmsv фундулюс.ndmsv фуникулер.ndmsv функтор.ndmsv фунт.ndmsv 
-фуральдегид.ndmsv фурор.ndmsv фурункул.ndmsv фурункулез.ndmsv фурфурол.ndmsv фуршет.ndmsv 
-фурьеризм.ndmsv фуст.ndmsv фут.ndmsv футокс.ndmsv футор.ndmsv футофунт.ndmsv 
-футроп.ndmsv футуризм.ndmsv фьорд.ndmsv фьючерс.ndmsv фюзен.ndmsv хабуб.ndmsv 
-хаггис.ndmsv хаз.ndmsv хайболл.ndmsv хайд.ndmsv халибит.ndmsv халифат.ndmsv 
-халцедон.ndmsv халькантит.ndmsv халькозин.ndmsv халькопирит.ndmsv хамас.ndmsv хаммам.ndmsv 
-хамсин.ndmsv хаос.ndmsv характрон.ndmsv хармалин.ndmsv харматан.ndmsv хармин.ndmsv 
-харт.ndmsv хасидизм.ndmsv хаус.ndmsv хафир.ndmsv хаффман.ndmsv хван.ndmsv 
-хвостизм.ndmsv хедер.ndmsv хеймвер.ndmsv хеморецептор.ndmsv хемосенсор.ndmsv хемосинтез.ndmsv 
-хемотаксис.ndmsv хенд.ndmsv хескер.ndmsv хиазм.ndmsv хиастолит.ndmsv хиатус.ndmsv 
-хилиазм.ndmsv хилиаст.ndmsv хилус.ndmsv химизм.ndmsv химикат.ndmsv химконцентрат.ndmsv 
-химлесхоз.ndmsv химозин.ndmsv химполимер.ndmsv химреактив.ndmsv химсклад.ndmsv химснаряд.ndmsv 
-химус.ndmsv хинальдин.ndmsv хинидин.ndmsv хинин.ndmsv хиноксалин.ndmsv хинолин.ndmsv 
-хинон.ndmsv хирограф.ndmsv хит-парад.ndmsv хитон.ndmsv хладагент.ndmsv хладон.ndmsv 
-хладоэлемент.ndmsv хлебозавод.ndmsv хлебокомбинат.ndmsv хлебород.ndmsv хлопкозавод.ndmsv хлопкокомбайн.ndmsv 
-хлорал.ndmsv хлоралгидрат.ndmsv хлорамин.ndmsv хлорат.ndmsv хлоратор.ndmsv хлорацетофенон.ndmsv 
-хлорбензол.ndmsv хлорвинил.ndmsv хлоргидратдиметиламин.ndmsv хлоргидрохинон.ndmsv хлорид.ndmsv хлорин.ndmsv 
-хлорит.ndmsv хлорнафталин.ndmsv хлоро-фтор-углерод.ndmsv хлоро-фтороуглерод.ndmsv хлоро-фторуглерод.ndmsv хлороз.ndmsv 
-хлоропласт.ndmsv хлоропрен.ndmsv хлорофилл.ndmsv хлорофос.ndmsv хлорохин.ndmsv хлорпарафин.ndmsv 
-хлорпикрин.ndmsv хлорпродукт.ndmsv хлорфторуглерод.ndmsv хлорэтанол.ndmsv хмелеграб.ndmsv ховерпорт.ndmsv 
-хоган.ndmsv хогсхед.ndmsv хозотдел.ndmsv хозрасчет.ndmsv холангит.ndmsv холестерин.ndmsv 
-холецистит.ndmsv холизм.ndmsv холин.ndmsv холл.ndmsv холлерит.ndmsv холокауст.ndmsv 
-холокост.ndmsv холостерин.ndmsv холст.ndmsv хон.ndmsv хондрит.ndmsv хонолит.ndmsv 
-хоппер.ndmsv хордометр.ndmsv хориоменингит.ndmsv хорион.ndmsv хориямб.ndmsv хорнпайп.ndmsv 
-хоспис.ndmsv хост.ndmsv хост-адаптер.ndmsv хост-ресурс.ndmsv хоудаун.ndmsv хоумленд.ndmsv 
-храм.ndmsv хризоберилл.ndmsv хризолит.ndmsv хризолиф.ndmsv хризопраз.ndmsv хризотил.ndmsv 
-христианит.ndmsv хролофилл.ndmsv хромат.ndmsv хроматизм.ndmsv хроматин.ndmsv хроматограф.ndmsv 
-хроматолиз.ndmsv хроматоскоп.ndmsv хроматофор.ndmsv хроматрон.ndmsv хромит.ndmsv хроммагнезит.ndmsv 
-хромомагнезит.ndmsv хромопласт.ndmsv хромопротеин.ndmsv хромоскоп.ndmsv хромофор.ndmsv хронограф.ndmsv 
-хронометр.ndmsv хронон.ndmsv хроноскоп.ndmsv хронофер.ndmsv хула-хуп.ndmsv хурал.ndmsv 
-царизм.ndmsv цветонос.ndmsv цедрат.ndmsv цезаризм.ndmsv цейхгауз.ndmsv целакант.ndmsv 
-целестин.ndmsv целибат.ndmsv целлит.ndmsv целлоидин.ndmsv целлон.ndmsv целлофан.ndmsv 
-целлулоид.ndmsv целостат.ndmsv цементит.ndmsv цементовоз.ndmsv ценз.ndmsv ценоз.ndmsv 
-ценозит.ndmsv цент.ndmsv центал.ndmsv центнер.ndmsv централизм.ndmsv центризм.ndmsv 
-центроплан.ndmsv центумвират.ndmsv ценуроз.ndmsv цеолит.ndmsv цеппелин.ndmsv церебролизат.ndmsv 
-церезин.ndmsv церемониал.ndmsv цереус.ndmsv церит.ndmsv церковнославянизм.ndmsv церолит.ndmsv 
-церулоплазмин.ndmsv церуссит.ndmsv цестус.ndmsv цехин.ndmsv цехком.ndmsv циан.ndmsv 
-цианамид.ndmsv цианат.ndmsv цианид.ndmsv цианин.ndmsv цианит.ndmsv цианоз.ndmsv 
-цианозит.ndmsv цианокобаламин.ndmsv цианометр.ndmsv цианурхлорид.ndmsv цибетин.ndmsv цикламен.ndmsv 
-циклит.ndmsv циклогексан.ndmsv циклогексанон.ndmsv циклогенез.ndmsv циклодром.ndmsv циклометр.ndmsv 
-циклонит.ndmsv циклонометр.ndmsv циклотрон.ndmsv циклофон.ndmsv цилиндр.ndmsv цилиндроид.ndmsv 
-цимофан.ndmsv цинизм.ndmsv цинкит.ndmsv циозит.ndmsv циперус.ndmsv циркон.ndmsv 
-циркулятор.ndmsv циркумфлекс.ndmsv цирроз.ndmsv цистеин.ndmsv цистин.ndmsv цистит.ndmsv 
-цистицеркоз.ndmsv цистоскоп.ndmsv цистрон.ndmsv цитозин.ndmsv цитолиз.ndmsv цитолизин.ndmsv 
-цитомегаловирус.ndmsv цитотаксис.ndmsv цитофиброметр.ndmsv цитофлюориметр.ndmsv цитохром.ndmsv цитрат.ndmsv 
-цитрин.ndmsv цитрованилин.ndmsv цитрон.ndmsv цитрус.ndmsv циферблат.ndmsv цугундер.ndmsv 
-чабрец.ndmsv чалдар.ndmsv чарльстон.ndmsv чарм.ndmsv чартер.ndmsv чартизм.ndmsv 
-часослов.ndmsv частокол.ndmsv частотомер.ndmsv чеддер.ndmsv чейн.ndmsv чекер.ndmsv 
-челдрон.ndmsv человеко-час.ndmsv чембур.ndmsv чемпионат.ndmsv чепан.ndmsv черноклен.ndmsv 
-чернолоз.ndmsv черностоп.ndmsv чернотал.ndmsv чернотроп.ndmsv честер.ndmsv честерфилд.ndmsv 
-четвертьфинал.ndmsv чизбургер.ndmsv чикс.ndmsv чилим.ndmsv чип.ndmsv чистец.ndmsv 
-чистоган.ndmsv чистотел.ndmsv чистоуст.ndmsv чокбор.ndmsv чонсам.ndmsv чрен.ndmsv 
-чувал.ndmsv чуккер.ndmsv чупрун.ndmsv шабер.ndmsv шабот.ndmsv шагомер.ndmsv 
-шалман.ndmsv шаманизм.ndmsv шамбертен.ndmsv шамберьер.ndmsv шамозит.ndmsv шампиньон.ndmsv 
-шампур.ndmsv шандал.ndmsv шандор.ndmsv шанкр.ndmsv шанс.ndmsv шапирограф.ndmsv 
-шарабан.ndmsv шарап.ndmsv шариат.ndmsv шарп.ndmsv шартрез.ndmsv шарф.ndmsv 
-шато-икем.ndmsv шаттл.ndmsv шахер-махер.ndmsv швербот.ndmsv шверт.ndmsv швертбот.ndmsv 
-шевер.ndmsv шевинг-процесс.ndmsv шеврет.ndmsv шед.ndmsv шедевр.ndmsv шеелит.ndmsv 
-шейкер.ndmsv шелкокомбинат.ndmsv шелл.ndmsv шеллер.ndmsv шелом.ndmsv шельф.ndmsv 
-шерл.ndmsv шессилит.ndmsv шестопер.ndmsv шибболет.ndmsv шиворот.ndmsv шиизм.ndmsv 
-шингард.ndmsv шиньон.ndmsv ширпотреб.ndmsv шистозомиаз.ndmsv шифервейс.ndmsv шифратор.ndmsv 
-шифротекст.ndmsv шихан.ndmsv шкафут.ndmsv шкерт.ndmsv шкив.ndmsv шкимушгар.ndmsv 
-шкот.ndmsv шлагбаум.ndmsv шлакобетон.ndmsv шлакоотвал.ndmsv шлам.ndmsv шлафор.ndmsv 
-шлейф.ndmsv шлем.ndmsv шлемофон.ndmsv шликер.ndmsv шлир.ndmsv шлифт.ndmsv 
-шлягер.ndmsv шлямбур.ndmsv шмальтин.ndmsv шмон.ndmsv шмуцтитул.ndmsv шнеллер.ndmsv 
-шовинизм.ndmsv шон.ndmsv шоу-театр.ndmsv шпалозавод.ndmsv шпангоут.ndmsv шпат.ndmsv 
-шпигат.ndmsv шпицрутен.ndmsv шприц-пистолет.ndmsv шпур.ndmsv шрам.ndmsv шримс.ndmsv 
-шрифт.ndmsv шрот.ndmsv штаб.ndmsv штаб-магазин.ndmsv штамб.ndmsv штамм.ndmsv 
-штангенглубиномер.ndmsv штангензубомер.ndmsv штангенинструмент.ndmsv штандарт.ndmsv штатив.ndmsv штауфф.ndmsv 
-штекер.ndmsv штеккер.ndmsv штерт.ndmsv штирборт.ndmsv штифт.ndmsv штихмас.ndmsv 
-штормтрап.ndmsv штос.ndmsv штрипс.ndmsv штрих-пунктир.ndmsv штундизм.ndmsv штурвал.ndmsv 
-штуртрап.ndmsv штуртрос.ndmsv штуф.ndmsv штыб.ndmsv шумопеленгатор.ndmsv шунгит.ndmsv 
-шунт.ndmsv шурум-бурум.ndmsv шушпан.ndmsv шушун.ndmsv шюцкор.ndmsv щуп.ndmsv 
-эбен.ndmsv эбонит.ndmsv эбуллиоскоп.ndmsv эвакопункт.ndmsv эвапоратор.ndmsv эвапорограф.ndmsv 
-эвапорометр.ndmsv эвгенол.ndmsv эвдемонизм.ndmsv эвдиалит.ndmsv эвдиометр.ndmsv эверглейд.ndmsv 
-эвердьюпойс.ndmsv эвкалипт.ndmsv эвклаз.ndmsv эвпатрид.ndmsv эвриптер.ndmsv эвриптерус.ndmsv 
-эвстресс.ndmsv эвфемизм.ndmsv эвфонизм.ndmsv эвфуизм.ndmsv эго-статус.ndmsv эгоизм.ndmsv 
-эготизм.ndmsv эдельвейс.ndmsv эдем.ndmsv эдикт.ndmsv эжектор.ndmsv эзельгофт.ndmsv 
-эзофагоскоп.ndmsv эйдетизм.ndmsv эйдос.ndmsv эйзенхауэр.ndmsv эйфориант.ndmsv эйхинин.ndmsv 
-эквалайзер.ndmsv экватив.ndmsv экватор.ndmsv экваториал.ndmsv экер.ndmsv экзархат.ndmsv 
-экземпляр.ndmsv экзерсис.ndmsv экзерциргауз.ndmsv экзогормон.ndmsv экзон.ndmsv экзосмос.ndmsv 
-экзостоз.ndmsv экзотизм.ndmsv экзотоксин.ndmsv экзофтальм.ndmsv экзоцитоз.ndmsv экзоэлектрон.ndmsv 
-экклезиаст.ndmsv эклектизм.ndmsv эклер.ndmsv эклиметр.ndmsv эковид.ndmsv экогенез.ndmsv 
-экономайзер.ndmsv экономизм.ndmsv экономсовет.ndmsv экосез.ndmsv экостандарт.ndmsv экотип.ndmsv 
-экотоксикант.ndmsv экотон.ndmsv экотоп.ndmsv экоцид.ndmsv экпозиметр.ndmsv экраноплан.ndmsv 
-эксгаустер.ndmsv эксикатор.ndmsv эксимер.ndmsv экситон.ndmsv экскаватор.ndmsv экскалибур.ndmsv 
-эксклав.ndmsv экскремент.ndmsv экскрет.ndmsv экскурс.ndmsv экслибрис.ndmsv эксод.ndmsv 
-экспандер.ndmsv эксперимент.ndmsv эксплантат.ndmsv экспликанд.ndmsv экспликат.ndmsv экспонат.ndmsv 
-экспонометр.ndmsv экспресс.ndmsv экспресс-анализ.ndmsv экспресс-анализатор.ndmsv экспресс-груз.ndmsv экспресс-метод.ndmsv 
-экспромт.ndmsv экссудат.ndmsv экстаз.ndmsv экстензометр.ndmsv экстензор.ndmsv экстент.ndmsv 
-экстернат.ndmsv экстероцептор.ndmsv экстерьер.ndmsv экстирпатор.ndmsv экстравазат.ndmsv экстрагент.ndmsv 
-экстракласс.ndmsv экстракод.ndmsv экстракт.ndmsv экстрактор.ndmsv экстремизм.ndmsv экстремум.ndmsv 
-экструдер.ndmsv эксудат.ndmsv эксцентриситет.ndmsv эксцесс.ndmsv эксцессив.ndmsv эктлипсис.ndmsv 
-эктобласт.ndmsv эктогенез.ndmsv экуменизм.ndmsv экуменополис.ndmsv эламит.ndmsv эластин.ndmsv 
-эластомер.ndmsv элатив.ndmsv элеватор.ndmsv элевон.ndmsv электорат.ndmsv электрет.ndmsv 
-электроавтобус.ndmsv электроанализ.ndmsv электробарабан.ndmsv электробур.ndmsv электробус.ndmsv электровибратор.ndmsv 
-электровоз.ndmsv электрогенератор.ndmsv электрогидроклапан.ndmsv электрод.ndmsv электродетонатор.ndmsv электроджет.ndmsv 
-электродиализ.ndmsv электродиализатор.ndmsv электродинамометр.ndmsv электрозавод.ndmsv электрозапал.ndmsv электроизолятор.ndmsv 
-электроинструмент.ndmsv электроинтегратор.ndmsv электрокамин.ndmsv электрокар.ndmsv электрокардиограф.ndmsv электрокардиостимулятор.ndmsv 
-электрокатализатор.ndmsv электроклассификатор.ndmsv электрокомбайн.ndmsv электрокран.ndmsv электрокультиватор.ndmsv электролиз.ndmsv 
-электролизер.ndmsv электролит.ndmsv электромагазин.ndmsv электромагнит.ndmsv электроматериал.ndmsv электромегафон.ndmsv 
-электромер.ndmsv электрометр.ndmsv электромеханизм.ndmsv электромиксер.ndmsv электромотор.ndmsv электронасос.ndmsv 
-электроорган.ndmsv электроосмос.ndmsv электроотдел.ndmsv электроплед.ndmsv электропневмоклапан.ndmsv электрополотер.ndmsv 
-электроприбор.ndmsv электропривод.ndmsv электропульт.ndmsv электропылесос.ndmsv электрорадионавигатор.ndmsv электрорефлектор.ndmsv 
-электросамовар.ndmsv электросигнал.ndmsv электроскоп.ndmsv электростартер.ndmsv электротаксис.ndmsv электротеплоаккумулятор.ndmsv 
-электротонус.ndmsv электроферросплав.ndmsv электрофильтр.ndmsv электрофон.ndmsv электрофор.ndmsv электроход.ndmsv 
-электрошнур.ndmsv электрощит.ndmsv электроэндоосмос.ndmsv электроэнцефалограф.ndmsv электроэякулятор.ndmsv электрум.ndmsv 
-элемент.ndmsv элениум.ndmsv эленхос.ndmsv элеолит.ndmsv элерон.ndmsv элефантиаз.ndmsv 
-элизиум.ndmsv эликсир.ndmsv элинвар.ndmsv элинт.ndmsv элитаризм.ndmsv элконин.ndmsv 
-эллинизм.ndmsv эллипс.ndmsv эллипсис.ndmsv эллипсограф.ndmsv эллипсоид.ndmsv эльван.ndmsv 
-эльзевир.ndmsv эман.ndmsv эманометр.ndmsv эмаскулятор.ndmsv эмбол.ndmsv эмбрион.ndmsv 
-эметин.ndmsv эмират.ndmsv эмиритон.ndmsv эмитрон.ndmsv эмиттер.ndmsv эммер.ndmsv 
-эмпиризм.ndmsv эмульгатор.ndmsv эмульсин.ndmsv эмульсификатор.ndmsv эмульсоид.ndmsv эмульсор.ndmsv 
-эмулятор.ndmsv эмфизематоз.ndmsv эмфитевзис.ndmsv эндартериит.ndmsv эндемизм.ndmsv эндобласт.ndmsv 
-эндокард.ndmsv эндокардит.ndmsv эндометрит.ndmsv эндопротез.ndmsv эндорадиозонд.ndmsv эндоскоп.ndmsv 
-эндосмометр.ndmsv эндосмос.ndmsv эндосперм.ndmsv эндотерм.ndmsv эндотоксин.ndmsv эндофит.ndmsv 
-эндоэквопротез.ndmsv энеолит.ndmsv энергетизм.ndmsv энергозапас.ndmsv энергокризис.ndmsv энергообъект.ndmsv 
-энергопродуктопровод.ndmsv энерготариф.ndmsv энозис.ndmsv энтазис.ndmsv энтерит.ndmsv энтероколит.ndmsv 
-энтероптоз.ndmsv энтеросептол.ndmsv энтобласт.ndmsv энтузиазм.ndmsv энцефалит.ndmsv энцефаломиелит.ndmsv 
-эозин.ndmsv эозоон.ndmsv эолит.ndmsv эоцен.ndmsv эпексегезис.ndmsv эпентезис.ndmsv 
-эпибласт.ndmsv эпигенез.ndmsv эпиглоттис.ndmsv эпиграф.ndmsv эпидермин.ndmsv эпидермис.ndmsv 
-эпидесмин.ndmsv эпидиаскоп.ndmsv эпидот.ndmsv эпикард.ndmsv эпикардит.ndmsv эпикриз.ndmsv 
-эпикуреизм.ndmsv эпилхлоргидрин.ndmsv эпилятор.ndmsv эпископ.ndmsv эпитет.ndmsv эпифеномен.ndmsv 
-эпифиз.ndmsv эпифилл.ndmsv эпифит.ndmsv эпихлоргидрин.ndmsv эпицен.ndmsv эпицентр.ndmsv 
-эпицикл.ndmsv эпод.ndmsv эпос.ndmsv эпсилон.ndmsv эпулис.ndmsv эратосфен.ndmsv 
-эргатив.ndmsv эргограф.ndmsv эргометр.ndmsv эрготизм.ndmsv эрготин.ndmsv эрготоксин.ndmsv 
-эректор.ndmsv эретизм.ndmsv эритрит.ndmsv эритроцит.ndmsv эритроцитоз.ndmsv эркер.ndmsv 
-эрлифт.ndmsv эрос.ndmsv эротизм.ndmsv эрстед.ndmsv эскадрон.ndmsv эскалоп.ndmsv 
-эскер.ndmsv эспадрон.ndmsv эспандер.ndmsv эспарцет.ndmsv эспонтон.ndmsv эссив.ndmsv 
-эстезиометр.ndmsv эстетизм.ndmsv эстомп.ndmsv эстрагон.ndmsv эстрадиол.ndmsv эстриол.ndmsv 
-эстроген.ndmsv эстрон.ndmsv эструс.ndmsv эта-мезон.ndmsv этаминал.ndmsv этан.ndmsv 
-этанол.ndmsv этатизм.ndmsv этернит.ndmsv этил.ndmsv этилакрилат.ndmsv этилацетат.ndmsv 
-этилбензол.ndmsv этилдифторфосфин.ndmsv этилдихлорфосфин.ndmsv этилен.ndmsv этиленпентамин.ndmsv этилфосфенилдихлорид.ndmsv 
-этилфосфинилдифторид.ndmsv этилфосфонилдифторид.ndmsv этилфосфонилдихлорид.ndmsv этимон.ndmsv этит.ndmsv этишкет.ndmsv 
-этногенез.ndmsv этноним.ndmsv этнос.ndmsv этноцид.ndmsv этриоскоп.ndmsv эукариот.ndmsv 
-эфедрин.ndmsv эфемероид.ndmsv эфиронос.ndmsv эффектор.ndmsv эхин.ndmsv эхинокактус.ndmsv 
-эхо-запрос.ndmsv эхо-кардиограф.ndmsv эхо-сигнал.ndmsv эхокардиограф.ndmsv эхолокатор.ndmsv эхолот.ndmsv 
-эхосигнал.ndmsv эцезис.ndmsv эякулят.ndmsv югер.ndmsv юз.ndmsv юлиус.ndmsv 
-юниорат.ndmsv юнктад.ndmsv юс.ndmsv ют.ndmsv юферс.ndmsv явор.ndmsv 
-ядохимикат.ndmsv яйцевод.ndmsv якобиан.ndmsv ял.ndmsv ямб.ndmsv яндекс.ndmsv 
-янсенизм.ndmsv ярд.ndmsv ярозит.ndmsv ятаган.ndmsv яхонт.ndmsv яхт-клуб.ndmsv 
-яхтклуб.ndmsv ящур.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 абандон.ndmsi абдомен.ndmsi абдуктор.ndmsi абелит.ndmsi абиетин.ndmsi аблятив.ndmsi 
 абляут.ndmsi абонемент.ndmsi аборт.ndmsi абрикотин.ndmsi абсент.ndmsi абсентеизм.ndmsi 
@@ -4650,6 +3202,1454 @@
 янсенизм.ndmsi ярд.ndmsi ярозит.ndmsi ятаган.ndmsi яхонт.ndmsi яхт-клуб.ndmsi 
 яхтклуб.ndmsi ящур.ndmsi :  <morph-С,мр,но,ед,им>;
 
+абандон.ndmsv абдомен.ndmsv абдуктор.ndmsv абелит.ndmsv абиетин.ndmsv аблятив.ndmsv 
+абляут.ndmsv абонемент.ndmsv аборт.ndmsv абрикотин.ndmsv абсент.ndmsv абсентеизм.ndmsv 
+абсолютизм.ndmsv абсорбент.ndmsv абсорбер.ndmsv абсорбциометр.ndmsv абсцесс.ndmsv авангард.ndmsv 
+аванзал.ndmsv аванпорт.ndmsv аванпост.ndmsv аванс.ndmsv авантюризм.ndmsv авантюрин.ndmsv 
+авгит.ndmsv август.ndmsv аверс.ndmsv авиаагрегат.ndmsv авиабензин.ndmsv авиабилет.ndmsv 
+авиагоризонт.ndmsv авиагруз.ndmsv авиадесант.ndmsv авиазавод.ndmsv авиакомпас.ndmsv авиалайнер.ndmsv 
+авиамаршрут.ndmsv авиамотор.ndmsv авиаотряд.ndmsv авиапорт.ndmsv авиаприбор.ndmsv авиапулемет.ndmsv 
+авиарейс.ndmsv авиасалон.ndmsv авиасев.ndmsv авиатехникум.ndmsv авиафонд.ndmsv авитаминоз.ndmsv 
+авлос.ndmsv авост.ndmsv авран.ndmsv автоаларм.ndmsv автобатальон.ndmsv автобензин.ndmsv 
+автобетоновоз.ndmsv автовагон.ndmsv автовоз.ndmsv автовокзал.ndmsv автогенез.ndmsv автогенератор.ndmsv 
+автогипноз.ndmsv автограф.ndmsv автогрейд.ndmsv автогрейдер.ndmsv автогудронатор.ndmsv автодин.ndmsv 
+автодиспетчер.ndmsv автодром.ndmsv автожир.ndmsv автокартограф.ndmsv автокатализ.ndmsv автоклав.ndmsv 
+автоклуб.ndmsv автокод.ndmsv автоколлиматор.ndmsv автокомбинат.ndmsv автокомпенсатор.ndmsv автокомпрессор.ndmsv 
+автоконтакт.ndmsv автокоррелятор.ndmsv автокран.ndmsv автокросс.ndmsv автол.ndmsv автолесовоз.ndmsv 
+автолиз.ndmsv автолист.ndmsv автомагазин.ndmsv автоматизм.ndmsv автомашинист.ndmsv автомонитор.ndmsv 
+автоморфизм.ndmsv автомотоклуб.ndmsv автоним.ndmsv автооператор.ndmsv автоответ.ndmsv автоотряд.ndmsv 
+автопавильон.ndmsv автопансионат.ndmsv автопереход.ndmsv автопилот.ndmsv автоповтор.ndmsv автополимер.ndmsv 
+автопортрет.ndmsv автоприцеп.ndmsv автопровод.ndmsv авторегулятор.ndmsv автореферат.ndmsv авторефрижератор.ndmsv 
+авторитаризм.ndmsv автосалон.ndmsv автосамосвал.ndmsv автосин.ndmsv автоспорт.ndmsv автостоп.ndmsv 
+автотаймер.ndmsv автотормоз.ndmsv автотрансформатор.ndmsv автотуризм.ndmsv автофильтр.ndmsv автофургон.ndmsv 
+автохром.ndmsv автоцементовоз.ndmsv автоцентр.ndmsv автоштурман.ndmsv агал.ndmsv агалит.ndmsv 
+агальматолит.ndmsv агафит.ndmsv агглютинин.ndmsv агенс.ndmsv агитпроп.ndmsv агитпункт.ndmsv 
+агломерат.ndmsv агломератовоз.ndmsv агломератопенобетон.ndmsv агон.ndmsv аграмант.ndmsv аграмматизм.ndmsv 
+аграф.ndmsv агреман.ndmsv агробиоценоз.ndmsv агрокомбинат.ndmsv агрокомплекс.ndmsv агрометр.ndmsv 
+агроприем.ndmsv агропункт.ndmsv адалин.ndmsv адамант.ndmsv адамсит.ndmsv адаптер.ndmsv 
+адаптометр.ndmsv адат.ndmsv аддендум.ndmsv аддуктор.ndmsv аденин.ndmsv аденит.ndmsv 
+аденовирус.ndmsv адермин.ndmsv адиантум.ndmsv адонизид.ndmsv адонилен.ndmsv адонис.ndmsv 
+адреналин.ndmsv адрон.ndmsv адсорбат.ndmsv адсорбент.ndmsv адсорбер.ndmsv адстрат.ndmsv 
+адуляр.ndmsv адюльтер.ndmsv ажгон.ndmsv азан.ndmsv азид.ndmsv азин.ndmsv 
+азиридинамид.ndmsv азобензол.ndmsv азотобактерин.ndmsv азотоген.ndmsv азотфиксатор.ndmsv азур.ndmsv 
+азурит.ndmsv аил.ndmsv айлант.ndmsv аймар.ndmsv айран.ndmsv айрол.ndmsv 
+академизм.ndmsv акант.ndmsv аканф.ndmsv акарицид.ndmsv аквавит.ndmsv аквамарин.ndmsv 
+акваплан.ndmsv акваполивольфрамат.ndmsv аквариум.ndmsv аквилон.ndmsv аккомпанемент.ndmsv аккордеон.ndmsv 
+аккредитив.ndmsv аккузатив.ndmsv аккумулятор.ndmsv акмеизм.ndmsv аколит.ndmsv аком.ndmsv 
+аконит.ndmsv аконитин.ndmsv акр.ndmsv акридин.ndmsv акрихин.ndmsv акробатизм.ndmsv 
+акролеин.ndmsv акроним.ndmsv акрофут.ndmsv акс.ndmsv акселератор.ndmsv акселерометр.ndmsv 
+аксельбант.ndmsv аксерофтол.ndmsv аксессуар.ndmsv аксиометр.ndmsv аксминстер.ndmsv аксон.ndmsv 
+акт.ndmsv актант.ndmsv активатор.ndmsv актин.ndmsv актинометр.ndmsv актиномикоз.ndmsv 
+актинон.ndmsv актограф.ndmsv актомиозин.ndmsv актор.ndmsv акут.ndmsv акцептор.ndmsv 
+акцидент.ndmsv аланин.ndmsv алас.ndmsv алгезис.ndmsv алгол.ndmsv алгометр.ndmsv 
+алгоритм.ndmsv алебастр.ndmsv алеврит.ndmsv алевролит.ndmsv алейрометр.ndmsv алейрон.ndmsv 
+александрит.ndmsv алеф.ndmsv ализарин.ndmsv аликзандер.ndmsv алинеатор.ndmsv алинит.ndmsv 
+алкагест.ndmsv алкалоз.ndmsv алкалоид.ndmsv алкил.ndmsv алкоголизм.ndmsv алкоголят.ndmsv 
+алкоран.ndmsv аллатив.ndmsv аллегоризм.ndmsv аллеломорф.ndmsv аллерген.ndmsv аллил.ndmsv 
+аллицин.ndmsv аллограф.ndmsv аллод.ndmsv алломон.ndmsv аллоним.ndmsv аллополиплоид.ndmsv 
+аллоскоп.ndmsv аллотип.ndmsv аллотрансплантат.ndmsv аллофан.ndmsv аллофон.ndmsv аллюр.ndmsv 
+алогизм.ndmsv алтаит.ndmsv алуноген.ndmsv альбакор.ndmsv альбедометр.ndmsv альбидум.ndmsv 
+альбинизм.ndmsv альбион.ndmsv альбит.ndmsv альбумин.ndmsv альбуминат.ndmsv альбуминоид.ndmsv 
+альбуцид.ndmsv альгин.ndmsv альгицид.ndmsv альдегид.ndmsv альдокортин.ndmsv альдостерон.ndmsv 
+алькасар.ndmsv альмандин.ndmsv альмукантарат.ndmsv альпинизм.ndmsv альт.ndmsv альтазимут.ndmsv 
+альтгорн.ndmsv альтернант.ndmsv альтернат.ndmsv альтернатор.ndmsv альтернион.ndmsv альтиграф.ndmsv 
+альтиметр.ndmsv альтруизм.ndmsv альфатрон.ndmsv альянс.ndmsv алюминат.ndmsv алюминон.ndmsv 
+амавроз.ndmsv амазонит.ndmsv амальгаматор.ndmsv амандин.ndmsv амарант.ndmsv амариллис.ndmsv 
+амбоцептор.ndmsv амбушюр.ndmsv амвон.ndmsv амебиаз.ndmsv амебоцит.ndmsv амейоз.ndmsv 
+аметист.ndmsv амиант.ndmsv амигдалин.ndmsv амид.ndmsv амидол.ndmsv амидопирин.ndmsv 
+амикрон.ndmsv амил.ndmsv амилацетат.ndmsv амилен.ndmsv амилоидоз.ndmsv аминопирин.ndmsv 
+аминопласт.ndmsv аминоспирт.ndmsv аминофенол.ndmsv амирис.ndmsv амитоз.ndmsv аммиакат.ndmsv 
+аммонал.ndmsv аммофос.ndmsv амнион.ndmsv аморализм.ndmsv аморит.ndmsv амортизатор.ndmsv 
+аморфизм.ndmsv амофор.ndmsv ампер-час.ndmsv ампервольтваттметр.ndmsv ампервольтметр.ndmsv амперметр.ndmsv 
+амплидин.ndmsv амулет.ndmsv амфетамин.ndmsv амфибол.ndmsv амфиболит.ndmsv амфидиплоид.ndmsv 
+амфимакр.ndmsv амфимиксис.ndmsv амфион.ndmsv амфитеатр.ndmsv анабазин.ndmsv анабаптизм.ndmsv 
+анабасис.ndmsv анабиоз.ndmsv анаболизм.ndmsv анаглиф.ndmsv анадиплосис.ndmsv анакард.ndmsv 
+анаколуф.ndmsv анализ.ndmsv анализатор.ndmsv анальцим.ndmsv анамнез.ndmsv анаморфизм.ndmsv 
+анаморфоз.ndmsv ананим.ndmsv анапест.ndmsv анаплазмоз.ndmsv анапофиз.ndmsv анаптиксис.ndmsv 
+анархизм.ndmsv анастамоз.ndmsv анастигмат.ndmsv анастомоз.ndmsv анатаз.ndmsv анатоксин.ndmsv 
+анатоцизм.ndmsv анафорез.ndmsv анахронизм.ndmsv анаэробиоз.ndmsv ангажемент.ndmsv ангидрид.ndmsv 
+ангидрит.ndmsv ангиит.ndmsv ангиоспазм.ndmsv ангиотензин.ndmsv англез.ndmsv англезит.ndmsv 
+англицизм.ndmsv англофон.ndmsv ангоб.ndmsv ангстрем.ndmsv андалузит.ndmsv андезин.ndmsv 
+андезит.ndmsv андерграунд.ndmsv андеррайтер.ndmsv андроген.ndmsv андрон.ndmsv андростерон.ndmsv 
+аневрин.ndmsv анемограф.ndmsv анемометр.ndmsv анеморумбограф.ndmsv анемоскоп.ndmsv анемохор.ndmsv 
+анестезин.ndmsv анетол.ndmsv анзерин.ndmsv анид.ndmsv анизол.ndmsv анилин.ndmsv 
+анимализм.ndmsv анимизм.ndmsv анионит.ndmsv анис.ndmsv анкас.ndmsv анкерит.ndmsv 
+анкилоз.ndmsv анкилостомоз.ndmsv анклав.ndmsv аннекс.ndmsv аннит.ndmsv аннуитет.ndmsv 
+аннулятор.ndmsv анонс.ndmsv анортит.ndmsv анортозит.ndmsv анортоскоп.ndmsv анофтальм.ndmsv 
+антаблемент.ndmsv антабус.ndmsv антагонизм.ndmsv антерозоид.ndmsv антефикс.ndmsv антецедент.ndmsv 
+антиаллерген.ndmsv антиапекс.ndmsv антиатом.ndmsv антибиоз.ndmsv антивибратор.ndmsv антивирус.ndmsv 
+антигиперон.ndmsv антидепрессант.ndmsv антидетонатор.ndmsv антидот.ndmsv антикатализатор.ndmsv антикатод.ndmsv 
+антиквариат.ndmsv антиклимакс.ndmsv антикоагулянт.ndmsv антилогарифм.ndmsv антиминс.ndmsv антимир.ndmsv 
+антимонат.ndmsv антимонит.ndmsv антимуссон.ndmsv антимутаген.ndmsv антинакипин.ndmsv антинейтрон.ndmsv 
+антинуклон.ndmsv антиоксидант.ndmsv антипассат.ndmsv антипирин.ndmsv антиполлютант.ndmsv антипротон.ndmsv 
+антиптозис.ndmsv антироман.ndmsv антисемитизм.ndmsv антиспаст.ndmsv антистимул.ndmsv антитеатр.ndmsv 
+антитезис.ndmsv антитоксин.ndmsv антифебрин.ndmsv антифермент.ndmsv антиферромагнетизм.ndmsv антифон.ndmsv 
+антифраз.ndmsv антифриз.ndmsv антифунгин.ndmsv антихлор.ndmsv антициклон.ndmsv античарм.ndmsv 
+антиэлектрон.ndmsv антоним.ndmsv антофиллит.ndmsv антракноз.ndmsv антракоз.ndmsv антракосиликоз.ndmsv 
+антракс.ndmsv антрацен.ndmsv антрацит.ndmsv антрекот.ndmsv антропоген.ndmsv антрополит.ndmsv 
+антропометр.ndmsv антропоним.ndmsv антуриум.ndmsv анус.ndmsv анфракс.ndmsv анхузин.ndmsv 
+анчар.ndmsv аншлюс.ndmsv анэструс.ndmsv аорист.ndmsv аортит.ndmsv апартамент.ndmsv 
+апартеид.ndmsv апекс.ndmsv апельсин.ndmsv аперитив.ndmsv апертометр.ndmsv апиоид.ndmsv 
+апитоксин.ndmsv апланат.ndmsv апланатизм.ndmsv апломб.ndmsv апоастр.ndmsv аподозис.ndmsv 
+апозиопезис.ndmsv апокалипсис.ndmsv апоконин.ndmsv апокриф.ndmsv аполид.ndmsv аполитизм.ndmsv 
+аполлоникон.ndmsv апомиксис.ndmsv апомикт.ndmsv апоневроз.ndmsv апостат.ndmsv апостроф.ndmsv 
+апофеоз.ndmsv апохромат.ndmsv апоцентр.ndmsv аппендикс.ndmsv аппендицит.ndmsv апперкот.ndmsv 
+апплет.ndmsv аппликатор.ndmsv аппрет.ndmsv априоризм.ndmsv арабизм.ndmsv арагонит.ndmsv 
+арахис.ndmsv арахноидит.ndmsv арборицид.ndmsv арбутин.ndmsv аргал.ndmsv аргентит.ndmsv 
+аргиллит.ndmsv аргинин.ndmsv аргироид.ndmsv аргон.ndmsv арготизм.ndmsv аргумент.ndmsv 
+ардометр.ndmsv ареал.ndmsv ареоид.ndmsv ареометр.ndmsv ариллоид.ndmsv ариллус.ndmsv 
+аристон.ndmsv арифмограф.ndmsv арифмометр.ndmsv аркбутан.ndmsv арккосеканс.ndmsv арккосинус.ndmsv 
+арккотангенс.ndmsv аркоз.ndmsv арксеканс.ndmsv арксинус.ndmsv арктангенс.ndmsv армагеддон.ndmsv 
+армальколит.ndmsv армозин.ndmsv армоцемент.ndmsv армюр.ndmsv ароматизатор.ndmsv арпан.ndmsv 
+арпанет.ndmsv аррасен.ndmsv арретир.ndmsv аррорут.ndmsv арсенал.ndmsv арсенат.ndmsv 
+арсенид.ndmsv арсенит.ndmsv арсенолит.ndmsv арсенопирит.ndmsv арсис.ndmsv арталин.ndmsv 
+артдивизион.ndmsv артериит.ndmsv артериосклероз.ndmsv артефакт.ndmsv артикул.ndmsv артистизм.ndmsv 
+артобстрел.ndmsv артос.ndmsv артроз.ndmsv артроскоп.ndmsv архаизм.ndmsv архетип.ndmsv 
+архибентос.ndmsv архиватор.ndmsv архитрав.ndmsv арьергард.ndmsv асбест.ndmsv асбестит.ndmsv 
+асбестобетон.ndmsv асбестоз.ndmsv асбестонит.ndmsv асболан.ndmsv асболит.ndmsv асбоцемент.ndmsv 
+асидерит.ndmsv асидетон.ndmsv асидол.ndmsv асиндетон.ndmsv асканит.ndmsv аскаридоз.ndmsv 
+аскетизм.ndmsv аспарагин.ndmsv аспарагус.ndmsv аспидиум.ndmsv аспиратор.ndmsv асс.ndmsv 
+ассемблер.ndmsv ассонанс.ndmsv ассортимент.ndmsv астатизм.ndmsv астеризм.ndmsv астероид.ndmsv 
+астигмат.ndmsv астигматизатор.ndmsv астрагал.ndmsv астралин.ndmsv астралит.ndmsv астрограф.ndmsv 
+астрокомпас.ndmsv астрокупол.ndmsv астрон.ndmsv астропеленгатор.ndmsv астроскоп.ndmsv астрофотометр.ndmsv 
+асфальтит.ndmsv асцит.ndmsv атавизм.ndmsv атаксит.ndmsv атеизм.ndmsv ателектаз.ndmsv 
+атероматоз.ndmsv атетоз.ndmsv атлетизм.ndmsv атмометр.ndmsv атмосфериум.ndmsv атолл.ndmsv 
+атомизатор.ndmsv атомизм.ndmsv атомоход.ndmsv атофан.ndmsv атрибут.ndmsv атриум.ndmsv 
+атропин.ndmsv аттентат.ndmsv аттенюатор.ndmsv аттестат.ndmsv аттитюд.ndmsv аттрактант.ndmsv 
+аттрактор.ndmsv аттракцион.ndmsv аттрибут.ndmsv аттрит.ndmsv аудиенц-зал.ndmsv аудиограф.ndmsv 
+аудиоматериал.ndmsv аудиометр.ndmsv аудион.ndmsv аудиоскоп.ndmsv аудиофон.ndmsv аудифон.ndmsv 
+ауксанограф.ndmsv ауксанометр.ndmsv ауксин.ndmsv аурамин.ndmsv аурат.ndmsv ауреомицин.ndmsv 
+аурипигмент.ndmsv аурихальцит.ndmsv аустенит.ndmsv аут.ndmsv ауткросс.ndmsv аутогипноз.ndmsv 
+аутотрансплантат.ndmsv аутригер.ndmsv афанит.ndmsv аферезис.ndmsv афицид.ndmsv афоризм.ndmsv 
+афронт.ndmsv аффект.ndmsv аффидевит.ndmsv аффикс.ndmsv аффинор.ndmsv ахондрит.ndmsv 
+ахромат.ndmsv ахроматизм.ndmsv ахроматин.ndmsv ацетальдегид.ndmsv ацетанилид.ndmsv ацетилен.ndmsv 
+ацетилхолин.ndmsv ацетометр.ndmsv ацидоз.ndmsv ацроптилон.ndmsv аэратор.ndmsv аэроаллерген.ndmsv 
+аэробиоз.ndmsv аэробус.ndmsv аэровокзал.ndmsv аэрогаммарадиометр.ndmsv аэрограф.ndmsv аэродром.ndmsv 
+аэроклуб.ndmsv аэролит.ndmsv аэролифт.ndmsv аэрометеорограф.ndmsv аэрометр.ndmsv аэрон.ndmsv 
+аэроневроз.ndmsv аэроплан.ndmsv аэросев.ndmsv аэросидерит.ndmsv аэросолоскоп.ndmsv аэростат.ndmsv 
+аэротаксис.ndmsv аэротермометр.ndmsv аэрофильтр.ndmsv аэрофит.ndmsv аэрофлот.ndmsv аэрофон.ndmsv 
+аэрофор.ndmsv аэрофототрансформатор.ndmsv бабувизм.ndmsv багер.ndmsv багрец.ndmsv бадан.ndmsv 
+бадминтон.ndmsv бадьян.ndmsv база-магазин.ndmsv базальт.ndmsv базамент.ndmsv базилект.ndmsv 
+байкалит.ndmsv байонет.ndmsv байпас.ndmsv байронизм.ndmsv байт-код.ndmsv бакан.ndmsv 
+бакаут.ndmsv бакборт.ndmsv бакелит.ndmsv баклажан.ndmsv бакпорт.ndmsv бакт.ndmsv 
+бактериоз.ndmsv бактериолиз.ndmsv бактериолизин.ndmsv бактериородопсин.ndmsv бактериостат.ndmsv бактерицид.ndmsv 
+бакштейн.ndmsv бал-маскарад.ndmsv балдахин.ndmsv балластер.ndmsv баллер.ndmsv баллистит.ndmsv 
+баллистокардиограф.ndmsv баллонет.ndmsv балмакан.ndmsv бальзамин.ndmsv бампер.ndmsv банан.ndmsv 
+бандитизм.ndmsv баннер.ndmsv баннерет.ndmsv бант.ndmsv баньян.ndmsv баобаб.ndmsv 
+баптизм.ndmsv барбакан.ndmsv барбарис.ndmsv барбет.ndmsv барбитал.ndmsv барбитурат.ndmsv 
+барботер.ndmsv барботин.ndmsv баргоут.ndmsv барельеф.ndmsv бареттер.ndmsv барион.ndmsv 
+барит.ndmsv барицентр.ndmsv баркан.ndmsv барн.ndmsv барограф.ndmsv барометр.ndmsv 
+барорецептор.ndmsv бароскоп.ndmsv баростат.ndmsv баротермометр.ndmsv барристер.ndmsv барстер.ndmsv 
+бартер.ndmsv бархоут.ndmsv баскетбол.ndmsv бассетгорн.ndmsv бастр.ndmsv батальон.ndmsv 
+батан.ndmsv батат.ndmsv батипитометр.ndmsv батиплан.ndmsv батискаф.ndmsv батитермограф.ndmsv 
+батман.ndmsv батокс.ndmsv батолит.ndmsv батометр.ndmsv батон.ndmsv батопорт.ndmsv 
+батуд.ndmsv батут.ndmsv баул.ndmsv баштан.ndmsv беватрон.ndmsv бедекер.ndmsv 
+бедлам.ndmsv бедленд.ndmsv бейдевинд.ndmsv бейлер.ndmsv бейсбол.ndmsv бейт.ndmsv 
+бейфут.ndmsv бейшлот.ndmsv бекар.ndmsv беккерельметр.ndmsv беккросс.ndmsv бекхенд.ndmsv 
+белозор.ndmsv белоус.ndmsv бельведер.ndmsv бельмес.ndmsv бельморез.ndmsv бельфлер.ndmsv 
+бензедрин.ndmsv бензиномер.ndmsv бензовоз.ndmsv бензоин.ndmsv бензол.ndmsv бензомер.ndmsv 
+бензонасос.ndmsv бензонафтол.ndmsv бензопровод.ndmsv бензорез.ndmsv бензофильтр.ndmsv бентонит.ndmsv 
+бентос.ndmsv бенуар.ndmsv бергамот.ndmsv бересклет.ndmsv берет.ndmsv берилл.ndmsv 
+бериллиоз.ndmsv берсез.ndmsv бест.ndmsv бестселлер.ndmsv бета-радиометр.ndmsv бетаин.ndmsv 
+бетатрон.ndmsv бетонит.ndmsv бетоновоз.ndmsv бетонолом.ndmsv бетононасос.ndmsv бетонэлемент.ndmsv 
+бефстроганов.ndmsv бешмет.ndmsv биатлон.ndmsv биб.ndmsv бибколлектор.ndmsv библиобус.ndmsv 
+бивалент.ndmsv бивектор.ndmsv бивертин.ndmsv бигус.ndmsv бигхед.ndmsv бизнес.ndmsv 
+бизнес-инкубатор.ndmsv бизнес-план.ndmsv бизнес-проект.ndmsv бикарбид.ndmsv бикарбонат.ndmsv биквадрат.ndmsv 
+бикомпакт.ndmsv бикс.ndmsv бикхед.ndmsv билирубин.ndmsv билирубинометр.ndmsv биллет.ndmsv 
+биллион.ndmsv бильгарциоз.ndmsv бильдаппарат.ndmsv биметалл.ndmsv бимс.ndmsv бинейтрон.ndmsv 
+бином.ndmsv биогенез.ndmsv биогеоценоз.ndmsv биогерм.ndmsv биоиндикатор.ndmsv биокатализатор.ndmsv 
+биолант.ndmsv биолизис.ndmsv биолит.ndmsv биологизм.ndmsv биоматериал.ndmsv биомицин.ndmsv 
+бионт.ndmsv биоорганизм.ndmsv биополимер.ndmsv биопотенциал.ndmsv биопрепарат.ndmsv биореактор.ndmsv 
+биорегулятор.ndmsv биоритм.ndmsv биосинтез.ndmsv биоскоп.ndmsv биостимулятор.ndmsv биостром.ndmsv 
+биотип.ndmsv биотит.ndmsv биотоп.ndmsv биотрон.ndmsv биотуалет.ndmsv биофильтр.ndmsv 
+биофильтратор.ndmsv биоценоз.ndmsv биоцикл.ndmsv биоэффект.ndmsv биплан.ndmsv бисмалит.ndmsv 
+биссиноз.ndmsv бистр.ndmsv бисульфат.ndmsv бисульфит.ndmsv битер.ndmsv битмап.ndmsv 
+битмэп.ndmsv битумовоз.ndmsv бифитер.ndmsv бифунктор.ndmsv бифштекс.ndmsv бихромат.ndmsv 
+бицепс.ndmsv бицилиндр.ndmsv благовест.ndmsv бланк-заказ.ndmsv бланкизм.ndmsv бланфикс.ndmsv 
+бласт.ndmsv бластомер.ndmsv блат.ndmsv блезир.ndmsv блейвейс.ndmsv блейзер.ndmsv 
+блейштейн.ndmsv бленкер.ndmsv блефарит.ndmsv блинд.ndmsv блинкер.ndmsv блистер.ndmsv 
+блистр.ndmsv блицтурнир.ndmsv блок-аппарат.ndmsv блок-комплект.ndmsv блок-контейнер.ndmsv блок-пакет.ndmsv 
+блок-полис.ndmsv блок-сигнал.ndmsv блок-тормоз.ndmsv блокатор.ndmsv блокгауз.ndmsv блокиратор.ndmsv 
+блокпост.ndmsv блокшив.ndmsv блузон.ndmsv блюз.ndmsv блюм.ndmsv блюмс.ndmsv 
+бод.ndmsv боезапас.ndmsv боезаряд.ndmsv боекомплект.ndmsv боеприпас.ndmsv бозон.ndmsv 
+бойкот.ndmsv бойлер.ndmsv бокал.ndmsv бокс.ndmsv боксит.ndmsv болиголов.ndmsv 
+болид.ndmsv болограф.ndmsv болометр.ndmsv болт.ndmsv большевизм.ndmsv болюс.ndmsv 
+бомбазин.ndmsv бомбардон.ndmsv бомбовоз.ndmsv бомбомет.ndmsv бомонд.ndmsv бонитет.ndmsv 
+боннет.ndmsv боп.ndmsv боразон.ndmsv борат.ndmsv борацит.ndmsv боргес.ndmsv 
+борд.ndmsv бордерленд.ndmsv борид.ndmsv борн.ndmsv борнит.ndmsv бороментол.ndmsv 
+боросиликат.ndmsv бороскоп.ndmsv бортприпас.ndmsv боскет.ndmsv ботворез.ndmsv ботулизм.ndmsv 
+брадзот.ndmsv брадион.ndmsv брайлофон.ndmsv бракет.ndmsv браманизм.ndmsv брамин.ndmsv 
+брандмауэр.ndmsv брандспойт.ndmsv брас.ndmsv брасс.ndmsv браузер.ndmsv брахманизм.ndmsv 
+бревис.ndmsv бревномер.ndmsv брегет.ndmsv брезент.ndmsv брейд-вымпел.ndmsv брекватер.ndmsv 
+бриз.ndmsv бриллиант.ndmsv бриллиантин.ndmsv брильянт.ndmsv бриолин.ndmsv брогам.ndmsv 
+брокат.ndmsv бромат.ndmsv бромацетон.ndmsv бромид.ndmsv бромоводород.ndmsv бромпортрет.ndmsv 
+бромурал.ndmsv бронежилет.ndmsv бронетранспортер.ndmsv бронхит.ndmsv бронхоаденит.ndmsv бронхоскоп.ndmsv 
+брудер.ndmsv брудергауз.ndmsv брудершафт.ndmsv брукит.ndmsv брульон.ndmsv бруцеллез.ndmsv 
+брэнд.ndmsv брюмер.ndmsv бтр.ndmsv буддизм.ndmsv бузун.ndmsv буклет.ndmsv 
+буксус.ndmsv буланжерит.ndmsv бульдозер.ndmsv бум.ndmsv бунд.ndmsv бундесвер.ndmsv 
+бундесрат.ndmsv бурат.ndmsv бурдон.ndmsv буревал.ndmsv буркун.ndmsv бурнонит.ndmsv 
+бурозем.ndmsv буронос.ndmsv буррет.ndmsv бурсит.ndmsv бурхан.ndmsv бустер.ndmsv 
+бут.ndmsv бутадиен.ndmsv бутерброд.ndmsv бутил.ndmsv бутилен.ndmsv бутирометр.ndmsv 
+бутобетон.ndmsv бутон.ndmsv бутстрап.ndmsv буцентавр.ndmsv бушприт.ndmsv бытовизм.ndmsv 
+бьеф.ndmsv бэкус.ndmsv бэр.ndmsv бювет.ndmsv бюст.ndmsv в-блокатор.ndmsv 
+ваап.ndmsv вагинизм.ndmsv вагинит.ndmsv вагонооборот.ndmsv вадемекум.ndmsv вазомотор.ndmsv 
+вазон.ndmsv вакуум-аппарат.ndmsv вакуум-компрессор.ndmsv вакуум-насос.ndmsv вакуум-пресс.ndmsv вакуум-фильтр.ndmsv 
+вакуум-щит.ndmsv вакуумметр.ndmsv валер.ndmsv вализер.ndmsv валокордин.ndmsv вальс.ndmsv 
+вальтрап.ndmsv вальян.ndmsv вампум.ndmsv ванадат.ndmsv ванадинит.ndmsv вандализм.ndmsv 
+вандемьер.ndmsv вандрут.ndmsv вантоз.ndmsv ванчес.ndmsv вапориметр.ndmsv варактор.ndmsv 
+варваризм.ndmsv вариатор.ndmsv вариетет.ndmsv вариолит.ndmsv вариометр.ndmsv вариофон.ndmsv 
+варитрон.ndmsv варметр.ndmsv варрант.ndmsv васкулит.ndmsv вассалитет.ndmsv ватервейс.ndmsv 
+ватержакет.ndmsv ватерклозет.ndmsv ватерпас.ndmsv ватерштаг.ndmsv ватман.ndmsv ватт-час.ndmsv 
+ваттметр.ndmsv вахтпарад.ndmsv вашгерд.ndmsv вгиб.ndmsv вебсайт.ndmsv вегетоневроз.ndmsv 
+ведаизм.ndmsv ведизм.ndmsv вездеход.ndmsv везикулит.ndmsv везувиан.ndmsv вейсманизм.ndmsv 
+векторметр.ndmsv велд.ndmsv велодром.ndmsv велозавод.ndmsv велокросс.ndmsv велосипед.ndmsv 
+велосит.ndmsv велоспорт.ndmsv велотренажер.ndmsv велоэргометр.ndmsv вельбот.ndmsv вельветин.ndmsv 
+вельветон.ndmsv вельд.ndmsv вельс.ndmsv велюр.ndmsv вендиспансер.ndmsv веннер.ndmsv 
+вентилятор.ndmsv вераскоп.ndmsv верджинел.ndmsv вердикт.ndmsv веризм.ndmsv верификатор.ndmsv 
+верлибр.ndmsv вермахт.ndmsv вермикулит.ndmsv вермильон.ndmsv верньер.ndmsv веронал.ndmsv 
+верп.ndmsv вертоград.ndmsv вертодром.ndmsv вертолет.ndmsv вестерн.ndmsv ветнадзор.ndmsv 
+ветпрепарат.ndmsv ветпункт.ndmsv ветровал.ndmsv ветролом.ndmsv ветромер.ndmsv ветрочет.ndmsv 
+взаимозачет.ndmsv взвоз.ndmsv взгляд.ndmsv взлом.ndmsv взмет.ndmsv взмыв.ndmsv 
+взнос.ndmsv взор.ndmsv взрез.ndmsv взрыв.ndmsv взъезд.ndmsv вибратор.ndmsv 
+вибрафон.ndmsv виброграф.ndmsv виброгрохот.ndmsv виброзонд.ndmsv виброметр.ndmsv вибромолот.ndmsv 
+виброскоп.ndmsv вибротрон.ndmsv виброфон.ndmsv виброшум.ndmsv вивианит.ndmsv вигамор.ndmsv 
+вигвам.ndmsv видеоадаптер.ndmsv видеоархив.ndmsv видеодокумент.ndmsv видеозал.ndmsv видеоимпульс.ndmsv 
+видеоканал.ndmsv видеоклип.ndmsv видеомагнитофон.ndmsv видеоматериал.ndmsv видеомонитор.ndmsv видеоплейер.ndmsv 
+видеопоказ.ndmsv видеопродукт.ndmsv видеопроектор.ndmsv видеорежим.ndmsv видеоряд.ndmsv видеосалон.ndmsv 
+видеосигнал.ndmsv видеосюжет.ndmsv видеотекс.ndmsv видеотекст.ndmsv видеотелефон.ndmsv видеотерминал.ndmsv 
+видеотюнер.ndmsv видеофильм.ndmsv видеоэкран.ndmsv видикон.ndmsv византин.ndmsv визионизм.ndmsv 
+визуализатор.ndmsv викариат.ndmsv викиап.ndmsv виксатин.ndmsv вилайет.ndmsv виллис.ndmsv 
+вильтон.ndmsv винград.ndmsv виндротор.ndmsv виндроуэр.ndmsv виндсерфер.ndmsv винзавод.ndmsv 
+винил.ndmsv винилит.ndmsv винипласт.ndmsv виноматериал.ndmsv виномер.ndmsv винопровод.ndmsv 
+винсент.ndmsv винторез.ndmsv винчестер.ndmsv виппер.ndmsv вирилизм.ndmsv вирт.ndmsv 
+вискозиметр.ndmsv вискозин.ndmsv висмутин.ndmsv висмутит.ndmsv висцин.ndmsv витализм.ndmsv 
+вителлин.ndmsv витерит.ndmsv вицмундир.ndmsv влагомер.ndmsv влагооборот.ndmsv водовод.ndmsv 
+водоворот.ndmsv водогнет.ndmsv водозабор.ndmsv водоканал.ndmsv водоотвод.ndmsv водоотлив.ndmsv 
+водоподъем.ndmsv водопровод.ndmsv водораздел.ndmsv водорез.ndmsv водосбор.ndmsv водосброс.ndmsv 
+водоскат.ndmsv водослив.ndmsv военкомат.ndmsv вождизм.ndmsv возглас.ndmsv воздуховод.ndmsv 
+воздухомер.ndmsv воздухообмен.ndmsv воздухопровод.ndmsv воздухофильтр.ndmsv возраст.ndmsv вокализм.ndmsv 
+вокатив.ndmsv вокодер.ndmsv волан.ndmsv волейбол.ndmsv волитив.ndmsv волластонит.ndmsv 
+волновод.ndmsv волнограф.ndmsv волнолет.ndmsv волнолом.ndmsv волномер.ndmsv волноотвод.ndmsv 
+волноплан.ndmsv волнорез.ndmsv волован.ndmsv волокнит.ndmsv воломит.ndmsv вольвокс.ndmsv 
+вольтаметр.ndmsv вольтамперметр.ndmsv вольтметр.ndmsv вольтомметр.ndmsv вольтоммиллиамперметр.ndmsv вольфрам.ndmsv 
+вольфрамат.ndmsv вольфрамит.ndmsv волюменометр.ndmsv волюметр.ndmsv волюминометр.ndmsv волюнтатив.ndmsv 
+воробьевит.ndmsv ворсит.ndmsv воскопресс.ndmsv восход.ndmsv вотум.ndmsv вронскиан.ndmsv 
+всас.ndmsv всхлип.ndmsv всхрап.ndmsv вуз.ndmsv вулкан.ndmsv вулканизм.ndmsv 
+вулканит.ndmsv вульгаризм.ndmsv вульпинит.ndmsv вульфенит.ndmsv вход.ndmsv въезд.ndmsv 
+выверт.ndmsv выгиб.ndmsv выжереб.ndmsv вызов.ndmsv выкос.ndmsv выкус.ndmsv 
+вылет.ndmsv вымпелком.ndmsv вымпелфал.ndmsv выпад.ndmsv выпот.ndmsv высвист.ndmsv 
+высов.ndmsv высотомер.ndmsv выхват.ndmsv выхлоп.ndmsv вычет.ndmsv вюрцит.ndmsv 
+габион.ndmsv габитус.ndmsv гавот.ndmsv гагат.ndmsv гадолинит.ndmsv газават.ndmsv 
+газатор.ndmsv газгольдер.ndmsv газлифт.ndmsv газоанализатор.ndmsv газоаппарат.ndmsv газобаллон.ndmsv 
+газобетон.ndmsv газовоз.ndmsv газоген.ndmsv газогенератор.ndmsv газоконденсат.ndmsv газолин.ndmsv 
+газомер.ndmsv газомет.ndmsv газометр.ndmsv газомотор.ndmsv газообмен.ndmsv газоотвод.ndmsv 
+газоотсос.ndmsv газопровод.ndmsv газопроводоотвод.ndmsv газосигнализатор.ndmsv газотрон.ndmsv газотурбовоз.ndmsv 
+газотурбогенератор.ndmsv газотурбоход.ndmsv газоход.ndmsv газошлакозолобетон.ndmsv гайдроп.ndmsv гайковерт.ndmsv 
+гайморит.ndmsv гайтан.ndmsv гакаборт.ndmsv галактометр.ndmsv галалит.ndmsv галантир.ndmsv 
+галеас.ndmsv галенит.ndmsv галеон.ndmsv галиот.ndmsv галипот.ndmsv галлицизм.ndmsv 
+галлон.ndmsv галлуазит.ndmsv галогенид.ndmsv галогенуглеводород.ndmsv галон.ndmsv галоп.ndmsv 
+галотан.ndmsv галп.ndmsv галс.ndmsv галфвинд.ndmsv гальванизм.ndmsv гальванометр.ndmsv 
+гальваноскоп.ndmsv гальваностереотип.ndmsv гальванотаксис.ndmsv гальюн.ndmsv гамамелис.ndmsv гамбургер.ndmsv 
+гамелан.ndmsv гаметофит.ndmsv гамильтониан.ndmsv гамлетизм.ndmsv гамма-плотномер.ndmsv гандбол.ndmsv 
+гандизм.ndmsv гандикап.ndmsv ганистер.ndmsv ганит.ndmsv гаолян.ndmsv гаплозис.ndmsv 
+гаптен.ndmsv гаптоглобин.ndmsv гарвард.ndmsv гардероб.ndmsv гарлем.ndmsv гармонизатор.ndmsv 
+гармонограф.ndmsv гарниерит.ndmsv гарнизон.ndmsv гарпиус.ndmsv гарт.ndmsv гастрит.ndmsv 
+гастроскоп.ndmsv гастрофилез.ndmsv гастроэнтерит.ndmsv гаулейтер.ndmsv гаусс.ndmsv гбайт.ndmsv 
+гваякол.ndmsv гвоздодер.ndmsv гебраизм.ndmsv гедонизм.ndmsv гейзерит.ndmsv гейландит.ndmsv 
+гейм.ndmsv геймбол.ndmsv гекельфон.ndmsv гекзаметр.ndmsv гексахлоран.ndmsv гексахорд.ndmsv 
+гексаэдр.ndmsv гексод.ndmsv гектар.ndmsv гектограмм.ndmsv гектограф.ndmsv гектолитр.ndmsv 
+гектометр.ndmsv гелигнит.ndmsv геликоид.ndmsv геликон.ndmsv геликоптер.ndmsv гелиограф.ndmsv 
+гелиодор.ndmsv гелиометр.ndmsv гелиоскоп.ndmsv гелиостат.ndmsv гелиотаксис.ndmsv гелиотроп.ndmsv 
+гелиотропин.ndmsv гелофит.ndmsv гельвет.ndmsv гельминтоз.ndmsv гельмпорт.ndmsv гем.ndmsv 
+гематин.ndmsv гематит.ndmsv гематобласт.ndmsv гематоген.ndmsv гематокрит.ndmsv гемоглобин.ndmsv 
+гемопоэз.ndmsv гемоторакс.ndmsv гемоцитометр.ndmsv генезис.ndmsv генерал-бас.ndmsv генералитет.ndmsv 
+генератор.ndmsv генетив.ndmsv генитив.ndmsv генобласт.ndmsv генотип.ndmsv генофонд.ndmsv 
+геноцид.ndmsv генриметр.ndmsv генштаб.ndmsv геоид.ndmsv геообъект.ndmsv геопроцесс.ndmsv 
+геоскоп.ndmsv геотаксис.ndmsv геотрон.ndmsv геотропизм.ndmsv геофон.ndmsv гепатит.ndmsv 
+гепатопротектор.ndmsv гептаметр.ndmsv гептан.ndmsv гептахорд.ndmsv гептаэдр.ndmsv гептод.ndmsv 
+герб.ndmsv германизм.ndmsv герминатор.ndmsv гермицид.ndmsv гермошлем.ndmsv героизм.ndmsv 
+герпес.ndmsv герундив.ndmsv герцметр.ndmsv гессиан.ndmsv гест.ndmsv гестаген.ndmsv 
+гетеризм.ndmsv гетеродин.ndmsv гетерозис.ndmsv гетероморфоз.ndmsv гетеротрансплантат.ndmsv гетит.ndmsv 
+геттер.ndmsv гешефт.ndmsv гештальт.ndmsv гиалин.ndmsv гиалит.ndmsv гиалоген.ndmsv 
+гиаломер.ndmsv гиацинт.ndmsv гиббереллин.ndmsv гиббсит.ndmsv гибискус.ndmsv гибридер.ndmsv 
+гигабайт.ndmsv гигантизм.ndmsv гигрин.ndmsv гигрограф.ndmsv гигрометр.ndmsv гигроскоп.ndmsv 
+гигростат.ndmsv гигрофит.ndmsv гидантоин.ndmsv гидденит.ndmsv гидразин.ndmsv гидрамнион.ndmsv 
+гидрант.ndmsv гидрартроз.ndmsv гидрастин.ndmsv гидрастинин.ndmsv гидрат.ndmsv гидрид.ndmsv 
+гидроавтомат.ndmsv гидроагрегат.ndmsv гидроаэродром.ndmsv гидроаэроионизатор.ndmsv гидробур.ndmsv гидрогенератор.ndmsv 
+гидродамал.ndmsv гидроканал.ndmsv гидроклав.ndmsv гидрокс.ndmsv гидроксил.ndmsv гидролит.ndmsv 
+гидролокатор.ndmsv гидрометеор.ndmsv гидромеханизм.ndmsv гидромонитор.ndmsv гидромотор.ndmsv гидронасос.ndmsv 
+гидронефроз.ndmsv гидроним.ndmsv гидроплан.ndmsv гидропланер.ndmsv гидропресс.ndmsv гидропривод.ndmsv 
+гидропульт.ndmsv гидроразрыв.ndmsv гидросамолет.ndmsv гидросепаратор.ndmsv гидроскоп.ndmsv гидростат.ndmsv 
+гидросульфат.ndmsv гидросульфит.ndmsv гидротаксис.ndmsv гидроторакс.ndmsv гидротормоз.ndmsv гидроторф.ndmsv 
+гидротрансформатор.ndmsv гидротроп.ndmsv гидротрубопровод.ndmsv гидротурбогенератор.ndmsv гидрофан.ndmsv гидрофит.ndmsv 
+гидрофон.ndmsv гидрофор.ndmsv гидрохинон.ndmsv гидроцилиндр.ndmsv гильберт.ndmsv гимен.ndmsv 
+гимн.ndmsv гинофор.ndmsv гипербатон.ndmsv гиперболоид.ndmsv гипервитаминоз.ndmsv гиперзаряд.ndmsv 
+гиперизм.ndmsv гиперкератоз.ndmsv гиперкинез.ndmsv гиперкосмос.ndmsv гиперон.ndmsv гиперостоз.ndmsv 
+гиперсол.ndmsv гиперстен.ndmsv гипертекст.ndmsv гипертензин.ndmsv гипертиреоз.ndmsv гипершар.ndmsv 
+гипноз.ndmsv гипнотизм.ndmsv гипобласт.ndmsv гиповитаминоз.ndmsv гипокауст.ndmsv гипоксантин.ndmsv 
+гиполимнион.ndmsv гипопаратиреоз.ndmsv гипопион.ndmsv гипостаз.ndmsv гипостасис.ndmsv гипостом.ndmsv 
+гипосульфит.ndmsv гипотаксис.ndmsv гипоталамус.ndmsv гипоталлус.ndmsv гипофаринкс.ndmsv гипофиз.ndmsv 
+гипоцентр.ndmsv гиппокамп.ndmsv гипсобетон.ndmsv гипсолит.ndmsv гипсометр.ndmsv гипсотермометр.ndmsv 
+гиратор.ndmsv гиробус.ndmsv гирогоризонт.ndmsv гирокомпас.ndmsv гиролит.ndmsv гирополукомпас.ndmsv 
+гироскоп.ndmsv гиростабилизатор.ndmsv гиростат.ndmsv гирудин.ndmsv гистамин.ndmsv гистерезис.ndmsv 
+гистерометр.ndmsv гистероскоп.ndmsv гистидин.ndmsv гистобласт.ndmsv гистогенез.ndmsv гит.ndmsv 
+гитерс.ndmsv гитлеризм.ndmsv гитов.ndmsv гладиолус.ndmsv глазомер.ndmsv глайд.ndmsv 
+гласис.ndmsv глауберит.ndmsv глауконит.ndmsv глаукофан.ndmsv глезер.ndmsv глейкометр.ndmsv 
+глет.ndmsv гликоген.ndmsv гликозид.ndmsv глинит.ndmsv глинобетон.ndmsv глинозем.ndmsv 
+глипт.ndmsv глиптодонт.ndmsv глистогон.ndmsv глиф.ndmsv глицерид.ndmsv глицерофосфат.ndmsv 
+глобин.ndmsv глобоид.ndmsv глобулин.ndmsv глобулит.ndmsv глоссит.ndmsv глубиномер.ndmsv 
+глубомер.ndmsv глутамат.ndmsv глутамин.ndmsv глыбодроб.ndmsv глюкагон.ndmsv глюкокортикоид.ndmsv 
+глюон.ndmsv глютен.ndmsv глютин.ndmsv гмелинит.ndmsv гнатонемус.ndmsv гнейс.ndmsv 
+гнет.ndmsv гномон.ndmsv гностицизм.ndmsv го-сотерн.ndmsv гоацин.ndmsv гоббл.ndmsv 
+говлит.ndmsv годограф.ndmsv голландер.ndmsv голлендер.ndmsv голливуд.ndmsv голотип.ndmsv 
+голофан.ndmsv голоцен.ndmsv голоэдр.ndmsv гоматропин.ndmsv гомеоморфизм.ndmsv гомеостазис.ndmsv 
+гомеостат.ndmsv гомерид.ndmsv гоминдан.ndmsv гоминьдан.ndmsv гомогенизатор.ndmsv гомоеозис.ndmsv 
+гомоморфизм.ndmsv гомополимер.ndmsv гомстед.ndmsv гонадотропин.ndmsv гониометр.ndmsv гонт.ndmsv 
+гопкалит.ndmsv гоппер-фидер.ndmsv горводоканал.ndmsv горельеф.ndmsv горжилхоз.ndmsv горизонт.ndmsv 
+горисполком.ndmsv горицвет.ndmsv горком.ndmsv горкомхоз.ndmsv гороптер.ndmsv гороскоп.ndmsv 
+горсовет.ndmsv госбюджет.ndmsv госдеп.ndmsv госдепартамент.ndmsv госзаказ.ndmsv госкомитет.ndmsv 
+госконцерн.ndmsv госкредит.ndmsv госпакет.ndmsv госпромхоз.ndmsv госпротокол.ndmsv госсипин.ndmsv 
+госуниверситет.ndmsv госхоз.ndmsv госцентр.ndmsv госэкзамен.ndmsv грабен.ndmsv гравилат.ndmsv 
+гравиметр.ndmsv гравитометр.ndmsv гравитон.ndmsv градиент.ndmsv грамицидин.ndmsv грамм.ndmsv 
+грамм-атом.ndmsv грамм-эквивалент.ndmsv граммофон.ndmsv гранатомет.ndmsv гранитоид.ndmsv гранолит.ndmsv 
+гранофир.ndmsv гранпасьянс.ndmsv грант.ndmsv гранулит.ndmsv гранулоцит.ndmsv гранулятор.ndmsv 
+граптолит.ndmsv грат.ndmsv граунд.ndmsv графитопласт.ndmsv графкомбинат.ndmsv графометр.ndmsv 
+грейпфрут.ndmsv грецизм.ndmsv гречиховод.ndmsv гридистор.ndmsv гриль-бар.ndmsv грим.ndmsv 
+гриот.ndmsv гриффон.ndmsv грозводоканал.ndmsv громоотвод.ndmsv гросс.ndmsv гросс-чартер.ndmsv 
+гросфатер.ndmsv грот.ndmsv гроулер.ndmsv груббер.ndmsv грузомакет.ndmsv грунтобетон.ndmsv 
+грунтозацеп.ndmsv грунтонос.ndmsv грунтопровод.ndmsv группоид.ndmsv грэмит.ndmsv грэхемит.ndmsv 
+гуанин.ndmsv гудронатор.ndmsv гужон.ndmsv гукер.ndmsv гульден.ndmsv гуманизм.ndmsv 
+гумин.ndmsv гумит.ndmsv гуммигут.ndmsv гуммикопал.ndmsv гуммит.ndmsv гумус.ndmsv 
+гурд.ndmsv гурт.ndmsv гуссит.ndmsv гуэмал.ndmsv гэз.ndmsv гюйс.ndmsv 
+дагерротип.ndmsv дадаизм.ndmsv дазар.ndmsv дайджест.ndmsv дайм.ndmsv дайон.ndmsv 
+дакриоаденит.ndmsv дакриоцистит.ndmsv дакрон.ndmsv дальномер.ndmsv дальтон.ndmsv дальтон-план.ndmsv 
+дальтонизм.ndmsv дамаст.ndmsv даменит.ndmsv дамп.ndmsv даосизм.ndmsv дарвинизм.ndmsv 
+датолит.ndmsv даукарин.ndmsv даусонит.ndmsv дацан.ndmsv дацит.ndmsv двоетес.ndmsv 
+двурост.ndmsv двутавр.ndmsv двучлен.ndmsv деаэратор.ndmsv дебаркадер.ndmsv дебит.ndmsv 
+девиатор.ndmsv девясил.ndmsv дегерминатор.ndmsv дедвейт.ndmsv дезагрегант.ndmsv дезигнат.ndmsv 
+дезинтегратор.ndmsv дезинфектор.ndmsv дезодорант.ndmsv дезодоратор.ndmsv дезоксирибонуклеотид.ndmsv деизм.ndmsv 
+деисус.ndmsv дейдвуд.ndmsv дейтафон.ndmsv дейтерид.ndmsv дейтрон.ndmsv декабризм.ndmsv 
+декагон.ndmsv декаграмм.ndmsv декаданс.ndmsv декалин.ndmsv декалитр.ndmsv декаметр.ndmsv 
+деканат.ndmsv декапод.ndmsv декастер.ndmsv декаэдр.ndmsv деклинатор.ndmsv деклинограф.ndmsv 
+деклинометр.ndmsv декодер.ndmsv декокт.ndmsv декомпрессор.ndmsv декор.ndmsv декорт.ndmsv 
+декортикатор.ndmsv декорум.ndmsv декремент.ndmsv декстрин.ndmsv декстринизатор.ndmsv декуплет.ndmsv 
+деликатес.ndmsv деликт.ndmsv делинквент.ndmsv делириум.ndmsv дельтаплан.ndmsv дельтоид.ndmsv 
+дельтоэдр.ndmsv дельфиниум.ndmsv демерол.ndmsv демикотон.ndmsv демимонд.ndmsv демодулятор.ndmsv 
+демонизм.ndmsv демос.ndmsv демультипликатор.ndmsv денатурат.ndmsv дендроид.ndmsv дендрометр.ndmsv 
+дендрон.ndmsv денотат.ndmsv денсиметр.ndmsv денситометр.ndmsv дентин.ndmsv деодорант.ndmsv 
+департамент.ndmsv депилятор.ndmsv деполяризатор.ndmsv депорт.ndmsv депрессант.ndmsv депрессор.ndmsv 
+дер.ndmsv дератизатор.ndmsv деревобетон.ndmsv дерен.ndmsv дерепрессор.ndmsv дериват.ndmsv 
+дермантин.ndmsv дерматин.ndmsv дерматит.ndmsv дерматоген.ndmsv дерматоз.ndmsv дерматоид.ndmsv 
+дерматофит.ndmsv дермоид.ndmsv дернорез.ndmsv дерносним.ndmsv деррик-кран.ndmsv десигнат.ndmsv 
+десикант.ndmsv десикатор.ndmsv дескриптор.ndmsv деспотизм.ndmsv деструктор.ndmsv десублиматор.ndmsv 
+детандер.ndmsv детектафон.ndmsv детектор.ndmsv детергент.ndmsv детерминатив.ndmsv детонатор.ndmsv 
+детонометр.ndmsv детранслятор.ndmsv детрит.ndmsv дефектоскоп.ndmsv деферент.ndmsv дефибратор.ndmsv 
+дефибрер.ndmsv дефибриллятор.ndmsv дефинитив.ndmsv дефис.ndmsv дефлегматор.ndmsv дефлектор.ndmsv 
+дефлятор.ndmsv дефолиант.ndmsv дефростер.ndmsv децемвират.ndmsv децибел.ndmsv децибелметр.ndmsv 
+дециграмм.ndmsv децилитр.ndmsv дециллион.ndmsv дециметр.ndmsv дешифратор.ndmsv деэмульгатор.ndmsv 
+деэмульсатор.ndmsv джаз.ndmsv джаз-банд.ndmsv джаз-оркестр.ndmsv джаз-центр.ndmsv джайв.ndmsv 
+джайнизм.ndmsv джампан.ndmsv джекфрут.ndmsv джемпринт.ndmsv джемсонит.ndmsv джеспилит.ndmsv 
+джиггер.ndmsv джингоизм.ndmsv джип.ndmsv джулеп.ndmsv джут.ndmsv дзерен.ndmsv 
+дзот.ndmsv диабаз.ndmsv диабет.ndmsv диагенез.ndmsv диагноз.ndmsv диаграф.ndmsv 
+диазин.ndmsv диазоматериал.ndmsv диазоэфир.ndmsv диаклаз.ndmsv диалектизм.ndmsv диализ.ndmsv 
+диализат.ndmsv диализатор.ndmsv диамант.ndmsv диамат.ndmsv диаметр.ndmsv диамид.ndmsv 
+диамин.ndmsv диапазон.ndmsv диапозитив.ndmsv диапроектор.ndmsv диартроз.ndmsv диаскоп.ndmsv 
+диастаз.ndmsv диастер.ndmsv диатез.ndmsv диатермокоагулятор.ndmsv диатомин.ndmsv диатомит.ndmsv 
+диафан.ndmsv диафанометр.ndmsv диафаноскоп.ndmsv диафиз.ndmsv диафильм.ndmsv диафон.ndmsv 
+дибазол.ndmsv дивертикул.ndmsv дивертисмент.ndmsv дивертор.ndmsv дивиденд.ndmsv дивидент.ndmsv 
+дивизион.ndmsv дивизор.ndmsv дивинил.ndmsv дигален.ndmsv дигидрат.ndmsv дигитайзер.ndmsv 
+дигиталис.ndmsv диглиф.ndmsv диграф.ndmsv дидактизм.ndmsv дидодекаэдр.ndmsv диен.ndmsv 
+диетпродукт.ndmsv дизайн.ndmsv дизассемблер.ndmsv дизель-мотор.ndmsv дизельэлектроход.ndmsv дизохол.ndmsv 
+дизъюнкт.ndmsv диксиленд.ndmsv диктант.ndmsv диктат.ndmsv диктограф.ndmsv диктофон.ndmsv 
+диктум.ndmsv дилатограф.ndmsv дилатометр.ndmsv дилижанс.ndmsv дилятатор.ndmsv димайз-чартер.ndmsv 
+димер.ndmsv диметилфталат.ndmsv диметр.ndmsv диморфизм.ndmsv димюон.ndmsv динаметр.ndmsv 
+динамизм.ndmsv динамобаллистокардиограф.ndmsv динамограф.ndmsv динамометр.ndmsv динамоскоп.ndmsv динамотор.ndmsv 
+динаполис.ndmsv динар.ndmsv динас.ndmsv динатрон.ndmsv динейтрон.ndmsv динорнис.ndmsv 
+диод.ndmsv дионин.ndmsv диопсид.ndmsv диоптаз.ndmsv диоптограф.ndmsv диоптр.ndmsv 
+диорит.ndmsv диплекс.ndmsv диплот.ndmsv дипротодон.ndmsv диргем.ndmsv директорат.ndmsv 
+дирхем.ndmsv дисбаланс.ndmsv дискант.ndmsv дисклимакс.ndmsv дисконтинуум.ndmsv дискос.ndmsv 
+дискриминант.ndmsv дискриминатор.ndmsv дискурс.ndmsv диспансер.ndmsv диспашер.ndmsv диспергатор.ndmsv 
+диспут.ndmsv диссектор.ndmsv диссонанс.ndmsv дистиллер.ndmsv дистиллят.ndmsv дистиллятор.ndmsv 
+дистресс.ndmsv дистрикт.ndmsv дисульфан.ndmsv дисульфат.ndmsv дисульфид.ndmsv дисульфонат.ndmsv 
+дитриглиф.ndmsv диурез.ndmsv диуретин.ndmsv дифенил.ndmsv дифениламин.ndmsv дифирамб.ndmsv 
+дифосген.ndmsv дифтерит.ndmsv дифтонгоид.ndmsv диффаматор.ndmsv диффеоморфизм.ndmsv дифферент.ndmsv 
+дифферентометр.ndmsv дифференциал.ndmsv дифференциатор.ndmsv диффузат.ndmsv дихлорофос.ndmsv дихлофос.ndmsv 
+дихроизм.ndmsv дихромат.ndmsv дицинодонт.ndmsv диэдр.ndmsv диэлектрофорез.ndmsv диэнцефалон.ndmsv 
+диэтил.ndmsv диэтиламид.ndmsv добор.ndmsv доворот.ndmsv доггер.ndmsv догкарт.ndmsv 
+догляд.ndmsv догмат.ndmsv догматизм.ndmsv додекаэдр.ndmsv дождемер.ndmsv дозатор.ndmsv 
+дозиметр.ndmsv доклад.ndmsv докторат.ndmsv документ.ndmsv документоооборот.ndmsv долерит.ndmsv 
+долиман.ndmsv доллар.ndmsv доломан.ndmsv дольмен.ndmsv домен.ndmsv доминиген.ndmsv 
+доминион.ndmsv домком.ndmsv домкрат.ndmsv домовоз.ndmsv домол.ndmsv донжон.ndmsv 
+донос.ndmsv доппель-центнер.ndmsv допризыв.ndmsv дормез.ndmsv дорн.ndmsv дортуар.ndmsv 
+достархан.ndmsv драглайн.ndmsv драгметалл.ndmsv драгстер.ndmsv драйв.ndmsv драматизм.ndmsv 
+драмтеатр.ndmsv драндулет.ndmsv дредноут.ndmsv дренчер.ndmsv дрифт.ndmsv дрифтер.ndmsv 
+дромгед.ndmsv дросс.ndmsv дрот.ndmsv друидизм.ndmsv дуализм.ndmsv дубликат.ndmsv 
+дублон.ndmsv дубль-бекар.ndmsv дубль-диез.ndmsv дубль-негатив.ndmsv дубль-позитив.ndmsv дукат.ndmsv 
+дульцин.ndmsv думпкар.ndmsv дунит.ndmsv дуоденит.ndmsv дуоплазмотрон.ndmsv дуплекс-процесс.ndmsv 
+дуплет.ndmsv дупликатор.ndmsv дутар.ndmsv дуумвират.ndmsv духан.ndmsv дымоанализатор.ndmsv 
+дымокур.ndmsv дымоотвод.ndmsv дымопровод.ndmsv дымоход.ndmsv дырокол.ndmsv дюйм.ndmsv 
+дюкер.ndmsv дюпрен.ndmsv дюрол.ndmsv дюрометр.ndmsv дюшес.ndmsv евродоллар.ndmsv 
+европеизм.ndmsv евросоюз.ndmsv емшан.ndmsv епископат.ndmsv ертаул.ndmsv ефод.ndmsv 
+жадеит.ndmsv жакан.ndmsv жакт.ndmsv жанр.ndmsv жанризм.ndmsv жаргонизм.ndmsv 
+жарт.ndmsv жбан.ndmsv жгут.ndmsv жезл.ndmsv железобетон.ndmsv железографит.ndmsv 
+желтозем.ndmsv желтоцвет.ndmsv женотдел.ndmsv женсовет.ndmsv жиклер.ndmsv жилкомхоз.ndmsv 
+жилотдел.ndmsv жилфонд.ndmsv жиркомбинат.ndmsv жирнозем.ndmsv жирокомбинат.ndmsv жирооборот.ndmsv 
+жиропот.ndmsv жироприказ.ndmsv жирорасчет.ndmsv жокей-клуб.ndmsv жом.ndmsv жор.ndmsv 
+жордан.ndmsv жостер.ndmsv жульен.ndmsv жупел.ndmsv журнализм.ndmsv журфикс.ndmsv 
+завком.ndmsv заворот.ndmsv заглот.ndmsv заготпункт.ndmsv загранаппарат.ndmsv заграндокумент.ndmsv 
+загс.ndmsv загул.ndmsv закидон.ndmsv законопроект.ndmsv залп.ndmsv зальбанд.ndmsv 
+замес.ndmsv заплот.ndmsv заплыв.ndmsv заратит.ndmsv зарез.ndmsv зарод.ndmsv 
+засев.ndmsv засов.ndmsv затл.ndmsv захлеб.ndmsv звездолет.ndmsv звездопад.ndmsv 
+зверосовхоз.ndmsv звздолет.ndmsv звуколокатор.ndmsv звукообраз.ndmsv звукопровод.ndmsv звукоряд.ndmsv 
+здравотдел.ndmsv здравпункт.ndmsv зеин.ndmsv землевоз.ndmsv землеотвод.ndmsv землесос.ndmsv 
+земснаряд.ndmsv земфонд.ndmsv зеолит.ndmsv зеркалит.ndmsv зерноаспиратор.ndmsv зернокомбайн.ndmsv 
+зернопровод.ndmsv зернопульт.ndmsv зерносклад.ndmsv зерносовхоз.ndmsv зерноэлеватор.ndmsv зет.ndmsv 
+зиггурат.ndmsv зиккурат.ndmsv зимоген.ndmsv зитцкриг.ndmsv златоцвет.ndmsv знакогенератор.ndmsv 
+зов.ndmsv золоотвал.ndmsv зонд.ndmsv зонт.ndmsv зоолит.ndmsv зоомагазин.ndmsv 
+зооморфизм.ndmsv зооноз.ndmsv зоопланктон.ndmsv зоосад.ndmsv зооценоз.ndmsv зооцентр.ndmsv 
+зумпф.ndmsv зыбун.ndmsv зюйд.ndmsv иглофильтр.ndmsv игнитрон.ndmsv идеализм.ndmsv 
+идентификатор.ndmsv идефикс.ndmsv идиобласт.ndmsv идиолект.ndmsv идиоматизм.ndmsv идиотизм.ndmsv 
+идиофон.ndmsv идокраз.ndmsv иезуитизм.ndmsv иероглиф.ndmsv изатин.ndmsv изафенин.ndmsv 
+изафет.ndmsv избирком.ndmsv извет.ndmsv извив.ndmsv извод.ndmsv изворот.ndmsv 
+изгиб.ndmsv излет.ndmsv измолот.ndmsv износ.ndmsv изоамилацетат.ndmsv изобутан.ndmsv 
+изобутилен.ndmsv изодиморфизм.ndmsv изоколон.ndmsv изолюкс.ndmsv изолятор.ndmsv изоморфизм.ndmsv 
+изопрен.ndmsv изоспин.ndmsv изотон.ndmsv изофермент.ndmsv изохолестерин.ndmsv изохронизм.ndmsv 
+изоцентр.ndmsv икарус.ndmsv иконоскоп.ndmsv иконостас.ndmsv икос.ndmsv икосаэдр.ndmsv 
+икромет.ndmsv икс.ndmsv икт.ndmsv иктус.ndmsv илеит.ndmsv иллиризм.ndmsv 
+иллюзион.ndmsv ильм.ndmsv ильменит.ndmsv имажинизм.ndmsv имамат.ndmsv имарет.ndmsv 
+именослов.ndmsv имидазол.ndmsv иммельман.ndmsv иммитанс.ndmsv имморализм.ndmsv иммунитет.ndmsv 
+иммуноглобулин.ndmsv иммунодепрессант.ndmsv иммунокорректор.ndmsv иммунопрепарат.ndmsv иммуностимулятор.ndmsv иммунотоксин.ndmsv 
+иммуноцит.ndmsv импеллер.ndmsv императив.ndmsv империал.ndmsv имперфект.ndmsv импичмент.ndmsv 
+импост.ndmsv инактиватор.ndmsv инвар.ndmsv инверсор.ndmsv инвертин.ndmsv инвертор.ndmsv 
+ингалятор.ndmsv ингибитор.ndmsv ингредиент.ndmsv ингридиент.ndmsv индамин.ndmsv индемнитет.ndmsv 
+индент.ndmsv индикан.ndmsv индикатив.ndmsv индикатор.ndmsv индикт.ndmsv индоксил.ndmsv 
+индол.ndmsv индоссамент.ndmsv индофенол.ndmsv индуизм.ndmsv индуктор.ndmsv инжектор.ndmsv 
+инклинатор.ndmsv инклинометр.ndmsv инклюзив.ndmsv инкремент.ndmsv инкубатор.ndmsv инозин.ndmsv 
+инозит.ndmsv инсайт.ndmsv инсектофунгицид.ndmsv инсорит.ndmsv инспекторат.ndmsv инсталлятор.ndmsv 
+инстинкт.ndmsv инсулин.ndmsv инсульт.ndmsv интеграл.ndmsv интегратор.ndmsv интеграф.ndmsv 
+интеллект.ndmsv интенсиметр.ndmsv интенсификатор.ndmsv интервал.ndmsv интердикт.ndmsv интеркомпрессор.ndmsv 
+интернат.ndmsv интернет.ndmsv интерполятор.ndmsv интерфакс.ndmsv интерфейс.ndmsv интерферометр.ndmsv 
+интерфикс.ndmsv интерцептор.ndmsv интерьер.ndmsv интроскоп.ndmsv интуиционизм.ndmsv инулин.ndmsv 
+инфикс.ndmsv инфильтрат.ndmsv инфинитив.ndmsv инфлятор.ndmsv информпатент.ndmsv информприбор.ndmsv 
+инфорсмент.ndmsv инцидент.ndmsv инъюнктив.ndmsv иоганнес.ndmsv иод.ndmsv иодид.ndmsv 
+иол.ndmsv ионизатор.ndmsv ионит.ndmsv ионоген.ndmsv иономер.ndmsv ионофорез.ndmsv 
+ионтофорез.ndmsv ипподром.ndmsv ипсилон.ndmsv иранизм.ndmsv иргизит.ndmsv ирмос.ndmsv 
+ислам.ndmsv исламизм.ndmsv испанизм.ndmsv испод.ndmsv исполком.ndmsv иссоп.ndmsv 
+истеблишмент.ndmsv истмат.ndmsv истод.ndmsv историзм.ndmsv истэблишмент.ndmsv итальянизм.ndmsv 
+итератор.ndmsv иудаизм.ndmsv ихтиоз.ndmsv ихтиокол.ndmsv ихтиол.ndmsv ихтиолит.ndmsv 
+ишиас.ndmsv йогурт.ndmsv йодат.ndmsv йодид.ndmsv йодоформ.ndmsv кабелепровод.ndmsv 
+кабель-кран.ndmsv кабестан.ndmsv кабошон.ndmsv кабриолет.ndmsv кавальер.ndmsv каверномер.ndmsv 
+каверпойнт.ndmsv кагал.ndmsv каганат.ndmsv кагат.ndmsv кадаверин.ndmsv кадавр.ndmsv 
+каданс.ndmsv кадастр.ndmsv казакин.ndmsv казеин.ndmsv казеиноген.ndmsv казимир.ndmsv 
+казинет.ndmsv каинит.ndmsv кайнозит.ndmsv кактоид.ndmsv кактус.ndmsv кала-азар.ndmsv 
+калам.ndmsv каламин.ndmsv каламит.ndmsv каландр.ndmsv калган.ndmsv калейдоскоп.ndmsv 
+калейдофон.ndmsv калиаппарат.ndmsv калибромер.ndmsv калиброметр.ndmsv калифат.ndmsv каллаит.ndmsv 
+каллус.ndmsv калоризатор.ndmsv калориметр.ndmsv калорифер.ndmsv калуфер.ndmsv калым.ndmsv 
+кальвадос.ndmsv кальвинизм.ndmsv калькулятор.ndmsv кальцекс.ndmsv кальцит.ndmsv кальциферол.ndmsv 
+кальян.ndmsv калюмет.ndmsv калютрон.ndmsv камбуз.ndmsv камербанд.ndmsv камерон.ndmsv 
+камертон.ndmsv камлот.ndmsv камнемет.ndmsv камнепад.ndmsv камуфлет.ndmsv камышит.ndmsv 
+канаус.ndmsv канделябр.ndmsv кандибобер.ndmsv кандиль-синап.ndmsv кандым.ndmsv канкан.ndmsv 
+канкроид.ndmsv канон.ndmsv кантаридин.ndmsv кантарус.ndmsv канторис.ndmsv канцеляризм.ndmsv 
+канцелярит.ndmsv канцер.ndmsv канцероген.ndmsv каньон.ndmsv каолин.ndmsv каолинит.ndmsv 
+каон.ndmsv каперс.ndmsv капилляр.ndmsv капитализм.ndmsv капитул.ndmsv капонир.ndmsv 
+капор.ndmsv капот.ndmsv капремонт.ndmsv каприс.ndmsv капролактам.ndmsv капрон.ndmsv 
+капсид.ndmsv каптал.ndmsv капут.ndmsv капюшон.ndmsv карабин.ndmsv карантин.ndmsv 
+карат.ndmsv карачун.ndmsv карбазол.ndmsv карбас.ndmsv карбинол.ndmsv карбоксил.ndmsv 
+карболеин.ndmsv карболен.ndmsv карболинеум.ndmsv карболит.ndmsv карбон.ndmsv карбонат.ndmsv 
+карбонил.ndmsv карбонит.ndmsv карборан.ndmsv карборунд.ndmsv карбункул.ndmsv карбункулез.ndmsv 
+карбюратор.ndmsv карбюризатор.ndmsv кардиган.ndmsv кардиограф.ndmsv кардиосклероз.ndmsv кардиостимулятор.ndmsv 
+кардит.ndmsv кардиф.ndmsv кариес.ndmsv карильон.ndmsv кариогенез.ndmsv кариотип.ndmsv 
+карленгс.ndmsv кармазин.ndmsv карнавал.ndmsv карналлит.ndmsv карнеол.ndmsv карнотит.ndmsv 
+каротин.ndmsv карраген.ndmsv карст.ndmsv картер.ndmsv карцер.ndmsv карьеризм.ndmsv 
+касса-реал.ndmsv кассир-автомат.ndmsv касситерит.ndmsv кассореал.ndmsv кастет.ndmsv катаболизм.ndmsv 
+катаклизм.ndmsv каталексис.ndmsv катализ.ndmsv катализатор.ndmsv катамаран.ndmsv катарсис.ndmsv 
+катастат.ndmsv кататермометр.ndmsv катафорез.ndmsv катафот.ndmsv катафронт.ndmsv катенан.ndmsv 
+катеноид.ndmsv катет.ndmsv катетер.ndmsv катетометр.ndmsv катехизатор.ndmsv катехизис.ndmsv 
+катехоламин.ndmsv катион.ndmsv катлинит.ndmsv католит.ndmsv католицизм.ndmsv катрен.ndmsv 
+каудекс.ndmsv каузатив.ndmsv каучуконос.ndmsv каф.ndmsv кафешантан.ndmsv кашемир.ndmsv 
+каштан.ndmsv кбайт.ndmsv кбит.ndmsv кбод.ndmsv квадрант.ndmsv квадриллион.ndmsv 
+квадрильон.ndmsv квадрумвират.ndmsv квадруплекс.ndmsv квадруплет.ndmsv квазар.ndmsv квазиатом.ndmsv 
+квазиделикт.ndmsv квазиимпульс.ndmsv квалификатор.ndmsv квантизатор.ndmsv квантификатор.ndmsv квантометр.ndmsv 
+квантор.ndmsv квартал.ndmsv квартер.ndmsv кварцит.ndmsv кватернион.ndmsv кверцит.ndmsv 
+кверцитрон.ndmsv квиетизм.ndmsv квикстеп.ndmsv квинтал.ndmsv квинтет.ndmsv квинтиллион.ndmsv 
+квинтильон.ndmsv кворум.ndmsv кеб.ndmsv кеватрон.ndmsv кегельбан.ndmsv кедр.ndmsv 
+кейбер.ndmsv кейс.ndmsv кекс.ndmsv келоид.ndmsv кельвин.ndmsv кенаф.ndmsv 
+кенотаф.ndmsv кенотрон.ndmsv керамзит.ndmsv керамит.ndmsv кераргирит.ndmsv кератин.ndmsv 
+кератит.ndmsv кератоз.ndmsv кератофир.ndmsv кермезит.ndmsv керн.ndmsv кернер.ndmsv 
+керогаз.ndmsv керонафт.ndmsv керосинопровод.ndmsv керосинорез.ndmsv керсантит.ndmsv керченит.ndmsv 
+кетгут.ndmsv кетчуп.ndmsv кианит.ndmsv кивот.ndmsv киддерминстер.ndmsv кизельгур.ndmsv 
+кизерит.ndmsv килдеркин.ndmsv килектор.ndmsv килим.ndmsv килоампер.ndmsv килобайт.ndmsv 
+килобар.ndmsv киловатт-час.ndmsv киловольтметр.ndmsv килограмм.ndmsv килограммометр.ndmsv килолитр.ndmsv 
+километр.ndmsv килоом.ndmsv килопонд.ndmsv килоэлектронвольт.ndmsv килт.ndmsv кильватер.ndmsv 
+кильсон.ndmsv кимберлит.ndmsv кимвал.ndmsv кимограф.ndmsv кингстон.ndmsv кинематограф.ndmsv 
+кинеограф.ndmsv кинескоп.ndmsv кинетеодолит.ndmsv кинетоскоп.ndmsv киноаппарат.ndmsv киноархив.ndmsv 
+кинобилет.ndmsv киновидеоматериал.ndmsv киновидеопоказ.ndmsv киновидеофильм.ndmsv киновидеофотодокумент.ndmsv кинодокумент.ndmsv 
+киножурнал.ndmsv кинозал.ndmsv киноизм.ndmsv кинокадр.ndmsv кинокомплект.ndmsv киноконцерн.ndmsv 
+киноконцерт.ndmsv киноматериал.ndmsv кинообъектив.ndmsv кинопавильон.ndmsv киноплакат.ndmsv кинопоказ.ndmsv 
+кинопроектор.ndmsv кинопрожектор.ndmsv кинопрокат.ndmsv кинопросмотр.ndmsv кинопулемет.ndmsv киносеанс.ndmsv 
+киносериал.ndmsv кинотеатр.ndmsv кинотеодолит.ndmsv кинотехникум.ndmsv кинофакультет.ndmsv кинофильм.ndmsv 
+кинофотодокумент.ndmsv кинофотоматериал.ndmsv кинофоторентгеноматериал.ndmsv кинофотофонодокумент.ndmsv кинофотофономатериал.ndmsv киноцентр.ndmsv 
+киноэкран.ndmsv киноэкскурс.ndmsv киот.ndmsv кипп.ndmsv кирказон.ndmsv киршвассер.ndmsv 
+кислород.ndmsv кислотомер.ndmsv китаизм.ndmsv кифоз.ndmsv клавесин.ndmsv клавилюкс.ndmsv 
+клавир.ndmsv клавицимбал.ndmsv клаксон.ndmsv кламмер.ndmsv клан.ndmsv клап.ndmsv 
+клапштос.ndmsv кларен.ndmsv кларендон.ndmsv кларенс.ndmsv кларнет.ndmsv классицизм.ndmsv 
+кластер.ndmsv клатрат.ndmsv клаусталит.ndmsv клевант.ndmsv клевеит.ndmsv клеймор.ndmsv 
+клерет.ndmsv клидонограф.ndmsv климакс.ndmsv климат.ndmsv климатрон.ndmsv клинекс.ndmsv 
+клинометр.ndmsv клиностат.ndmsv клинчер.ndmsv клир.ndmsv клиренс.ndmsv клирос.ndmsv 
+клистрон.ndmsv клитор.ndmsv клов.ndmsv клонус.ndmsv клопомор.ndmsv клопфер.ndmsv 
+клот.ndmsv клуатр.ndmsv клупп.ndmsv клюв.ndmsv клюз.ndmsv клюфт.ndmsv 
+клямс.ndmsv кляп.ndmsv кляссер.ndmsv кнастер.ndmsv кнессет.ndmsv кнехт.ndmsv 
+книгообмен.ndmsv книксен.ndmsv кнут.ndmsv коагулянт.ndmsv коагулят.ndmsv коагулятор.ndmsv 
+коацерват.ndmsv кобалтин.ndmsv кобальт.ndmsv кобальтин.ndmsv кобблер.ndmsv кобол.ndmsv 
+когерер.ndmsv кодасил.ndmsv кодекс.ndmsv кодер.ndmsv кодон.ndmsv кожтовар.ndmsv 
+кожуун.ndmsv козлетон.ndmsv коитус.ndmsv кок-сагыз.ndmsv кокаин.ndmsv кокаинизм.ndmsv 
+кокос.ndmsv кокпит.ndmsv коксит.ndmsv коксобензол.ndmsv коксоцерит.ndmsv кокцидиоз.ndmsv 
+коленвал.ndmsv колет.ndmsv колит.ndmsv коллаген.ndmsv коллайдер.ndmsv коллапс.ndmsv 
+коллапсар.ndmsv колларгол.ndmsv коллект.ndmsv коллектив.ndmsv коллетериум.ndmsv коллиматор.ndmsv 
+коллодиум.ndmsv коллоквиум.ndmsv коллоксилин.ndmsv коловорот.ndmsv колоквинт.ndmsv колонат.ndmsv 
+колоноскоп.ndmsv колонтитул.ndmsv колор.ndmsv колориметр.ndmsv колофон.ndmsv колтун.ndmsv 
+колумбит.ndmsv колун.ndmsv колхицин.ndmsv колчедан.ndmsv кольдкрем.ndmsv кольт.ndmsv 
+кольтер.ndmsv колюр.ndmsv комбайн.ndmsv комбед.ndmsv комбижир.ndmsv комбинат.ndmsv 
+комбинезон.ndmsv комизм.ndmsv комикс.ndmsv комингс.ndmsv комиссариат.ndmsv комитат.ndmsv 
+комитет.ndmsv коммунизм.ndmsv коммуникатор.ndmsv коммутатор.ndmsv компандер.ndmsv компаратор.ndmsv 
+компаунд.ndmsv компендиум.ndmsv компенсатор.ndmsv компиллятор.ndmsv комплекс.ndmsv комплексон.ndmsv 
+комплемент.ndmsv комплимент.ndmsv комплот.ndmsv композер.ndmsv композит.ndmsv компостер.ndmsv 
+компресс.ndmsv компрессор.ndmsv комптометр.ndmsv комптонит.ndmsv компьютер.ndmsv комсостав.ndmsv 
+конвейер.ndmsv конвектор.ndmsv конвент.ndmsv конвертер.ndmsv конвертоплан.ndmsv конвертор.ndmsv 
+конгломерат.ndmsv конгрев.ndmsv конгресс.ndmsv конгресс-холл.ndmsv конденсат.ndmsv конденсатор.ndmsv 
+конденсор.ndmsv кондиционер.ndmsv кондоминиум.ndmsv кондуктометр.ndmsv конезавод.ndmsv конесовхоз.ndmsv 
+кониметр.ndmsv конклав.ndmsv конкорданс.ndmsv конкордат.ndmsv конкремент.ndmsv конкубинат.ndmsv 
+конкур.ndmsv коннектор.ndmsv коноид.ndmsv коносамент.ndmsv консенсус.ndmsv консервант.ndmsv 
+консилиум.ndmsv консистометр.ndmsv консолет.ndmsv консонанс.ndmsv консонант.ndmsv консорциум.ndmsv 
+конспект.ndmsv константан.ndmsv констриктор.ndmsv конструкт.ndmsv консулат.ndmsv консумент.ndmsv 
+контактор.ndmsv контаминант.ndmsv контейнер.ndmsv контейнеровоз.ndmsv контингент.ndmsv континент.ndmsv 
+континуум.ndmsv контоид.ndmsv контокоррент.ndmsv контрабас.ndmsv контраданс.ndmsv контражур.ndmsv 
+контрапост.ndmsv контраргумент.ndmsv контратип.ndmsv контрафагот.ndmsv контрафорс.ndmsv контрацептив.ndmsv 
+контрбанкет.ndmsv контрбрас.ndmsv контргамбит.ndmsv контргрейфер.ndmsv контргруз.ndmsv контрданс.ndmsv 
+контрдовод.ndmsv контрейлер.ndmsv контрзаговор.ndmsv контркалибр.ndmsv контрклин.ndmsv контркривошип.ndmsv 
+контрманевр.ndmsv контрнегатив.ndmsv контроллер.ndmsv контрольприбор.ndmsv контрответ.ndmsv контрпривод.ndmsv 
+контрприем.ndmsv контрприказ.ndmsv контрпроект.ndmsv контррезервуар.ndmsv контррельс.ndmsv контртитул.ndmsv 
+контрудар.ndmsv контрфорс.ndmsv контрштамп.ndmsv контрэскарп.ndmsv конфайнмент.ndmsv конфекцион.ndmsv 
+конферанс.ndmsv конференц-зал.ndmsv конфигуратор.ndmsv конфикс.ndmsv конформизм.ndmsv конфузор.ndmsv 
+концентр.ndmsv концентрат.ndmsv концентратор.ndmsv концепт.ndmsv концепт-план.ndmsv концерн.ndmsv 
+конъюнкт.ndmsv конъюнктив.ndmsv конъюнктивит.ndmsv кооператив.ndmsv координатограф.ndmsv копирайт.ndmsv 
+копиручет.ndmsv копновоз.ndmsv копролит.ndmsv коракл.ndmsv коралл.ndmsv кораллит.ndmsv 
+коран.ndmsv корвет.ndmsv корволант.ndmsv кордебалет.ndmsv кордиамин.ndmsv кордиерит.ndmsv 
+кордит.ndmsv кореопсис.ndmsv кориандр.ndmsv корибант.ndmsv кориум.ndmsv кормофит.ndmsv 
+корн.ndmsv корнеед.ndmsv корнеплод.ndmsv корнер.ndmsv корнет-а-пистон.ndmsv корнит.ndmsv 
+корнишон.ndmsv корнпапир.ndmsv коронавирус.ndmsv коронаротромбоз.ndmsv коронограф.ndmsv коротрон.ndmsv 
+корпункт.ndmsv коррелометр.ndmsv коррелят.ndmsv коррелятор.ndmsv корригент.ndmsv коррпункт.ndmsv 
+корт.ndmsv кортизон.ndmsv кортикостероид.ndmsv корунд.ndmsv косеканс.ndmsv косинус.ndmsv 
+космограф.ndmsv космодром.ndmsv космолет.ndmsv космоплан.ndmsv космос.ndmsv космотрон.ndmsv 
+косоур.ndmsv косс.ndmsv кострец.ndmsv котангенс.ndmsv котиледон.ndmsv котильон.ndmsv 
+котлоагрегат.ndmsv котлован.ndmsv котонизатор.ndmsv коулсонит.ndmsv кофактор.ndmsv кофермент.ndmsv 
+кофр.ndmsv коффердам.ndmsv кохинор.ndmsv кочкорез.ndmsv кошт.ndmsv коэффициент.ndmsv 
+краз.ndmsv крайисполком.ndmsv крайком.ndmsv крайоблгорисполком.ndmsv краковян.ndmsv крамбол.ndmsv 
+краниопаг.ndmsv крапп.ndmsv краскопульт.ndmsv краснозем.ndmsv краснотал.ndmsv красоднев.ndmsv 
+кратер.ndmsv кратир.ndmsv кратоген.ndmsv кратон.ndmsv крафт.ndmsv крахмалопродукт.ndmsv 
+креатин.ndmsv кредитанштальт.ndmsv кредитив.ndmsv крезол.ndmsv крейт.ndmsv крейцер.ndmsv 
+крейцкопф.ndmsv крекер.ndmsv крекинг-процесс.ndmsv кремневодород.ndmsv кремнезем.ndmsv кремнеуглеводород.ndmsv 
+кренгельс.ndmsv креномер.ndmsv кренометр.ndmsv креозол.ndmsv креозот.ndmsv креолин.ndmsv 
+креометр.ndmsv креон.ndmsv креп-жаккард.ndmsv креп-марокен.ndmsv креп-шифон.ndmsv кресс-салат.ndmsv 
+кретинизм.ndmsv крешер.ndmsv кривошип.ndmsv криз.ndmsv крикет.ndmsv кринолин.ndmsv 
+кринум.ndmsv криогидрат.ndmsv криозонд.ndmsv криолит.ndmsv криометр.ndmsv криопротектор.ndmsv 
+криостат.ndmsv криотрон.ndmsv криптобиоз.ndmsv криптограф.ndmsv криптон.ndmsv криптофит.ndmsv 
+кристадин.ndmsv кристалл.ndmsv кристаллизатор.ndmsv кристаллит.ndmsv кристаллогидрат.ndmsv кристаллоид.ndmsv 
+кристобалит.ndmsv критицизм.ndmsv крокер.ndmsv крокус.ndmsv кронглас.ndmsv кронштейн.ndmsv 
+крор.ndmsv кросс.ndmsv кросс-курс.ndmsv кроссворд.ndmsv кроссинговер.ndmsv кроссовер.ndmsv 
+кротон.ndmsv круговорот.ndmsv кругозор.ndmsv кругооборот.ndmsv круиз.ndmsv крупозавод.ndmsv 
+крупон.ndmsv крутогор.ndmsv крутояр.ndmsv крым-сагыз.ndmsv крюгерранд.ndmsv крюйсов.ndmsv 
+крюммер.ndmsv ксантин.ndmsv ксантофилл.ndmsv ксенолит.ndmsv ксенон.ndmsv ксенотрансплантат.ndmsv 
+ксероз.ndmsv ксерокс.ndmsv ксерофит.ndmsv ксероформ.ndmsv ксилол.ndmsv ксилолит.ndmsv 
+ксилометр.ndmsv ксилофон.ndmsv ку-клукс-клан.ndmsv кубизм.ndmsv кубит.ndmsv кубоид.ndmsv 
+кубометр.ndmsv кубооктаэдр.ndmsv куверт.ndmsv кукан.ndmsv кукельван.ndmsv кукерсит.ndmsv 
+куламон.ndmsv кулон.ndmsv кулонометр.ndmsv кульверт.ndmsv кульм.ndmsv кульман.ndmsv 
+культиватор.ndmsv культпоход.ndmsv культуризм.ndmsv культфонд.ndmsv кумарин.ndmsv кумпол.ndmsv 
+кунгас.ndmsv куприт.ndmsv купферштейн.ndmsv курбан-байрам.ndmsv курбет.ndmsv курвиметр.ndmsv 
+курзал.ndmsv курослеп.ndmsv курсограф.ndmsv кусторез.ndmsv кутас.ndmsv кьят.ndmsv 
+кэш-файл.ndmsv кяриз.ndmsv лабардан.ndmsv лабиринт.ndmsv лабиринтодонт.ndmsv лабиум.ndmsv 
+лабрадорит.ndmsv лабрум.ndmsv лавсан.ndmsv ладдетрон.ndmsv лазер.ndmsv лазулит.ndmsv 
+лазурит.ndmsv лайм.ndmsv лайнер.ndmsv лакколит.ndmsv лакмус.ndmsv лаконизм.ndmsv 
+лакриматор.ndmsv лактарин.ndmsv лактобутирометр.ndmsv лактокрит.ndmsv лактометр.ndmsv лактон.ndmsv 
+лактоскоп.ndmsv лактофлавин.ndmsv лал.ndmsv ламаизм.ndmsv ламаркизм.ndmsv ламберт.ndmsv 
+ламбрадор.ndmsv ламбрекен.ndmsv ламинит.ndmsv лампион.ndmsv лампрофир.ndmsv лангет.ndmsv 
+лангустин.ndmsv ландвер.ndmsv ландолет.ndmsv ландрин.ndmsv ландшафт.ndmsv ландштурм.ndmsv 
+ланкорд.ndmsv ланолин.ndmsv лантан.ndmsv лантанид.ndmsv лантаноид.ndmsv лапароскоп.ndmsv 
+лапласиан.ndmsv лаптоп.ndmsv ларингит.ndmsv ларингоскоп.ndmsv ларингоспазм.ndmsv ларингофон.ndmsv 
+латекс.ndmsv латерит.ndmsv латинизм.ndmsv лацкан.ndmsv лацпорт.ndmsv левеллер.ndmsv 
+левират.ndmsv левкас.ndmsv легализм.ndmsv леггемоглобин.ndmsv легион.ndmsv легитимизм.ndmsv 
+легумин.ndmsv ледебурит.ndmsv ледерин.ndmsv ледогенератор.ndmsv ледокол.ndmsv ледолом.ndmsv 
+ледопад.ndmsv ледорез.ndmsv ледоруб.ndmsv ледосброс.ndmsv ледостав.ndmsv лейас.ndmsv 
+лейборизм.ndmsv лейкоз.ndmsv лейкопласт.ndmsv лейкопоэз.ndmsv лейкотроп.ndmsv лейкоцит.ndmsv 
+лейкоцитоз.ndmsv лейнафос.ndmsv лейтмотив.ndmsv лейцин.ndmsv лейцит.ndmsv лейцитит.ndmsv 
+лейчестер.ndmsv лекиф.ndmsv лексикон.ndmsv ленд-лиз.ndmsv ленинизм.ndmsv леонтиазис.ndmsv 
+леотард.ndmsv лепидодендрон.ndmsv лепидолит.ndmsv лептоспироз.ndmsv лесозавод.ndmsv лесокомбайн.ndmsv 
+лесокомбинат.ndmsv лесоматериал.ndmsv лесоповал.ndmsv лесопункт.ndmsv лесосклад.ndmsv леспромхоз.ndmsv 
+лесс.ndmsv лесстройматериал.ndmsv лесхоз.ndmsv лецитин.ndmsv лецитис.ndmsv лжеплод.ndmsv 
+лиард.ndmsv либерализм.ndmsv ливнеотвод.ndmsv ливнесброс.ndmsv ливр.ndmsv лиганд.ndmsv 
+лигнин.ndmsv лигнит.ndmsv лигностон.ndmsv лигроин.ndmsv лидар.ndmsv лиддит.ndmsv 
+лизат.ndmsv лизгольдер.ndmsv лизиметр.ndmsv лизин.ndmsv лизис.ndmsv лизоклин.ndmsv 
+лизол.ndmsv лизоформ.ndmsv лизоцим.ndmsv ликбез.ndmsv ликвидитет.ndmsv ликвидус.ndmsv 
+ликтрос.ndmsv лимитер.ndmsv лимитроф.ndmsv лимниграф.ndmsv лимонит.ndmsv лимузин.ndmsv 
+лимфаденит.ndmsv лимфангит.ndmsv лимфангоит.ndmsv лимфогранулематоз.ndmsv лимфоцит.ndmsv лингафон.ndmsv 
+линеаризм.ndmsv линимент.ndmsv линин.ndmsv линкер.ndmsv линкольн.ndmsv линкор.ndmsv 
+линкруст.ndmsv линнеит.ndmsv линобатист.ndmsv линоксин.ndmsv линолеат.ndmsv линолеум.ndmsv 
+линтер.ndmsv лионез.ndmsv липарит.ndmsv липоид.ndmsv липопротеин.ndmsv липотропин.ndmsv 
+липофусцин.ndmsv лиризм.ndmsv лириодендрон.ndmsv лисохвост.ndmsv лисп.ndmsv листер.ndmsv 
+литакиноскоп.ndmsv литаскоп.ndmsv литерал.ndmsv литогенез.ndmsv литопон.ndmsv литотес.ndmsv 
+литофит.ndmsv литофон.ndmsv литр.ndmsv литфонд.ndmsv лиф.ndmsv лифт.ndmsv 
+лифтер.ndmsv лихнис.ndmsv лихтеровоз.ndmsv логарифм.ndmsv логицизм.ndmsv логогриф.ndmsv 
+логометр.ndmsv логос.ndmsv логотип.ndmsv ложемент.ndmsv локатив.ndmsv локатор.ndmsv 
+локаут.ndmsv локдаун.ndmsv локер.ndmsv локнит.ndmsv локомотив.ndmsv локон.ndmsv 
+локус.ndmsv ломонос.ndmsv ломоносовит.ndmsv лонгет.ndmsv лонгулит.ndmsv лонгхорн.ndmsv 
+лонгшез.ndmsv лонжерон.ndmsv лордоз.ndmsv лотос.ndmsv лоуд.ndmsv лофт.ndmsv 
+лубрикатор.ndmsv лугорез.ndmsv луидор.ndmsv лунатизм.ndmsv луноход.ndmsv лупанар.ndmsv 
+лупулин.ndmsv льдоаккумулятор.ndmsv льдогенератор.ndmsv льнозавод.ndmsv льнокомбайн.ndmsv льнокомбинат.ndmsv 
+льноматериал.ndmsv льносовхоз.ndmsv люверс.ndmsv люггер.ndmsv люизит.ndmsv люксметр.ndmsv 
+люксон.ndmsv люля-кебаб.ndmsv люмен.ndmsv люменотроп.ndmsv люменофорэкран.ndmsv люминал.ndmsv 
+люминограф.ndmsv люминофор.ndmsv люмпен-пролетариат.ndmsv люнет.ndmsv люнкерит.ndmsv люпин.ndmsv 
+люпус.ndmsv люстрин.ndmsv люфт.ndmsv люэс.ndmsv ляд.ndmsv лян.ndmsv 
+ляп.ndmsv ляпсус.ndmsv лярд.ndmsv магизм.ndmsv магистрат.ndmsv магнезит.ndmsv 
+магнетизм.ndmsv магнетит.ndmsv магнетометр.ndmsv магнетон.ndmsv магнетрон.ndmsv магнитограф.ndmsv 
+магнитокардиограф.ndmsv магнитометр.ndmsv магнитоплан.ndmsv магнитопровод.ndmsv магнитоскоп.ndmsv магнитотаксис.ndmsv 
+магнитофон.ndmsv магнификат.ndmsv магнолит.ndmsv магнон.ndmsv мадригал.ndmsv маздаизм.ndmsv 
+маздеизм.ndmsv мазер.ndmsv мазохизм.ndmsv маис.ndmsv майлар.ndmsv майоран.ndmsv 
+макадам.ndmsv макаронизм.ndmsv маквис.ndmsv макогон.ndmsv макроагрегат.ndmsv макроанализ.ndmsv 
+макрогенератор.ndmsv макроклимат.ndmsv макрокосм.ndmsv макролит.ndmsv макромир.ndmsv макрон.ndmsv 
+макрообъект.ndmsv макроорганизм.ndmsv макропроцесс.ndmsv макропроцессор.ndmsv макрорадикал.ndmsv макрорельеф.ndmsv 
+макрорус.ndmsv макрос.ndmsv макрошлиф.ndmsv макроэлемент.ndmsv максвелл.ndmsv максимакс.ndmsv 
+максимин.ndmsv максимон.ndmsv максимум.ndmsv малахит.ndmsv маллеин.ndmsv мальм.ndmsv 
+мальпост.ndmsv мангал.ndmsv манганат.ndmsv манганин.ndmsv манганит.ndmsv мангольд.ndmsv 
+мангостан.ndmsv манизм.ndmsv манифест.ndmsv манихеизм.ndmsv манометр.ndmsv манор.ndmsv 
+маностат.ndmsv маноцитин.ndmsv мантелет.ndmsv мануал.ndmsv манускрипт.ndmsv маншон.ndmsv 
+маньеризм.ndmsv маразм.ndmsv маракас.ndmsv мараскин.ndmsv мареограф.ndmsv марзан.ndmsv 
+маринизм.ndmsv марказит.ndmsv марксизм.ndmsv мармит.ndmsv марокен.ndmsv марс.ndmsv 
+марсоход.ndmsv март.ndmsv мартен.ndmsv мартенсит.ndmsv мартин-штаг.ndmsv мартингал.ndmsv 
+мартинизм.ndmsv марципан.ndmsv марш-маневр.ndmsv марш-парад.ndmsv маршрутизатор.ndmsv маседуан.ndmsv 
+маскарад.ndmsv маскарон.ndmsv маскот.ndmsv маскхалат.ndmsv маслозавод.ndmsv масломер.ndmsv 
+маслопровод.ndmsv маслорадиатор.ndmsv маслосырзавод.ndmsv маслофильтр.ndmsv масс-спектр.ndmsv масс-спектрограф.ndmsv 
+масс-спектрометр.ndmsv массикот.ndmsv массоперенос.ndmsv мастикатор.ndmsv мастихин.ndmsv мастоидит.ndmsv 
+матанализ.ndmsv мателот.ndmsv матлот.ndmsv матриархат.ndmsv матрикул.ndmsv матч-турнир.ndmsv 
+маузер.ndmsv мауэрлат.ndmsv махизм.ndmsv махметр.ndmsv мачжан.ndmsv машино-час.ndmsv 
+маюскул.ndmsv мбайт.ndmsv мгд-генератор.ndmsv меандр.ndmsv мегабар.ndmsv мегабит.ndmsv 
+мегавольт.ndmsv мегалит.ndmsv мегалополис.ndmsv мегампер.ndmsv меганит.ndmsv мегаполис.ndmsv 
+мегасейм.ndmsv мегаскоп.ndmsv мегатрон.ndmsv мегафайл.ndmsv мегафон.ndmsv меггер.ndmsv 
+мегом.ndmsv мегометр.ndmsv мегомметр.ndmsv медальон.ndmsv меджлис.ndmsv медиатор.ndmsv 
+медикамент.ndmsv мединститут.ndmsv мединструмент.ndmsv медиумизм.ndmsv медосбор.ndmsv медосмотр.ndmsv 
+медпрепарат.ndmsv медпункт.ndmsv медрадиопрепарат.ndmsv медсанбат.ndmsv межпарламент.ndmsv мезальянс.ndmsv 
+мезоатом.ndmsv мезолит.ndmsv мезон.ndmsv мезонин.ndmsv мезорельеф.ndmsv мезоскаф.ndmsv 
+мезотрон.ndmsv мезофилл.ndmsv мезофит.ndmsv мейоз.ndmsv мейозис.ndmsv мелаконит.ndmsv 
+меламин.ndmsv меланжер.ndmsv меланин.ndmsv меланоз.ndmsv мелантерит.ndmsv мелизм.ndmsv 
+мелинит.ndmsv мелиорант.ndmsv мелис.ndmsv мелкозем.ndmsv мелодион.ndmsv мелонит.ndmsv 
+мелос.ndmsv мелофон.ndmsv мелькомбинат.ndmsv мельтон.ndmsv мельхиор.ndmsv мембранофон.ndmsv 
+меморандум.ndmsv мемориал.ndmsv менгир.ndmsv менделеевит.ndmsv менделизм.ndmsv менингит.ndmsv 
+менталитет.ndmsv ментициррус.ndmsv ментол.ndmsv менуэт.ndmsv меньшевизм.ndmsv меридиан.ndmsv 
+меркаптан.ndmsv меркаптид.ndmsv мерседес.ndmsv мескалин.ndmsv месмеризм.ndmsv мессенджер.ndmsv 
+мессианизм.ndmsv мессидор.ndmsv местком.ndmsv месяцеслов.ndmsv метабазис.ndmsv метабиоз.ndmsv 
+метаболизм.ndmsv метаболит.ndmsv метагенез.ndmsv метакрилат.ndmsv метакристалл.ndmsv металл.ndmsv 
+металлозавод.ndmsv металлоид.ndmsv металлокомбинат.ndmsv металлолом.ndmsv металлофермент.ndmsv металлофон.ndmsv 
+метан.ndmsv метанол.ndmsv метанопродуцент.ndmsv метасиликат.ndmsv метасоматоз.ndmsv метастаз.ndmsv 
+метафайл.ndmsv метафосфат.ndmsv метацентр.ndmsv метгемоглобин.ndmsv метемпсихоз.ndmsv метеозонд.ndmsv 
+метеоприбор.ndmsv метеорадиолокатор.ndmsv метеоризм.ndmsv метеорит.ndmsv метеорограф.ndmsv метеоролит.ndmsv 
+метил.ndmsv метиламин.ndmsv метилат.ndmsv метилбутадиен.ndmsv метилен.ndmsv метиленхлорид.ndmsv 
+метионин.ndmsv методизм.ndmsv метол.ndmsv метоп.ndmsv метрит.ndmsv метромост.ndmsv 
+метроном.ndmsv метрополитен.ndmsv механизм.ndmsv механицизм.ndmsv механорецептор.ndmsv мехзавод.ndmsv 
+мехкарьер.ndmsv мехмат.ndmsv мигматит.ndmsv мид.ndmsv мидриаз.ndmsv миелин.ndmsv 
+миелит.ndmsv микалекс.ndmsv миканит.ndmsv микоз.ndmsv микроавтобус.ndmsv микроамперметр.ndmsv 
+микроанализ.ndmsv микроанализатор.ndmsv микробар.ndmsv микробарограф.ndmsv микробарометр.ndmsv микроваттметр.ndmsv 
+микровзрыв.ndmsv микровизор.ndmsv микрограф.ndmsv микроинтерферометр.ndmsv микроинфаркт.ndmsv микрокалориметр.ndmsv 
+микрокалькулятор.ndmsv микроклимат.ndmsv микрокод.ndmsv микроколориметр.ndmsv микрокомпьютер.ndmsv микроконтинент.ndmsv 
+микроконтроллер.ndmsv микрокосм.ndmsv микрокосмос.ndmsv микрокристалл.ndmsv микрокулон.ndmsv микролит.ndmsv 
+микром.ndmsv микроманипулятор.ndmsv микроманометр.ndmsv микромер.ndmsv микрометеор.ndmsv микрометр.ndmsv 
+микромиллиметр.ndmsv микромир.ndmsv микронивелир.ndmsv микрообъект.ndmsv микрообъем.ndmsv микроом.ndmsv 
+микроомметр.ndmsv микроорганизм.ndmsv микропирометр.ndmsv микроприбор.ndmsv микропринт.ndmsv микропроектор.ndmsv 
+микропроцессор.ndmsv микрорадиоавтограф.ndmsv микрорайон.ndmsv микрорельеф.ndmsv микросейсм.ndmsv микросейсмометр.ndmsv 
+микроскоп.ndmsv микроспектрофотометр.ndmsv микросрез.ndmsv микротекст.ndmsv микротелевизор.ndmsv микротелефон.ndmsv 
+микротом.ndmsv микротранзистор.ndmsv микротрон.ndmsv микротуман.ndmsv микрофильм.ndmsv микрофильтр.ndmsv 
+микрофон.ndmsv микрофотометр.ndmsv микроэлектрод.ndmsv микроэлектрон.ndmsv миксер.ndmsv миксограф.ndmsv 
+миксоматоз.ndmsv микшер.ndmsv милитаризм.ndmsv милиум.ndmsv миллерит.ndmsv миллиамперметр.ndmsv 
+миллибар.ndmsv милливольтамперметр.ndmsv милливольтметр.ndmsv миллиграмм.ndmsv миллилитр.ndmsv миллиметр.ndmsv 
+миллирадиан.ndmsv миллирентген.ndmsv мильрейс.ndmsv миманс.ndmsv мимеограф.ndmsv миметизм.ndmsv 
+минарет.ndmsv минерал.ndmsv минерализатор.ndmsv минералит.ndmsv минералопровод.ndmsv мини-завод.ndmsv 
+мини-контейнер.ndmsv мини-пивзавод.ndmsv миникомпьютер.ndmsv минимакс.ndmsv минимализм.ndmsv миниметр.ndmsv 
+минимум.ndmsv минорат.ndmsv минускул.ndmsv миньон.ndmsv миоглобин.ndmsv миограф.ndmsv 
+миозин.ndmsv миозис.ndmsv миозит.ndmsv миокард.ndmsv миокардит.ndmsv миоцен.ndmsv 
+мирабилит.ndmsv миробалан.ndmsv миррор.ndmsv мирт.ndmsv мистицизм.ndmsv митоз.ndmsv 
+миф.ndmsv млат.ndmsv мнемометр.ndmsv мнемон.ndmsv многоплан.ndmsv многочлен.ndmsv 
+мобайл.ndmsv могар.ndmsv моделизм.ndmsv модем.ndmsv модератор.ndmsv модернизм.ndmsv 
+модильон.ndmsv модификатор.ndmsv модулянт.ndmsv модулятор.ndmsv модус.ndmsv мозолин.ndmsv 
+мокрец.ndmsv молескин.ndmsv молибден.ndmsv молибденит.ndmsv молитвослов.ndmsv моллюскоцид.ndmsv 
+молниеотвод.ndmsv молокозавод.ndmsv молокомер.ndmsv молокоотсос.ndmsv молокопровод.ndmsv молотоглав.ndmsv 
+мольберт.ndmsv момент.ndmsv монархизм.ndmsv монацит.ndmsv монгольфьер.ndmsv монд.ndmsv 
+монизм.ndmsv монитор.ndmsv моноаллергоид.ndmsv моноанализатор.ndmsv моногенизм.ndmsv моногидрат.ndmsv 
+моноид.ndmsv моноканал.ndmsv монокомпаратор.ndmsv монокристалл.ndmsv монокуляр.ndmsv моном.ndmsv 
+мононуклеоз.ndmsv моноплан.ndmsv монополизм.ndmsv монорельс.ndmsv монорим.ndmsv монотеизм.ndmsv 
+монофизит.ndmsv монохорд.ndmsv монохром.ndmsv моноцит.ndmsv монтесинос.ndmsv монтмориллонит.ndmsv 
+монумент.ndmsv мопед.ndmsv морализм.ndmsv морганизм.ndmsv морген.ndmsv мордент.ndmsv 
+морион.ndmsv морфин.ndmsv морфинизм.ndmsv морфоз.ndmsv мосгорсуд.ndmsv мотет.ndmsv 
+мотив.ndmsv мотобол.ndmsv мотобот.ndmsv мотовелосипед.ndmsv мотовоз.ndmsv мотодельтаплан.ndmsv 
+мотодром.ndmsv мотозавод.ndmsv мотокросс.ndmsv мотокультиватор.ndmsv мотопункт.ndmsv мотороллер.ndmsv 
+мотоспорт.ndmsv мотоцикл.ndmsv мотошлем.ndmsv мохер.ndmsv моцион.ndmsv муар.ndmsv 
+муидор.ndmsv муллит.ndmsv мультивибратор.ndmsv мультиплексор.ndmsv мультиплет.ndmsv мультициклон.ndmsv 
+мультфильм.ndmsv мусковит.ndmsv мусоровоз.ndmsv мусоропровод.ndmsv мусоросброс.ndmsv мусс.ndmsv 
+муссон.ndmsv муст.ndmsv мутаген.ndmsv мутатор.ndmsv мутон.ndmsv мутуализм.ndmsv 
+мухаррем.ndmsv мухомор.ndmsv мухояр.ndmsv мухур.ndmsv муцин.ndmsv мушкет.ndmsv 
+мушкетон.ndmsv мылонафт.ndmsv мэйнфрейм.ndmsv мюзет.ndmsv мюзетт.ndmsv мюзик-холл.ndmsv 
+мюзикл.ndmsv мюон.ndmsv мюридизм.ndmsv мясоед.ndmsv мясокомбинат.ndmsv мясоптицекомбинат.ndmsv 
+мясопуст.ndmsv мясосовхоз.ndmsv набла-оператор.ndmsv навет.ndmsv навицерт.ndmsv нагиб.ndmsv 
+нагнет.ndmsv нагрев.ndmsv надвиг.ndmsv наддув.ndmsv надир.ndmsv надкласс.ndmsv 
+надкус.ndmsv надотряд.ndmsv надсмотр.ndmsv нажин.ndmsv нажор.ndmsv найл.ndmsv 
+найм.ndmsv наказ.ndmsv наклев.ndmsv наклономер.ndmsv накос.ndmsv накрап.ndmsv 
+нактоуз.ndmsv намолот.ndmsv намост.ndmsv нанизм.ndmsv наноатом.ndmsv наос.ndmsv 
+напалм.ndmsv наплыв.ndmsv наполеон.ndmsv наполеондор.ndmsv напрокат.ndmsv наркомат.ndmsv 
+наркотин.ndmsv нарост.ndmsv нарсуд.ndmsv нартекс.ndmsv нарцеин.ndmsv нарцисс.ndmsv 
+нативизм.ndmsv натр.ndmsv натролит.ndmsv натурализм.ndmsv натюрморт.ndmsv наукоград.ndmsv 
+наутофон.ndmsv нафтен.ndmsv нафтол.ndmsv нахрап.ndmsv нахшлаг.ndmsv нацизм.ndmsv 
+национализм.ndmsv начет.ndmsv начсостав.ndmsv нгултрум.ndmsv неакцепт.ndmsv небаланс.ndmsv 
+небосвод.ndmsv небосклон.ndmsv небоскреб.ndmsv невзнос.ndmsv невзрыв.ndmsv неврит.ndmsv 
+невродиспансер.ndmsv невроз.ndmsv неврофиброматоз.ndmsv невус.ndmsv невыезд.ndmsv невыход.ndmsv 
+невычет.ndmsv негабарит.ndmsv негативизм.ndmsv негатрон.ndmsv недобор.ndmsv недогляд.ndmsv 
+недожин.ndmsv недокал.ndmsv недокомплект.ndmsv недокорм.ndmsv недолив.ndmsv недолов.ndmsv 
+недомес.ndmsv недомол.ndmsv недомолот.ndmsv недорасход.ndmsv недород.ndmsv недосев.ndmsv 
+недоучет.ndmsv недочет.ndmsv незачет.ndmsv нейзильбер.ndmsv нейл.ndmsv нейлон.ndmsv 
+нейрин.ndmsv нейристор.ndmsv нейрит.ndmsv нейрокомпьютер.ndmsv нейромодулятор.ndmsv нейрон.ndmsv 
+нейрорегулятор.ndmsv нейротоксикант.ndmsv нейтрализатор.ndmsv нейтрализм.ndmsv нейтралитет.ndmsv нейтродин.ndmsv 
+нейтрофил.ndmsv неклен.ndmsv некробиоз.ndmsv некроз.ndmsv нексус.ndmsv нектар.ndmsv 
+нектарин.ndmsv нектаронос.ndmsv нектон.ndmsv нектофор.ndmsv нематоцид.ndmsv нематоцист.ndmsv 
+неметалл.ndmsv неоген.ndmsv неолит.ndmsv неологизм.ndmsv неон.ndmsv неонацизм.ndmsv 
+неопрен.ndmsv неореализм.ndmsv неотип.ndmsv неофашизм.ndmsv неоцен.ndmsv непентес.ndmsv 
+непотизм.ndmsv непровар.ndmsv нептунизм.ndmsv нервизм.ndmsv нерол.ndmsv несговор.ndmsv 
+несессер.ndmsv нетбол.ndmsv нетоскоп.ndmsv неуд.ndmsv неучет.ndmsv неф.ndmsv 
+нефелинит.ndmsv нефелометр.ndmsv нефоскоп.ndmsv нефрит.ndmsv нефроз.ndmsv нефтевоз.ndmsv 
+нефтедоллар.ndmsv нефтезавод.ndmsv нефтекараван.ndmsv нефтепровод.ndmsv нефтепродуктопровод.ndmsv нефтерайон.ndmsv 
+нефтесклад.ndmsv нивоз.ndmsv нигилизм.ndmsv нигрозин.ndmsv нигрол.ndmsv никелин.ndmsv 
+никколит.ndmsv нимб.ndmsv нисан.ndmsv ниссан.ndmsv нистагм.ndmsv нитевод.ndmsv 
+нитон.ndmsv нитрагин.ndmsv нитрид.ndmsv нитрил.ndmsv нитрит.ndmsv нитробензол.ndmsv 
+нитроглицерин.ndmsv нитрометр.ndmsv нитрон.ndmsv нитропластификатор.ndmsv нитротолуол.ndmsv нитрофенол.ndmsv 
+нихром.ndmsv нобилитет.ndmsv новакулит.ndmsv новокаин.ndmsv новотел.ndmsv новояз.ndmsv 
+нозематоз.ndmsv нокаут.ndmsv нокдаун.ndmsv ноктовизор.ndmsv ноктюрн.ndmsv номадизм.ndmsv 
+номен.ndmsv номинал.ndmsv номинализм.ndmsv номинат.ndmsv номогенез.ndmsv номоканон.ndmsv 
+нонет.ndmsv нониллион.ndmsv нониус.ndmsv нонсенс.ndmsv норд.ndmsv норимон.ndmsv 
+нормобласт.ndmsv норсульфазол.ndmsv нотариат.ndmsv нотис.ndmsv ноумен.ndmsv нуклеин.ndmsv 
+нуклеопротеид.ndmsv нуклеотид.ndmsv нуклеус.ndmsv нуклид.ndmsv нуклон.ndmsv нумератор.ndmsv 
+нуммулит.ndmsv нут.ndmsv нутромер.ndmsv нуцеллус.ndmsv ньюмаркет.ndmsv ньютон.ndmsv 
+нэп.ndmsv нюанс.ndmsv обапол.ndmsv обвес.ndmsv обвоз.ndmsv обертон.ndmsv 
+обет.ndmsv обзавод.ndmsv обзол.ndmsv обком.ndmsv облакомер.ndmsv облет.ndmsv 
+облизбирком.ndmsv облисполком.ndmsv обмол.ndmsv обмолот.ndmsv обогрев.ndmsv обсидиан.ndmsv 
+обстрел.ndmsv обсчет.ndmsv обтуратор.ndmsv обтюратор.ndmsv обхват.ndmsv оверарм.ndmsv 
+овердрафт.ndmsv овогенез.ndmsv овоскоп.ndmsv овсец.ndmsv овцесовхоз.ndmsv огнепровод.ndmsv 
+огнецвет.ndmsv одеон.ndmsv однотес.ndmsv одноцвет.ndmsv одночлен.ndmsv одограф.ndmsv 
+одометр.ndmsv одонтобласт.ndmsv одонтограф.ndmsv одонтокласт.ndmsv одонтолит.ndmsv одоратор.ndmsv 
+оз.ndmsv озокерит.ndmsv озон.ndmsv озонатор.ndmsv озонид.ndmsv озонометр.ndmsv 
+оидиум.ndmsv окат.ndmsv океан.ndmsv океанариум.ndmsv окенит.ndmsv оккультизм.ndmsv 
+оклад.ndmsv окоем.ndmsv окот.ndmsv окрол.ndmsv окружком.ndmsv оксалат.ndmsv 
+оксигемоглобин.ndmsv оксигемометр.ndmsv оксигенатор.ndmsv оксид.ndmsv оксиликвит.ndmsv оксиморон.ndmsv 
+окситоцин.ndmsv оксюморон.ndmsv октакорд.ndmsv октаметр.ndmsv октан.ndmsv октант.ndmsv 
+октаэдр.ndmsv октаэдрит.ndmsv октет.ndmsv октил.ndmsv октильон.ndmsv октод.ndmsv 
+олеандр.ndmsv олеат.ndmsv олеин.ndmsv олеонафт.ndmsv олефин.ndmsv оливенит.ndmsv 
+оливин.ndmsv олигоклаз.ndmsv олигонуклеотид.ndmsv олигоцен.ndmsv ольстер.ndmsv омброметр.ndmsv 
+омегатрон.ndmsv омет.ndmsv омикрон.ndmsv омлет.ndmsv омметр.ndmsv омнибус.ndmsv 
+омограф.ndmsv омоморф.ndmsv омоним.ndmsv омофон.ndmsv омофор.ndmsv омфалит.ndmsv 
+омфацит.ndmsv онанизм.ndmsv ондограф.ndmsv ондулятор.ndmsv онер.ndmsv оникс.ndmsv 
+онкоген.ndmsv онкорнавирус.ndmsv онтогенез.ndmsv оолит.ndmsv опалин.ndmsv операнд.ndmsv 
+опиат.ndmsv опистограф.ndmsv оплот.ndmsv оплыв.ndmsv опопанакс.ndmsv опорос.ndmsv 
+опсонин.ndmsv опт.ndmsv оптиметр.ndmsv оптимизатор.ndmsv оптимизм.ndmsv оптимум.ndmsv 
+оптофон.ndmsv оптрон.ndmsv опус.ndmsv опцион.ndmsv оранжад.ndmsv оргазм.ndmsv 
+организм.ndmsv органоген.ndmsv органоид.ndmsv органон.ndmsv органопрепарат.ndmsv органофосфат.ndmsv 
+органум.ndmsv оргкомитет.ndmsv орготдел.ndmsv оргплан.ndmsv орграф.ndmsv ордонанс.ndmsv 
+ореол.ndmsv оригинал-дубликат.ndmsv оригинал-макет.ndmsv оркестрион.ndmsv орлец.ndmsv орлоп.ndmsv 
+орнитоз.ndmsv орнитоптер.ndmsv орогенез.ndmsv орогенезис.ndmsv орс.ndmsv орсин.ndmsv 
+ортикон.ndmsv ортит.ndmsv ортоводород.ndmsv ортогенез.ndmsv ортоклаз.ndmsv ортопантомограф.ndmsv 
+ортоферрит.ndmsv ортоцентр.ndmsv ортштейн.ndmsv орфарион.ndmsv орфеорион.ndmsv орфизм.ndmsv 
+орхит.ndmsv оршад.ndmsv ослоп.ndmsv осмометр.ndmsv осмос.ndmsv осот.ndmsv 
+оссеин.ndmsv остеит.ndmsv остеоартрит.ndmsv остеобласт.ndmsv остеокласт.ndmsv остеомиелит.ndmsv 
+остеон.ndmsv остеопороз.ndmsv остеосклероз.ndmsv остеофит.ndmsv остеохондрит.ndmsv остеохондроз.ndmsv 
+остит.ndmsv остракизм.ndmsv остракон.ndmsv острец.ndmsv остропестр.ndmsv осциллограф.ndmsv 
+осциллоскоп.ndmsv осциллятор.ndmsv отгиб.ndmsv отзовизм.ndmsv отзыв.ndmsv отит.ndmsv 
+отказ.ndmsv откус.ndmsv отмин.ndmsv отогрев.ndmsv отолит.ndmsv отосклероз.ndmsv 
+отоскоп.ndmsv отофон.ndmsv отоцист.ndmsv отпад.ndmsv отсвет.ndmsv отсчет.ndmsv 
+оттрелит.ndmsv отунит.ndmsv отъезд.ndmsv оуэнизм.ndmsv офикальцит.ndmsv офиклеид.ndmsv 
+офиолит.ndmsv офис.ndmsv офис-клаб.ndmsv офит.ndmsv офорт.ndmsv офсайд.ndmsv 
+офтальмоскоп.ndmsv охотнадзор.ndmsv очерет.ndmsv очкур.ndmsv паб.ndmsv павильон.ndmsv 
+павинол.ndmsv пагамент.ndmsv паганизм.ndmsv пагодит.ndmsv падеграс.ndmsv падекатр.ndmsv 
+падепатинер.ndmsv падуб.ndmsv падун.ndmsv пайп.ndmsv пакер.ndmsv пакетбот.ndmsv 
+паккард.ndmsv паккер.ndmsv паклен.ndmsv пакт.ndmsv палагонит.ndmsv паланкин.ndmsv 
+палантин.ndmsv палас.ndmsv палатинат.ndmsv палафит.ndmsv палеоген.ndmsv палеолит.ndmsv 
+палеоцен.ndmsv паликар.ndmsv палимпсест.ndmsv палингенез.ndmsv палиндром.ndmsv палисад.ndmsv 
+палисандр.ndmsv палладиум.ndmsv палласит.ndmsv паллет.ndmsv паллиатив.ndmsv паллограф.ndmsv 
+пальмитин.ndmsv пальстаб.ndmsv палюс.ndmsv памперс.ndmsv панарабизм.ndmsv панбархат.ndmsv 
+панген.ndmsv пангенезис.ndmsv пандан.ndmsv панданус.ndmsv пандус.ndmsv панелевоз.ndmsv 
+панкреас.ndmsv панкреатин.ndmsv панкреатит.ndmsv панлогизм.ndmsv паннус.ndmsv паноптикум.ndmsv 
+панпсихизм.ndmsv пансионат.ndmsv панславизм.ndmsv пантеизм.ndmsv пантеон.ndmsv пантограф.ndmsv 
+пантокрин.ndmsv пантометр.ndmsv пантопон.ndmsv пантоскоп.ndmsv пантостат.ndmsv пантюркизм.ndmsv 
+панчбол.ndmsv панчингбол.ndmsv папаверин.ndmsv папаин.ndmsv папайотин.ndmsv папизм.ndmsv 
+паповавирус.ndmsv паппус.ndmsv парабеллум.ndmsv парабиоз.ndmsv параболоид.ndmsv параван.ndmsv 
+парагнейс.ndmsv парагон.ndmsv парагонит.ndmsv параграф.ndmsv парадокс.ndmsv паразитизм.ndmsv 
+паразитоз.ndmsv параизомер.ndmsv параклет.ndmsv параклит.ndmsv парализатор.ndmsv паралипоменон.ndmsv 
+параллакс.ndmsv параллелепипед.ndmsv параллелизм.ndmsv параллелограмм.ndmsv паралогизм.ndmsv параметр.ndmsv 
+параметрит.ndmsv параметрон.ndmsv парангон.ndmsv паранефрит.ndmsv парантез.ndmsv парапарез.ndmsv 
+параплан.ndmsv парапротеин.ndmsv парапроцесс.ndmsv парасинапсис.ndmsv паратаксис.ndmsv паратиф.ndmsv 
+паратонзиллит.ndmsv параф.ndmsv парафимоз.ndmsv парацетамол.ndmsv парашютизм.ndmsv паргасит.ndmsv 
+парез.ndmsv паризит.ndmsv парламент.ndmsv пармезан.ndmsv парогенератор.ndmsv парод.ndmsv 
+пародонтоз.ndmsv пародос.ndmsv пароксизм.ndmsv паромер.ndmsv паромотор.ndmsv пароним.ndmsv 
+паронит.ndmsv паропровод.ndmsv паростоз.ndmsv паротит.ndmsv паротурбогенератор.ndmsv парсизм.ndmsv 
+партактив.ndmsv партбилет.ndmsv партком.ndmsv партнерс.ndmsv партон.ndmsv партсъезд.ndmsv 
+паслен.ndmsv пассажиро-груз.ndmsv пассаметр.ndmsv пассеизм.ndmsv пассиватор.ndmsv пастеризатор.ndmsv 
+пастис.ndmsv пасторат.ndmsv патерностер.ndmsv патиссон.ndmsv патогенез.ndmsv патриархат.ndmsv 
+патриотизм.ndmsv патрициат.ndmsv патронат.ndmsv патроним.ndmsv паттерн.ndmsv паужин.ndmsv 
+пауперизм.ndmsv пахит.ndmsv пацифизм.ndmsv пеан.ndmsv пегамоид.ndmsv пегматит.ndmsv 
+педантизм.ndmsv педвуз.ndmsv педикулез.ndmsv педогенез.ndmsv педометр.ndmsv педсовет.ndmsv 
+педсостав.ndmsv пейджер.ndmsv пейсмекер.ndmsv пекан.ndmsv пекогон.ndmsv пектин.ndmsv 
+пектолит.ndmsv пелагит.ndmsv пеленгатор.ndmsv пелетрон.ndmsv пелит.ndmsv пелорус.ndmsv 
+пелькомпас.ndmsv пельтаст.ndmsv пемзобетон.ndmsv пеммикан.ndmsv пемфигус.ndmsv пен-клуб.ndmsv 
+пенал.ndmsv пендрагон.ndmsv пенеплен.ndmsv пенетрометр.ndmsv пенис.ndmsv пеницилл.ndmsv 
+пенициллин.ndmsv пеннивейт.ndmsv пенобетон.ndmsv пеногипс.ndmsv пеноматериал.ndmsv пенопласт.ndmsv 
+пенополиизоцианурат.ndmsv пенополистирол.ndmsv пеносиликат.ndmsv пенс.ndmsv пентагрид.ndmsv пентадом.ndmsv 
+пентаметр.ndmsv пентан.ndmsv пентасульфид.ndmsv пентахорд.ndmsv пентаэдр.ndmsv пентеконтор.ndmsv 
+пентекостис.ndmsv пентландит.ndmsv пентод.ndmsv пентоксид.ndmsv пентолит.ndmsv пентрит.ndmsv 
+пентхауз.ndmsv пентхаус.ndmsv пенчингбол.ndmsv пеньюар.ndmsv пеплобетон.ndmsv пеплум.ndmsv 
+пепсин.ndmsv пептон.ndmsv перборат.ndmsv первообраз.ndmsv первоцвет.ndmsv первоэлемент.ndmsv 
+пергамен.ndmsv пергамин.ndmsv перевод.ndmsv переворот.ndmsv перегиб.ndmsv перегляд.ndmsv 
+перегрев.ndmsv перегуд.ndmsv передир.ndmsv передопрос.ndmsv переем.ndmsv пережим.ndmsv 
+перекос.ndmsv перелаз.ndmsv переливт.ndmsv перемол.ndmsv перемолот.ndmsv перепад.ndmsv 
+перепев.ndmsv переплет.ndmsv перепляс.ndmsv переприем.ndmsv перерасчет.ndmsv перерод.ndmsv 
+перерыв.ndmsv пересвист.ndmsv пересев.ndmsv пересказ.ndmsv переспрос.ndmsv пересчет.ndmsv 
+переучет.ndmsv перечет.ndmsv периаденит.ndmsv перибласт.ndmsv перигастрит.ndmsv перидот.ndmsv 
+перидотит.ndmsv перикард.ndmsv перикардит.ndmsv периклаз.ndmsv периметр.ndmsv периметрит.ndmsv 
+периневрит.ndmsv период.ndmsv периодат.ndmsv периодонт.ndmsv периодонтит.ndmsv периост.ndmsv 
+периостит.ndmsv перипласт.ndmsv периптер.ndmsv перископ.ndmsv перисперм.ndmsv перистом.ndmsv 
+перитифлит.ndmsv перитонит.ndmsv перицентр.ndmsv перицит.ndmsv перкалин.ndmsv перколятор.ndmsv 
+перламутр.ndmsv перлвейс.ndmsv перлон.ndmsv перманганат.ndmsv пермансив.ndmsv пермеаметр.ndmsv 
+пермутатор.ndmsv пермутит.ndmsv перовскит.ndmsv перозис.ndmsv пероксид.ndmsv перрадиус.ndmsv 
+персистор.ndmsv персонал.ndmsv персульфат.ndmsv пертит.ndmsv перфект.ndmsv перфоввод.ndmsv 
+перфоратор.ndmsv перхлорат.ndmsv перхлорвинил.ndmsv перцептрон.ndmsv песколюб.ndmsv пескомет.ndmsv 
+пессимизм.ndmsv пессимум.ndmsv пестицид.ndmsv петаз.ndmsv петалит.ndmsv петрогенезис.ndmsv 
+петроглиф.ndmsv петродоллар.ndmsv петролатум.ndmsv петролеум.ndmsv петросилекс.ndmsv петцит.ndmsv 
+пещур.ndmsv пи-мезон.ndmsv пиан.ndmsv пианизм.ndmsv пиар.ndmsv пиастр.ndmsv 
+пивбар.ndmsv пивзавод.ndmsv пигус.ndmsv пиелит.ndmsv пиелонефрит.ndmsv пиетет.ndmsv 
+пиетизм.ndmsv пижонит.ndmsv пизолит.ndmsv пикап.ndmsv пикер.ndmsv пикет.ndmsv 
+пикноз.ndmsv пикнометр.ndmsv пикограмм.ndmsv пикокулон.ndmsv пиколин.ndmsv пикон.ndmsv 
+пикорнавирус.ndmsv пикрат.ndmsv пикрин.ndmsv пикрит.ndmsv пикрол.ndmsv пикротоксин.ndmsv 
+пиксафон.ndmsv пиксидиум.ndmsv пилав.ndmsv пиллерс.ndmsv пилокарпин.ndmsv пилокарпус.ndmsv 
+пилон.ndmsv пилорус.ndmsv пилум.ndmsv пимент.ndmsv пинакоид.ndmsv пинбол.ndmsv 
+пинцет.ndmsv пиодерматоз.ndmsv пиодермит.ndmsv пиоз.ndmsv пион.ndmsv пионеротряд.ndmsv 
+пионефрит.ndmsv пионефроз.ndmsv пиоскоп.ndmsv пиоторакс.ndmsv пиперазин.ndmsv пиперидин.ndmsv 
+пиперин.ndmsv пипермент.ndmsv пиперонал.ndmsv пиразин.ndmsv пиразол.ndmsv пиранометр.ndmsv 
+пираргирит.ndmsv пиргелиометр.ndmsv пиргеометр.ndmsv пиргом.ndmsv пирекс.ndmsv пиреноид.ndmsv 
+пиретрум.ndmsv пиридин.ndmsv пиридоксин.ndmsv пиримидин.ndmsv пиробензол.ndmsv пирогаллол.ndmsv 
+пирозапал.ndmsv пирокатехин.ndmsv пироксен.ndmsv пироксилин.ndmsv пиролиз.ndmsv пиролюзит.ndmsv 
+пирометр.ndmsv пироморфит.ndmsv пирон.ndmsv пиронафт.ndmsv пироп.ndmsv пиропатрон.ndmsv 
+пироплазмоз.ndmsv пироскаф.ndmsv пироскоп.ndmsv пиросмалит.ndmsv пиростат.ndmsv пиросульфат.ndmsv 
+пирофиллит.ndmsv пирофотометр.ndmsv пирошнур.ndmsv пироэффект.ndmsv пиррол.ndmsv пирролидин.ndmsv 
+пирротин.ndmsv пирротит.ndmsv пирс.ndmsv пируэт.ndmsv писсуар.ndmsv пистацит.ndmsv 
+пистолет.ndmsv питербот.ndmsv питириаз.ndmsv питометр.ndmsv питономорф.ndmsv питоцин.ndmsv 
+питтицит.ndmsv питуитрин.ndmsv пифос.ndmsv пищекомбинат.ndmsv пищеконцентрат.ndmsv плавзавод.ndmsv 
+плавсостав.ndmsv плагиат.ndmsv плагиоклаз.ndmsv плаз.ndmsv плазматрон.ndmsv плазмин.ndmsv 
+плазмоген.ndmsv плазмоид.ndmsv плазмолиз.ndmsv плазмон.ndmsv плазмотип.ndmsv плазмотрон.ndmsv 
+плазмохин.ndmsv плазмоцид.ndmsv планеризм.ndmsv планеродром.ndmsv планетоид.ndmsv планетолет.ndmsv 
+планетоход.ndmsv планиметр.ndmsv планктер.ndmsv планктон.ndmsv планометр.ndmsv пластбетон.ndmsv 
+пластеин.ndmsv пластикат.ndmsv пластикатор.ndmsv пластификатор.ndmsv пластобетон.ndmsv пластометр.ndmsv 
+пластрон.ndmsv платан.ndmsv платинат.ndmsv платинит.ndmsv платиноид.ndmsv платинотрон.ndmsv 
+платонизм.ndmsv плац-парад.ndmsv плацдарм.ndmsv плашкоут.ndmsv плебисцит.ndmsv плебс.ndmsv 
+плевел.ndmsv плед.ndmsv плейас.ndmsv плейер.ndmsv плейстон.ndmsv плейстоцен.ndmsv 
+плексиглас.ndmsv плексит.ndmsv плектр.ndmsv племзавод.ndmsv племколхоз.ndmsv племконзавод.ndmsv 
+племотдел.ndmsv племптицерепродуктор.ndmsv племптицесовхоз.ndmsv племрепродуктор.ndmsv племсовхоз.ndmsv племхоз.ndmsv 
+пленум.ndmsv плеоназм.ndmsv плеонаст.ndmsv плеопод.ndmsv плеохроизм.ndmsv плес.ndmsv 
+плессиметр.ndmsv плетизмограф.ndmsv плиофильм.ndmsv плиоцен.ndmsv плис.ndmsv плодосбор.ndmsv 
+плодосмен.ndmsv плодосовхоз.ndmsv плодосъем.ndmsv плоскорез.ndmsv плотномер.ndmsv плотокараван.ndmsv 
+плотоход.ndmsv плумбат.ndmsv плумбит.ndmsv плутеус.ndmsv плутонизм.ndmsv плювиограф.ndmsv 
+плювиоз.ndmsv плювиометр.ndmsv плюр.ndmsv плюрализм.ndmsv плюсквамперфект.ndmsv пневматолиз.ndmsv 
+пневматолит.ndmsv пневматофор.ndmsv пневмеркатор.ndmsv пневмограф.ndmsv пневмоинструмент.ndmsv пневмокониоз.ndmsv 
+пневмонит.ndmsv пневмоскоп.ndmsv пневмостартер.ndmsv пневмостом.ndmsv пневмоторакс.ndmsv пневмотормоз.ndmsv 
+пневмоход.ndmsv победит.ndmsv подвид.ndmsv подгнет.ndmsv подграф.ndmsv поддомен.ndmsv 
+поджим.ndmsv подзавод.ndmsv подзаряд.ndmsv подзыв.ndmsv подиум.ndmsv подканал.ndmsv 
+подкатод.ndmsv подкласс.ndmsv подкомитет.ndmsv подлет.ndmsv подмыв.ndmsv поднаряд.ndmsv 
+подобъект.ndmsv подогрев.ndmsv подоператор.ndmsv подотдел.ndmsv подотряд.ndmsv подофил.ndmsv 
+подпар.ndmsv подпараграф.ndmsv подпараметр.ndmsv подпредел.ndmsv подпроект.ndmsv подпункт.ndmsv 
+подрайон.ndmsv подрод.ndmsv подрыв.ndmsv подсвист.ndmsv подсед.ndmsv подсчет.ndmsv 
+подтекст.ndmsv подтип.ndmsv подхват.ndmsv подцед.ndmsv подцентр.ndmsv позитивизм.ndmsv 
+позитрон.ndmsv позумент.ndmsv позыв.ndmsv пойнт.ndmsv показ.ndmsv полиамид.ndmsv 
+полианит.ndmsv полиартрит.ndmsv полибазит.ndmsv поливитамин.ndmsv полигалит.ndmsv полигенизм.ndmsv 
+полиграф.ndmsv полиизопрен.ndmsv поликарбонат.ndmsv поликристалл.ndmsv поликсен.ndmsv полимент.ndmsv 
+полимерконтейнер.ndmsv полимерраствор.ndmsv полиметалл.ndmsv полиневрит.ndmsv полином.ndmsv полиоэнцефалит.ndmsv 
+полипептид.ndmsv полиплоид.ndmsv полипоз.ndmsv полисахарид.ndmsv полисерозит.ndmsv полиспаст.ndmsv 
+полистирол.ndmsv полисульфид.ndmsv политеизм.ndmsv политес.ndmsv политехникум.ndmsv политкомикс.ndmsv 
+политотдел.ndmsv политпросвет.ndmsv политсостав.ndmsv полифонизм.ndmsv полиформальдегид.ndmsv полифосфат.ndmsv 
+полихлорвинил.ndmsv полихлорид.ndmsv полихронид.ndmsv полицилиндр.ndmsv полиэдр.ndmsv полиэкран.ndmsv 
+полиэстер.ndmsv полиэтилен.ndmsv полиэтилентерефталат.ndmsv полиэфир.ndmsv полиэфиримид.ndmsv поллиноз.ndmsv 
+поллютант.ndmsv полонез.ndmsv полонизм.ndmsv полтергейст.ndmsv полуавтомат.ndmsv полуантрацит.ndmsv 
+полубаркас.ndmsv полубархат.ndmsv полубимс.ndmsv полубокс.ndmsv полуборт.ndmsv полувагон.ndmsv 
+полувал.ndmsv полуватман.ndmsv полувзвод.ndmsv полувольт.ndmsv полугар.ndmsv полугидрат.ndmsv 
+полудиаметр.ndmsv полуимпериал.ndmsv полуинвариант.ndmsv полуинтервал.ndmsv полукадр.ndmsv полуклюз.ndmsv 
+полукокс.ndmsv полуколлоид.ndmsv полукомплект.ndmsv полукупол.ndmsv полулист.ndmsv полуметалл.ndmsv 
+полумир.ndmsv полумост.ndmsv полуоборот.ndmsv полуовал.ndmsv полуопал.ndmsv полупериод.ndmsv 
+полупилон.ndmsv полуповорот.ndmsv полуподвал.ndmsv полупоклон.ndmsv полуприсед.ndmsv полуприцеп.ndmsv 
+полуразъем.ndmsv полураскос.ndmsv полураспад.ndmsv полусвет.ndmsv полусвод.ndmsv полусумматор.ndmsv 
+полутакт.ndmsv полуустав.ndmsv полуфабрикат.ndmsv полуфинал.ndmsv полуцикл.ndmsv полуцилиндр.ndmsv 
+полушепот.ndmsv полуштоф.ndmsv полуэскадрон.ndmsv полуют.ndmsv польдер.ndmsv поляризатор.ndmsv 
+поляриметр.ndmsv полярископ.ndmsv поляристробометр.ndmsv полярограф.ndmsv поляроид.ndmsv полярон.ndmsv 
+помдамур.ndmsv помост.ndmsv помпельмус.ndmsv помпон.ndmsv понор.ndmsv понтификат.ndmsv 
+поп-арт.ndmsv поролон.ndmsv портатив.ndmsv портбукет.ndmsv портланд.ndmsv портландцемент.ndmsv 
+портплед.ndmsv портсигар.ndmsv портшез.ndmsv порфирин.ndmsv порфирит.ndmsv порфироид.ndmsv 
+порыв.ndmsv посвист.ndmsv посев.ndmsv послеимпульс.ndmsv постамент.ndmsv постикум.ndmsv 
+постпакет.ndmsv постплиоцен.ndmsv постскриптум.ndmsv постулат.ndmsv постфикс.ndmsv потенциал.ndmsv 
+потенциометр.ndmsv потир.ndmsv почтамт.ndmsv пошепт.ndmsv пошиб.ndmsv прагматизм.ndmsv 
+празем.ndmsv празеодим.ndmsv прайд.ndmsv прайс-лист.ndmsv пракрит.ndmsv практикум.ndmsv 
+практицизм.ndmsv прапор.ndmsv преанимизм.ndmsv превентор.ndmsv предиктор.ndmsv преднизолон.ndmsv 
+предпарламент.ndmsv предпроцессор.ndmsv презерватив.ndmsv президиум.ndmsv прейскурант.ndmsv прелюд.ndmsv 
+премикс.ndmsv премоляр.ndmsv преон.ndmsv препарат.ndmsv препринт.ndmsv препроцессор.ndmsv 
+преселектор.ndmsv пресс-автомат.ndmsv пресс-конвейер.ndmsv пресс-материал.ndmsv пресс-релиз.ndmsv пресс-тайм.ndmsv 
+пресс-центр.ndmsv прессшпан.ndmsv престол.ndmsv претерит.ndmsv преферанс.ndmsv префикс.ndmsv 
+префиксоид.ndmsv преформизм.ndmsv прецедент.ndmsv преципитат.ndmsv привкус.ndmsv привнос.ndmsv 
+приворот.ndmsv пригород.ndmsv пригрев.ndmsv пригруз.ndmsv приезд.ndmsv призматоид.ndmsv 
+призмоид.ndmsv призор.ndmsv приливомер.ndmsv прилов.ndmsv принос.ndmsv принтер.ndmsv 
+принцип.ndmsv принципат.ndmsv приорат.ndmsv приплав.ndmsv приплыв.ndmsv припляс.ndmsv 
+присвист.ndmsv присев.ndmsv присед.ndmsv присест.ndmsv присчет.ndmsv приуз.ndmsv 
+прификс.ndmsv прихлеб.ndmsv прихлоп.ndmsv причет.ndmsv причт.ndmsv проброс.ndmsv 
+провиант.ndmsv провинциализм.ndmsv провирус.ndmsv провитамин.ndmsv проволокобетон.ndmsv проворот.ndmsv 
+прогар.ndmsv прогестерон.ndmsv прогестин.ndmsv прогестоген.ndmsv прогиб.ndmsv прогнатизм.ndmsv 
+прогноз.ndmsv программатор.ndmsv прогрев.ndmsv прогресс.ndmsv продир.ndmsv продотряд.ndmsv 
+продпункт.ndmsv продром.ndmsv продукт.ndmsv продуктообмен.ndmsv продуктопровод.ndmsv проектор.ndmsv 
+прожект.ndmsv прозаизм.ndmsv прозенцефалон.ndmsv прозор.ndmsv прозэнцефалон.ndmsv прокариот.ndmsv 
+проквестор.ndmsv прокос.ndmsv проктит.ndmsv проктодеум.ndmsv прокус.ndmsv пролактин.ndmsv 
+проламин.ndmsv пролепсис.ndmsv пролеткульт.ndmsv пролифератион.ndmsv промен.ndmsv променад.ndmsv 
+промикропс.ndmsv промискуитет.ndmsv промотор.ndmsv промстройпроект.ndmsv пронаос.ndmsv пронатор.ndmsv 
+пронефрос.ndmsv прононс.ndmsv пронотум.ndmsv пронуклеус.ndmsv пропан.ndmsv пропанол.ndmsv 
+пропарокситон.ndmsv пропеллер.ndmsv пропердин.ndmsv пропилен.ndmsv проплыв.ndmsv прополис.ndmsv 
+проприоцептор.ndmsv пропс.ndmsv проран.ndmsv просвет.ndmsv просеминар.ndmsv проскениум.ndmsv 
+прософт.ndmsv проспект.ndmsv простагландин.ndmsv простатит.ndmsv просцениум.ndmsv просчет.ndmsv 
+протагон.ndmsv протазан.ndmsv протазис.ndmsv проталлиум.ndmsv протамин.ndmsv протаргол.ndmsv 
+протеид.ndmsv протеин.ndmsv протекторат.ndmsv протеус.ndmsv противовес.ndmsv противогаз.ndmsv 
+противоугон.ndmsv протобласт.ndmsv протовирус.ndmsv протогин.ndmsv протограф.ndmsv протозооз.ndmsv 
+протокол.ndmsv протоконтинент.ndmsv протон.ndmsv протонотариат.ndmsv протопектин.ndmsv протопласт.ndmsv 
+протоподит.ndmsv проторакс.ndmsv проторенессанс.ndmsv протрактор.ndmsv протромбин.ndmsv протуберанц-спектроскоп.ndmsv 
+профбилет.ndmsv профермент.ndmsv профибринолизин.ndmsv профилограф.ndmsv профилометр.ndmsv профит.ndmsv 
+профицит.ndmsv профком.ndmsv профконсультант.ndmsv профотбор.ndmsv профсоюз.ndmsv профцентр.ndmsv 
+процесс.ndmsv процессор.ndmsv прочет.ndmsv проэструс.ndmsv прудонизм.ndmsv прустит.ndmsv 
+псалтерион.ndmsv псаммит.ndmsv псаммофит.ndmsv псевдоапокриф.ndmsv псевдовектор.ndmsv псевдокод.ndmsv 
+псевдокристалл.ndmsv псевдоним.ndmsv псевдопереход.ndmsv псевдораствор.ndmsv псевдоскаляр.ndmsv псевдофольклор.ndmsv 
+псевтерминал.ndmsv псилоз.ndmsv псион.ndmsv пситтакоз.ndmsv психизм.ndmsv психоанализ.ndmsv 
+психогальванометр.ndmsv психогенез.ndmsv психогериат.ndmsv психоз.ndmsv психометр.ndmsv психон.ndmsv 
+психоневроз.ndmsv психостимулятор.ndmsv психрограф.ndmsv психрометр.ndmsv псориаз.ndmsv птеридосперм.ndmsv 
+птиалин.ndmsv птифур.ndmsv птоз.ndmsv птомаин.ndmsv пуаз.ndmsv пуант.ndmsv 
+пуантилизм.ndmsv пудрет.ndmsv пуловер.ndmsv пульверизатор.ndmsv пульман.ndmsv пульмонит.ndmsv 
+пульпер.ndmsv пульпит.ndmsv пульповод.ndmsv пульпомер.ndmsv пульпомет.ndmsv пульпопровод.ndmsv 
+пульс.ndmsv пульсар.ndmsv пульсатор.ndmsv пульсиметр.ndmsv пульсометр.ndmsv пульт.ndmsv 
+пункт.ndmsv пунсон.ndmsv пунцон.ndmsv пургатив.ndmsv пурген.ndmsv пуризм.ndmsv 
+пурин.ndmsv пуританизм.ndmsv пурпурин.ndmsv путемер.ndmsv путепровод.ndmsv путчизм.ndmsv 
+пуф.ndmsv пуццолан.ndmsv пушкинизм.ndmsv пчелосовхоз.ndmsv пшат.ndmsv пылемер.ndmsv 
+пыльцевход.ndmsv пьедестал.ndmsv пьезокристалл.ndmsv пьезометр.ndmsv пьемонтит.ndmsv пьютер.ndmsv 
+пэдлбол.ndmsv пюпитр.ndmsv пяртнерс.ndmsv рабдит.ndmsv рабдом.ndmsv раввинат.ndmsv 
+равелин.ndmsv радиан.ndmsv радиант.ndmsv радиатор.ndmsv радикализм.ndmsv радикулит.ndmsv 
+радиоавтограф.ndmsv радиоальтиметр.ndmsv радиоаппарат.ndmsv радиоветромер.ndmsv радиовизор.ndmsv радиоволновод.ndmsv 
+радиовысотомер.ndmsv радиогониометр.ndmsv радиогоризонт.ndmsv радиодальномер.ndmsv радиодиапазон.ndmsv радиозавод.ndmsv 
+радиозонд.ndmsv радиоизотоп.ndmsv радиоимпульс.ndmsv радиоинженер.ndmsv радиоинтерферометр.ndmsv радиоканал.ndmsv 
+радиокаскад.ndmsv радиоклип.ndmsv радиокомбайн.ndmsv радиокомитет.ndmsv радиокомпаратор.ndmsv радиокомпас.ndmsv 
+радиокомплекс.ndmsv радиокомпонент.ndmsv радиоконцерт.ndmsv радиолит.ndmsv радиолокатор.ndmsv радиолот.ndmsv 
+радиолярит.ndmsv радиомаркер.ndmsv радиоматериал.ndmsv радиометеорограф.ndmsv радиометр.ndmsv радиомодем.ndmsv 
+радионавигатор.ndmsv радионуклеид.ndmsv радионуклид.ndmsv радиообмен.ndmsv радиопеленгатор.ndmsv радиоперехват.ndmsv 
+радиоприем.ndmsv радиопродукт.ndmsv радиопротектор.ndmsv радиопульсар.ndmsv радиорепродуктор.ndmsv радиорупор.ndmsv 
+радиосигнал.ndmsv радиоспектрометр.ndmsv радиоспектроскоп.ndmsv радиотелеграф.ndmsv радиотелескоп.ndmsv радиотелефон.ndmsv 
+радиотовар.ndmsv радиоуглерод.ndmsv радиоуровнемер.ndmsv радиоцентр.ndmsv радиоцикл.ndmsv радиошум.ndmsv 
+радиоэлектрон.ndmsv радиоэлемент.ndmsv радиус-вектор.ndmsv радон.ndmsv радонометр.ndmsv разбаланс.ndmsv 
+разброд.ndmsv разворот.ndmsv разгар.ndmsv разгиб.ndmsv раздор.ndmsv раздув.ndmsv 
+разер.ndmsv разлад.ndmsv разлет.ndmsv размол.ndmsv разогрев.ndmsv разъезд.ndmsv 
+райграс.ndmsv райком.ndmsv райпищекомбинат.ndmsv райсовет.ndmsv райфикешт.ndmsv райцентр.ndmsv 
+ракетодром.ndmsv ракетоплан.ndmsv ракурс.ndmsv рамадан.ndmsv рамблер.ndmsv раммельсбергит.ndmsv 
+рамс.ndmsv рамуляриоз.ndmsv ранверсман.ndmsv ранд.ndmsv рант.ndmsv рапид.ndmsv 
+раппорт.ndmsv рапс.ndmsv раритет.ndmsv расизм.ndmsv расогенез.ndmsv распатор.ndmsv 
+расплод.ndmsv расплыв.ndmsv рассвет.ndmsv рассев.ndmsv расстрел.ndmsv расходомер.ndmsv 
+раунд.ndmsv раут.ndmsv рахат-лукум.ndmsv рахис.ndmsv рахит.ndmsv рахитизм.ndmsv 
+рацемат.ndmsv рашкет.ndmsv рашпер.ndmsv рдест.ndmsv реагент.ndmsv реактанс.ndmsv 
+реактант.ndmsv реактопласт.ndmsv реализм.ndmsv реальгар.ndmsv ребус.ndmsv ревант.ndmsv 
+реваншизм.ndmsv реввоенсовет.ndmsv реверанс.ndmsv ревербератор.ndmsv реверберометр.ndmsv реверс.ndmsv 
+реверсор.ndmsv ревертант.ndmsv ревком.ndmsv ревматизм.ndmsv ревмокардит.ndmsv револьвер.ndmsv 
+ревтрибунал.ndmsv регенерат.ndmsv регенератор.ndmsv регион.ndmsv регистр.ndmsv регламент.ndmsv 
+реглет.ndmsv реголит.ndmsv регресс.ndmsv регулятор.ndmsv редан.ndmsv редингот.ndmsv 
+редуктор.ndmsv редут.ndmsv редюит.ndmsv реестр.ndmsv резен.ndmsv резерват.ndmsv 
+резервуар.ndmsv резерпин.ndmsv резинат.ndmsv резинит.ndmsv резинозис.ndmsv резинол.ndmsv 
+резист.ndmsv резистанс.ndmsv резистин.ndmsv резистор.ndmsv резит.ndmsv резнатрон.ndmsv 
+резол.ndmsv резонанс.ndmsv резонатор.ndmsv резонон.ndmsv резорцин.ndmsv результант.ndmsv 
+результат.ndmsv резус-фактор.ndmsv резьбомер.ndmsv реимпорт.ndmsv рейд.ndmsv рейдер.ndmsv 
+рейс.ndmsv рейсмас.ndmsv рейсмус.ndmsv рейсфедер.ndmsv рейхсвер.ndmsv рейхсрат.ndmsv 
+реквием.ndmsv реквизит.ndmsv рекордер.ndmsv рекордизм.ndmsv рекостав.ndmsv рекредитив.ndmsv 
+рексит.ndmsv ректификат.ndmsv ректификатор.ndmsv ректон.ndmsv ректорат.ndmsv ректороманоскоп.ndmsv 
+ректоскоп.ndmsv рекуперат.ndmsv рекуператор.ndmsv релаксатор.ndmsv релаксин.ndmsv реликт.ndmsv 
+релин.ndmsv релит.ndmsv рельсотранспортер.ndmsv релятивизм.ndmsv ремедиум.ndmsv ремингтон.ndmsv 
+ремкомплект.ndmsv ремонстрант.ndmsv ремонтуар.ndmsv рен.ndmsv ренессанс.ndmsv ренет.ndmsv 
+ренин.ndmsv ренклод.ndmsv ренонс.ndmsv рентген.ndmsv рентгенметр.ndmsv рентгенолаборант.ndmsv 
+реовирус.ndmsv реокардиограф.ndmsv реометр.ndmsv реотаксис.ndmsv реотан.ndmsv реотропизм.ndmsv 
+реофит.ndmsv реохорд.ndmsv репеллент.ndmsv репеллер.ndmsv репер.ndmsv репертуар.ndmsv 
+реперфоратор.ndmsv реперфотрансмиттер.ndmsv репитер.ndmsv репликар.ndmsv репликон.ndmsv репорт.ndmsv 
+репрессор.ndmsv реприманд.ndmsv репринт.ndmsv репродуктор.ndmsv репродуцент.ndmsv репшнур.ndmsv 
+ресивер.ndmsv рескрипт.ndmsv респект.ndmsv респиратор.ndmsv респирометр.ndmsv рестарт.ndmsv 
+ресторан.ndmsv рестрикт.ndmsv ретикулин.ndmsv ретинен.ndmsv ретинит.ndmsv ретинол.ndmsv 
+ретранслятор.ndmsv ретраншемент.ndmsv ретровирус.ndmsv ретрорефлектор.ndmsv реум.ndmsv референдум.ndmsv 
+рефлектометр.ndmsv рефлектор.ndmsv рефлотрон.ndmsv рефлюкс.ndmsv реформизм.ndmsv рефрактометр.ndmsv 
+рефрактор.ndmsv рефрен.ndmsv рефрижератор.ndmsv рецепт.ndmsv рецептер.ndmsv рецептор.ndmsv 
+рецидивизм.ndmsv рецикл.ndmsv речитатив.ndmsv реэкспорт.ndmsv риаколит.ndmsv риал.ndmsv 
+рибонуклеотид.ndmsv рибофлавин.ndmsv риванол.ndmsv ригодон.ndmsv ригоризм.ndmsv ризалит.ndmsv 
+ризопод.ndmsv риккетсиоз.ndmsv риксдалер.ndmsv ринит.ndmsv риновирус.ndmsv риноскоп.ndmsv 
+риокан.ndmsv риолит.ndmsv риометр.ndmsv риппер.ndmsv рисс.ndmsv ритм.ndmsv 
+риторизм.ndmsv ритуализм.ndmsv риф.ndmsv рифмоплет.ndmsv рифт.ndmsv рицин.ndmsv 
+рицинин.ndmsv роббер.ndmsv роброн.ndmsv робурит.ndmsv ровер.ndmsv рогоз.ndmsv 
+родамин.ndmsv роданид.ndmsv родентицид.ndmsv роджер.ndmsv рододендрон.ndmsv родонит.ndmsv 
+родопсин.ndmsv родохрозит.ndmsv родстер.ndmsv рожнец.ndmsv розанилин.ndmsv розеин.ndmsv 
+розмарин.ndmsv рок-н-ролл.ndmsv ролл.ndmsv роллер.ndmsv рольмопс.ndmsv романизм.ndmsv 
+романтизм.ndmsv ромб.ndmsv ромбододекаэдр.ndmsv ромбоэдр.ndmsv ромштекс.ndmsv ронгалит.ndmsv 
+росомер.ndmsv ростбиф.ndmsv ростер.ndmsv ростерит.ndmsv ростомер.ndmsv ротаметр.ndmsv 
+ротапринт.ndmsv ротацизм.ndmsv ротон.ndmsv роуд.ndmsv роульс.ndmsv роштейн.ndmsv 
+роялизм.ndmsv рубеллит.ndmsv рубероид.ndmsv рубрикатор.ndmsv рудерпост.ndmsv рудимент.ndmsv 
+рудовоз.ndmsv русиа-петролиум.ndmsv русизм.ndmsv руссоизм.ndmsv рутил.ndmsv рыбозавод.ndmsv 
+рыбокомбинат.ndmsv рыбонасос.ndmsv рыбоподъем.ndmsv рыбхоз.ndmsv рыдван.ndmsv рым.ndmsv 
+рэгтайм.ndmsv рэкет.ndmsv рэл.ndmsv рэн.ndmsv ряст.ndmsv сабайон.ndmsv 
+сабан.ndmsv сабеизм.ndmsv сабур.ndmsv саван.ndmsv саган.ndmsv садизм.ndmsv 
+саз.ndmsv сайзер.ndmsv сайодин.ndmsv сайт.ndmsv саккос.ndmsv сакман.ndmsv 
+саксаул.ndmsv саксгорн.ndmsv саксофон.ndmsv салипирин.ndmsv салицин.ndmsv салол.ndmsv 
+салолин.ndmsv саломас.ndmsv салун.ndmsv сальварсан.ndmsv сальмонеллез.ndmsv сальпингит.ndmsv 
+самарскит.ndmsv саммит.ndmsv самоанализ.ndmsv самовозврат.ndmsv самогипноз.ndmsv самоклад.ndmsv 
+самолето-рейс.ndmsv самолетовылет.ndmsv самонаклад.ndmsv самообман.ndmsv самооговор.ndmsv самоостанов.ndmsv 
+самоотвод.ndmsv самоотчет.ndmsv самопал.ndmsv самопресс.ndmsv саморазрыв.ndmsv самораспад.ndmsv 
+самосвал.ndmsv самосин.ndmsv самосплав.ndmsv самостил.ndmsv самосуд.ndmsv самотряс.ndmsv 
+самоцвет.ndmsv сампан.ndmsv самум.ndmsv самшит.ndmsv санбат.ndmsv сангвинизм.ndmsv 
+санидин.ndmsv санктус.ndmsv санпросвет.ndmsv санскрит.ndmsv сантибар.ndmsv сантиграмм.ndmsv 
+сантилитр.ndmsv сантим.ndmsv сантиметр.ndmsv сантипуаз.ndmsv сантистокс.ndmsv сантонин.ndmsv 
+сапонат.ndmsv сапонин.ndmsv сапонит.ndmsv сапр.ndmsv сапролит.ndmsv сапропелит.ndmsv 
+сапрофит.ndmsv сапун.ndmsv сардер.ndmsv сардоникс.ndmsv сарказм.ndmsv саркоид.ndmsv 
+сарос.ndmsv сассафрас.ndmsv сатанизм.ndmsv сателлоид.ndmsv сатинер.ndmsv сатинет.ndmsv 
+сатириаз.ndmsv сатириазис.ndmsv сатуратор.ndmsv сатурнизм.ndmsv сауэр.ndmsv сафлор.ndmsv 
+сафранин.ndmsv сафрол.ndmsv сахарат.ndmsv сахарид.ndmsv сахариметр.ndmsv сахарозавод.ndmsv 
+сахарометр.ndmsv сахаромицет.ndmsv сахаронос.ndmsv сбыт.ndmsv свеклокомбайн.ndmsv свеклосовхоз.ndmsv 
+сверхбаллон.ndmsv сверхгигант.ndmsv сверхдредноут.ndmsv сверхкомплект.ndmsv сверхорганизм.ndmsv свес.ndmsv 
+световод.ndmsv светодиод.ndmsv светолюб.ndmsv светопровод.ndmsv светорегулятор.ndmsv светосигнал.ndmsv 
+светофильтр.ndmsv светофор.ndmsv свингометр.ndmsv свиносовхоз.ndmsv своп.ndmsv сворот.ndmsv 
+сглаз.ndmsv сдув.ndmsv сеанс.ndmsv севооборот.ndmsv севосмен.ndmsv севр.ndmsv 
+сегунат.ndmsv сезам.ndmsv сейм.ndmsv сейсмоаппарат.ndmsv сейсмограф.ndmsv сейсмометр.ndmsv 
+сейсмоскоп.ndmsv сейф.ndmsv секанс.ndmsv секатор.ndmsv секретариат.ndmsv секретер.ndmsv 
+секретин.ndmsv секс.ndmsv секстаккорд.ndmsv секстан.ndmsv секстант.ndmsv секстет.ndmsv 
+секстиллион.ndmsv секстильон.ndmsv сексуализм.ndmsv секундомер.ndmsv селектор.ndmsv селенид.ndmsv 
+селесброс.ndmsv сельсин.ndmsv сельсовет.ndmsv сельфактор.ndmsv семеномер.ndmsv семестр.ndmsv 
+семиинвариант.ndmsv семинар.ndmsv семитизм.ndmsv семфонд.ndmsv семявход.ndmsv семяпровод.ndmsv 
+сенармонтит.ndmsv сенат.ndmsv сеновал.ndmsv сенсибилизатор.ndmsv сенситометр.ndmsv сенсуализм.ndmsv 
+сентипуаз.ndmsv сеньорат.ndmsv сеньорен-конвент.ndmsv сепаратизм.ndmsv сепаратор.ndmsv сепиолит.ndmsv 
+сепсис.ndmsv септаккорд.ndmsv септемвират.ndmsv септет.ndmsv септиллион.ndmsv септильон.ndmsv 
+сервант.ndmsv сервелат.ndmsv сервилизм.ndmsv сервис.ndmsv сервис-период.ndmsv сервитут.ndmsv 
+сервоклапан.ndmsv сервокомпенсатор.ndmsv сервомеханизм.ndmsv сервомотор.ndmsv сервопривод.ndmsv сериал.ndmsv 
+серин.ndmsv сериф.ndmsv серицин.ndmsv серицит.ndmsv серкес.ndmsv серотонин.ndmsv 
+серп.ndmsv серпантин.ndmsv серпент.ndmsv серпентинит.ndmsv сертификат.ndmsv серум.ndmsv 
+серфер.ndmsv сестон.ndmsv сеттльмент.ndmsv сжим.ndmsv сибилянт.ndmsv сигнализатор.ndmsv 
+сидерат.ndmsv сидерит.ndmsv сидероз.ndmsv сидеролит.ndmsv сидеростат.ndmsv сиенит.ndmsv 
+сикамор.ndmsv сиккатив.ndmsv сикоз.ndmsv сикомор.ndmsv сикурс.ndmsv силан.ndmsv 
+силикальцит.ndmsv силикоз.ndmsv силикон.ndmsv силикофосфат.ndmsv силицид.ndmsv силлабизм.ndmsv 
+силлиманит.ndmsv силлогизм.ndmsv силоксан.ndmsv силоксид.ndmsv силомер.ndmsv силон.ndmsv 
+силумин.ndmsv силуминит.ndmsv силур.ndmsv сильванит.ndmsv сильвин.ndmsv сильвинит.ndmsv 
+сильфон.ndmsv симбиоз.ndmsv символизм.ndmsv симплекс.ndmsv симпозиум.ndmsv симптом.ndmsv 
+симфиз.ndmsv симфонизм.ndmsv синап.ndmsv синапс.ndmsv синапсис.ndmsv синглет.ndmsv 
+синдесмоз.ndmsv синдетикон.ndmsv синдикат.ndmsv синдолор.ndmsv синдром.ndmsv синедрион.ndmsv 
+синемаскоп.ndmsv синематограф.ndmsv синерезис.ndmsv синерод.ndmsv синестрол.ndmsv синклит.ndmsv 
+синкретизм.ndmsv синод.ndmsv синоним.ndmsv синопсис.ndmsv синостоз.ndmsv синтаксис.ndmsv 
+синтез.ndmsv синтезатор.ndmsv синтекс.ndmsv синтоизм.ndmsv синтомицин.ndmsv синусит.ndmsv 
+синхондроз.ndmsv синхроимпульс.ndmsv синхроконтакт.ndmsv синхронизатор.ndmsv синхронизм.ndmsv синхроноскоп.ndmsv 
+синхросигнал.ndmsv синхроскоп.ndmsv синхротрон.ndmsv синхрофазотрон.ndmsv синхроциклотрон.ndmsv синьоритет.ndmsv 
+сионизм.ndmsv сиринкс.ndmsv систр.ndmsv ситар.ndmsv сифилис.ndmsv скайсуипер.ndmsv 
+скаленоэдр.ndmsv скальол.ndmsv скальп.ndmsv сканер.ndmsv скаполит.ndmsv скарб.ndmsv 
+скарификатор.ndmsv скарн.ndmsv скатол.ndmsv скаутизм.ndmsv скафандр.ndmsv сквид.ndmsv 
+скейт.ndmsv скейтборд.ndmsv скелетон.ndmsv скеннер.ndmsv скепсис.ndmsv скептицизм.ndmsv 
+скипетр.ndmsv скирдовоз.ndmsv скифл.ndmsv склерит.ndmsv склерометр.ndmsv склерон.ndmsv 
+склероскоп.ndmsv сколиоз.ndmsv скольдер.ndmsv скополамин.ndmsv скородит.ndmsv скоростемер.ndmsv 
+скотопрогон.ndmsv скрап.ndmsv скрининг-тест.ndmsv скрипт.ndmsv скрофулез.ndmsv скруббер.ndmsv 
+скрупул.ndmsv славянизм.ndmsv слад.ndmsv слайд.ndmsv слайдер.ndmsv слиперс.ndmsv 
+словораздел.ndmsv слогораздел.ndmsv слот.ndmsv слюдинит.ndmsv слюногон.ndmsv сляб.ndmsv 
+смарагд.ndmsv смарагдит.ndmsv смилакс.ndmsv смитсонит.ndmsv снеговал.ndmsv снегозанос.ndmsv 
+снеголом.ndmsv снегомер.ndmsv снегопад.ndmsv снегоступ.ndmsv снеготранспортер.ndmsv снегоход.ndmsv 
+снобизм.ndmsv снобол.ndmsv сноп.ndmsv собес.ndmsv совдеп.ndmsv соверен.ndmsv 
+совмин.ndmsv совнарком.ndmsv совнархоз.ndmsv согрев.ndmsv содалит.ndmsv содар.ndmsv 
+содоклад.ndmsv созыв.ndmsv сокет.ndmsv соланин.ndmsv солемер.ndmsv соленоид.ndmsv 
+солерет.ndmsv солерод.ndmsv солерос.ndmsv солесос.ndmsv солецизм.ndmsv солидат.ndmsv 
+солидол.ndmsv солидус.ndmsv солипсизм.ndmsv солиситор.ndmsv солитон.ndmsv соллюкс.ndmsv 
+солнцеворот.ndmsv солнцецвет.ndmsv соломер.ndmsv соломит.ndmsv соломовяз.ndmsv соломотряс.ndmsv 
+сольвент.ndmsv соляриум.ndmsv соматотропин.ndmsv сомит.ndmsv сонант.ndmsv сонар.ndmsv 
+сонм.ndmsv сонометр.ndmsv сополимер.ndmsv сопор.ndmsv сопромат.ndmsv сопроцессор.ndmsv 
+сорбат.ndmsv сорбент.ndmsv сорбит.ndmsv сорегент.ndmsv сорит.ndmsv соробан.ndmsv 
+сорокоуст.ndmsv сорорат.ndmsv сортамент.ndmsv сортимент.ndmsv сорус.ndmsv соскоб.ndmsv 
+соссюрит.ndmsv сосуд.ndmsv сотерн.ndmsv соул.ndmsv софизм.ndmsv софит.ndmsv 
+софт.ndmsv софтбол.ndmsv социал-демократ.ndmsv социализм.ndmsv социум.ndmsv спад.ndmsv 
+спайдер.ndmsv спандекс.ndmsv спейсер.ndmsv спекл.ndmsv спектр.ndmsv спектрогелиограф.ndmsv 
+спектрогелиометр.ndmsv спектрограф.ndmsv спектрометр.ndmsv спектрорадиометр.ndmsv спектросенситометр.ndmsv спектроскоп.ndmsv 
+спектрофотометр.ndmsv спекулярит.ndmsv спеллер.ndmsv спен.ndmsv спенкер.ndmsv сперматозоид.ndmsv 
+сперматоцид.ndmsv спермацет.ndmsv спермин.ndmsv спецаукцион.ndmsv спецвагон.ndmsv спецгруз.ndmsv 
+спецжелезобетон.ndmsv спецзаказ.ndmsv специнструмент.ndmsv спецкласс.ndmsv спецкомплект.ndmsv спецконтингент.ndmsv 
+спецкурс.ndmsv спецобъект.ndmsv спецотдел.ndmsv спецподъезд.ndmsv спецрадиоматериал.ndmsv спецрейс.ndmsv 
+спецсамолет.ndmsv спецсеминар.ndmsv спецсимвол.ndmsv спецстройматериал.ndmsv спецэкспортер.ndmsv спецэффект.ndmsv 
+спидбол.ndmsv спидометр.ndmsv спидстер.ndmsv спинакер.ndmsv спинар.ndmsv спинет.ndmsv 
+спинор.ndmsv спинтарископ.ndmsv спиритизм.ndmsv спирограф.ndmsv спирометр.ndmsv спиртомер.ndmsv 
+спиртометр.ndmsv сплайн.ndmsv спленит.ndmsv сплин.ndmsv сподумен.ndmsv спойлер.ndmsv 
+спонгин.ndmsv спонгит.ndmsv спондилит.ndmsv спорофилл.ndmsv спорофит.ndmsv спорт.ndmsv 
+спортзал.ndmsv спортклуб.ndmsv спот.ndmsv спрайт.ndmsv спредер.ndmsv спринклер.ndmsv 
+спринт.ndmsv сприт.ndmsv спрос.ndmsv спуд.ndmsv спул.ndmsv спурт.ndmsv 
+срыв.ndmsv ссыппункт.ndmsv стабилизатор.ndmsv стабилитрон.ndmsv ставролит.ndmsv стагирит.ndmsv 
+стадиал.ndmsv стаз.ndmsv стакер.ndmsv сталагмит.ndmsv сталагмометр.ndmsv сталактит.ndmsv 
+сталебетон.ndmsv сталинит.ndmsv стальбетон.ndmsv станнат.ndmsv станнит.ndmsv станс.ndmsv 
+станционер.ndmsv стаплер.ndmsv старн.ndmsv старнпост.ndmsv старнсон.ndmsv старославянизм.ndmsv 
+статер.ndmsv статир.ndmsv статолит.ndmsv статор.ndmsv статоскоп.ndmsv статотчет.ndmsv 
+статоцист.ndmsv стаут.ndmsv стачком.ndmsv стеарат.ndmsv стеатит.ndmsv стеблеплод.ndmsv 
+стейкбургер.ndmsv стеклограф.ndmsv стеклопакет.ndmsv стеклопласт.ndmsv стеклоприбор.ndmsv стеклотекстолит.ndmsv 
+стеклохолст.ndmsv стеклярус.ndmsv стелларатор.ndmsv стеллит.ndmsv стем.ndmsv стемпид.ndmsv 
+стенд.ndmsv стендер.ndmsv стенолом.ndmsv стеноп.ndmsv стенотип.ndmsv степотип.ndmsv 
+степс.ndmsv стер.ndmsv стерадиан.ndmsv стереоавтограф.ndmsv стереобат.ndmsv стереограф.ndmsv 
+стереодиапозитив.ndmsv стереоизомер.ndmsv стереокартограф.ndmsv стереокомпаратор.ndmsv стереомагнитофон.ndmsv стереометр.ndmsv 
+стереомикроскоп.ndmsv стереопроектор.ndmsv стереоскоп.ndmsv стереотаксис.ndmsv стереофильм.ndmsv стереоэкран.ndmsv 
+стереоэффект.ndmsv стерилизатор.ndmsv стерин.ndmsv стернит.ndmsv стероид.ndmsv стетоскоп.ndmsv 
+стетсон.ndmsv стефанит.ndmsv стибин.ndmsv стибнит.ndmsv стивер.ndmsv стигмат.ndmsv 
+стигматизм.ndmsv стилет.ndmsv стилобат.ndmsv стилограф.ndmsv стилолит.ndmsv стилометр.ndmsv 
+стильб.ndmsv стильбит.ndmsv стимер.ndmsv стимул.ndmsv стимулянт.ndmsv стимулятор.ndmsv 
+стипль-чез.ndmsv стиптицин.ndmsv стиракс.ndmsv стишовит.ndmsv стоговоз.ndmsv стожар.ndmsv 
+стоицизм.ndmsv стокс.ndmsv столон.ndmsv стоматит.ndmsv стоматоскоп.ndmsv стомп.ndmsv 
+стоп-кран.ndmsv стоп-овер.ndmsv стоп-сигнал.ndmsv стопин.ndmsv стоун.ndmsv стоцвет.ndmsv 
+страбизм.ndmsv страдивариус.ndmsv страз.ndmsv страстоцвет.ndmsv стратоплан.ndmsv стратостат.ndmsv 
+страхфонд.ndmsv стрекун.ndmsv стрелолист.ndmsv стренер.ndmsv стрептомицин.ndmsv стресс.ndmsv 
+стресс-детектор.ndmsv стрессор.ndmsv стример.ndmsv стриммер.ndmsv стрип.ndmsv стриппер.ndmsv 
+стриптиз.ndmsv стрихнин.ndmsv строанцианит.ndmsv строб.ndmsv стробил.ndmsv стробилус.ndmsv 
+стробимпульс.ndmsv стробоскоп.ndmsv стройбат.ndmsv стройотряд.ndmsv строматолит.ndmsv стронцианит.ndmsv 
+стропконтейнер.ndmsv строфант.ndmsv строфулус.ndmsv струнобетон.ndmsv студебеккер.ndmsv ступор.ndmsv 
+субимпульс.ndmsv субконтинент.ndmsv субконтракт.ndmsv сублимат.ndmsv субмикрон.ndmsv субподряд.ndmsv 
+субпродукт.ndmsv субрегион.ndmsv субстрат.ndmsv субстратостат.ndmsv субсчет.ndmsv субтитр.ndmsv 
+субфебрилитет.ndmsv субштамм.ndmsv суверенитет.ndmsv сугроб.ndmsv судооборот.ndmsv судоподъем.ndmsv 
+судоремонт.ndmsv сузафон.ndmsv сукцинит.ndmsv султанат.ndmsv сульгин.ndmsv сульфазол.ndmsv 
+сульфамид.ndmsv сульфаниламид.ndmsv сульфгидрат.ndmsv сульфидин.ndmsv сульфонал.ndmsv сумет.ndmsv 
+сумматор.ndmsv суннизм.ndmsv суперген.ndmsv супергетеродин.ndmsv суперкар.ndmsv суперкомпьютер.ndmsv 
+суперкремникон.ndmsv суперлайнер.ndmsv супермапипезиметр.ndmsv супермарафон.ndmsv супермаркет.ndmsv суперортикон.ndmsv 
+суперпарамагнетизм.ndmsv суперпластификатор.ndmsv суперсплав.ndmsv суперстрат.ndmsv суперсульфат.ndmsv супертанкер.ndmsv 
+супертоксикант.ndmsv супертоксин.ndmsv суперфильм.ndmsv суперфосфат.ndmsv суперэкотоксикант.ndmsv суперэкслибрис.ndmsv 
+супин.ndmsv супинатор.ndmsv суррогат.ndmsv сурфактант.ndmsv суслон.ndmsv суспензор.ndmsv 
+суфизм.ndmsv суфляр.ndmsv суфражизм.ndmsv суффикс.ndmsv сухогруз.ndmsv суходол.ndmsv 
+сухолом.ndmsv сухолюб.ndmsv сухоцвет.ndmsv сучкорез.ndmsv сфагнум.ndmsv сфалерит.ndmsv 
+сфен.ndmsv сфеноид.ndmsv сферокристалл.ndmsv сферолит.ndmsv сферометр.ndmsv сферопласт.ndmsv 
+сферосидерит.ndmsv сфигмограф.ndmsv сфигмоманометр.ndmsv сфигмометр.ndmsv сфинктер.ndmsv схематизм.ndmsv 
+сценизм.ndmsv сцинтиллометр.ndmsv сцинтиллоскоп.ndmsv сцинтиллятор.ndmsv съезд.ndmsv сыропуст.ndmsv 
+сэбин.ndmsv сюзеренитет.ndmsv сюрвейер.ndmsv сюрреализм.ndmsv сямисэн.ndmsv табес.ndmsv 
+табльдот.ndmsv табулятор.ndmsv тазиметр.ndmsv тайгеркэт.ndmsv тайм.ndmsv тайм-аут.ndmsv 
+тайм-чартер.ndmsv таймаут.ndmsv таймер.ndmsv таймограф.ndmsv таймун.ndmsv таймшит.ndmsv 
+тайфун.ndmsv таконит.ndmsv таксиметр.ndmsv таксис.ndmsv таксит.ndmsv таксометр.ndmsv 
+таксомотор.ndmsv таксон.ndmsv таксофон.ndmsv такт.ndmsv тактометр.ndmsv такыр.ndmsv 
+таламус.ndmsv талант.ndmsv талер.ndmsv талес.ndmsv талион.ndmsv талипот.ndmsv 
+талис.ndmsv талисман.ndmsv таллом.ndmsv талмуд.ndmsv талмудизм.ndmsv талькомагнезит.ndmsv 
+тамаринд.ndmsv тамбур-шлюз.ndmsv тамбурин.ndmsv тампон.ndmsv тамтам.ndmsv танатоценоз.ndmsv 
+танбур.ndmsv тангенс.ndmsv тангор.ndmsv тандем.ndmsv тандер.ndmsv танид.ndmsv 
+танин.ndmsv танкодром.ndmsv таннат.ndmsv таннин.ndmsv тантал.ndmsv танталат.ndmsv 
+танталит.ndmsv танцзал.ndmsv танцкласс.ndmsv тарантас.ndmsv тарарам.ndmsv тардион.ndmsv 
+тардон.ndmsv тарлатан.ndmsv тартар.ndmsv тартразин.ndmsv тартрат.ndmsv тархун.ndmsv 
+тасманит.ndmsv тау-сагыз.ndmsv таутохронизм.ndmsv тахеометр.ndmsv тахилит.ndmsv тахиметр.ndmsv 
+тахиол.ndmsv тахион.ndmsv тахограф.ndmsv тахометр.ndmsv тацет.ndmsv твердозем.ndmsv 
+твердомер.ndmsv твил.ndmsv твин.ndmsv твист.ndmsv твэл.ndmsv театр.ndmsv 
+тегмен.ndmsv тезаурус.ndmsv тезис.ndmsv теизм.ndmsv теин.ndmsv тейлоризм.ndmsv 
+текс.ndmsv тексроп.ndmsv текст.ndmsv текст-процессор.ndmsv текстовинит.ndmsv текстолит.ndmsv 
+тектит.ndmsv теламон.ndmsv телеавтограф.ndmsv телевизор.ndmsv телеграф.ndmsv телеканал.ndmsv 
+телекиноматериал.ndmsv телекинопроектор.ndmsv телекласс.ndmsv телекомплекс.ndmsv телекоптер.ndmsv телекс.ndmsv 
+телемарафон.ndmsv телематериал.ndmsv телеметр.ndmsv телемонитор.ndmsv телемост.ndmsv теленейрон.ndmsv 
+телеобъектив.ndmsv телепорт.ndmsv телерадиокомплекс.ndmsv телерадиоцентр.ndmsv телеран.ndmsv телеросс.ndmsv 
+телесейсм.ndmsv телесериал.ndmsv телескоп.ndmsv телеспектроскоп.ndmsv телесюжет.ndmsv телетайп.ndmsv 
+телетекст.ndmsv телетермометр.ndmsv телефакс.ndmsv телефильм.ndmsv телефотометр.ndmsv телецентр.ndmsv 
+телеэкран.ndmsv теллур.ndmsv теллурат.ndmsv теллурид.ndmsv теллурит.ndmsv теллурометр.ndmsv 
+теломер.ndmsv телорез.ndmsv тельсон.ndmsv тельфер.ndmsv тембр.ndmsv темп.ndmsv 
+темпл.ndmsv темпон.ndmsv тенар.ndmsv тенардит.ndmsv тендерометр.ndmsv тенезм.ndmsv 
+тенелюб.ndmsv тенериф.ndmsv тензиометр.ndmsv тензометр.ndmsv тензор.ndmsv теннантит.ndmsv 
+тенорит.ndmsv тент.ndmsv тенториум.ndmsv теобромин.ndmsv теодолит.ndmsv теорикон.ndmsv 
+теофиллин.ndmsv тепловизор.ndmsv тепловоз.ndmsv теплоизолятор.ndmsv тепломер.ndmsv теплообмен.ndmsv 
+теплоотвод.ndmsv теплопеленгатор.ndmsv теплоперенос.ndmsv теплоприбор.ndmsv теплород.ndmsv теплофильтр.ndmsv 
+теплоход.ndmsv теплурометр.ndmsv терабайт.ndmsv терабит.ndmsv теракт.ndmsv тератоген.ndmsv 
+терблиг.ndmsv тергит.ndmsv терилен.ndmsv термидор.ndmsv термин.ndmsv терминал.ndmsv 
+терминатор.ndmsv терминизм.ndmsv термистор.ndmsv термоантрацит.ndmsv термобарометр.ndmsv термобиметалл.ndmsv 
+термогазоанализатор.ndmsv термогенератор.ndmsv термограф.ndmsv термозит.ndmsv термоиндикатор.ndmsv термокаутер.ndmsv 
+термоконтейнер.ndmsv термометр.ndmsv термоперенос.ndmsv термопериод.ndmsv термопласт.ndmsv термопрен.ndmsv 
+термопсис.ndmsv терморегулятор.ndmsv терморезистор.ndmsv терморецептор.ndmsv термосифон.ndmsv термоскоп.ndmsv 
+термостат.ndmsv термотаксис.ndmsv термотрон.ndmsv термофосфат.ndmsv термоэлектрогенератор.ndmsv термоэлектрон.ndmsv 
+термоэлемент.ndmsv терн.ndmsv терпентин.ndmsv терпинол.ndmsv терразит.ndmsv террамицин.ndmsv 
+террариум.ndmsv терренкур.ndmsv террикон.ndmsv террор.ndmsv терроризм.ndmsv терцет.ndmsv 
+тессаракт.ndmsv тест-акт.ndmsv тестер.ndmsv тестон.ndmsv тетанус.ndmsv тетраборат.ndmsv 
+тетрагидрофуран.ndmsv тетрадимит.ndmsv тетраметр.ndmsv тетраморф.ndmsv тетрапод.ndmsv тетрафтор.ndmsv 
+тетрафторбромпропан.ndmsv тетрафторбромэтан.ndmsv тетрафтордибромпропан.ndmsv тетрафтордихлорпропан.ndmsv тетрафтордихлорэтан.ndmsv тетрафтортетрахлорпропан.ndmsv 
+тетрафтортрихлор.ndmsv тетрафторхлорпропан.ndmsv тетрафторхлорэтан.ndmsv тетрахлорметан.ndmsv тетрахорд.ndmsv тетраэдр.ndmsv 
+тетраэдрит.ndmsv тетраэтилен.ndmsv тетраэтиленпентамин.ndmsv тетраэтилентамин.ndmsv тетрил.ndmsv тетробол.ndmsv 
+тетрод.ndmsv тетродотоксин.ndmsv тетроксид.ndmsv тетрофторид.ndmsv тефилин.ndmsv тефлон.ndmsv 
+тефрит.ndmsv тефроит.ndmsv техминимум.ndmsv технадзор.ndmsv техникум.ndmsv техницизм.ndmsv 
+технотрон.ndmsv техосмотр.ndmsv техотдел.ndmsv техперсонал.ndmsv техуглерод.ndmsv техцентр.ndmsv 
+тиазин.ndmsv тиазол.ndmsv тиамин.ndmsv тикер.ndmsv тиккер.ndmsv тиллит.ndmsv 
+тимберс.ndmsv тимин.ndmsv тимол.ndmsv тимпанит.ndmsv тимус.ndmsv тимьян.ndmsv 
+тинкал.ndmsv тиоальдегид.ndmsv тиокол.ndmsv тиол.ndmsv тионил.ndmsv тионилхлорид.ndmsv 
+тиосульфат.ndmsv тиоурацил.ndmsv тиофос.ndmsv тиоцианат.ndmsv тиоэфир.ndmsv типикон.ndmsv 
+типометр.ndmsv типоразмер.ndmsv типун.ndmsv тиратрон.ndmsv тиреоидин.ndmsv тиристор.ndmsv 
+тирит.ndmsv тирозин.ndmsv тироксин.ndmsv тирольен.ndmsv тирс.ndmsv титанат.ndmsv 
+титанит.ndmsv тиф.ndmsv тифлит.ndmsv тиходол.ndmsv тобогган.ndmsv товарообмен.ndmsv 
+товарооборот.ndmsv токопровод.ndmsv токосъем.ndmsv токоферол.ndmsv токсикант.ndmsv токсикоз.ndmsv 
+токсин.ndmsv токсоплазм.ndmsv токсоплазмоз.ndmsv толкун.ndmsv толобат.ndmsv толуол.ndmsv 
+томограф.ndmsv томсенолит.ndmsv томсонит.ndmsv тонар.ndmsv тонарм.ndmsv тонвал.ndmsv 
+тонер.ndmsv тонзиллит.ndmsv тонно-километр.ndmsv тонометр.ndmsv тонус.ndmsv тонфильм.ndmsv 
+топазолит.ndmsv топенант.ndmsv топинамбур.ndmsv топливомер.ndmsv топливопровод.ndmsv топоним.ndmsv 
+топотип.ndmsv топтимберс.ndmsv топчан.ndmsv топшур.ndmsv торакс.ndmsv торбан.ndmsv 
+торбанит.ndmsv торбернит.ndmsv торгпред.ndmsv торгсин.ndmsv торианит.ndmsv торизм.ndmsv 
+торит.ndmsv торкрет.ndmsv торкретбетон.ndmsv торн.ndmsv тороид.ndmsv торон.ndmsv 
+торос.ndmsv торс.ndmsv торт.ndmsv торус.ndmsv торфобетон.ndmsv торфобрикет.ndmsv 
+торфокомпост.ndmsv торфонасос.ndmsv торфорез.ndmsv торфосос.ndmsv торшер.ndmsv торшон.ndmsv 
+тост.ndmsv тостер.ndmsv тотализатор.ndmsv тотемизм.ndmsv тофус.ndmsv траверз.ndmsv 
+травертин.ndmsv травматизм.ndmsv травмопункт.ndmsv травокос.ndmsv трагакант.ndmsv трагант.ndmsv 
+трагизм.ndmsv трайлер.ndmsv трактат.ndmsv трамблер.ndmsv трамп.ndmsv трамплин.ndmsv 
+трамтарарам.ndmsv транажер.ndmsv транзиент.ndmsv транзистор.ndmsv транквилизатор.ndmsv транс.ndmsv 
+трансбордер.ndmsv трансвертер.ndmsv трансдуктор.ndmsv трансепт.ndmsv транскодер.ndmsv транскриптор.ndmsv 
+транслятор.ndmsv трансмиттер.ndmsv транспарант.ndmsv трансплантат.ndmsv транспозон.ndmsv транспорт.ndmsv 
+транспортер.ndmsv транспьютер.ndmsv транссудат.ndmsv трансуран.ndmsv трансфер.ndmsv трансферт.ndmsv 
+трансфикс.ndmsv трансфокатор.ndmsv трансформ.ndmsv трансформатор.ndmsv трап.ndmsv трапецоид.ndmsv 
+трапецоэдр.ndmsv трапп.ndmsv трас.ndmsv трассер.ndmsv траст.ndmsv траст-актив.ndmsv 
+траст-отдел.ndmsv траст-фонд.ndmsv траулер.ndmsv трахеит.ndmsv трахит.ndmsv тред-юнион.ndmsv 
+трейлер.ndmsv тремблер.ndmsv тремолит.ndmsv тремор.ndmsv трен.ndmsv тренажер.ndmsv 
+треншальтер.ndmsv треонин.ndmsv трепел.ndmsv трехчлен.ndmsv трешкоут.ndmsv триазин.ndmsv 
+триаминотринитробензол.ndmsv триамциналон.ndmsv триас.ndmsv триацетат.ndmsv трибометр.ndmsv трибунал.ndmsv 
+трибунат.ndmsv трибутилфосфат.ndmsv тривектор.ndmsv тривиум.ndmsv тригидрат.ndmsv триглиф.ndmsv 
+триглицерин.ndmsv триграф.ndmsv тридимит.ndmsv тризм.ndmsv трикальцийфосфат.ndmsv триколор.ndmsv 
+трикотин.ndmsv триллер.ndmsv тримаран.ndmsv тримезол.ndmsv тример.ndmsv триместр.ndmsv 
+триметилолэтантринитрат.ndmsv триметилоэтантринитрат.ndmsv триметилфосфит.ndmsv триметр.ndmsv триммер.ndmsv тримюон.ndmsv 
+тринископ.ndmsv тринитробензол.ndmsv тринитроксилол.ndmsv тринитротолуол.ndmsv тринитрофенол.ndmsv трином.ndmsv 
+триоксид.ndmsv триолет.ndmsv трип.ndmsv трипанозомоз.ndmsv трипаносомоз.ndmsv триплан.ndmsv 
+триплекс.ndmsv триплет.ndmsv триплит.ndmsv триполифосфат.ndmsv триппер.ndmsv трипс.ndmsv 
+трипсин.ndmsv трипсиноген.ndmsv триптан.ndmsv триптофан.ndmsv тритикал.ndmsv триумвират.ndmsv 
+триумф.ndmsv трифан.ndmsv трифенил.ndmsv трифенилен.ndmsv трифлорум.ndmsv трифторбромметан.ndmsv 
+трифторбромпропан.ndmsv трифторбромэтан.ndmsv трифтордибромпропан.ndmsv трифтордибромэтан.ndmsv трифтордихлорпропан.ndmsv трифтордихлорэтан.ndmsv 
+трифторид.ndmsv трифторпентахлорпропан.ndmsv трифтортетрахлор.ndmsv трифтортрибромпропан.ndmsv трифтортрихлорпропан.ndmsv трифтортрихлорэтан.ndmsv 
+трифторхлорметан.ndmsv трифторхлорпропан.ndmsv трифторхлорэтан.ndmsv трихиаз.ndmsv трихинеллез.ndmsv трихиноз.ndmsv 
+трихит.ndmsv трихлорнитрометан.ndmsv трихлорэтан.ndmsv трихлорэтилен.ndmsv трихом.ndmsv трихомоноз.ndmsv 
+трихоцефалез.ndmsv трицепс.ndmsv триэдр.ndmsv триэтаноламин.ndmsv триэтаноламиногидрохлорид.ndmsv триэтилфосфит.ndmsv 
+троакар.ndmsv троетес.ndmsv троилит.ndmsv троллейбус.ndmsv троллейвоз.ndmsv троллейкар.ndmsv 
+тромб.ndmsv тромбин.ndmsv тромбоген.ndmsv тромбоз.ndmsv тромбопластин.ndmsv тромбофлебит.ndmsv 
+тромбоцит.ndmsv тромп.ndmsv тропизм.ndmsv тропот.ndmsv трос.ndmsv трот.ndmsv 
+тротил.ndmsv трофобиоз.ndmsv трофоневроз.ndmsv трохантин.ndmsv трохотрон.ndmsv троцкизм.ndmsv 
+труакар.ndmsv трубопровод.ndmsv труборез.ndmsv трубоцвет.ndmsv трудфронт.ndmsv трюизм.ndmsv 
+туаз.ndmsv туальденор.ndmsv туан.ndmsv тубафон.ndmsv тубдиспансер.ndmsv туберкулез.ndmsv 
+туберкулин.ndmsv тубус.ndmsv туманограф.ndmsv тумблер.ndmsv тумор.ndmsv турбоагрегат.ndmsv 
+турбобур.ndmsv турбовентилятор.ndmsv турбовоз.ndmsv турбогенератор.ndmsv турбодетандер.ndmsv турбокомпрессор.ndmsv 
+турбонасос.ndmsv турбопровод.ndmsv турбоход.ndmsv турбоэлектроход.ndmsv туризм.ndmsv турион.ndmsv 
+турмалин.ndmsv турнепс.ndmsv турникет.ndmsv турнюр.ndmsv туроператор.ndmsv турпоход.ndmsv 
+турф.ndmsv тустеп.ndmsv туфобетон.ndmsv тюнер.ndmsv тюрбан.ndmsv тюрингит.ndmsv 
+тюркизм.ndmsv тютюн.ndmsv тягомер.ndmsv тягун.ndmsv уаз.ndmsv уайт-спирит.ndmsv 
+уанстеп.ndmsv убиквист.ndmsv убрус.ndmsv увоз.ndmsv увулит.ndmsv углеводород.ndmsv 
+углегипс.ndmsv углепровод.ndmsv углесос.ndmsv узус.ndmsv узуфрукт.ndmsv уик-энд.ndmsv 
+уклонизм.ndmsv уклономер.ndmsv украинизм.ndmsv укус.ndmsv улет.ndmsv ульманит.ndmsv 
+ульмин.ndmsv ультиматум.ndmsv ультрамарин.ndmsv ультрамикрометр.ndmsv ультрамикроскоп.ndmsv ультрамонтан.ndmsv 
+ультрафильтр.ndmsv ультрафиолет.ndmsv умет.ndmsv умлаут.ndmsv умляут.ndmsv умформер.ndmsv 
+унанимизм.ndmsv универсам.ndmsv университет.ndmsv универсум.ndmsv унионизм.ndmsv унитаз.ndmsv 
+унитаризм.ndmsv ункус.ndmsv унтертон.ndmsv уорд.ndmsv уралит.ndmsv уран.ndmsv 
+уранат.ndmsv уранил.ndmsv уранилдинитрат.ndmsv уранилкарбонат.ndmsv уранинит.ndmsv уранит.ndmsv 
+ураноскоп.ndmsv урат.ndmsv урацил.ndmsv урбанизм.ndmsv уретан.ndmsv уретрит.ndmsv 
+уретроренофиброскоп.ndmsv уретроскоп.ndmsv уринал.ndmsv урман.ndmsv уробилин.ndmsv уровнемер.ndmsv 
+уродан.ndmsv урометр.ndmsv уротропин.ndmsv уряд.ndmsv утильзавод.ndmsv утопизм.ndmsv 
+ухаб.ndmsv уход.ndmsv учес.ndmsv фабком.ndmsv фабрикат.ndmsv фавор.ndmsv 
+фаворитизм.ndmsv фагоцит.ndmsv фагоцитоз.ndmsv фазер.ndmsv фазис.ndmsv фазитрон.ndmsv 
+фазоинвертор.ndmsv фазоиндикатор.ndmsv фазокомпенсатор.ndmsv фазометр.ndmsv фазорегулятор.ndmsv фазотрон.ndmsv 
+файербол.ndmsv файл.ndmsv факолит.ndmsv факс.ndmsv факт.ndmsv фактис.ndmsv 
+фактор.ndmsv факториал.ndmsv факультатив.ndmsv факультет.ndmsv фаланстер.ndmsv фалл.ndmsv 
+фаллос.ndmsv фалреп.ndmsv фальбанд.ndmsv фалькон.ndmsv фальконет.ndmsv фальсификат.ndmsv 
+фальстарт.ndmsv фальстем.ndmsv фальцаппарат.ndmsv фальцбейн.ndmsv фальцет.ndmsv фальшборт.ndmsv 
+фальшфейер.ndmsv фаматинит.ndmsv фамулус.ndmsv фанатизм.ndmsv фаншон.ndmsv фарватер.ndmsv 
+фарингит.ndmsv фаринотом.ndmsv фармаколит.ndmsv фармакосидерит.ndmsv фарс.ndmsv фарфор.ndmsv 
+фассаит.ndmsv фатализм.ndmsv фатум.ndmsv фаустпатрон.ndmsv фацет.ndmsv фашизм.ndmsv 
+фаэтон.ndmsv фаялит.ndmsv фаянс.ndmsv федерализм.ndmsv фельетон.ndmsv фельзит.ndmsv 
+феминизм.ndmsv фен.ndmsv фенакит.ndmsv фенацетин.ndmsv фенил.ndmsv фенилаланин.ndmsv 
+фенилен.ndmsv фенокристалл.ndmsv фенол.ndmsv фенолит.ndmsv фенолоспирт.ndmsv фенолспирт.ndmsv 
+фенолформальдегид.ndmsv фенолфталеин.ndmsv фенолят.ndmsv феномен.ndmsv фенотип.ndmsv феод.ndmsv 
+феодализм.ndmsv феракрил.ndmsv ферберит.ndmsv ферментоанализатор.ndmsv фермион.ndmsv фермуар.ndmsv 
+феромон.ndmsv феррат.ndmsv феррит.ndmsv ферровольфрам.ndmsv ферропсевдобрукит.ndmsv феррорезонанс.ndmsv 
+ферросиликон.ndmsv ферросиликохром.ndmsv ферросплав.ndmsv феррохром.ndmsv фетишизм.ndmsv фетоскоп.ndmsv 
+фетр.ndmsv фефер.ndmsv фиакр.ndmsv фиат.ndmsv фибрин.ndmsv фибринбиопласт.ndmsv 
+фибриноген.ndmsv фибробласт.ndmsv фибробронхоскоп.ndmsv фиброгастродуоденоскоп.ndmsv фиброгастроскоп.ndmsv фиброид.ndmsv 
+фиброин.ndmsv фиброколоноскоп.ndmsv фибролит.ndmsv фиброскоп.ndmsv фиброцит.ndmsv фидеизм.ndmsv 
+фидеикомисс.ndmsv фидер.ndmsv фиельд.ndmsv физалис.ndmsv физмат.ndmsv фикс.ndmsv 
+фиксатив.ndmsv фиксатуар.ndmsv филателизм.ndmsv филипс.ndmsv филлипсит.ndmsv филлит.ndmsv 
+филлокактус.ndmsv филогенез.ndmsv филодендрон.ndmsv филон.ndmsv фильдекос.ndmsv фильдеперс.ndmsv 
+фильм.ndmsv фильмокомбинат.ndmsv фильмоскоп.ndmsv фильмостат.ndmsv фильмофон.ndmsv фильмофонд.ndmsv 
+фильтрат.ndmsv филэллин.ndmsv филюм.ndmsv фимиам.ndmsv фимоз.ndmsv фингал.ndmsv 
+фингер.ndmsv финиметр.ndmsv финишер.ndmsv финмаркет.ndmsv финотдел.ndmsv финт.ndmsv 
+фиорд.ndmsv фирман.ndmsv фирмацит.ndmsv фирн.ndmsv фитин.ndmsv фитогормон.ndmsv 
+фитопланктон.ndmsv фитотоксин.ndmsv фитотрон.ndmsv фитоценоз.ndmsv флавин.ndmsv фламин.ndmsv 
+фланелет.ndmsv флат.ndmsv флаттер.ndmsv флебит.ndmsv флеболит.ndmsv флеботом.ndmsv 
+флегматизм.ndmsv флежолет.ndmsv флексагон.ndmsv флексатон.ndmsv флексор.ndmsv флексорайтер.ndmsv 
+флер.ndmsv флерон.ndmsv флинт.ndmsv флинтглас.ndmsv флип.ndmsv флиппер.ndmsv 
+флицид.ndmsv флобафен.ndmsv флогистон.ndmsv флогопит.ndmsv флоккул.ndmsv флоккулус.ndmsv 
+флоккулятор.ndmsv флокс.ndmsv флокулянт.ndmsv фломастер.ndmsv флоридин.ndmsv флортимберс.ndmsv 
+флотоконцентрат.ndmsv флювиометр.ndmsv флюксоид.ndmsv флюорит.ndmsv флюороскоп.ndmsv флютбет.ndmsv 
+фляер.ndmsv фокометр.ndmsv фокстрот.ndmsv фокус-покус.ndmsv фол.ndmsv фолдер.ndmsv 
+фолиант.ndmsv фолликул.ndmsv фолликулин.ndmsv фолликулит.ndmsv фольклор.ndmsv фолькмот.ndmsv 
+фольксваген.ndmsv фон.ndmsv фонавтограф.ndmsv фонд.ndmsv фонендоскоп.ndmsv фонограф.ndmsv 
+фонодокумент.ndmsv фонокардиограф.ndmsv фонолит.ndmsv фонометр.ndmsv фонон.ndmsv фонопор.ndmsv 
+фоноскоп.ndmsv фонт.ndmsv форамен.ndmsv форвакуум.ndmsv форд.ndmsv фордевинд.ndmsv 
+фордизм.ndmsv фордун.ndmsv форез.ndmsv форинт.ndmsv форлянд.ndmsv форм-фактор.ndmsv 
+формализм.ndmsv формальдегид.ndmsv форматер.ndmsv форматив.ndmsv формил.ndmsv формуляр.ndmsv 
+фороракос.ndmsv форстерит.ndmsv фортран.ndmsv форум.ndmsv форхенд.ndmsv форцепс.ndmsv 
+форштадт.ndmsv форштос.ndmsv фосфид.ndmsv фосфин.ndmsv фосфит.ndmsv фосфоазот.ndmsv 
+фосфорит.ndmsv фосфороскоп.ndmsv фот.ndmsv фото-робот.ndmsv фотоавтомат.ndmsv фотоальбом.ndmsv 
+фотоаппарат.ndmsv фотоархив.ndmsv фотогелиограф.ndmsv фотоген.ndmsv фотодетектор.ndmsv фотодиод.ndmsv 
+фотодокумент.ndmsv фотодубликат.ndmsv фотозал.ndmsv фотоинжектор.ndmsv фотокадр.ndmsv фотокартограф.ndmsv 
+фотокатализатор.ndmsv фотокатод.ndmsv фотоколориметр.ndmsv фотоконкурс.ndmsv фотолиз.ndmsv фотоматериал.ndmsv 
+фотометр.ndmsv фотон.ndmsv фотонабор.ndmsv фотонейтрон.ndmsv фотообъектив.ndmsv фотоофсет.ndmsv 
+фотопериод.ndmsv фотоплан.ndmsv фотополимер.ndmsv фотополяриметр.ndmsv фотопортрет.ndmsv фотопроцесс.ndmsv 
+фотопулемет.ndmsv фотореактив.ndmsv фоторезист.ndmsv фоторезистор.ndmsv фоторецептор.ndmsv фотосинтез.ndmsv 
+фотоскоп.ndmsv фотостат.ndmsv фототаймер.ndmsv фототаксис.ndmsv фототелеграф.ndmsv фототелескоп.ndmsv 
+фототеодолит.ndmsv фототранзистор.ndmsv фототрансформатор.ndmsv фототрафарет.ndmsv фототриангулятор.ndmsv фотофон.ndmsv 
+фотофорез.ndmsv фотохромизм.ndmsv фотохронограф.ndmsv фотоцинкограф.ndmsv фотошаблон.ndmsv фотоэкспонометр.ndmsv 
+фотоэлектрокалориметр.ndmsv фотоэлектрон.ndmsv фотоэлемент.ndmsv фотоэтюд.ndmsv фотоэффект.ndmsv фразеологизм.ndmsv 
+франклин.ndmsv франклинит.ndmsv франко-вагон.ndmsv франко-завод.ndmsv франко-лихтер.ndmsv франко-порт.ndmsv 
+франко-резервуар.ndmsv франко-склад.ndmsv фратрицид.ndmsv фрейдизм.ndmsv фрейм.ndmsv фреон.ndmsv 
+фридмон.ndmsv фризер.ndmsv фрикцион.ndmsv фример.ndmsv фристайл.ndmsv фритюр.ndmsv 
+фронт.ndmsv фронтир.ndmsv фронтиспис.ndmsv фронтит.ndmsv фрюктидор.ndmsv фталазол.ndmsv 
+фталеин.ndmsv фтириаз.ndmsv фтор.ndmsv фторбромметан.ndmsv фторбромпропан.ndmsv фторбромэтан.ndmsv 
+фторгептахлорпропан.ndmsv фтордибромметан.ndmsv фтордибромпропан.ndmsv фтордибромэтан.ndmsv фтордихлорметан.ndmsv фтордихлорпропан.ndmsv 
+фтордихлорэтан.ndmsv фторид.ndmsv фтороалюминат.ndmsv фторопласт.ndmsv фторосиликат.ndmsv фтороуглерод.ndmsv 
+фторпентабромпропан.ndmsv фторпентахлорпропан.ndmsv фторпентахлорэтан.ndmsv фторполимер.ndmsv фторсекстабромпропан.ndmsv фторсекстахлорпропан.ndmsv 
+фтортетрабромпропан.ndmsv фтортетрабромэтан.ndmsv фтортетрахлорпропан.ndmsv фтортетрахлорэтан.ndmsv фтортрибромпропан.ndmsv фтортрибромэтан.ndmsv 
+фтортрихлорметан.ndmsv фтортрихлорпропан.ndmsv фтортрихлорэтан.ndmsv фторуглерод.ndmsv фторфосфат.ndmsv фторхлорметан.ndmsv 
+фторхлорпропан.ndmsv фторхлорэтан.ndmsv фторэластомер.ndmsv фукс.ndmsv фуксин.ndmsv фуксит.ndmsv 
+фукус.ndmsv фульгурит.ndmsv фульминат.ndmsv фуляр.ndmsv фумигант.ndmsv фумигатор.ndmsv 
+фунгицид.ndmsv фундамент.ndmsv фундулюс.ndmsv фуникулер.ndmsv функтор.ndmsv фунт.ndmsv 
+фуральдегид.ndmsv фурор.ndmsv фурункул.ndmsv фурункулез.ndmsv фурфурол.ndmsv фуршет.ndmsv 
+фурьеризм.ndmsv фуст.ndmsv фут.ndmsv футокс.ndmsv футор.ndmsv футофунт.ndmsv 
+футроп.ndmsv футуризм.ndmsv фьорд.ndmsv фьючерс.ndmsv фюзен.ndmsv хабуб.ndmsv 
+хаггис.ndmsv хаз.ndmsv хайболл.ndmsv хайд.ndmsv халибит.ndmsv халифат.ndmsv 
+халцедон.ndmsv халькантит.ndmsv халькозин.ndmsv халькопирит.ndmsv хамас.ndmsv хаммам.ndmsv 
+хамсин.ndmsv хаос.ndmsv характрон.ndmsv хармалин.ndmsv харматан.ndmsv хармин.ndmsv 
+харт.ndmsv хасидизм.ndmsv хаус.ndmsv хафир.ndmsv хаффман.ndmsv хван.ndmsv 
+хвостизм.ndmsv хедер.ndmsv хеймвер.ndmsv хеморецептор.ndmsv хемосенсор.ndmsv хемосинтез.ndmsv 
+хемотаксис.ndmsv хенд.ndmsv хескер.ndmsv хиазм.ndmsv хиастолит.ndmsv хиатус.ndmsv 
+хилиазм.ndmsv хилиаст.ndmsv хилус.ndmsv химизм.ndmsv химикат.ndmsv химконцентрат.ndmsv 
+химлесхоз.ndmsv химозин.ndmsv химполимер.ndmsv химреактив.ndmsv химсклад.ndmsv химснаряд.ndmsv 
+химус.ndmsv хинальдин.ndmsv хинидин.ndmsv хинин.ndmsv хиноксалин.ndmsv хинолин.ndmsv 
+хинон.ndmsv хирограф.ndmsv хит-парад.ndmsv хитон.ndmsv хладагент.ndmsv хладон.ndmsv 
+хладоэлемент.ndmsv хлебозавод.ndmsv хлебокомбинат.ndmsv хлебород.ndmsv хлопкозавод.ndmsv хлопкокомбайн.ndmsv 
+хлорал.ndmsv хлоралгидрат.ndmsv хлорамин.ndmsv хлорат.ndmsv хлоратор.ndmsv хлорацетофенон.ndmsv 
+хлорбензол.ndmsv хлорвинил.ndmsv хлоргидратдиметиламин.ndmsv хлоргидрохинон.ndmsv хлорид.ndmsv хлорин.ndmsv 
+хлорит.ndmsv хлорнафталин.ndmsv хлоро-фтор-углерод.ndmsv хлоро-фтороуглерод.ndmsv хлоро-фторуглерод.ndmsv хлороз.ndmsv 
+хлоропласт.ndmsv хлоропрен.ndmsv хлорофилл.ndmsv хлорофос.ndmsv хлорохин.ndmsv хлорпарафин.ndmsv 
+хлорпикрин.ndmsv хлорпродукт.ndmsv хлорфторуглерод.ndmsv хлорэтанол.ndmsv хмелеграб.ndmsv ховерпорт.ndmsv 
+хоган.ndmsv хогсхед.ndmsv хозотдел.ndmsv хозрасчет.ndmsv холангит.ndmsv холестерин.ndmsv 
+холецистит.ndmsv холизм.ndmsv холин.ndmsv холл.ndmsv холлерит.ndmsv холокауст.ndmsv 
+холокост.ndmsv холостерин.ndmsv холст.ndmsv хон.ndmsv хондрит.ndmsv хонолит.ndmsv 
+хоппер.ndmsv хордометр.ndmsv хориоменингит.ndmsv хорион.ndmsv хориямб.ndmsv хорнпайп.ndmsv 
+хоспис.ndmsv хост.ndmsv хост-адаптер.ndmsv хост-ресурс.ndmsv хоудаун.ndmsv хоумленд.ndmsv 
+храм.ndmsv хризоберилл.ndmsv хризолит.ndmsv хризолиф.ndmsv хризопраз.ndmsv хризотил.ndmsv 
+христианит.ndmsv хролофилл.ndmsv хромат.ndmsv хроматизм.ndmsv хроматин.ndmsv хроматограф.ndmsv 
+хроматолиз.ndmsv хроматоскоп.ndmsv хроматофор.ndmsv хроматрон.ndmsv хромит.ndmsv хроммагнезит.ndmsv 
+хромомагнезит.ndmsv хромопласт.ndmsv хромопротеин.ndmsv хромоскоп.ndmsv хромофор.ndmsv хронограф.ndmsv 
+хронометр.ndmsv хронон.ndmsv хроноскоп.ndmsv хронофер.ndmsv хула-хуп.ndmsv хурал.ndmsv 
+царизм.ndmsv цветонос.ndmsv цедрат.ndmsv цезаризм.ndmsv цейхгауз.ndmsv целакант.ndmsv 
+целестин.ndmsv целибат.ndmsv целлит.ndmsv целлоидин.ndmsv целлон.ndmsv целлофан.ndmsv 
+целлулоид.ndmsv целостат.ndmsv цементит.ndmsv цементовоз.ndmsv ценз.ndmsv ценоз.ndmsv 
+ценозит.ndmsv цент.ndmsv центал.ndmsv центнер.ndmsv централизм.ndmsv центризм.ndmsv 
+центроплан.ndmsv центумвират.ndmsv ценуроз.ndmsv цеолит.ndmsv цеппелин.ndmsv церебролизат.ndmsv 
+церезин.ndmsv церемониал.ndmsv цереус.ndmsv церит.ndmsv церковнославянизм.ndmsv церолит.ndmsv 
+церулоплазмин.ndmsv церуссит.ndmsv цестус.ndmsv цехин.ndmsv цехком.ndmsv циан.ndmsv 
+цианамид.ndmsv цианат.ndmsv цианид.ndmsv цианин.ndmsv цианит.ndmsv цианоз.ndmsv 
+цианозит.ndmsv цианокобаламин.ndmsv цианометр.ndmsv цианурхлорид.ndmsv цибетин.ndmsv цикламен.ndmsv 
+циклит.ndmsv циклогексан.ndmsv циклогексанон.ndmsv циклогенез.ndmsv циклодром.ndmsv циклометр.ndmsv 
+циклонит.ndmsv циклонометр.ndmsv циклотрон.ndmsv циклофон.ndmsv цилиндр.ndmsv цилиндроид.ndmsv 
+цимофан.ndmsv цинизм.ndmsv цинкит.ndmsv циозит.ndmsv циперус.ndmsv циркон.ndmsv 
+циркулятор.ndmsv циркумфлекс.ndmsv цирроз.ndmsv цистеин.ndmsv цистин.ndmsv цистит.ndmsv 
+цистицеркоз.ndmsv цистоскоп.ndmsv цистрон.ndmsv цитозин.ndmsv цитолиз.ndmsv цитолизин.ndmsv 
+цитомегаловирус.ndmsv цитотаксис.ndmsv цитофиброметр.ndmsv цитофлюориметр.ndmsv цитохром.ndmsv цитрат.ndmsv 
+цитрин.ndmsv цитрованилин.ndmsv цитрон.ndmsv цитрус.ndmsv циферблат.ndmsv цугундер.ndmsv 
+чабрец.ndmsv чалдар.ndmsv чарльстон.ndmsv чарм.ndmsv чартер.ndmsv чартизм.ndmsv 
+часослов.ndmsv частокол.ndmsv частотомер.ndmsv чеддер.ndmsv чейн.ndmsv чекер.ndmsv 
+челдрон.ndmsv человеко-час.ndmsv чембур.ndmsv чемпионат.ndmsv чепан.ndmsv черноклен.ndmsv 
+чернолоз.ndmsv черностоп.ndmsv чернотал.ndmsv чернотроп.ndmsv честер.ndmsv честерфилд.ndmsv 
+четвертьфинал.ndmsv чизбургер.ndmsv чикс.ndmsv чилим.ndmsv чип.ndmsv чистец.ndmsv 
+чистоган.ndmsv чистотел.ndmsv чистоуст.ndmsv чокбор.ndmsv чонсам.ndmsv чрен.ndmsv 
+чувал.ndmsv чуккер.ndmsv чупрун.ndmsv шабер.ndmsv шабот.ndmsv шагомер.ndmsv 
+шалман.ndmsv шаманизм.ndmsv шамбертен.ndmsv шамберьер.ndmsv шамозит.ndmsv шампиньон.ndmsv 
+шампур.ndmsv шандал.ndmsv шандор.ndmsv шанкр.ndmsv шанс.ndmsv шапирограф.ndmsv 
+шарабан.ndmsv шарап.ndmsv шариат.ndmsv шарп.ndmsv шартрез.ndmsv шарф.ndmsv 
+шато-икем.ndmsv шаттл.ndmsv шахер-махер.ndmsv швербот.ndmsv шверт.ndmsv швертбот.ndmsv 
+шевер.ndmsv шевинг-процесс.ndmsv шеврет.ndmsv шед.ndmsv шедевр.ndmsv шеелит.ndmsv 
+шейкер.ndmsv шелкокомбинат.ndmsv шелл.ndmsv шеллер.ndmsv шелом.ndmsv шельф.ndmsv 
+шерл.ndmsv шессилит.ndmsv шестопер.ndmsv шибболет.ndmsv шиворот.ndmsv шиизм.ndmsv 
+шингард.ndmsv шиньон.ndmsv ширпотреб.ndmsv шистозомиаз.ndmsv шифервейс.ndmsv шифратор.ndmsv 
+шифротекст.ndmsv шихан.ndmsv шкафут.ndmsv шкерт.ndmsv шкив.ndmsv шкимушгар.ndmsv 
+шкот.ndmsv шлагбаум.ndmsv шлакобетон.ndmsv шлакоотвал.ndmsv шлам.ndmsv шлафор.ndmsv 
+шлейф.ndmsv шлем.ndmsv шлемофон.ndmsv шликер.ndmsv шлир.ndmsv шлифт.ndmsv 
+шлягер.ndmsv шлямбур.ndmsv шмальтин.ndmsv шмон.ndmsv шмуцтитул.ndmsv шнеллер.ndmsv 
+шовинизм.ndmsv шон.ndmsv шоу-театр.ndmsv шпалозавод.ndmsv шпангоут.ndmsv шпат.ndmsv 
+шпигат.ndmsv шпицрутен.ndmsv шприц-пистолет.ndmsv шпур.ndmsv шрам.ndmsv шримс.ndmsv 
+шрифт.ndmsv шрот.ndmsv штаб.ndmsv штаб-магазин.ndmsv штамб.ndmsv штамм.ndmsv 
+штангенглубиномер.ndmsv штангензубомер.ndmsv штангенинструмент.ndmsv штандарт.ndmsv штатив.ndmsv штауфф.ndmsv 
+штекер.ndmsv штеккер.ndmsv штерт.ndmsv штирборт.ndmsv штифт.ndmsv штихмас.ndmsv 
+штормтрап.ndmsv штос.ndmsv штрипс.ndmsv штрих-пунктир.ndmsv штундизм.ndmsv штурвал.ndmsv 
+штуртрап.ndmsv штуртрос.ndmsv штуф.ndmsv штыб.ndmsv шумопеленгатор.ndmsv шунгит.ndmsv 
+шунт.ndmsv шурум-бурум.ndmsv шушпан.ndmsv шушун.ndmsv шюцкор.ndmsv щуп.ndmsv 
+эбен.ndmsv эбонит.ndmsv эбуллиоскоп.ndmsv эвакопункт.ndmsv эвапоратор.ndmsv эвапорограф.ndmsv 
+эвапорометр.ndmsv эвгенол.ndmsv эвдемонизм.ndmsv эвдиалит.ndmsv эвдиометр.ndmsv эверглейд.ndmsv 
+эвердьюпойс.ndmsv эвкалипт.ndmsv эвклаз.ndmsv эвпатрид.ndmsv эвриптер.ndmsv эвриптерус.ndmsv 
+эвстресс.ndmsv эвфемизм.ndmsv эвфонизм.ndmsv эвфуизм.ndmsv эго-статус.ndmsv эгоизм.ndmsv 
+эготизм.ndmsv эдельвейс.ndmsv эдем.ndmsv эдикт.ndmsv эжектор.ndmsv эзельгофт.ndmsv 
+эзофагоскоп.ndmsv эйдетизм.ndmsv эйдос.ndmsv эйзенхауэр.ndmsv эйфориант.ndmsv эйхинин.ndmsv 
+эквалайзер.ndmsv экватив.ndmsv экватор.ndmsv экваториал.ndmsv экер.ndmsv экзархат.ndmsv 
+экземпляр.ndmsv экзерсис.ndmsv экзерциргауз.ndmsv экзогормон.ndmsv экзон.ndmsv экзосмос.ndmsv 
+экзостоз.ndmsv экзотизм.ndmsv экзотоксин.ndmsv экзофтальм.ndmsv экзоцитоз.ndmsv экзоэлектрон.ndmsv 
+экклезиаст.ndmsv эклектизм.ndmsv эклер.ndmsv эклиметр.ndmsv эковид.ndmsv экогенез.ndmsv 
+экономайзер.ndmsv экономизм.ndmsv экономсовет.ndmsv экосез.ndmsv экостандарт.ndmsv экотип.ndmsv 
+экотоксикант.ndmsv экотон.ndmsv экотоп.ndmsv экоцид.ndmsv экпозиметр.ndmsv экраноплан.ndmsv 
+эксгаустер.ndmsv эксикатор.ndmsv эксимер.ndmsv экситон.ndmsv экскаватор.ndmsv экскалибур.ndmsv 
+эксклав.ndmsv экскремент.ndmsv экскрет.ndmsv экскурс.ndmsv экслибрис.ndmsv эксод.ndmsv 
+экспандер.ndmsv эксперимент.ndmsv эксплантат.ndmsv экспликанд.ndmsv экспликат.ndmsv экспонат.ndmsv 
+экспонометр.ndmsv экспресс.ndmsv экспресс-анализ.ndmsv экспресс-анализатор.ndmsv экспресс-груз.ndmsv экспресс-метод.ndmsv 
+экспромт.ndmsv экссудат.ndmsv экстаз.ndmsv экстензометр.ndmsv экстензор.ndmsv экстент.ndmsv 
+экстернат.ndmsv экстероцептор.ndmsv экстерьер.ndmsv экстирпатор.ndmsv экстравазат.ndmsv экстрагент.ndmsv 
+экстракласс.ndmsv экстракод.ndmsv экстракт.ndmsv экстрактор.ndmsv экстремизм.ndmsv экстремум.ndmsv 
+экструдер.ndmsv эксудат.ndmsv эксцентриситет.ndmsv эксцесс.ndmsv эксцессив.ndmsv эктлипсис.ndmsv 
+эктобласт.ndmsv эктогенез.ndmsv экуменизм.ndmsv экуменополис.ndmsv эламит.ndmsv эластин.ndmsv 
+эластомер.ndmsv элатив.ndmsv элеватор.ndmsv элевон.ndmsv электорат.ndmsv электрет.ndmsv 
+электроавтобус.ndmsv электроанализ.ndmsv электробарабан.ndmsv электробур.ndmsv электробус.ndmsv электровибратор.ndmsv 
+электровоз.ndmsv электрогенератор.ndmsv электрогидроклапан.ndmsv электрод.ndmsv электродетонатор.ndmsv электроджет.ndmsv 
+электродиализ.ndmsv электродиализатор.ndmsv электродинамометр.ndmsv электрозавод.ndmsv электрозапал.ndmsv электроизолятор.ndmsv 
+электроинструмент.ndmsv электроинтегратор.ndmsv электрокамин.ndmsv электрокар.ndmsv электрокардиограф.ndmsv электрокардиостимулятор.ndmsv 
+электрокатализатор.ndmsv электроклассификатор.ndmsv электрокомбайн.ndmsv электрокран.ndmsv электрокультиватор.ndmsv электролиз.ndmsv 
+электролизер.ndmsv электролит.ndmsv электромагазин.ndmsv электромагнит.ndmsv электроматериал.ndmsv электромегафон.ndmsv 
+электромер.ndmsv электрометр.ndmsv электромеханизм.ndmsv электромиксер.ndmsv электромотор.ndmsv электронасос.ndmsv 
+электроорган.ndmsv электроосмос.ndmsv электроотдел.ndmsv электроплед.ndmsv электропневмоклапан.ndmsv электрополотер.ndmsv 
+электроприбор.ndmsv электропривод.ndmsv электропульт.ndmsv электропылесос.ndmsv электрорадионавигатор.ndmsv электрорефлектор.ndmsv 
+электросамовар.ndmsv электросигнал.ndmsv электроскоп.ndmsv электростартер.ndmsv электротаксис.ndmsv электротеплоаккумулятор.ndmsv 
+электротонус.ndmsv электроферросплав.ndmsv электрофильтр.ndmsv электрофон.ndmsv электрофор.ndmsv электроход.ndmsv 
+электрошнур.ndmsv электрощит.ndmsv электроэндоосмос.ndmsv электроэнцефалограф.ndmsv электроэякулятор.ndmsv электрум.ndmsv 
+элемент.ndmsv элениум.ndmsv эленхос.ndmsv элеолит.ndmsv элерон.ndmsv элефантиаз.ndmsv 
+элизиум.ndmsv эликсир.ndmsv элинвар.ndmsv элинт.ndmsv элитаризм.ndmsv элконин.ndmsv 
+эллинизм.ndmsv эллипс.ndmsv эллипсис.ndmsv эллипсограф.ndmsv эллипсоид.ndmsv эльван.ndmsv 
+эльзевир.ndmsv эман.ndmsv эманометр.ndmsv эмаскулятор.ndmsv эмбол.ndmsv эмбрион.ndmsv 
+эметин.ndmsv эмират.ndmsv эмиритон.ndmsv эмитрон.ndmsv эмиттер.ndmsv эммер.ndmsv 
+эмпиризм.ndmsv эмульгатор.ndmsv эмульсин.ndmsv эмульсификатор.ndmsv эмульсоид.ndmsv эмульсор.ndmsv 
+эмулятор.ndmsv эмфизематоз.ndmsv эмфитевзис.ndmsv эндартериит.ndmsv эндемизм.ndmsv эндобласт.ndmsv 
+эндокард.ndmsv эндокардит.ndmsv эндометрит.ndmsv эндопротез.ndmsv эндорадиозонд.ndmsv эндоскоп.ndmsv 
+эндосмометр.ndmsv эндосмос.ndmsv эндосперм.ndmsv эндотерм.ndmsv эндотоксин.ndmsv эндофит.ndmsv 
+эндоэквопротез.ndmsv энеолит.ndmsv энергетизм.ndmsv энергозапас.ndmsv энергокризис.ndmsv энергообъект.ndmsv 
+энергопродуктопровод.ndmsv энерготариф.ndmsv энозис.ndmsv энтазис.ndmsv энтерит.ndmsv энтероколит.ndmsv 
+энтероптоз.ndmsv энтеросептол.ndmsv энтобласт.ndmsv энтузиазм.ndmsv энцефалит.ndmsv энцефаломиелит.ndmsv 
+эозин.ndmsv эозоон.ndmsv эолит.ndmsv эоцен.ndmsv эпексегезис.ndmsv эпентезис.ndmsv 
+эпибласт.ndmsv эпигенез.ndmsv эпиглоттис.ndmsv эпиграф.ndmsv эпидермин.ndmsv эпидермис.ndmsv 
+эпидесмин.ndmsv эпидиаскоп.ndmsv эпидот.ndmsv эпикард.ndmsv эпикардит.ndmsv эпикриз.ndmsv 
+эпикуреизм.ndmsv эпилхлоргидрин.ndmsv эпилятор.ndmsv эпископ.ndmsv эпитет.ndmsv эпифеномен.ndmsv 
+эпифиз.ndmsv эпифилл.ndmsv эпифит.ndmsv эпихлоргидрин.ndmsv эпицен.ndmsv эпицентр.ndmsv 
+эпицикл.ndmsv эпод.ndmsv эпос.ndmsv эпсилон.ndmsv эпулис.ndmsv эратосфен.ndmsv 
+эргатив.ndmsv эргограф.ndmsv эргометр.ndmsv эрготизм.ndmsv эрготин.ndmsv эрготоксин.ndmsv 
+эректор.ndmsv эретизм.ndmsv эритрит.ndmsv эритроцит.ndmsv эритроцитоз.ndmsv эркер.ndmsv 
+эрлифт.ndmsv эрос.ndmsv эротизм.ndmsv эрстед.ndmsv эскадрон.ndmsv эскалоп.ndmsv 
+эскер.ndmsv эспадрон.ndmsv эспандер.ndmsv эспарцет.ndmsv эспонтон.ndmsv эссив.ndmsv 
+эстезиометр.ndmsv эстетизм.ndmsv эстомп.ndmsv эстрагон.ndmsv эстрадиол.ndmsv эстриол.ndmsv 
+эстроген.ndmsv эстрон.ndmsv эструс.ndmsv эта-мезон.ndmsv этаминал.ndmsv этан.ndmsv 
+этанол.ndmsv этатизм.ndmsv этернит.ndmsv этил.ndmsv этилакрилат.ndmsv этилацетат.ndmsv 
+этилбензол.ndmsv этилдифторфосфин.ndmsv этилдихлорфосфин.ndmsv этилен.ndmsv этиленпентамин.ndmsv этилфосфенилдихлорид.ndmsv 
+этилфосфинилдифторид.ndmsv этилфосфонилдифторид.ndmsv этилфосфонилдихлорид.ndmsv этимон.ndmsv этит.ndmsv этишкет.ndmsv 
+этногенез.ndmsv этноним.ndmsv этнос.ndmsv этноцид.ndmsv этриоскоп.ndmsv эукариот.ndmsv 
+эфедрин.ndmsv эфемероид.ndmsv эфиронос.ndmsv эффектор.ndmsv эхин.ndmsv эхинокактус.ndmsv 
+эхо-запрос.ndmsv эхо-кардиограф.ndmsv эхо-сигнал.ndmsv эхокардиограф.ndmsv эхолокатор.ndmsv эхолот.ndmsv 
+эхосигнал.ndmsv эцезис.ndmsv эякулят.ndmsv югер.ndmsv юз.ndmsv юлиус.ndmsv 
+юниорат.ndmsv юнктад.ndmsv юс.ndmsv ют.ndmsv юферс.ndmsv явор.ndmsv 
+ядохимикат.ndmsv яйцевод.ndmsv якобиан.ndmsv ял.ndmsv ямб.ndmsv яндекс.ndmsv 
+янсенизм.ndmsv ярд.ndmsv ярозит.ndmsv ятаган.ndmsv яхонт.ndmsv яхт-клуб.ndmsv 
+яхтклуб.ndmsv ящур.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 афалин.= :
   LLAFC+;
 
@@ -5435,13 +5435,13 @@
 таз.= фальшпол.= :
   LLAAS+;
 
-авиакеросин.ndmsv аэропорт.ndmsv бензоспирт.ndmsv детсад.ndmsv космопорт.ndmsv креп-жоржет.ndmsv 
-лесосад.ndmsv марафет.ndmsv политчас.ndmsv получас.ndmsv пуд.ndmsv скит.ndmsv 
-таз.ndmsv фальшпол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 авиакеросин.ndmsi аэропорт.ndmsi бензоспирт.ndmsi детсад.ndmsi космопорт.ndmsi креп-жоржет.ndmsi 
 лесосад.ndmsi марафет.ndmsi политчас.ndmsi получас.ndmsi пуд.ndmsi скит.ndmsi 
 таз.ndmsi фальшпол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+авиакеросин.ndmsv аэропорт.ndmsv бензоспирт.ndmsv детсад.ndmsv космопорт.ndmsv креп-жоржет.ndmsv 
+лесосад.ndmsv марафет.ndmsv политчас.ndmsv получас.ndmsv пуд.ndmsv скит.ndmsv 
+таз.ndmsv фальшпол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.18:
   LLBEP+;
@@ -5465,9 +5465,9 @@
 
 баб.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-баб.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 баб.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+баб.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 баба.= :
   LLFKI+ or LLFKH+ or LLEDK+;
@@ -5480,13 +5480,13 @@
 бабушкин.= :
   LLDWW+ or LLFUS+;
 
-бабушкин.amsi :  <morph-П,мр,ед,им>;
-
-бабушкин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бабушкин.admsv :  <morph-П,мр,ед,вн,но>;
 
 бабушкин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бабушкин.amsi :  <morph-П,мр,ед,им>;
+
+бабушкин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бабь.= :
   LLDXV+ or LLARY+;
@@ -5494,9 +5494,9 @@
 баг.= :
   LLAAM+ or LLCKV+;
 
-баг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 баг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+баг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 багла.= серге.= :
   LLEDJ+;
@@ -5509,9 +5509,9 @@
 баз.= :
   LLAAS+ or LLAFX+;
 
-баз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 баз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+баз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 баз.ndfpg :  <morph-С,жр,но,мн,рд>;
 
@@ -5524,21 +5524,21 @@
 лагос.= либкнехт.= стамбул.= энгельс.= :
   LLDWW+ or LLEBJ+;
 
+андрос.ndmsi баймак.ndmsi белиз.ndmsi васюган.ndmsi геллерт.ndmsi кологрив.ndmsi 
+лагос.ndmsi либкнехт.ndmsi стамбул.ndmsi энгельс.ndmsi :  <morph-С,мр,но,ед,им>;
+
 андрос.nlmsi баймак.nlmsi белиз.nlmsi васюган.nlmsi геллерт.nlmsi кологрив.nlmsi 
 лагос.nlmsi либкнехт.nlmsi стамбул.nlmsi энгельс.nlmsi :  <morph-С,мр,од,ед,им>;
 
 андрос.ndmsv баймак.ndmsv белиз.ndmsv васюган.ndmsv геллерт.ndmsv кологрив.ndmsv 
 лагос.ndmsv либкнехт.ndmsv стамбул.ndmsv энгельс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-андрос.ndmsi баймак.ndmsi белиз.ndmsi васюган.ndmsi геллерт.ndmsi кологрив.ndmsi 
-лагос.ndmsi либкнехт.ndmsi стамбул.ndmsi энгельс.ndmsi :  <morph-С,мр,но,ед,им>;
-
 байт.= килобит.= мегабайт.= :
   LLAAQ+ or LLBZI+;
 
-байт.ndmsv килобит.ndmsv мегабайт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 байт.ndmsi килобит.ndmsi мегабайт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+байт.ndmsv килобит.ndmsv мегабайт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 баклуш.= гамаш.= :
   LLAFM+ or LLBBY+;
@@ -5560,9 +5560,9 @@
 базар.= балаган.= фасон.= :
   LLAAQ+ or LLBGR+ or LLBYU+;
 
-базар.ndmsv балаган.ndmsv фасон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 базар.ndmsi балаган.ndmsi фасон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+базар.ndmsv балаган.ndmsv фасон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 балагур.= :
   LLACI+ or LLBGR+ or LLBRO+ or LLBYU+;
@@ -5609,22 +5609,22 @@
 бангладеш.= :
   LLDWV+ or LLDXB+ or LLAYI+ or LLBRM+;
 
-бангладеш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бангладеш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бангладеш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 багаж.= бандаж.= блиндаж.= гараж.= картеж.= крепеж.= 
 монтаж.= муляж.= правеж.= рубеж.= стеллаж.= чертеж.= 
 шантаж.= :
   LLAAJ+ or LLBYZ+;
 
-багаж.ndmsv бандаж.ndmsv блиндаж.ndmsv гараж.ndmsv картеж.ndmsv крепеж.ndmsv 
-монтаж.ndmsv муляж.ndmsv правеж.ndmsv рубеж.ndmsv стеллаж.ndmsv чертеж.ndmsv 
-шантаж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 багаж.ndmsi бандаж.ndmsi блиндаж.ndmsi гараж.ndmsi картеж.ndmsi крепеж.ndmsi 
 монтаж.ndmsi муляж.ndmsi правеж.ndmsi рубеж.ndmsi стеллаж.ndmsi чертеж.ndmsi 
 шантаж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+багаж.ndmsv бандаж.ndmsv блиндаж.ndmsv гараж.ndmsv картеж.ndmsv крепеж.ndmsv 
+монтаж.ndmsv муляж.ndmsv правеж.ndmsv рубеж.ndmsv стеллаж.ndmsv чертеж.ndmsv 
+шантаж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 банкро.= охо.= пя.= :
   LLCYM+;
@@ -5632,13 +5632,13 @@
 бар.= :
   LLAAQ+ or LLBFN+ or LLBRK+;
 
-бар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-бар.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 бар.ndmsi :  <morph-С,мр,но,ед,им>;
 
 бар.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+бар.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+бар.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 баран.= :
   LLACI+ or LLAXZ+ or LLBFF+ or LLBRK+ or LLCJW+ or LLEAU+;
@@ -5694,9 +5694,9 @@
 бакен.= бархан.= отход.= :
   LLAAQ+ or LLBYZ+ or LLDJV+;
 
-бакен.ndmsv бархан.ndmsv отход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бакен.ndmsi бархан.ndmsi отход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бакен.ndmsv бархан.ndmsv отход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бархат.= картон.= шоколад.= :
   LLAAO+ or LLBRK+ or LLBYU+;
@@ -5711,25 +5711,25 @@
 барыш.= :
   LLAAJ+ or LLDWW+ or LLBZU+;
 
-барыш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 барыш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+барыш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бас.= :
   LLAAS+ or LLACI+ or LLBGJ+ or LLBRK+ or LLBZO+ or LLCJW+;
 
-бас.nlmsi :  <morph-С,мр,од,ед,им>;
+бас.ndmsi :  <morph-С,мр,но,ед,им>;
 
 бас.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-бас.ndmsi :  <morph-С,мр,но,ед,им>;
+бас.nlmsi :  <morph-С,мр,од,ед,им>;
 
 бассейн.= :
   LLAAQ+ or LLDLU+;
 
-бассейн.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бассейн.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бассейн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бассейнов.= лоскутов.= огурцов.= померанцев.= ячменев.= :
   LLFQF+ or LLDLU+;
@@ -5742,18 +5742,18 @@
 басурман.= :
   LLACI+ or LLBFM+ or LLBRO+;
 
-басурман.nlmsi :  <morph-С,мр,од,ед,им>;
-
 басурман.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+басурман.nlmsi :  <morph-С,мр,од,ед,им>;
 
 басурман.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 бат.= :
   LLAAQ+ or LLDNV+ or LLDPS+;
 
-бат.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бат.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 батаре.= :
   LLAYG+ or LLBPW+ or LLBQK+ or LLDQB+;
@@ -5783,9 +5783,9 @@
 баш.= :
   LLAAH+ or LLBRK+ or LLBZO+;
 
-баш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 баш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+баш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 баянг.= :
   LLEAD+;
@@ -5827,9 +5827,9 @@
 бежецк.= березовск.= :
   LLDWW+ or LLFKB+ or LLFKA+ or LLBEP+ or LLDYV+;
 
-бежецк.nlmsi березовск.nlmsi :  <morph-С,мр,од,ед,им>;
-
 бежецк.ndmsv березовск.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+бежецк.nlmsi березовск.nlmsi :  <morph-С,мр,од,ед,им>;
 
 бежецк.ndmsi березовск.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -5893,15 +5893,15 @@
 бел.= :
   LLAAQ+ or LLFIN+ or LLAUN+ or LLAYL+ or LLBCE+ or LLBHS+ or LLBNP+ or LLBRK+ or LLBRO+ or LLCJW+ or LLDKF+ or LLDNF+;
 
-бел.amss :  <morph-П,мр,ед,кр>;
-
-бел.nlfpg :  <morph-С,жр,од,мн,рд>;
+бел.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 бел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-бел.ndmsi :  <morph-С,мр,но,ед,им>;
+бел.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-бел.nlfpv :  <morph-С,жр,од,мн,вн>;
+бел.amss :  <morph-П,мр,ед,кр>;
+
+бел.ndmsi :  <morph-С,мр,но,ед,им>;
 
 белен.= :
   LLDWW+ or LLAGL+ or LLAUO+ or LLDLO+;
@@ -5973,9 +5973,9 @@
 бенджамин.= :
   LLFJS+;
 
-бенджамин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 бенджамин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+бенджамин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 бени.= :
   LLDWZ+ or LLAYG+ or LLBPY+;
@@ -6057,9 +6057,9 @@
 берестов.= :
   LLFQF+ or LLEDS+ or LLDKJ+;
 
-берестов.amss :  <morph-П,мр,ед,кр>;
-
 берестов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+берестов.amss :  <morph-П,мр,ед,кр>;
 
 беллини.= берзини.= берлускони.= бруни.= гершуни.= гольдони.= 
 :
@@ -6073,9 +6073,9 @@
 берингов.= :
   LLADX+;
 
-берингов.amsi :  <morph-П,мр,ед,им>;
-
 берингов.admsv :  <morph-П,мр,ед,вн,но>;
+
+берингов.amsi :  <morph-П,мр,ед,им>;
 
 беркли.= :
   LLFJD+ or LLBPR+;
@@ -6083,11 +6083,11 @@
 берлин.= :
   LLDWW+ or LLAFX+ or LLAYI+;
 
+берлин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 берлин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 берлин.ndmsi :  <morph-С,мр,но,ед,им>;
-
-берлин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 бахуриц.= бежаниц.= бежиц.= берниц.= бистриц.= бобровиц.= 
 быстриц.= варениц.= вижниц.= витославлиц.= врац.= выриц.= 
@@ -6108,9 +6108,9 @@
 бескрыл.= :
   LLACI+ or LLDKJ+;
 
-бескрыл.amss :  <morph-П,мр,ед,кр>;
-
 бескрыл.nlmsi :  <morph-С,мр,од,ед,им>;
+
+бескрыл.amss :  <morph-П,мр,ед,кр>;
 
 бесперебо.= необыча.= чрезвыча.= :
   LLBQP+;
@@ -6141,9 +6141,9 @@
 бессмысленно.= зачем.= здесь.= :
   LLAEK+ or LLFLU+;
 
-бессмысленно.x зачем.x здесь.x :  <morph-ПРЕДК,0>;
-
 бессмысленно.e зачем.e здесь.e :  <morph-Н,0>;
+
+бессмысленно.x зачем.x здесь.x :  <morph-ПРЕДК,0>;
 
 бесснеж.= :
   LLBDC+ or LLBYU+ or LLDNT+;
@@ -6193,11 +6193,11 @@
 бирюк.= битюг.= :
   LLACG+ or LLDWW+;
 
+бирюк.ndmsi битюг.ndmsi :  <morph-С,мр,но,ед,им>;
+
 бирюк.ndmsv битюг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бирюк.nlmsi битюг.nlmsi :  <morph-С,мр,од,ед,им>;
-
-бирюк.ndmsi битюг.ndmsi :  <morph-С,мр,но,ед,им>;
 
 бирюч.= сивуч.= :
   LLACF+ or LLBFF+;
@@ -6209,13 +6209,13 @@
 
 бит.amss :  <morph-П,мр,ед,кр>;
 
-бит.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бит.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бит.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 бит.ndmpg :  <morph-С,мр,но,мн,рд>;
 
-бит.ndfpg :  <morph-С,жр,но,мн,рд>;
+бит.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 аминов.= бакланов.= бентонитов.= битов.= бойков.= боровков.= 
 валерианов.= волосков.= воротников.= глазков.= горшков.= гребенщиков.= 
@@ -6327,32 +6327,6 @@
 /ru/words/words.29:
   LLAAH+;
 
-аллонж.ndmsv амбалаж.ndmsv антураж.ndmsv апрош.ndmsv арбитраж.ndmsv бакшиш.ndmsv 
-банкаброш.ndmsv бареж.ndmsv барраж.ndmsv бельэтаж.ndmsv бизнес-колледж.ndmsv блокаж.ndmsv 
-бракераж.ndmsv вернисаж.ndmsv вкладыш.ndmsv вояж.ndmsv всевобуч.ndmsv всеобуч.ndmsv 
-выкидыш.ndmsv гамма-каротаж.ndmsv гашиш.ndmsv генерал-марш.ndmsv гуляш.ndmsv дебош.ndmsv 
-дегоржаж.ndmsv демарш.ndmsv демонтаж.ndmsv дерапаж.ndmsv диспач.ndmsv дубляж.ndmsv 
-ерофеич.ndmsv зародыш.ndmsv зильбергрош.ndmsv зондаж.ndmsv идиш.ndmsv имидж.ndmsv 
-инструктаж.ndmsv интерлиньяж.ndmsv кампеш.ndmsv камуфляж.ndmsv капелюш.ndmsv каптаж.ndmsv 
-карагач.ndmsv карт-бланш.ndmsv картонаж.ndmsv картридж.ndmsv километраж.ndmsv кинорепортаж.ndmsv 
-китч.ndmsv кливаж.ndmsv клинч.ndmsv коллаж.ndmsv колледж.ndmsv коллеж.ndmsv 
-кольматаж.ndmsv контрмарш.ndmsv коттедж.ndmsv креп-эпонж.ndmsv кукиш.ndmsv кулаж.ndmsv 
-куш.ndmsv кэтч.ndmsv лаваш.ndmsv ландыш.ndmsv лекаж.ndmsv ленч.ndmsv 
-макинтош.ndmsv макияж.ndmsv матч.ndmsv матчиш.ndmsv меланж.ndmsv метилоранж.ndmsv 
-наигрыш.ndmsv налыгач.ndmsv обглодыш.ndmsv оборыш.ndmsv огарыш.ndmsv окатыш.ndmsv 
-околыш.ndmsv оскребыш.ndmsv отыгрыш.ndmsv панаш.ndmsv партстаж.ndmsv пастилаж.ndmsv 
-патронаж.ndmsv патронташ.ndmsv педколледж.ndmsv пеонаж.ndmsv перевертыш.ndmsv пикотаж.ndmsv 
-плач.ndmsv плюмаж.ndmsv подскребыш.ndmsv подхалимаж.ndmsv политипаж.ndmsv полуплач.ndmsv 
-полуэкипаж.ndmsv примаж.ndmsv проигрыш.ndmsv променаж.ndmsv путч.ndmsv радиорепортаж.ndmsv 
-резерваж.ndmsv репортаж.ndmsv розыгрыш.ndmsv саботаж.ndmsv сандвич.ndmsv свертыш.ndmsv 
-свитч.ndmsv скатыш.ndmsv скетч.ndmsv скотч.ndmsv смерч.ndmsv стаж.ndmsv 
-стаффаж.ndmsv судоэкипаж.ndmsv сэндвич.ndmsv тампонаж.ndmsv тоннаж.ndmsv транш.ndmsv 
-трельяж.ndmsv тренаж.ndmsv трикотаж.ndmsv увраж.ndmsv фабзавуч.ndmsv фетиш.ndmsv 
-фиксаж.ndmsv флердоранж.ndmsv флэш.ndmsv фоторепортаж.ndmsv френч.ndmsv хадж.ndmsv 
-хедж.ndmsv хеш.ndmsv хронометраж.ndmsv цеж.ndmsv цинаш.ndmsv чардаш.ndmsv 
-чинш.ndmsv шарж.ndmsv шпионаж.ndmsv эпатаж.ndmsv эпонж.ndmsv эскамонтаж.ndmsv 
-этвеш.ndmsv этикетаж.ndmsv ягдташ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 аллонж.ndmsi амбалаж.ndmsi антураж.ndmsi апрош.ndmsi арбитраж.ndmsi бакшиш.ndmsi 
 банкаброш.ndmsi бареж.ndmsi барраж.ndmsi бельэтаж.ndmsi бизнес-колледж.ndmsi блокаж.ndmsi 
 бракераж.ndmsi вернисаж.ndmsi вкладыш.ndmsi вояж.ndmsi всевобуч.ndmsi всеобуч.ndmsi 
@@ -6379,6 +6353,32 @@
 чинш.ndmsi шарж.ndmsi шпионаж.ndmsi эпатаж.ndmsi эпонж.ndmsi эскамонтаж.ndmsi 
 этвеш.ndmsi этикетаж.ndmsi ягдташ.ndmsi :  <morph-С,мр,но,ед,им>;
 
+аллонж.ndmsv амбалаж.ndmsv антураж.ndmsv апрош.ndmsv арбитраж.ndmsv бакшиш.ndmsv 
+банкаброш.ndmsv бареж.ndmsv барраж.ndmsv бельэтаж.ndmsv бизнес-колледж.ndmsv блокаж.ndmsv 
+бракераж.ndmsv вернисаж.ndmsv вкладыш.ndmsv вояж.ndmsv всевобуч.ndmsv всеобуч.ndmsv 
+выкидыш.ndmsv гамма-каротаж.ndmsv гашиш.ndmsv генерал-марш.ndmsv гуляш.ndmsv дебош.ndmsv 
+дегоржаж.ndmsv демарш.ndmsv демонтаж.ndmsv дерапаж.ndmsv диспач.ndmsv дубляж.ndmsv 
+ерофеич.ndmsv зародыш.ndmsv зильбергрош.ndmsv зондаж.ndmsv идиш.ndmsv имидж.ndmsv 
+инструктаж.ndmsv интерлиньяж.ndmsv кампеш.ndmsv камуфляж.ndmsv капелюш.ndmsv каптаж.ndmsv 
+карагач.ndmsv карт-бланш.ndmsv картонаж.ndmsv картридж.ndmsv километраж.ndmsv кинорепортаж.ndmsv 
+китч.ndmsv кливаж.ndmsv клинч.ndmsv коллаж.ndmsv колледж.ndmsv коллеж.ndmsv 
+кольматаж.ndmsv контрмарш.ndmsv коттедж.ndmsv креп-эпонж.ndmsv кукиш.ndmsv кулаж.ndmsv 
+куш.ndmsv кэтч.ndmsv лаваш.ndmsv ландыш.ndmsv лекаж.ndmsv ленч.ndmsv 
+макинтош.ndmsv макияж.ndmsv матч.ndmsv матчиш.ndmsv меланж.ndmsv метилоранж.ndmsv 
+наигрыш.ndmsv налыгач.ndmsv обглодыш.ndmsv оборыш.ndmsv огарыш.ndmsv окатыш.ndmsv 
+околыш.ndmsv оскребыш.ndmsv отыгрыш.ndmsv панаш.ndmsv партстаж.ndmsv пастилаж.ndmsv 
+патронаж.ndmsv патронташ.ndmsv педколледж.ndmsv пеонаж.ndmsv перевертыш.ndmsv пикотаж.ndmsv 
+плач.ndmsv плюмаж.ndmsv подскребыш.ndmsv подхалимаж.ndmsv политипаж.ndmsv полуплач.ndmsv 
+полуэкипаж.ndmsv примаж.ndmsv проигрыш.ndmsv променаж.ndmsv путч.ndmsv радиорепортаж.ndmsv 
+резерваж.ndmsv репортаж.ndmsv розыгрыш.ndmsv саботаж.ndmsv сандвич.ndmsv свертыш.ndmsv 
+свитч.ndmsv скатыш.ndmsv скетч.ndmsv скотч.ndmsv смерч.ndmsv стаж.ndmsv 
+стаффаж.ndmsv судоэкипаж.ndmsv сэндвич.ndmsv тампонаж.ndmsv тоннаж.ndmsv транш.ndmsv 
+трельяж.ndmsv тренаж.ndmsv трикотаж.ndmsv увраж.ndmsv фабзавуч.ndmsv фетиш.ndmsv 
+фиксаж.ndmsv флердоранж.ndmsv флэш.ndmsv фоторепортаж.ndmsv френч.ndmsv хадж.ndmsv 
+хедж.ndmsv хеш.ndmsv хронометраж.ndmsv цеж.ndmsv цинаш.ndmsv чардаш.ndmsv 
+чинш.ndmsv шарж.ndmsv шпионаж.ndmsv эпатаж.ndmsv эпонж.ndmsv эскамонтаж.ndmsv 
+этвеш.ndmsv этикетаж.ndmsv ягдташ.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 блош.= босонож.= :
   LLBRI+ or LLBRM+ or LLBSM+;
 
@@ -6394,18 +6394,18 @@
 боб.= :
   LLAAQ+ or LLFKQ+ or LLFHQ+ or LLAVQ+ or LLAVT+ or LLCJW+;
 
+боб.ndmsi :  <morph-С,мр,но,ед,им>;
+
 боб.nlmsi :  <morph-С,мр,од,ед,им>;
 
 боб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-боб.ndmsi :  <morph-С,мр,но,ед,им>;
-
 бобрик.= восток.= дамаск.= фанг.= хмельник.= :
   LLAAM+ or LLDWW+;
 
-бобрик.ndmsv восток.ndmsv дамаск.ndmsv фанг.ndmsv хмельник.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бобрик.ndmsi восток.ndmsi дамаск.ndmsi фанг.ndmsi хмельник.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бобрик.ndmsv восток.ndmsv дамаск.ndmsv фанг.ndmsv хмельник.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бобрин.= грязов.= кремен.= мухав.= олон.= петродвор.= 
 сторожин.= трускав.= чадоб.= :
@@ -6416,11 +6416,11 @@
 
 бобров.amss :  <morph-П,мр,ед,кр>;
 
+бобров.ndmsi :  <morph-С,мр,но,ед,им>;
+
 бобров.nlmsi :  <morph-С,мр,од,ед,им>;
 
 бобров.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-бобров.ndmsi :  <morph-С,мр,но,ед,им>;
 
 бога.= :
   LLELT+ or LLCYK+;
@@ -6467,9 +6467,9 @@
 богородск.= :
   LLDWW+ or LLDYP+ or LLBEP+ or LLDYV+ or LLDZV+;
 
-богородск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 богородск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+богородск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 богословск.= винницк.= горбатовск.= житомирск.= македонск.= :
   LLFJZ+ or LLBEP+;
@@ -6485,11 +6485,11 @@
 богучар.= :
   LLDWW+ or LLEAJ+;
 
-богучар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 богучар.ndmsi :  <morph-С,мр,но,ед,им>;
 
 богучар.npg :  <morph-С,мн,мн,рд>;
+
+богучар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.30:
   LLDQB+;
@@ -6556,9 +6556,9 @@
 болот.= :
   LLEBJ+ or LLBYU+ or LLCAG+;
 
-болот.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 болот.nlmsi :  <morph-С,мр,од,ед,им>;
+
+болот.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 болотц.= :
   LLART+;
@@ -6584,9 +6584,9 @@
 большепанюшев.= :
   LLFVB+;
 
-большепанюшев.amsi :  <morph-П,мр,ед,им>;
-
 большепанюшев.admsv :  <morph-П,мр,ед,вн,но>;
+
+большепанюшев.amsi :  <morph-П,мр,ед,им>;
 
 большерот.= широкорот.= :
   LLACI+ or LLDKO+;
@@ -6616,18 +6616,18 @@
 бор.= :
   LLAAS+ or LLAFX+ or LLAYB+ or LLAYJ+ or LLBYZ+ or LLCLM+ or LLDJV+ or LLFIE+;
 
+бор.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 бор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бор.ndmsi :  <morph-С,мр,но,ед,им>;
 
-бор.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 бордо.= :
   LLADL+ or LLAEG+ or LLAEK+ or LLDWY+;
 
-бордо.ndn :  <morph-С,ср,но,0>;
-
 бордо.a :  <morph-П,0>;
+
+бордо.ndn :  <morph-С,ср,но,0>;
 
 бордо.e :  <morph-Н,0>;
 
@@ -6661,11 +6661,11 @@
 карпинск.= луначарск.= пржевальск.= свирск.= халевинск.= :
   LLDWW+ or LLFJZ+;
 
-анинск.ndmsv боровинск.ndmsv волчанск.ndmsv высоцк.ndmsv горицк.ndmsv каменск.ndmsv 
-карпинск.ndmsv луначарск.ndmsv пржевальск.ndmsv свирск.ndmsv халевинск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 анинск.ndmsi боровинск.ndmsi волчанск.ndmsi высоцк.ndmsi горицк.ndmsi каменск.ndmsi 
 карпинск.ndmsi луначарск.ndmsi пржевальск.ndmsi свирск.ndmsi халевинск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+анинск.ndmsv боровинск.ndmsv волчанск.ndmsv высоцк.ndmsv горицк.ndmsv каменск.ndmsv 
+карпинск.ndmsv луначарск.ndmsv пржевальск.ndmsv свирск.ndmsv халевинск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 борович.= :
   LLDYL+ or LLCJW+;
@@ -6718,17 +6718,17 @@
 хлебопродукт.= чебот.= :
   LLAAQ+ or LLDJV+;
 
-аз.ndmsv ботфорт.ndmsv всход.ndmsv инициал.ndmsv кадр.ndmsv котурн.ndmsv 
-курс.ndmsv лампас.ndmsv маневр.ndmsv морепродукт.ndmsv мясопродукт.ndmsv нард.ndmsv 
-нефтепродукт.ndmsv огнеупор.ndmsv пасс.ndmsv пейс.ndmsv пересуд.ndmsv разносол.ndmsv 
-расспрос.ndmsv рельс.ndmsv ресурс.ndmsv рыбопродукт.ndmsv стройматериал.ndmsv фант.ndmsv 
-хлебопродукт.ndmsv чебот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 аз.ndmsi ботфорт.ndmsi всход.ndmsi инициал.ndmsi кадр.ndmsi котурн.ndmsi 
 курс.ndmsi лампас.ndmsi маневр.ndmsi морепродукт.ndmsi мясопродукт.ndmsi нард.ndmsi 
 нефтепродукт.ndmsi огнеупор.ndmsi пасс.ndmsi пейс.ndmsi пересуд.ndmsi разносол.ndmsi 
 расспрос.ndmsi рельс.ndmsi ресурс.ndmsi рыбопродукт.ndmsi стройматериал.ndmsi фант.ndmsi 
 хлебопродукт.ndmsi чебот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+аз.ndmsv ботфорт.ndmsv всход.ndmsv инициал.ndmsv кадр.ndmsv котурн.ndmsv 
+курс.ndmsv лампас.ndmsv маневр.ndmsv морепродукт.ndmsv мясопродукт.ndmsv нард.ndmsv 
+нефтепродукт.ndmsv огнеупор.ndmsv пасс.ndmsv пейс.ndmsv пересуд.ndmsv разносол.ndmsv 
+расспрос.ndmsv рельс.ndmsv ресурс.ndmsv рыбопродукт.ndmsv стройматериал.ndmsv фант.ndmsv 
+хлебопродукт.ndmsv чебот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 авен.= барт.= бейтс.= боос.= боулдер.= браун.= 
 вагит.= вэйн.= клинтон.= мелоун.= морт.= мюнхгаузен.= 
@@ -6775,18 +6775,18 @@
 братин.= :
   LLFUS+ or LLAFX+;
 
-братин.amsi :  <morph-П,мр,ед,им>;
-
 братин.admsv :  <morph-П,мр,ед,вн,но>;
+
+братин.amsi :  <morph-П,мр,ед,им>;
 
 братин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 брач.= :
   LLDWW+ or LLBYZ+ or LLCJW+;
 
-брач.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 брач.ndmsi :  <morph-С,мр,но,ед,им>;
+
+брач.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бре.= :
   LLAPA+ or LLAQQ+ or LLCQX+ or LLDHB+;
@@ -6804,9 +6804,9 @@
 бремен.= :
   LLDWW+ or LLELV+ or LLELW+;
 
-бремен.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бремен.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бремен.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 брехн.= хвастн.= хохотн.= :
   LLFWF+ or LLDQH+;
@@ -6872,28 +6872,19 @@
 бруклин.= синергис.= :
   LLFNX+;
 
-бруклин.ndmsv синергис.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бруклин.ndmsi синергис.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бруклин.ndmsv синергис.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 брус.= :
   LLAAZ+ or LLCCZ+ or LLCGW+ or LLCJW+;
 
-брус.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 брус.ndmsi :  <morph-С,мр,но,ед,им>;
+
+брус.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.37:
   LLFQF+ or LLDKJ+;
-
-аистов.amss акулов.amss байков.amss баканов.amss баков.amss балыков.amss 
-барсов.amss барсуков.amss бельков.amss бердов.amss бобков.amss брусков.amss 
-бубликов.amss вершков.amss ветлов.amss вьюнов.amss гоголин.amss грибков.amss 
-груздев.amss гудков.amss джутов.amss дроздов.amss дроков.amss дятлов.amss 
-жеребцов.amss карасев.amss карпов.amss лосев.amss лотков.amss мальков.amss 
-маршев.amss окороков.amss окунев.amss пауков.amss писцов.amss пятаков.amss 
-райков.amss ракитов.amss скворцов.amss снежков.amss судаков.amss сурков.amss 
-суслов.amss цветков.amss чижов.amss :  <morph-П,мр,ед,кр>;
 
 аистов.nlmsi акулов.nlmsi байков.nlmsi баканов.nlmsi баков.nlmsi балыков.nlmsi 
 барсов.nlmsi барсуков.nlmsi бельков.nlmsi бердов.nlmsi бобков.nlmsi брусков.nlmsi 
@@ -6903,6 +6894,15 @@
 маршев.nlmsi окороков.nlmsi окунев.nlmsi пауков.nlmsi писцов.nlmsi пятаков.nlmsi 
 райков.nlmsi ракитов.nlmsi скворцов.nlmsi снежков.nlmsi судаков.nlmsi сурков.nlmsi 
 суслов.nlmsi цветков.nlmsi чижов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+аистов.amss акулов.amss байков.amss баканов.amss баков.amss балыков.amss 
+барсов.amss барсуков.amss бельков.amss бердов.amss бобков.amss брусков.amss 
+бубликов.amss вершков.amss ветлов.amss вьюнов.amss гоголин.amss грибков.amss 
+груздев.amss гудков.amss джутов.amss дроздов.amss дроков.amss дятлов.amss 
+жеребцов.amss карасев.amss карпов.amss лосев.amss лотков.amss мальков.amss 
+маршев.amss окороков.amss окунев.amss пауков.amss писцов.amss пятаков.amss 
+райков.amss ракитов.amss скворцов.amss снежков.amss судаков.amss сурков.amss 
+суслов.amss цветков.amss чижов.amss :  <morph-П,мр,ед,кр>;
 
 бруштейн.= :
   LLFJX+ or LLFHI+;
@@ -6937,9 +6937,9 @@
 бубнов.= :
   LLFQF+ or LLFOU+ or LLBRK+ or LLDKJ+;
 
-бубнов.amss :  <morph-П,мр,ед,кр>;
-
 бубнов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+бубнов.amss :  <morph-П,мр,ед,кр>;
 
 буг.= :
   LLDWW+ or LLCKV+;
@@ -6985,31 +6985,31 @@
 
 бук.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-бук.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-бук.nlmpv :  <morph-С,мр,од,мн,вн>;
+бук.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 бук.ndmsi :  <morph-С,мр,но,ед,им>;
 
-бук.nlmpg :  <morph-С,мр,од,мн,рд>;
-
 бук.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+бук.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+бук.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 буккер.= :
   LLAAQ+ or LLBYZ+ or LLFRF+ or LLEUU+;
 
-буккер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 буккер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+буккер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 букс.= :
   LLAAQ+ or LLAFX+ or LLCBF+;
 
 букс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-букс.ndmsi :  <morph-С,мр,но,ед,им>;
-
 букс.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+букс.ndmsi :  <morph-С,мр,но,ед,им>;
 
 буксир.= :
   LLAAQ+ or LLBYZ+ or LLCDH+;
@@ -7041,13 +7041,13 @@
 бур.= :
   LLAAQ+ or LLACI+ or LLAGL+ or LLBHS+ or LLBNP+ or LLBRH+ or LLBRK+ or LLBSP+ or LLBYU+ or LLDKF+ or LLDQC+;
 
-бур.amss :  <morph-П,мр,ед,кр>;
+бур.ndmsi :  <morph-С,мр,но,ед,им>;
 
-бур.nlmsi :  <morph-С,мр,од,ед,им>;
+бур.amss :  <morph-П,мр,ед,кр>;
 
 бур.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-бур.ndmsi :  <morph-С,мр,но,ед,им>;
+бур.nlmsi :  <morph-С,мр,од,ед,им>;
 
 буре.= :
   LLCZE+ or LLEAY+;
@@ -7136,9 +7136,9 @@
 бывало.= :
   LLDTT+;
 
-бывало.p :  <morph-ЧАСТ,0>;
-
 бывало.y :  <morph-ВВОДН,0>;
+
+бывало.p :  <morph-ЧАСТ,0>;
 
 был.= :
   LLCJC+ or LLDNF+;
@@ -7162,11 +7162,11 @@
 бычин.= :
   LLAEY+ or LLAFX+ or LLDKJ+;
 
-бычин.amss :  <morph-П,мр,ед,кр>;
+бычин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 бычин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-бычин.ndfpg :  <morph-С,жр,но,мн,рд>;
+бычин.amss :  <morph-П,мр,ед,кр>;
 
 бычин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
@@ -7201,9 +7201,9 @@
 вавилон.= :
   LLDWW+ or LLDJV+;
 
-вавилон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вавилон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вавилон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вагон.= :
   LLAAQ+ or LLAER+ or LLBRK+ or LLBYZ+;
@@ -7231,13 +7231,13 @@
 вал.= :
   LLAAS+ or LLFIN+ or LLAUI+ or LLAYF+ or LLBGI+ or LLBHS+ or LLBNP+ or LLBRK+ or LLBSW+ or LLCJW+ or LLFLQ+;
 
-вал.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 вал.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+вал.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 вал.ndmsi :  <morph-С,мр,но,ед,им>;
 
-вал.nlfpv :  <morph-С,жр,од,мн,вн>;
+вал.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 валевск.= ивинск.= рокецк.= :
   LLFKA+;
@@ -7251,11 +7251,11 @@
 валентин.= :
   LLFLG+ or LLFIN+ or LLBRK+;
 
-валентин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 валентин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 валентин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+валентин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 валери.= юли.= :
   LLFHY+ or LLFHW+ or LLFKU+ or LLFKT+;
@@ -7444,9 +7444,9 @@
 валерьян.= :
   LLFHI+ or LLAFX+ or LLBRK+;
 
-валерьян.nlmsi :  <morph-С,мр,од,ед,им>;
-
 валерьян.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+валерьян.nlmsi :  <morph-С,мр,од,ед,им>;
 
 валк.= :
   LLDXP+ or LLDYM+;
@@ -7457,9 +7457,9 @@
 ван.= :
   LLDWW+ or LLBYZ+ or LLFPZ+;
 
-ван.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ван.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ван.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ванил.= гибел.= горизонтал.= добродетел.= морал.= нормал.= 
 пастел.= :
@@ -7468,9 +7468,9 @@
 ванин.= :
   LLFJG+ or LLFUS+ or LLDZR+;
 
-ванин.amsi :  <morph-П,мр,ед,им>;
-
 ванин.nlmsi :  <morph-С,мр,од,ед,им>;
+
+ванин.amsi :  <morph-П,мр,ед,им>;
 
 ванин.admsv :  <morph-П,мр,ед,вн,но>;
 
@@ -7508,9 +7508,9 @@
 варган.= дуван.= хер.= :
   LLAAQ+ or LLBIA+ or LLBNU+;
 
-варган.ndmsv дуван.ndmsv хер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 варган.ndmsi дуван.ndmsi хер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+варган.ndmsv дуван.ndmsv хер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.39:
   LLFHI+;
@@ -7594,11 +7594,11 @@
 вдов.= :
   LLAGT+ or LLAYJ+ or LLBFF+ or LLDKJ+;
 
+вдов.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 вдов.amss :  <morph-П,мр,ед,кр>;
 
 вдов.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-вдов.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 вблизи.= вдоль.= взамен.= вкось.= вкруг.= внизу.= 
 внутри.= внутрь.= вовнутрь.= вокруг.= вослед.= вперед.= 
@@ -7640,18 +7640,18 @@
 веер.= :
   LLABM+ or LLEBJ+ or LLBYZ+ or LLCJW+;
 
+веер.ndmsi :  <morph-С,мр,но,ед,им>;
+
 веер.nlmsi :  <morph-С,мр,од,ед,им>;
 
 веер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-веер.ndmsi :  <morph-С,мр,но,ед,им>;
-
 вез.= :
   LLFLY+ or LLCWH+ or LLEMD+ or LLCWW+;
 
-вез.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 вез.vnpdpms :  <morph-Г,нс,пе,дст,прш,мр,ед>;
+
+вез.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 вездесущ.= грязнущ.= длиннущ.= лежач.= страждущ.= толстущ.= 
 узкоплеч.= чарующ.= :
@@ -7666,15 +7666,15 @@
 век.= :
   LLABP+ or LLAEK+ or LLBBY+ or LLCAD+ or LLCBF+;
 
-век.ndnpg :  <morph-С,ср,но,мн,рд>;
+век.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 век.e :  <morph-Н,0>;
 
-век.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-век.ndmsi :  <morph-С,мр,но,ед,им>;
+век.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 век.npg :  <morph-С,мн,мн,рд>;
+
+век.ndmsi :  <morph-С,мр,но,ед,им>;
 
 вековуш.= квакуш.= хохлуш.= :
   LLAGZ+ or LLBRM+;
@@ -7689,11 +7689,9 @@
 велик.= :
   LLDWW+ or LLBDW+ or LLDZV+;
 
-:  <morph-П,мр,ед,кр>;
+велик.ndmsi :  <morph-С,мр,но,ед,им>;
 
 велик.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-велик.ndmsi :  <morph-С,мр,но,ед,им>;
 
 великолеп.= :
   LLBDD+ or LLBYU+ or LLDNS+;
@@ -7701,16 +7699,16 @@
 вельмож.= :
   LLAEV+ or LLBYU+;
 
-вельмож.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 вельмож.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+вельмож.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 вен.= :
   LLAFX+ or LLDXR+ or LLAYB+ or LLAYI+ or LLBYZ+ or LLCAG+ or LLCJW+ or LLETJ+;
 
-вен.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 вен.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+вен.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 венгер.= голланд.= испан.= кабардин.= красав.= литов.= 
 шотланд.= :
@@ -7760,9 +7758,9 @@
 вермонт.= :
   LLEEK+ or LLAYI+;
 
-вермонт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вермонт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вермонт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вертел.= шомпол.= :
   LLABM+ or LLDOO+;
@@ -7781,11 +7779,11 @@
 верх.= :
   LLABH+ or LLAEG+ or LLBCC+;
 
+верх.ndmsi :  <morph-С,мр,но,ед,им>;
+
 верх.a :  <morph-П,0>;
 
 верх.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-верх.ndmsi :  <morph-С,мр,но,ед,им>;
 
 верхн.= :
   LLBER+;
@@ -7814,9 +7812,9 @@
 вес.= :
   LLABJ+ or LLBSW+ or LLBUA+ or LLBUV+ or LLDJV+ or LLDNF+;
 
-вес.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вес.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вес.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 весел.= :
   LLBHS+ or LLBNP+ or LLBRK+ or LLDKF+ or LLDNT+ or LLDOO+ or LLDPD+;
@@ -7910,9 +7908,9 @@
 взброс.= :
   LLAAQ+ or LLFWS+;
 
-взброс.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 взброс.ndmsi :  <morph-С,мр,но,ед,им>;
+
+взброс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 взбуш.= набуш.= :
   LLFYI+ or LLFYJ+;
@@ -7952,9 +7950,9 @@
 вздор.= :
   LLAAO+ or LLBGR+ or LLBYU+;
 
-вздор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вздор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вздор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 взима.= :
   LLCZH+ or LLDAI+ or LLDEM+;
@@ -7981,9 +7979,9 @@
 вид.= :
   LLAAO+ or LLEBJ+;
 
-вид.nlmsi :  <morph-С,мр,од,ед,им>;
-
 вид.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+вид.nlmsi :  <morph-С,мр,од,ед,им>;
 
 вид.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -8051,9 +8049,9 @@
 вилючинск.= :
   LLDWW+ or LLBEP+ or LLDZV+;
 
-вилючинск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вилючинск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вилючинск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вин.= :
   LLAFX+ or LLBCE+ or LLBIK+ or LLBNP+ or LLBYZ+ or LLCAG+ or LLCXA+ or LLCXI+ or LLCYK+;
@@ -8077,11 +8075,11 @@
 вис.= :
   LLAAQ+ or LLDWW+ or LLFZW+ or LLBWA+ or LLCJW+;
 
-вис.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 вис.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вис.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вис.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 висл.= :
   LLDXR+ or LLDLO+;
@@ -8158,11 +8156,11 @@
 владимир.= :
   LLDWW+ or LLFKQ+ or LLFHQ+ or LLAYI+;
 
-владимир.nlmsi :  <morph-С,мр,од,ед,им>;
+владимир.ndmsi :  <morph-С,мр,но,ед,им>;
 
 владимир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-владимир.ndmsi :  <morph-С,мр,но,ед,им>;
+владимир.nlmsi :  <morph-С,мр,од,ед,им>;
 
 влач.= :
   LLBHI+ or LLBMS+;
@@ -8173,9 +8171,9 @@
 влет.= :
   LLAAQ+ or LLAEK+;
 
-влет.e :  <morph-Н,0>;
-
 влет.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+влет.e :  <morph-Н,0>;
 
 влет.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -8211,11 +8209,11 @@
 внук.= инок.= :
   LLACG+ or LLAGR+;
 
-внук.nlfpg инок.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 внук.nlmsi инок.nlmsi :  <morph-С,мр,од,ед,им>;
 
 внук.nlfpv инок.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+внук.nlfpg инок.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 внутригородск.= :
   LLCJG+;
@@ -8226,9 +8224,9 @@
 внучат.= :
   LLAHC+ or LLBYZ+ or LLDKJ+;
 
-внучат.amss :  <morph-П,мр,ед,кр>;
-
 внучат.npg :  <morph-С,мн,мн,рд>;
+
+внучат.amss :  <morph-П,мр,ед,кр>;
 
 во.= :
   LLDTD+ or LLAPG+ or LLAQP+ or LLASO+ or LLBAH+ or LLBBH+ or LLBPJ+ or LLFZI+;
@@ -8242,13 +8240,13 @@
 вод.= :
   LLAAQ+ or LLAFX+ or LLBRK+ or LLBYZ+ or LLDJS+;
 
-вод.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вод.ndmsi :  <morph-С,мр,но,ед,им>;
 
 вод.npg :  <morph-С,мн,мн,рд>;
 
 вод.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+вод.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 водовоз.= :
   LLAAQ+ or LLACI+ or LLBRO+ or LLBYZ+;
@@ -8262,9 +8260,9 @@
 водоем.= :
   LLAAQ+ or LLBSV+ or LLBYZ+;
 
-водоем.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 водоем.ndmsi :  <morph-С,мр,но,ед,им>;
+
+водоем.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 водолаз.= :
   LLACI+ or LLBRK+ or LLBYZ+;
@@ -8294,9 +8292,9 @@
 воевод.= :
   LLAEY+ or LLECP+;
 
-воевод.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 воевод.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+воевод.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 военнопленн.= :
   LLDJZ+ or LLDLU+;
@@ -8307,9 +8305,9 @@
 воз.= :
   LLAAS+ or LLBRK+ or LLGAD+ or LLCJW+;
 
-воз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 воз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+воз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 возве.= :
   LLFXE+ or LLFZC+;
@@ -8346,16 +8344,6 @@
 /ru/words/words.41:
   LLAAK+;
 
-балык.ndmsv блеск.ndmsv брех.ndmsv бульончик.ndmsv валежник.ndmsv верезг.ndmsv 
-вереск.ndmsv визг.ndmsv воздух.ndmsv войлок.ndmsv воск.ndmsv горох.ndmsv 
-грог.ndmsv долг.ndmsv дребезг.ndmsv известняк.ndmsv коньяк.ndmsv крик.ndmsv 
-крупник.ndmsv крыжовник.ndmsv лапник.ndmsv ликерчик.ndmsv лоск.ndmsv лязг.ndmsv 
-мак.ndmsv мышьяк.ndmsv пенник.ndmsv перчик.ndmsv писк.ndmsv разбег.ndmsv 
-рассольник.ndmsv рислинг.ndmsv салатик.ndmsv ситник.ndmsv ситчик.ndmsv смех.ndmsv 
-срок.ndmsv супчик.ndmsv сурик.ndmsv табак.ndmsv творог.ndmsv тик.ndmsv 
-травник.ndmsv укропчик.ndmsv урюк.ndmsv холстик.ndmsv чеснок.ndmsv шиповник.ndmsv 
-шорох.ndmsv щелок.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 балык.ndmsi блеск.ndmsi брех.ndmsi бульончик.ndmsi валежник.ndmsi верезг.ndmsi 
 вереск.ndmsi визг.ndmsi воздух.ndmsi войлок.ndmsi воск.ndmsi горох.ndmsi 
 грог.ndmsi долг.ndmsi дребезг.ndmsi известняк.ndmsi коньяк.ndmsi крик.ndmsi 
@@ -8365,6 +8353,16 @@
 срок.ndmsi супчик.ndmsi сурик.ndmsi табак.ndmsi творог.ndmsi тик.ndmsi 
 травник.ndmsi укропчик.ndmsi урюк.ndmsi холстик.ndmsi чеснок.ndmsi шиповник.ndmsi 
 шорох.ndmsi щелок.ndmsi :  <morph-С,мр,но,ед,им>;
+
+балык.ndmsv блеск.ndmsv брех.ndmsv бульончик.ndmsv валежник.ndmsv верезг.ndmsv 
+вереск.ndmsv визг.ndmsv воздух.ndmsv войлок.ndmsv воск.ndmsv горох.ndmsv 
+грог.ndmsv долг.ndmsv дребезг.ndmsv известняк.ndmsv коньяк.ndmsv крик.ndmsv 
+крупник.ndmsv крыжовник.ndmsv лапник.ndmsv ликерчик.ndmsv лоск.ndmsv лязг.ndmsv 
+мак.ndmsv мышьяк.ndmsv пенник.ndmsv перчик.ndmsv писк.ndmsv разбег.ndmsv 
+рассольник.ndmsv рислинг.ndmsv салатик.ndmsv ситник.ndmsv ситчик.ndmsv смех.ndmsv 
+срок.ndmsv супчик.ndmsv сурик.ndmsv табак.ndmsv творог.ndmsv тик.ndmsv 
+травник.ndmsv укропчик.ndmsv урюк.ndmsv холстик.ndmsv чеснок.ndmsv шиповник.ndmsv 
+шорох.ndmsv щелок.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 возжажд.= заор.= зарж.= застон.= порж.= прорж.= 
 простон.= :
@@ -8418,16 +8416,16 @@
 волжск.= каспийск.= приморск.= :
   LLDWW+ or LLDYP+ or LLBEL+;
 
-волжск.ndmsv каспийск.ndmsv приморск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 волжск.ndmsi каспийск.ndmsi приморск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+волжск.ndmsv каспийск.ndmsv приморск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 волк.= :
   LLAAY+ or LLACG+;
 
-волк.nlmsi :  <morph-С,мр,од,ед,им>;
-
 волк.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+волк.nlmsi :  <morph-С,мр,од,ед,им>;
 
 волк.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -8450,20 +8448,20 @@
 волокит.= :
   LLAEY+ or LLAFX+ or LLBYU+;
 
-волокит.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 волокит.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+волокит.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 волокит.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 волос.= :
   LLABW+ or LLCJW+ or LLDJS+;
 
-волос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 волос.ndmsi :  <morph-С,мр,но,ед,им>;
 
 волос.npg :  <morph-С,мн,мн,рд>;
+
+волос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 волос.ndmpg :  <morph-С,мр,но,мн,рд>;
 
@@ -8482,15 +8480,15 @@
 вольниц.= полениц.= тупиц.= :
   LLAFF+ or LLAFO+;
 
-вольниц.nlfpg полениц.nlfpg тупиц.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-вольниц.nlmpv полениц.nlmpv тупиц.nlmpv :  <morph-С,мр,од,мн,вн>;
+вольниц.nlfpv полениц.nlfpv тупиц.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 вольниц.ndfpg полениц.ndfpg тупиц.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-вольниц.nlmpg полениц.nlmpg тупиц.nlmpg :  <morph-С,мр,од,мн,рд>;
+вольниц.nlmpv полениц.nlmpv тупиц.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-вольниц.nlfpv полениц.nlfpv тупиц.nlfpv :  <morph-С,жр,од,мн,вн>;
+вольниц.nlfpg полениц.nlfpg тупиц.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+вольниц.nlmpg полениц.nlmpg тупиц.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 вольнодум.= :
   LLACI+ or LLAYI+ or LLBDD+ or LLBYT+;
@@ -8502,11 +8500,11 @@
 
 вольт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-вольт.ndmsi :  <morph-С,мр,но,ед,им>;
-
 вольт.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 вольт.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+вольт.ndmsi :  <morph-С,мр,но,ед,им>;
 
 вон.= :
   LLAEK+ or LLDTS+ or LLAFX+ or LLGBH+ or LLFXA+ or LLDNF+;
@@ -8669,24 +8667,24 @@
 ворон.= :
   LLACI+ or LLAGT+ or LLAVH+ or LLAYB+ or LLBFF+ or LLBGR+ or LLBHS+ or LLBNP+ or LLBRK+ or LLCIR+ or LLCIZ+ or LLDNF+;
 
-ворон.nlfpg :  <morph-С,жр,од,мн,рд>;
+ворон.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 ворон.nlmsi :  <morph-С,мр,од,ед,им>;
 
-ворон.nlfpv :  <morph-С,жр,од,мн,вн>;
+ворон.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 воронов.= :
   LLDWW+ or LLFQF+ or LLFUO+;
 
-воронов.amsi :  <morph-П,мр,ед,им>;
+воронов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+воронов.admsv :  <morph-П,мр,ед,вн,но>;
 
 воронов.nlmsi :  <morph-С,мр,од,ед,им>;
 
 воронов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-воронов.admsv :  <morph-П,мр,ед,вн,но>;
-
-воронов.ndmsi :  <morph-С,мр,но,ед,им>;
+воронов.amsi :  <morph-П,мр,ед,им>;
 
 воронь.= :
   LLARY+ or LLEAY+;
@@ -8694,11 +8692,11 @@
 ворот.= :
   LLAAQ+ or LLAHC+ or LLBYU+ or LLCJW+ or LLDIB+;
 
-ворот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ворот.ndmsi :  <morph-С,мр,но,ед,им>;
 
 ворот.npg :  <morph-С,мн,мн,рд>;
+
+ворот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ворош.= :
   LLBHE+ or LLBMS+ or LLCJW+;
@@ -8782,9 +8780,9 @@
 вощин.= :
   LLFQF+ or LLAFX+ or LLBYU+;
 
-вощин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 вощин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+вощин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 впа.= :
   LLBPW+ or LLGBQ+;
@@ -8836,9 +8834,9 @@
 вруб.= :
   LLAAQ+ or LLFWK+ or LLFXQ+ or LLBRK+ or LLCJW+;
 
-вруб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вруб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вруб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вс.= :
   LLEEL+ or LLFWB+;
@@ -8904,14 +8902,14 @@
 втируш.nlfpg дорогуш.nlfpg книгонош.nlfpg копуш.nlfpg крикуш.nlfpg роднуш.nlfpg 
 святош.nlfpg хромуш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-втируш.nlmpv дорогуш.nlmpv книгонош.nlmpv копуш.nlmpv крикуш.nlmpv роднуш.nlmpv 
-святош.nlmpv хромуш.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 втируш.nlmpg дорогуш.nlmpg книгонош.nlmpg копуш.nlmpg крикуш.nlmpg роднуш.nlmpg 
 святош.nlmpg хромуш.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 втируш.nlfpv дорогуш.nlfpv книгонош.nlfpv копуш.nlfpv крикуш.nlfpv роднуш.nlfpv 
 святош.nlfpv хромуш.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+втируш.nlmpv дорогуш.nlmpv книгонош.nlmpv копуш.nlmpv крикуш.nlmpv роднуш.nlmpv 
+святош.nlmpv хромуш.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 втол.= натол.= подтол.= протол.= растол.= :
   LLGCV+;
@@ -8933,9 +8931,9 @@
 втэк.= :
   LLAAM+ or LLEEK+ or LLEEO+;
 
-втэк.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 втэк.ndmsi :  <morph-С,мр,но,ед,им>;
+
+втэк.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вулканизир.= :
   LLCEU+ or LLCGD+;
@@ -8962,9 +8960,9 @@
 выбор.= :
   LLAAY+ or LLBRK+ or LLBYU+ or LLDJV+;
 
-выбор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выбор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выбор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выбро.= :
   LLGDI+ or LLFXO+ or LLGDJ+ or LLGDK+;
@@ -9035,9 +9033,9 @@
 выдох.= :
   LLAAM+ or LLGEC+;
 
-выдох.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выдох.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выдох.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выдр.= :
   LLAGT+ or LLAVH+;
@@ -9058,17 +9056,17 @@
 выжиг.= :
   LLAAM+ or LLAFG+;
 
-выжиг.nlfpg :  <morph-С,жр,од,мн,рд>;
+выжиг.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 выжиг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-выжиг.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-выжиг.ndmsi :  <morph-С,мр,но,ед,им>;
+выжиг.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 выжиг.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-выжиг.nlfpv :  <morph-С,жр,од,мн,вн>;
+выжиг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выжиг.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 воробь.= выжл.= кенгур.= льв.= негрит.= осл.= 
 пс.= соловь.= щегл.= :
@@ -9168,11 +9166,11 @@
 слом.= сцеп.= :
   LLAAQ+ or LLFWK+ or LLFXQ+ or LLBRK+;
 
-вылом.ndmsv отцеп.ndmsv подкорм.ndmsv прикорм.ndmsv прицеп.ndmsv разлом.ndmsv 
-слом.ndmsv сцеп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вылом.ndmsi отцеп.ndmsi подкорм.ndmsi прикорм.ndmsi прицеп.ndmsi разлом.ndmsi 
 слом.ndmsi сцеп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вылом.ndmsv отцеп.ndmsv подкорм.ndmsv прикорм.ndmsv прицеп.ndmsv разлом.ndmsv 
+слом.ndmsv сцеп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вым.= :
   LLGFA+ or LLGFE+ or LLGFF+ or LLFZO+ or LLGCG+ or LLEAU+ or LLDRA+ or LLGFK+;
@@ -9236,9 +9234,9 @@
 выпар.= :
   LLAAQ+ or LLGDP+ or LLGDQ+ or LLBRK+ or LLBSO+;
 
-выпар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выпар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выпар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выпас.= :
   LLAAQ+ or LLGFN+;
@@ -9308,9 +9306,9 @@
 выруб.= :
   LLAAQ+ or LLFWK+ or LLGGA+ or LLBRK+ or LLCJW+;
 
-выруб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выруб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выруб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вымыл.= выпял.= высал.= :
   LLFXB+ or LLGDQ+;
@@ -9330,9 +9328,9 @@
 выжим.= вымолот.= высев.= :
   LLAAQ+ or LLBRK+ or LLBSO+;
 
-выжим.ndmsv вымолот.ndmsv высев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выжим.ndmsi вымолот.ndmsi высев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выжим.ndmsv вымолот.ndmsv высев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 высел.= :
   LLFWV+ or LLFWW+ or LLBSP+ or LLCJW+;
@@ -9437,9 +9435,9 @@
 выход.= :
   LLAAQ+ or LLAYI+ or LLBRK+;
 
-выход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выхоло.= :
   LLGCH+ or LLFXO+ or LLFTA+;
@@ -9494,11 +9492,11 @@
 вьюн.= :
   LLAAQ+ or LLACI+ or LLCJW+;
 
-вьюн.nlmsi :  <morph-С,мр,од,ед,им>;
+вьюн.ndmsi :  <morph-С,мр,но,ед,им>;
 
 вьюн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-вьюн.ndmsi :  <morph-С,мр,но,ед,им>;
+вьюн.nlmsi :  <morph-С,мр,од,ед,им>;
 
 вя.= :
   LLAZL+ or LLAZR+ or LLBWD+;
@@ -9506,11 +9504,11 @@
 вяз.= :
   LLAAQ+ or LLBRK+ or LLBSW+ or LLBVY+ or LLDNF+;
 
-вяз.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 вяз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вяз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вяз.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 вязан.= :
   LLBRK+ or LLDLO+ or LLDNT+;
@@ -9547,9 +9545,9 @@
 га.= :
   LLABZ+ or LLADL+ or LLEMR+ or LLAQQ+ or LLAQZ+ or LLBPK+ or LLDZD+ or LLBPW+ or LLEMT+ or LLELZ+ or LLCXI+ or LLCYK+;
 
-га.ndn :  <morph-С,ср,но,0>;
-
 га.ndm :  <morph-С,мр,но,0>;
+
+га.ndn :  <morph-С,ср,но,0>;
 
 ассири.= валли.= гава.= европе.= ибери.= инде.= 
 камбоджи.= киммери.= красноарме.= ланки.= мала.= малагаси.= 
@@ -9582,9 +9580,9 @@
 газ.= :
   LLAAO+ or LLCBF+;
 
-газ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 газ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+газ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 газел.= :
   LLBFF+ or LLDNF+ or LLDNL+;
@@ -9623,11 +9621,11 @@
 галич.= :
   LLDWV+ or LLEBH+ or LLBFG+;
 
-галич.nlmsi :  <morph-С,мр,од,ед,им>;
+галич.ndmsi :  <morph-С,мр,но,ед,им>;
 
 галич.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-галич.ndmsi :  <morph-С,мр,но,ед,им>;
+галич.nlmsi :  <morph-С,мр,од,ед,им>;
 
 галичск.= омсукчанск.= раменск.= :
   LLBEP+ or LLDYV+ or LLDZV+;
@@ -9662,9 +9660,9 @@
 гарев.= громов.= :
   LLFQF+ or LLCJC+ or LLDKJ+;
 
-гарев.amss громов.amss :  <morph-П,мр,ед,кр>;
-
 гарев.nlmsi громов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+гарев.amss громов.amss :  <morph-П,мр,ед,кр>;
 
 гарибальди.= :
   LLEBV+ or LLAYG+ or LLBPY+;
@@ -9701,11 +9699,11 @@
 геллер.= ген.= кавун.= кресс.= рейтер.= :
   LLAAQ+ or LLEBJ+;
 
+геллер.ndmsi ген.ndmsi кавун.ndmsi кресс.ndmsi рейтер.ndmsi :  <morph-С,мр,но,ед,им>;
+
 геллер.nlmsi ген.nlmsi кавун.nlmsi кресс.nlmsi рейтер.nlmsi :  <morph-С,мр,од,ед,им>;
 
 геллер.ndmsv ген.ndmsv кавун.ndmsv кресс.ndmsv рейтер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-геллер.ndmsi ген.ndmsi кавун.ndmsi кресс.ndmsi рейтер.ndmsi :  <morph-С,мр,но,ед,им>;
 
 генерал.= :
   LLACI+ or LLBRL+;
@@ -9742,18 +9740,18 @@
 героин.= графин.= :
   LLAAQ+ or LLDQR+;
 
-героин.ndmsv графин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 героин.ndmsi графин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+героин.ndmsv графин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 герц.= :
   LLABR+ or LLDXN+;
 
 герц.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-герц.ndmsi :  <morph-С,мр,но,ед,им>;
-
 герц.ndmpg :  <morph-С,мр,но,мн,рд>;
+
+герц.ndmsi :  <morph-С,мр,но,ед,им>;
 
 гетерозигот.= гомозигот.= доминант.= монокультур.= несвобод.= орбит.= 
 :
@@ -9773,9 +9771,9 @@
 гидролиз.= :
   LLAAQ+ or LLCHP+ or LLCHI+;
 
-гидролиз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 гидролиз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гидролиз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.50:
   LLDMT+;
@@ -9797,9 +9795,9 @@
 гипс.= спирт.= :
   LLAAO+ or LLCCZ+ or LLCGW+;
 
-гипс.ndmsv спирт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 гипс.ndmsi спирт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гипс.ndmsv спирт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 авторулев.= гирорулев.= :
   LLCIP+;
@@ -9810,18 +9808,18 @@
 глав.= :
   LLAEY+ or LLAFX+ or LLBRK+ or LLBYU+ or LLDLO+;
 
+глав.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 глав.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 глав.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-глав.nlmpg :  <morph-С,мр,од,мн,рд>;
-
 воронежстройматериал.= главкадр.= минторгресурс.= :
   LLEEK+ or LLEFQ+;
 
-воронежстройматериал.ndmsv главкадр.ndmsv минторгресурс.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 воронежстройматериал.ndmsi главкадр.ndmsi минторгресурс.ndmsi :  <morph-С,мр,но,ед,им>;
+
+воронежстройматериал.ndmsv главкадр.ndmsv минторгресурс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 волгоградканалводстро.= главмосзеленхозстро.= громобо.= зарубежнефтебазстро.= иван-ча.= первома.= 
 сина.= союзоргтехводстро.= :
@@ -9834,28 +9832,28 @@
 глагол.= :
   LLAAQ+ or LLEMV+ or LLEMW+ or LLBIA+ or LLBNU+ or LLDML+ or LLDOK+;
 
-глагол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 глагол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+глагол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вест.= глад.= глен.= гололед.= насест.= нашест.= 
 повет.= пригар.= степ.= триод.= хлуп.= :
   LLAAQ+ or LLDNF+;
 
-вест.ndmsv глад.ndmsv глен.ndmsv гололед.ndmsv насест.ndmsv нашест.ndmsv 
-повет.ndmsv пригар.ndmsv степ.ndmsv триод.ndmsv хлуп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вест.ndmsi глад.ndmsi глен.ndmsi гололед.ndmsi насест.ndmsi нашест.ndmsi 
 повет.ndmsi пригар.ndmsi степ.ndmsi триод.ndmsi хлуп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вест.ndmsv глад.ndmsv глен.ndmsv гололед.ndmsv насест.ndmsv нашест.ndmsv 
+повет.ndmsv пригар.ndmsv степ.ndmsv триод.ndmsv хлуп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 глаз.= :
   LLABX+ or LLAHC+ or LLCKB+;
 
-глаз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 глаз.ndmsi :  <morph-С,мр,но,ед,им>;
 
 глаз.npg :  <morph-С,мн,мн,рд>;
+
+глаз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 глаз.ndmpg :  <morph-С,мр,но,мн,рд>;
 
@@ -9890,11 +9888,11 @@
 глиссад.= корректив.= формант.= :
   LLAAQ+ or LLAFX+ or LLBZE+;
 
-глиссад.ndmsv корректив.ndmsv формант.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 глиссад.ndmsi корректив.ndmsi формант.ndmsi :  <morph-С,мр,но,ед,им>;
 
 глиссад.ndfpg корректив.ndfpg формант.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+глиссад.ndmsv корректив.ndmsv формант.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бизнес-сектор.= бруствер.= буйреп.= глиссер.= джемпер.= драйвер.= 
 кампус.= клипер.= лихтер.= мэйлер.= омут.= ордер.= 
@@ -9917,9 +9915,9 @@
 
 глист.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-глист.nlmsi :  <morph-С,мр,од,ед,им>;
-
 глист.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+глист.nlmsi :  <morph-С,мр,од,ед,им>;
 
 гло.= :
   LLEMX+ or LLEMY+;
@@ -10040,9 +10038,9 @@
 говор.= :
   LLAAQ+ or LLBHS+ or LLBNP+ or LLCJW+;
 
-говор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 говор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+говор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 говорят.= кажется.= может.= скажем.= :
   LLFGK+;
@@ -10052,11 +10050,11 @@
 гол.= :
   LLAAQ+ or LLAYF+ or LLAYL+ or LLDKF+ or LLDNF+;
 
+гол.ndmsi :  <morph-С,мр,но,ед,им>;
+
 гол.amss :  <morph-П,мр,ед,кр>;
 
 гол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-гол.ndmsi :  <morph-С,мр,но,ед,им>;
 
 голб.= :
   LLAXX+;
@@ -10069,13 +10067,13 @@
 голов.= :
   LLFQF+ or LLAEY+ or LLAFX+ or LLBRK+;
 
-голов.nlmsi :  <morph-С,мр,од,ед,им>;
-
-голов.nlmpv :  <morph-С,мр,од,мн,вн>;
+голов.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 голов.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-голов.nlmpg :  <morph-С,мр,од,мн,рд>;
+голов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+голов.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 головн.= :
   LLCIR+ or LLCJC+ or LLDQH+;
@@ -10119,13 +10117,13 @@
 голуб.= :
   LLAFH+ or LLAVH+ or LLAYB+ or LLBIU+ or LLBNS+ or LLBRO+ or LLCIW+ or LLCKD+ or LLDMT+;
 
-голуб.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 голуб.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+голуб.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 голуб.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-голуб.nlfpv :  <morph-С,жр,од,мн,вн>;
+голуб.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 голыш.= :
   LLAAJ+ or LLACF+ or LLBRG+;
@@ -10139,11 +10137,11 @@
 бот.= гольф.= кед.= ласт.= унт.= :
   LLAAQ+ or LLDJT+;
 
-бот.ndmsv гольф.ndmsv кед.ndmsv ласт.ndmsv унт.ndmsv :  <morph-С,мр,но,ед,вн>;
+бот.npg гольф.npg кед.npg ласт.npg унт.npg :  <morph-С,мн,мн,рд>;
 
 бот.ndmsi гольф.ndmsi кед.ndmsi ласт.ndmsi унт.ndmsi :  <morph-С,мр,но,ед,им>;
 
-бот.npg гольф.npg кед.npg ласт.npg унт.npg :  <morph-С,мн,мн,рд>;
+бот.ndmsv гольф.ndmsv кед.ndmsv ласт.ndmsv унт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 гом.= :
   LLDYC+;
@@ -10151,9 +10149,9 @@
 гомон.= :
   LLAAO+ or LLBGI+;
 
-гомон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 гомон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гомон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 гон.= :
   LLAAQ+ or LLAYJ+ or LLBRK+ or LLBSP+ or LLBSW+;
@@ -10229,9 +10227,9 @@
 горн.= :
   LLAAQ+ or LLDWW+ or LLBEW+;
 
-горн.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 горн.ndmsi :  <morph-С,мр,но,ед,им>;
+
+горн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 горничн.= подконвойн.= :
   LLAKZ+ or LLDLO+;
@@ -10256,9 +10254,9 @@
 городищ.= :
   LLARI+ or LLARS+ or LLDXX+;
 
-городищ.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 городищ.ndmpg :  <morph-С,мр,но,мн,рд>;
+
+городищ.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 городов.= :
   LLFQF+ or LLCIR+;
@@ -10271,13 +10269,13 @@
 горохов.= :
   LLDWW+ or LLFQF+ or LLDYH+ or LLDKF+;
 
-горохов.amss :  <morph-П,мр,ед,кр>;
+горохов.ndmsi :  <morph-С,мр,но,ед,им>;
 
-горохов.nlmsi :  <morph-С,мр,од,ед,им>;
+горохов.amss :  <morph-П,мр,ед,кр>;
 
 горохов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-горохов.ndmsi :  <morph-С,мр,но,ед,им>;
+горохов.nlmsi :  <morph-С,мр,од,ед,им>;
 
 горрайорган.= зернопродукт.= :
   LLAAQ+ or LLDJR+;
@@ -10289,9 +10287,9 @@
 горск.= :
   LLDWW+ or LLBEL+ or LLDYX+ or LLDZV+;
 
-горск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 горск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+горск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 горш.= :
   LLBEE+ or LLCJW+;
@@ -10302,11 +10300,11 @@
 горюн.= :
   LLACI+ or LLDWW+ or LLDPO+;
 
-горюн.ndmsv :  <morph-С,мр,но,ед,вн>;
+горюн.ndmsi :  <morph-С,мр,но,ед,им>;
 
 горюн.nlmsi :  <morph-С,мр,од,ед,им>;
 
-горюн.ndmsi :  <morph-С,мр,но,ед,им>;
+горюн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 горюч.= :
   LLATU+ or LLBDR+;
@@ -10316,9 +10314,9 @@
 горюш.= :
   LLAFD+ or LLBTH+;
 
-горюш.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 горюш.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+горюш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 горяч.= :
   LLATU+ or LLBDU+ or LLBHE+ or LLBMS+ or LLBRI+;
@@ -10373,16 +10371,16 @@
 госпож.= :
   LLAHA+;
 
-госпож.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 госпож.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+госпож.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 гост.= :
   LLAAQ+ or LLASO+ or LLDMT+ or LLDPO+;
 
-гост.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 гост.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гост.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 гостин.= :
   LLAKS+ or LLAXZ+ or LLDKJ+;
@@ -10399,9 +10397,9 @@
 
 гофр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-гофр.ndmsi :  <morph-С,мр,но,ед,им>;
-
 гофр.npg :  <morph-С,мн,мн,рд>;
+
+гофр.ndmsi :  <morph-С,мр,но,ед,им>;
 
 гра.= :
   LLBPJ+ or LLDRJ+;
@@ -10409,9 +10407,9 @@
 граб.= :
   LLAAQ+ or LLBIU+ or LLBNS+ or LLBTU+;
 
-граб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 граб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+граб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 грабел.= :
   LLDNZ+ or LLDOO+;
@@ -10439,9 +10437,9 @@
 гран.= :
   LLABW+ or LLBHS+ or LLBNP+ or LLBRK+ or LLDNF+;
 
-гран.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 гран.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гран.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 гран.ndmpg :  <morph-С,мр,но,мн,рд>;
 
@@ -10451,13 +10449,13 @@
 граф.= :
   LLAAQ+ or LLACI+ or LLAFX+ or LLBII+ or LLBNN+;
 
-граф.nlmsi :  <morph-С,мр,од,ед,им>;
+граф.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 граф.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-граф.ndmsi :  <morph-С,мр,но,ед,им>;
+граф.nlmsi :  <morph-С,мр,од,ед,им>;
 
-граф.ndfpg :  <morph-С,жр,но,мн,рд>;
+граф.ndmsi :  <morph-С,мр,но,ед,им>;
 
 гре.= :
   LLBAD+ or LLBBI+ or LLEND+ or LLCRU+ or LLDAK+ or LLDEM+;
@@ -10484,18 +10482,18 @@
 
 гренадин.ndmsv чаус.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-гренадин.ndmsi чаус.ndmsi :  <morph-С,мр,но,ед,им>;
-
 гренадин.npg чаус.npg :  <morph-С,мн,мн,рд>;
+
+гренадин.ndmsi чаус.ndmsi :  <morph-С,мр,но,ед,им>;
 
 грех.= морг.= недосуг.= скок.= фук.= :
   LLAAM+ or LLAEL+;
 
-грех.xn морг.xn недосуг.xn скок.xn фук.xn :  <morph-ПРЕДК,нст>;
+грех.ndmsi морг.ndmsi недосуг.ndmsi скок.ndmsi фук.ndmsi :  <morph-С,мр,но,ед,им>;
 
 грех.ndmsv морг.ndmsv недосуг.ndmsv скок.ndmsv фук.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-грех.ndmsi морг.ndmsi недосуг.ndmsi скок.ndmsi фук.ndmsi :  <morph-С,мр,но,ед,им>;
+грех.xn морг.xn недосуг.xn скок.xn фук.xn :  <morph-ПРЕДК,нст>;
 
 грехов.= :
   LLFQF+ or LLBYU+;
@@ -10596,9 +10594,9 @@
 гром.= :
   LLABN+ or LLBII+ or LLBNN+ or LLBSW+;
 
-гром.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 гром.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гром.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 грохо.= :
   LLCUL+ or LLENE+ or LLENF+;
@@ -10619,9 +10617,9 @@
 беляш.= ганаш.= грош.= :
   LLAAJ+ or LLBCB+;
 
-беляш.ndmsv ганаш.ndmsv грош.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 беляш.ndmsi ганаш.ndmsi грош.ndmsi :  <morph-С,мр,но,ед,им>;
+
+беляш.ndmsv ганаш.ndmsv грош.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 гру.= :
   LLBAH+ or LLBBH+ or LLCSF+;
@@ -10644,9 +10642,9 @@
 
 груз.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
-груз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 груз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+груз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.54:
   LLCJW+;
@@ -10654,9 +10652,9 @@
 грунт.= :
   LLAAS+ or LLCCZ+ or LLCGW+;
 
-грунт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 грунт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+грунт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 грунтов.= :
   LLBRK+ or LLCJC+ or LLDLP+;
@@ -10688,13 +10686,13 @@
 грязнух.= :
   LLAFG+ or LLDXP+;
 
-грязнух.nlfpg :  <morph-С,жр,од,мн,рд>;
+грязнух.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 грязнух.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-грязнух.nlmpg :  <morph-С,мр,од,мн,рд>;
+грязнух.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-грязнух.nlfpv :  <morph-С,жр,од,мн,вн>;
+грязнух.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 грян.= :
   LLGBL+ or LLFXT+;
@@ -10737,13 +10735,13 @@
 гулен.= :
   LLAFH+ or LLDNW+;
 
-гулен.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 гулен.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+гулен.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 гулен.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-гулен.nlfpv :  <morph-С,жр,од,мн,вн>;
+гулен.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 гулькевич.= :
   LLDYK+;
@@ -10785,11 +10783,11 @@
 гусев.= :
   LLDWW+ or LLFJG+;
 
-гусев.nlmsi :  <morph-С,мр,од,ед,им>;
+гусев.ndmsi :  <morph-С,мр,но,ед,им>;
 
 гусев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-гусев.ndmsi :  <morph-С,мр,но,ед,им>;
+гусев.nlmsi :  <morph-С,мр,од,ед,им>;
 
 гусь-хрустальн.= долгопрудн.= заозерн.= изобильн.= мирн.= семисопочн.= 
 :
@@ -10817,11 +10815,11 @@
 да.= :
   LLDTM+ or LLAEL+ or LLALV+ or LLAMG+ or LLBPW+ or LLGAR+ or LLFXR+;
 
-да.xn :  <morph-ПРЕДК,нст>;
-
 да.i :  <morph-СОЮЗ,0>;
 
 да.p :  <morph-ЧАСТ,0>;
+
+да.xn :  <morph-ПРЕДК,нст>;
 
 дав.= леп.= :
   LLBII+ or LLBNN+ or LLBRK+;
@@ -10908,9 +10906,9 @@
 дар.= :
   LLAAQ+ or LLBHS+ or LLBNP+ or LLCCZ+ or LLFWB+ or LLCGW+;
 
-дар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дарвин.= :
   LLGSD+ or LLFHJ+;
@@ -10964,9 +10962,9 @@
 двор.= :
   LLAAQ+ or LLAYB+ or LLBZO+;
 
-двор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 двор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+двор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дворецк.= :
   LLBDI+ or LLFJZ+;
@@ -11141,9 +11139,9 @@
 дележ.= драч.= зубреж.= кругляш.= :
   LLAAJ+ or LLBRI+;
 
-дележ.ndmsv драч.ndmsv зубреж.ndmsv кругляш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дележ.ndmsi драч.ndmsi зубреж.ndmsi кругляш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дележ.ndmsv драч.ndmsv зубреж.ndmsv кругляш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.59:
   LLBYU+;
@@ -11185,9 +11183,9 @@
 дергач.= :
   LLAAJ+ or LLACF+ or LLDYL+;
 
-дергач.nlmsi :  <morph-С,мр,од,ед,им>;
-
 дергач.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+дергач.nlmsi :  <morph-С,мр,од,ед,им>;
 
 дергач.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -11210,9 +11208,9 @@
 дерн.= :
   LLAAO+ or LLBHS+ or LLBNP+ or LLCCZ+ or LLCGW+ or LLFWI+ or LLFWG+;
 
-дерн.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дерн.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дерн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дернист.= :
   LLFVD+;
@@ -11293,18 +11291,18 @@
 детин.= :
   LLAEY+ or LLAXZ+;
 
-детин.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 детин.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+детин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 детищ.= созданьиц.= :
   LLARS+ or LLASC+;
 
 детищ.nlnpg созданьиц.nlnpg :  <morph-С,ср,од,мн,рд>;
 
-детищ.ndnpg созданьиц.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 детищ.nlnpv созданьиц.nlnpv :  <morph-С,ср,од,мн,вн>;
+
+детищ.ndnpg созданьиц.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 детонир.= :
   LLCBI+ or LLCFO+;
@@ -11352,9 +11350,9 @@
 ангарск.= дзержинск.= :
   LLDWW+ or LLDYP+ or LLBEP+;
 
-ангарск.ndmsv дзержинск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ангарск.ndmsi дзержинск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ангарск.ndmsv дзержинск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ди.= :
   LLADE+ or LLBST+;
@@ -11362,13 +11360,13 @@
 див.= :
   LLACI+ or LLAGT+ or LLBII+ or LLBNN+ or LLBYU+ or LLCAG+ or LLCGW+;
 
-див.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 див.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-див.nlmsi :  <morph-С,мр,од,ед,им>;
+див.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 див.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+див.nlmsi :  <morph-С,мр,од,ед,им>;
 
 диверсифицир.= :
   LLCDF+ or LLCGD+;
@@ -11386,9 +11384,9 @@
 дим.= :
   LLAAQ+ or LLFKP+ or LLFHO+;
 
-дим.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дим.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дим.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.62:
   LLEEJ+;
@@ -11567,15 +11565,15 @@
 добруш.= :
   LLDWV+ or LLFIX+ or LLFJA+;
 
-добруш.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 добруш.nlmsi :  <morph-С,мр,од,ед,им>;
 
 добруш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
+добруш.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 добруш.ndmsi :  <morph-С,мр,но,ед,им>;
 
-добруш.nlfpv :  <morph-С,жр,од,мн,вн>;
+добруш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 добряч.= земляч.= моряч.= простач.= середняч.= толстяч.= 
 :
@@ -11655,15 +11653,15 @@
 док.= :
   LLAAM+ or LLAFG+ or LLFWB+;
 
+док.ndmsi :  <morph-С,мр,но,ед,им>;
+
+док.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 док.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 док.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 док.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-док.ndmsi :  <morph-С,мр,но,ед,им>;
-
-док.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 док.nlfpv :  <morph-С,жр,од,мн,вн>;
 
@@ -11681,9 +11679,9 @@
 дол.= :
   LLAAQ+ or LLANO+ or LLGDA+ or LLGDB+ or LLDNX+ or LLDQH+;
 
-дол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 долб.= :
   LLBII+ or LLBNN+ or LLBZQ+;
@@ -11691,9 +11689,9 @@
 долбеж.= фураж.= :
   LLAAJ+ or LLBRI+ or LLBYZ+;
 
-долбеж.ndmsv фураж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 долбеж.ndmsi фураж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+долбеж.ndmsv фураж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 доле.= :
   LLAEK+ or LLFYZ+;
@@ -11733,19 +11731,19 @@
 дом.= :
   LLABK+ or LLBUV+ or LLCJW+ or LLGFE+ or LLFZO+ or LLGCG+ or LLGFK+;
 
-дом.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дом.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дом.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 голосин.= домин.= кирпичин.= кусин.= мостин.= островин.= 
 стволин.= холодин.= :
   LLAET+ or LLAFX+;
 
-голосин.ndmpg домин.ndmpg кирпичин.ndmpg кусин.ndmpg мостин.ndmpg островин.ndmpg 
-стволин.ndmpg холодин.ndmpg :  <morph-С,мр,но,мн,рд>;
-
 голосин.ndfpg домин.ndfpg кирпичин.ndfpg кусин.ndfpg мостин.ndfpg островин.ndfpg 
 стволин.ndfpg холодин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+голосин.ndmpg домин.ndmpg кирпичин.ndmpg кусин.ndmpg мостин.ndmpg островин.ndmpg 
+стволин.ndmpg холодин.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 доминик.= :
   LLFOA+ or LLDXP+;
@@ -11779,11 +11777,11 @@
 дон.= :
   LLACI+ or LLEBJ+ or LLFPY+ or LLAYJ+ or LLDYH+ or LLBRK+ or LLBYZ+ or LLDIC+ or LLDPO+;
 
+дон.ndmsi :  <morph-С,мр,но,ед,им>;
+
 дон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дон.nlmsi :  <morph-С,мр,од,ед,им>;
-
-дон.ndmsi :  <morph-С,мр,но,ед,им>;
 
 доначисл.= :
   LLBKX+;
@@ -11878,9 +11876,9 @@
 дот.= :
   LLAAQ+ or LLGFQ+;
 
-дот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дотир.= :
   LLCDC+ or LLCGD+ or LLCHC+;
@@ -11891,9 +11889,9 @@
 дох.= :
   LLAFU+ or LLDXP+ or LLBVZ+;
 
-дох.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 дох.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+дох.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 выцве.= доцве.= зацве.= повыцве.= процве.= рассве.= 
 :
@@ -11938,18 +11936,18 @@
 парфян.= подолян.= :
   LLBFS+;
 
-будетлян.nlmpv волынян.nlmpv древлян.nlmpv иосифлян.nlmpv коринфян.nlmpv мидян.nlmpv 
-парфян.nlmpv подолян.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 будетлян.nlmpg волынян.nlmpg древлян.nlmpg иосифлян.nlmpg коринфян.nlmpg мидян.nlmpg 
 парфян.nlmpg подолян.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+будетлян.nlmpv волынян.nlmpv древлян.nlmpv иосифлян.nlmpv коринфян.nlmpv мидян.nlmpv 
+парфян.nlmpv подолян.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 дрейф.= :
   LLAAQ+ or LLBGG+ or LLCBF+;
 
-дрейф.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дрейф.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дрейф.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дрем.= :
   LLAFX+ or LLAHY+ or LLAKB+;
@@ -12063,11 +12061,11 @@
 бак.= дрязг.= :
   LLAAM+ or LLBBY+;
 
-бак.ndmsv дрязг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бак.ndmsi дрязг.ndmsi :  <morph-С,мр,но,ед,им>;
 
 бак.npg дрязг.npg :  <morph-С,мн,мн,рд>;
+
+бак.ndmsv дрязг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 дрян.= :
   LLBVR+ or LLBYU+ or LLDNF+ or LLDNL+;
@@ -12083,11 +12081,11 @@
 дуб.= :
   LLAAS+ or LLACI+ or LLBII+ or LLBNN+ or LLBRK+ or LLCJW+;
 
-дуб.nlmsi :  <morph-С,мр,од,ед,им>;
+дуб.ndmsi :  <morph-С,мр,но,ед,им>;
 
 дуб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-дуб.ndmsi :  <morph-С,мр,но,ед,им>;
+дуб.nlmsi :  <morph-С,мр,од,ед,им>;
 
 дуба.= :
   LLDZD+ or LLENV+ or LLEMF+;
@@ -12102,13 +12100,13 @@
 дубин.= шляп.= :
   LLAFH+ or LLAFX+ or LLBRK+ or LLBYZ+;
 
+дубин.nlmpg шляп.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 дубин.nlfpg шляп.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 дубин.nlmpv шляп.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 дубин.ndfpg шляп.ndfpg :  <morph-С,жр,но,мн,рд>;
-
-дубин.nlmpg шляп.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 дубин.nlfpv шляп.nlfpv :  <morph-С,жр,од,мн,вн>;
 
@@ -12156,9 +12154,9 @@
 дубров.= :
   LLFQF+ or LLAFX+ or LLBRK+ or LLBYZ+ or LLDZR+;
 
-дубров.nlmsi :  <morph-С,мр,од,ед,им>;
-
 дубров.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+дубров.nlmsi :  <morph-С,мр,од,ед,им>;
 
 дуд.= :
   LLAGE+ or LLAWS+ or LLBRK+;
@@ -12182,18 +12180,18 @@
 дун.= :
   LLEBJ+ or LLFIR+ or LLGBL+ or LLFKY+;
 
-дун.nlfpg :  <morph-С,жр,од,мн,рд>;
+дун.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 дун.nlmsi :  <morph-С,мр,од,ед,им>;
 
-дун.nlfpv :  <morph-С,жр,од,мн,вн>;
+дун.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 дур.= :
   LLAGT+ or LLAVM+ or LLBFF+ or LLBGI+ or LLBVR+ or LLDNF+;
 
-дур.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 дур.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+дур.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 дурач.= :
   LLBHH+ or LLBMV+ or LLCKD+;
@@ -12208,18 +12206,18 @@
 дус.= :
   LLFIR+ or LLFKY+;
 
-дус.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 дус.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+дус.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 дух.= наушник.= :
   LLAAM+ or LLACG+ or LLBCC+;
 
+дух.ndmsi наушник.ndmsi :  <morph-С,мр,но,ед,им>;
+
 дух.nlmsi наушник.nlmsi :  <morph-С,мр,од,ед,им>;
 
 дух.ndmsv наушник.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-дух.ndmsi наушник.ndmsi :  <morph-С,мр,но,ед,им>;
 
 духов.= :
   LLFQF+ or LLFUO+ or LLBRK+ or LLBYU+ or LLCJC+;
@@ -12233,9 +12231,9 @@
 душ.= :
   LLAAH+ or LLAFU+ or LLBHE+ or LLBMS+ or LLBRG+ or LLBRI+ or LLBYU+ or LLCJW+;
 
-душ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 душ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+душ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 душ.ndfpg :  <morph-С,жр,но,мн,рд>;
 
@@ -12328,542 +12326,6 @@
 
 /ru/words/words.67:
   LLEEK+;
-
-абалгаз.ndmsv абанагроавтотранс.ndmsv абатскспецгазсервис.ndmsv абинскрайгаз.ndmsv авиабанк.ndmsv авиаприбор-холдинг.ndmsv 
-авиаприборпроект.ndmsv авиаприборхолдинг.ndmsv авиапром.ndmsv авиапромсервис.ndmsv авиаремонт.ndmsv авиаспецмонтаж.ndmsv 
-авиаспецснабсбыт.ndmsv авиастар.ndmsv автобанк.ndmsv автобытсервис.ndmsv автоваз.ndmsv автовазагрегат.ndmsv 
-автовазбанк.ndmsv автовазтранс.ndmsv автовокзалсервис.ndmsv автогаз.ndmsv автодеталь-сервис.ndmsv автодорресурс.ndmsv 
-автозаз.ndmsv автозазсервис.ndmsv автоимпорт.ndmsv автокраз.ndmsv автоприбор.ndmsv автопромимпорт.ndmsv 
-автопромматериал.ndmsv автосельхозмаш-холдинг.ndmsv автосельхозмашхолдинг.ndmsv автосельхозторг.ndmsv автосервис.ndmsv автоснабсбыт.ndmsv 
-автостройпроект.ndmsv автотехтранс.ndmsv автотракторооптторг.ndmsv автотрактороптторг.ndmsv автотранссервис.ndmsv автоэкспорт.ndmsv 
-автрокон-холдинг.ndmsv агробизнесцентр.ndmsv агродорсервис.ndmsv агроинкомбанк.ndmsv агроинторг.ndmsv агрокурорт.ndmsv 
-агроландшафт.ndmsv агромашимпорт.ndmsv агромехмонтаж.ndmsv агромонтаж.ndmsv агромостожелезобетон.ndmsv агропищепром.ndmsv 
-агроплемзавод.ndmsv агроприбор.ndmsv агропродсервис.ndmsv агропроект.ndmsv агропром.ndmsv агропромавтотранс.ndmsv 
-агропромбанк.ndmsv агропромкомбинат.ndmsv агропромкомплекс.ndmsv агропромкомплект.ndmsv агропроммехмонтаж.ndmsv агропромпрогресс.ndmsv 
-агропромремонт.ndmsv агропромсервис.ndmsv агропромснаб.ndmsv агропромсоюз.ndmsv агропромспецстроймонтаж.ndmsv агропромстандарт.ndmsv 
-агропромстройматериал.ndmsv агропромстройтранс.ndmsv агропромтехнопол.ndmsv агропромтехпроект.ndmsv агропромтехсервис.ndmsv агропромтранс.ndmsv 
-агрос.ndmsv агросевер.ndmsv агросиб.ndmsv агроснаб.ndmsv агроснабкомплект.ndmsv агроспецмонтаж.ndmsv 
-агротехпром.ndmsv агротехсервис.ndmsv агротехцентр.ndmsv агроторг.ndmsv агротранс.ndmsv агрофермероргснаб.ndmsv 
-агрохим.ndmsv агрохимполимер.ndmsv агрохимцентр.ndmsv агрохолод.ndmsv агрохолодпром.ndmsv адыггаз.ndmsv 
-адыгейнефтепродукт.ndmsv адыгеяавтотранс.ndmsv адыгеяагроснаб.ndmsv азовмежрайгаз.ndmsv айрекс.ndmsv академинвест.ndmsv 
-аксаймежрайгаз.ndmsv алагиррайгаз.ndmsv алатырьгоргаз.ndmsv алгайагропромтранс.ndmsv алдангоргаз.ndmsv алейскмежрайгаз.ndmsv 
-алейскхлебопродукт.ndmsv александровагропромснаб.ndmsv александровогайагропромснаб.ndmsv александровремтехпред.ndmsv алексеевкарайгаз.ndmsv алексеевскагропромтранс.ndmsv 
-алексеевскремтехпред.ndmsv алмаздортранс.ndmsv алмазэкспорт.ndmsv алмазювелир.ndmsv алмазювелир-экспорт.ndmsv алмазювелирэкспорт.ndmsv 
-алтайавтодор.ndmsv алтайавтотранс.ndmsv алтайагрокоопмолпром.ndmsv алтайагрокоопмясопром.ndmsv алтайагропромпроект.ndmsv алтайагропромснаб.ndmsv 
-алтайагропромтранс.ndmsv алтайагросервис.ndmsv алтайагроспецмонтаж.ndmsv алтайагротранс.ndmsv алтайвинагропром.ndmsv алтайвитамин.ndmsv 
-алтайгаз.ndmsv алтайкрайгаз.ndmsv алтайкрайгазсервис.ndmsv алтайлестоппром.ndmsv алтаймедпрепарат.ndmsv алтаймежхозлес.ndmsv 
-алтаймрамор.ndmsv алтайнефтепродукт.ndmsv алтайовощхоз.ndmsv алтайполиметалл.ndmsv алтайптицеводкомплект.ndmsv алтайремстройбыт.ndmsv 
-алтайремстроймонтаж.ndmsv алтайсахарагропром.ndmsv алтайсельхозводопровод.ndmsv алтайскагропромавтотранс.ndmsv алтайскагропромснаб.ndmsv алтайскремтехпред.ndmsv 
-алтайстройкомплект.ndmsv алтайстройматериал.ndmsv алтайстройтранс.ndmsv алтайтурист.ndmsv алтайхимпром.ndmsv алтайхлебопродукт.ndmsv 
-алтайэнергоремонт.ndmsv альфа-банк.ndmsv амур-порт.ndmsv амуравтотранс.ndmsv амурагроснаб.ndmsv амурагротехсервис.ndmsv 
-амурагроэлектроремонт.ndmsv амургаз.ndmsv амуржилкомхоз.ndmsv амурлес.ndmsv амурлеспром.ndmsv амурнефтепродукт.ndmsv 
-амуроблгаз.ndmsv амурремпроект.ndmsv амурскмежрайгаз.ndmsv амурэлектромонтаж.ndmsv амурэнергоремонт.ndmsv анадырьремтехснаб.ndmsv 
-аналитприбор.ndmsv анапагоргаз.ndmsv ангаралес.ndmsv ангарскгоргаз.ndmsv ангарскнефтеоргсинтез.ndmsv ангарскнефтехимпроект.ndmsv 
-ангарсктеплохиммонтаж.ndmsv ангарскхимнефтеремонт.ndmsv анилпром.ndmsv анлагенбау-инжиниринг.ndmsv апатитгражданпроект.ndmsv апатитсельхозсервис.ndmsv 
-апатитырайгаз.ndmsv апшеронскрайгаз.ndmsv ардонмежрайгаз.ndmsv арзамасспирт.ndmsv аркадакагропроммехмонтажкомплект.ndmsv аркадакагропромснаб.ndmsv 
-аркадакагропромтранс.ndmsv аркадакмежрайгаз.ndmsv аркадакхлебопродукт.ndmsv арктикснаб.ndmsv армавиргоргаз.ndmsv армавироптторг.ndmsv 
-армконтракт.ndmsv арсеньевагропромтранс.ndmsv арсеньевмежрайгаз.ndmsv артикком.ndmsv архангельскавтодор.ndmsv архангельскавтотранс.ndmsv 
-архангельскагропром.ndmsv архангельскагропромснаб.ndmsv архангельскгаз.ndmsv архангельскгоргаз.ndmsv архангельскконтракт.ndmsv архангельсклессбыт.ndmsv 
-архангельсклестоппром.ndmsv архангельскнефтепродукт.ndmsv архангельскоблснаб.ndmsv архангельскоптторг.ndmsv архангельскрыбпром.ndmsv архангельсктурист.ndmsv 
-архптицепромснабсбыт.ndmsv архрыбсбыт.ndmsv архстройматериал.ndmsv архстройтранс.ndmsv асткиновидеопрокат.ndmsv астраханьавтодор.ndmsv 
-астраханьавтотранс.ndmsv астраханьагропромпроект.ndmsv астраханьбумпром.ndmsv астраханьгазпром.ndmsv астраханьмежрайгаз.ndmsv астраханьнефтепродукт.ndmsv 
-астраханьоблгаз.ndmsv астраханьпромстройпроект.ndmsv астраханьптицепром.ndmsv астро-гермес.ndmsv астробанк.ndmsv асуавтотранс.ndmsv 
-аткарскагропромснаб.ndmsv аткарскагропромтранс.ndmsv атомзащитаинформ.ndmsv атоминформ.ndmsv атомпром.ndmsv атомпромкомплекс.ndmsv 
-атомрудмет.ndmsv атомфлот.ndmsv атомэнергокомплект.ndmsv атомэнергопроект.ndmsv атомэнергоремонт.ndmsv атомэнергоэкспорт.ndmsv 
-ахтарскрайгаз.ndmsv ачинскагроавтотранс.ndmsv ачинскагропромснаб.ndmsv аэроприбор.ndmsv аэропроект.ndmsv багратионовскремтехпред.ndmsv 
-байкаллес.ndmsv байкалпротеин.ndmsv бакалеяоптторг.ndmsv бакпрепарат.ndmsv баксанрайгаз.ndmsv балаковоагропроммехмонтаж.ndmsv 
-балаковоагропромснаб.ndmsv балаковоагропромтранс.ndmsv балаковомежрайгаз.ndmsv балаковотурбоатомэнергоремонт.ndmsv балашовагропроммехмонтаж.ndmsv балашовагропромснаб.ndmsv 
-балашовмежрайгаз.ndmsv балкар-трейдинг.ndmsv балтайагропромтранс.ndmsv балтийскмежрайгаз.ndmsv балткран.ndmsv балтмонтаж.ndmsv 
-балтсудопроект.ndmsv бамнефтепродукт.ndmsv бамтрансвзрывпром.ndmsv бамтранстехмонтаж.ndmsv барнаулагропромснаб.ndmsv барнаулгоргаз.ndmsv 
-барнаулметаллоптторг.ndmsv батайскгоргаз.ndmsv башавтотранс.ndmsv башгипронефтехим.ndmsv башкортостантурист.ndmsv башкран.ndmsv 
-башлеспром.ndmsv башнефтепродукт.ndmsv башнефтехимзавод.ndmsv башпромбанк.ndmsv башстройтранс.ndmsv баштрансгаз.ndmsv 
-башэлектромонтаж.ndmsv безенчукагропромснаб.ndmsv безенчукагроремтехпред.ndmsv безенчукмежрайгаз.ndmsv безымянкаагропромтранс.ndmsv белавтомаз.ndmsv 
-белан.ndmsv белвитамин.ndmsv белгородавтотранс.ndmsv белгородагропромсервис.ndmsv белгороднефтепродукт.ndmsv белгородоблгаз.ndmsv 
-белгородорггаз.ndmsv белгородтоппром.ndmsv белгородэнергоремонт.ndmsv белкомхлебпрод.ndmsv беловомежрайгаз.ndmsv беловопогрузтранс.ndmsv 
-белогорскгаз.ndmsv белореченскрайгаз.ndmsv белоярскгаз.ndmsv белпласт.ndmsv белторгпроект.ndmsv бельсклес.ndmsv 
-березоворайгаз.ndmsv беринговремтехснаб.ndmsv бесланрайгаз.ndmsv бизнес-парк.ndmsv бизнес-центр.ndmsv бийскмежрайгаз.ndmsv 
-бийсктехноторг.ndmsv билибиноремтехснаб.ndmsv биомашприбор.ndmsv биомед.ndmsv биомедпрепарат.ndmsv биопрепарат-центр.ndmsv 
-биоснабсбыт.ndmsv биотехпрогресс.ndmsv биохимзавод.ndmsv биохиммашпроект.ndmsv биохимпром.ndmsv биробиджаноблгаз.ndmsv 
-биробиджанхлеб.ndmsv биробиджанхлебопродукт.ndmsv благовещенскмежрайгаз.ndmsv благсантехмонтаж.ndmsv бобровагропромснаб.ndmsv богатовскагропромтранс.ndmsv 
-богородскрайгаз.ndmsv боготолагропромснаб.ndmsv богучанлес.ndmsv богучарагропромтранс.ndmsv большаковремтехпред.ndmsv большеглушицкагпропромтранс.ndmsv 
-большеречьемежрайгаз.ndmsv большесолдатскагропромснаб.ndmsv большечерниговскагропромтранс.ndmsv бомонт.ndmsv бондариагропромснаб.ndmsv бондариремтехпред.ndmsv 
-боровичимежрайгаз.ndmsv борскагропромтранс.ndmsv брасовомежрайгаз.ndmsv братскгидропроект.ndmsv братскжелезобетон.ndmsv братсклес.ndmsv 
-братскпромэнергокомплект.ndmsv братскстройкомплект.ndmsv братскэнергопроект.ndmsv братскэнергостройтранс.ndmsv брюховецкаярайгаз.ndmsv брянскавтотранс.ndmsv 
-брянскгазпроект.ndmsv брянскгорстройзаказчик.ndmsv брянсккомплект.ndmsv брянскмежрайгаз.ndmsv брянскнефтепродукт.ndmsv брянскоблгаз.ndmsv 
-брянскпромбетон.ndmsv брянсксантехмонтаж.ndmsv брянсксвязьинформ.ndmsv брянскспиртпром.ndmsv брянскстройтранс.ndmsv брянсктоппром.ndmsv 
-брянскхолод.ndmsv брянскцемент.ndmsv брянскчернобыльстройзаказчик.ndmsv бугурусланмежрайгаз.ndmsv будимекс.ndmsv бузулукмежрайгаз.ndmsv 
-буйнакскгаз.ndmsv бумлесоптторг.ndmsv бумоптторг.ndmsv бургазгеотерм.ndmsv буржелезобетон.ndmsv бурятавтотранс.ndmsv 
-бурятавтотранссервис.ndmsv бурятагропроммехмонтаж.ndmsv бурятагропромпроект.ndmsv бурятагропромремонт.ndmsv бурятгаз.ndmsv бурятгражданпроект.ndmsv 
-бурятлестоппром.ndmsv бурятматтехресурс.ndmsv бурятнефтепродукт.ndmsv бурятпромстройпроект.ndmsv бурятрыбпром.ndmsv бурятскагропромснаб.ndmsv 
-бурятскагропромстандарт.ndmsv бурятскмолагропром.ndmsv бурятскпищепром.ndmsv бурятспирт.ndmsv бурятстройматериал.ndmsv бурятхлебпром.ndmsv 
-бутурлиновкаагропромтранс.ndmsv быковорайгаз.ndmsv быковоремтехпред.ndmsv валдаймежрайгаз.ndmsv ванинолесоэкспорт.ndmsv варитекс.ndmsv 
-варьеганнефтегаз.ndmsv варьеганнефтеснаб.ndmsv васхнил.ndmsv велижагропромснаб.ndmsv велижагропромтехмонтаж.ndmsv велижагропромтранс.ndmsv 
-вельскагропромснаб.ndmsv вельсклес.ndmsv вельскмежрайгаз.ndmsv вельскремтехпред.ndmsv верхнебуреинскрайгаз.ndmsv верхневолгоэлектромонтаж.ndmsv 
-верхнекамсклес.ndmsv верхнемамонагропромтранс.ndmsv верхнетоемскремтехпредхимснаб.ndmsv верхнехаваагропромтранс.ndmsv вершинскагропромтранс.ndmsv вершинырайгаз.ndmsv 
-ветсанутильзавод.ndmsv вешенскмежрайгаз.ndmsv викуловоагропромтранс.ndmsv виноагропром.ndmsv виноградовскремтехпредхимснаб.ndmsv виноградпром.ndmsv 
-вичугамежрайгаз.ndmsv владивостокагропромснаб.ndmsv владивостокмежрайгаз.ndmsv владивостокоптснаб.ndmsv владивостокстройкомплект.ndmsv владикавказ-газоаппарат.ndmsv 
-владикавказгоргаз.ndmsv владимиравтосервис.ndmsv владимиравтотранс.ndmsv владимирагроинформ.ndmsv владимирагропищепром.ndmsv владимирагропромпроект.ndmsv 
-владимирагропромснаб.ndmsv владимирагропромтранс.ndmsv владимиргазпроект.ndmsv владимирглавснаб.ndmsv владимиргоргаз.ndmsv владимирнефтепродукт.ndmsv 
-владимироблгаз.ndmsv владимироптторг.ndmsv владимирпищепроект.ndmsv владимирптицепром.ndmsv владимирремтехпред.ndmsv владимирстройматериал.ndmsv 
-владимирторф.ndmsv владимирэкогаз.ndmsv владимирэлектроникаагропром.ndmsv владимирэнергомонтаж.ndmsv владинтерлес.ndmsv владинтерлес-центр.ndmsv 
-владстройтранс.ndmsv внешагропромсервис.ndmsv внешинторг.ndmsv внешконсульт.ndmsv внешлес.ndmsv внешпромтехобмен.ndmsv 
-внешстройимпорт.ndmsv внешторгбанк.ndmsv внешторгиздат.ndmsv внештрейдинвест.ndmsv внииалмаз.ndmsv вниибиохимпрепарат.ndmsv 
-вниигаз.ndmsv вниигеоцветмет.ndmsv вниижелезобетон.ndmsv внииинструмент.ndmsv вниимотопром.ndmsv вниинаучприбор.ndmsv 
-вниинефтехим.ndmsv вниипигидротрубопровод.ndmsv вниипиморнефтегаз.ndmsv вниипиэт.ndmsv вниипромгаз.ndmsv вниистандарт.ndmsv 
-вниистройполимер.ndmsv внииэгазпром.ndmsv внииэлектротранспорт.ndmsv внииэпрант.ndmsv внипигидротрубопровод.ndmsv внипиморнефтегаз.ndmsv 
-внипистройполимер.ndmsv внипиэнергопром.ndmsv водтрансприбор.ndmsv воентех.ndmsv волгаэнергомонтаж.ndmsv волгаэнергоремонт.ndmsv 
-волгаэнергоснабкомплект.ndmsv волгаэнергостройпром.ndmsv волгобиосинтез.ndmsv волговзрывпром.ndmsv волговятмашэлектроснабсбыт.ndmsv волгогаз.ndmsv 
-волгоградавтодор.ndmsv волгоградавтотранс.ndmsv волгоградагропроект.ndmsv волгоградагропромтранс.ndmsv волгоградгоргаз.ndmsv волгоградметаллоторг.ndmsv 
-волгограднефтепродукт.ndmsv волгоградоблгаз.ndmsv волгоградтоппром.ndmsv волгоградтрансгаз.ndmsv волгоградэлектротранс.ndmsv волгоградэнергосетьпроект.ndmsv 
-волгодизельаппарат.ndmsv волгодонскмежрайгаз.ndmsv волгокамподводтрубопровод.ndmsv волгонефтехиммонтаж.ndmsv волгоспецмонтаж.ndmsv волгостальмонтаж.ndmsv 
-волготанкер.ndmsv волготрансгаз.ndmsv волгоэлектромонтаж.ndmsv волгоэнергомонтаж.ndmsv волгоэнергопромстройпроект.ndmsv волгоэнергостройпром.ndmsv 
-волжскагропромтранс.ndmsv волжскиймежрайгаз.ndmsv волжскийрайгаз.ndmsv вологдаавтотранс.ndmsv вологдаагроавтотранс.ndmsv вологдаагропроект.ndmsv 
-вологдаагропромавтотранс.ndmsv вологдаагростройсервис.ndmsv вологдаагрохим.ndmsv вологдагоргаз.ndmsv вологдаленпромэкспорт.ndmsv вологдалестоппром.ndmsv 
-вологдалесторг.ndmsv вологдамежхозлес.ndmsv вологдаметаллоптторг.ndmsv вологдамонтажпроект.ndmsv вологдамясопром.ndmsv вологданефтепродукт.ndmsv 
-вологдаоблагропромснаб.ndmsv вологдаоблбыт.ndmsv вологдаоблгаз.ndmsv вологдапроект.ndmsv вологдаптицепром.ndmsv вологдасвинопром.ndmsv 
-вологдасвинпром.ndmsv вологдаснаб.ndmsv вологдаторф.ndmsv вологдахлебпром.ndmsv вологодавтодор.ndmsv вологодметаллопторг.ndmsv 
-волоколамскагропромснаб.ndmsv волховторг.ndmsv волчихинскремтехпред.ndmsv вольскмежрайгаз.ndmsv воробьевкаагропромтранс.ndmsv воронежавтодор.ndmsv 
-воронежавторемонт.ndmsv воронежавтотранс.ndmsv воронежагроконтракт.ndmsv воронежагропромкомплект.ndmsv воронежагропромснаб.ndmsv воронежагропромстройматериал.ndmsv 
-воронежагропромтранс.ndmsv воронежагроснаб.ndmsv воронежагроспецмонтаж.ndmsv воронежгоргаз.ndmsv воронежгорсвет.ndmsv воронежконсервпром.ndmsv 
-воронежмасложирагропром.ndmsv воронежмолпром.ndmsv воронежнефтепродукт.ndmsv воронежоблавтобыттранс.ndmsv воронежоблавтотрансгаз.ndmsv воронежоблбытсоюз.ndmsv 
-воронежоблгаз.ndmsv воронежоблмебельбыт.ndmsv воронежоблремстройпроект.ndmsv воронежоблснаб.ndmsv воронежпищепром.ndmsv воронежрыбхоз.ndmsv 
-воронежсадпитомник.ndmsv воронежсахарагропром.ndmsv воронежсахарпром.ndmsv воронежсвязьинформ.ndmsv воронежсинтезкаучук.ndmsv воронежстрой-холдинг.ndmsv 
-воронежтранссервис.ndmsv воскозавод.ndmsv воскресенскагропромтранс.ndmsv воскресенскцемент.ndmsv востокгидромонтаж.ndmsv востокгипрозем.ndmsv 
-востокметаллургмонтаж.ndmsv востокмонтажгаз.ndmsv востокнефтегазсантехмонтаж.ndmsv востокнефтезаводмонтаж.ndmsv востоксантехмонтаж.ndmsv востоксиб.ndmsv 
-востоксибрыбниипроект.ndmsv востоксибсантехмонтаж.ndmsv востоксибсельэнергопроект.ndmsv востоксибсельэнергопром.ndmsv востоктехмонтаж.ndmsv востокэнергомонтаж.ndmsv 
-востокэнерготехнадзор.ndmsv востсибгипроспецагропром.ndmsv востсибнефтегаз.ndmsv востсибэлемент.ndmsv воткинскмежрайгаз.ndmsv вторметинвест.ndmsv 
-вторметресурс.ndmsv вторнефтепродукт.ndmsv вторцветмет.ndmsv вторчермет.ndmsv вузцентр.ndmsv выксалес.ndmsv 
-выселкирайгаз.ndmsv вычегдалес.ndmsv вяземскагропром.ndmsv вяземскагропромтранс.ndmsv вяземскмежрайгаз.ndmsv вязникиагропромснаб.ndmsv 
-вязникиремтехпред.ndmsv вязьмаагропромснаб.ndmsv вязьмазернопродукт.ndmsv вятводспирт.ndmsv вятлесосплав.ndmsv гаврилов-ямрайгаз.ndmsv 
-гавриловкаагропромснаб.ndmsv гаврилово-посадрайгаз.ndmsv гагаринагропромснаб.ndmsv газавтосбыт.ndmsv газавтосервис.ndmsv газкомплектимпэкс.ndmsv 
-газмашаппарат.ndmsv газнадзор.ndmsv газпром.ndmsv газсантехмонтаж.ndmsv газтранссервис.ndmsv газэкспорт.ndmsv 
-газэнергосервис.ndmsv гвардейскмежрайгаз.ndmsv гвардейскремтехпред.ndmsv гексаметилендиаминсебацинат.ndmsv геленджикавтоснаб.ndmsv геленджикгоргаз.ndmsv 
-геосервис.ndmsv геосинтез.ndmsv геоцентр.ndmsv гермес-союз.ndmsv гивцнефтегаз.ndmsv гидродормост.ndmsv 
-гидрометприбор.ndmsv гидрометцентр.ndmsv гидромонтаж.ndmsv гидроприбор.ndmsv гидропроект.ndmsv гидроспецпроект.ndmsv 
-гидроцветмет.ndmsv гидроэлектромонтаж.ndmsv гидроэнергоснаб.ndmsv гипроавтотранс.ndmsv гипробиосинтез.ndmsv гипрогазцентр.ndmsv 
-гипрокоммунводоканал.ndmsv гипрокоммундортранс.ndmsv гипроленпром.ndmsv гипролестранс.ndmsv гипролесхим.ndmsv гипромашпром.ndmsv 
-гипронииавиапром.ndmsv гипрониигаз.ndmsv гипрониимедпром.ndmsv гипрониинефтетранс.ndmsv гипрониисельхоз.ndmsv гипропищепром.ndmsv 
-гипрополимер.ndmsv гипроречтранс.ndmsv гипрорыбфлот.ndmsv гипросахар.ndmsv гипросельпром.ndmsv гипроспецгаз.ndmsv 
-гипростроймост.ndmsv гипротранс.ndmsv гипротрансмост.ndmsv гипротюменнефтегаз.ndmsv гипротюменьнефтегаз.ndmsv гипрохолод.ndmsv 
-гипроцветмет.ndmsv гипроцемент.ndmsv гипроэнергоремонт.ndmsv главгостехнадзор.ndmsv главгосэнергонадзор.ndmsv главдорресторан.ndmsv 
-главинтурист.ndmsv главкомат.ndmsv главкосмос.ndmsv главлесхоз.ndmsv главнефтепродукт.ndmsv главплан.ndmsv 
-главпочтамт.ndmsv главснаб.ndmsv главтабак.ndmsv глазовмежрайгаз.ndmsv глинарайгаз.ndmsv глинкаагропромснаб.ndmsv 
-глушицамежрайгаз.ndmsv глушковоагропромснаб.ndmsv гнииэлектроагрегат.ndmsv говорковолес.ndmsv гознак.ndmsv гольшмановомежрайгаз.ndmsv 
-горбачев-фонд.ndmsv горжилобмен.ndmsv горкомсервис.ndmsv гормолзавод.ndmsv гормолкомбинат.ndmsv гормост.ndmsv 
-горно-алтайгаз.ndmsv горнозаводскцемент.ndmsv гороховецремтехпред.ndmsv горпищекомбинат.ndmsv горпищеторг.ndmsv горплодоовощторг.ndmsv 
-горпроект.ndmsv горпромкомбинат.ndmsv горпромторг.ndmsv горрайлинорган.ndmsv гортехнадзор.ndmsv гортопсбыт.ndmsv 
-горторг.ndmsv горшечноеагропромснаб.ndmsv горькнефтеоргсинтез.ndmsv горэлектротранс.ndmsv госагропром.ndmsv госархив.ndmsv 
-госархстройнадзор.ndmsv госатомнадзор.ndmsv госгазнадзор.ndmsv госгидромет.ndmsv госгортехнадзор.ndmsv госземзапас.ndmsv 
-госкомвуз.ndmsv госкомзем.ndmsv госкомиздат.ndmsv госкоминтурист.ndmsv госкомконтракт.ndmsv госкомлегпром.ndmsv 
-госкомоборонпром.ndmsv госкомпром.ndmsv госкомрезерв.ndmsv госкомсанэпидемнадзор.ndmsv госкомсанэпиднадзор.ndmsv госкомсанэпидназдор.ndmsv 
-госкомсевер.ndmsv госкомстат.ndmsv госкомстатат.ndmsv госкомтруд.ndmsv госкомэпиднадзор.ndmsv госконтракт.ndmsv 
-госконцерт.ndmsv гослесфонд.ndmsv госметр.ndmsv госмкомвуз.ndmsv госниибиоприбор.ndmsv госниикарбамидпроект.ndmsv 
-госниимедполимер.ndmsv госниинефтехим.ndmsv госнииэлектроагрегат.ndmsv госплемзавод.ndmsv госплемконезавод.ndmsv госплемптицезавод.ndmsv 
-госплемсовхоз.ndmsv госпроматомнадзор.ndmsv госрезерв.ndmsv госсанэпидемнадзор.ndmsv госсанэпиднадзор.ndmsv госсовет.ndmsv 
-госстрахнадзор.ndmsv гостехнадзор.ndmsv госфильмофонд.ndmsv госэкономплан.ndmsv грибановкаагропромтранс.ndmsv гринкомплекс.ndmsv 
-грозгипронефтехим.ndmsv грозгоргаз.ndmsv грознефтегаз.ndmsv грознефтеоргсинтез.ndmsv грязовецлес.ndmsv гудермесмежрайгаз.ndmsv 
-гуковогоргаз.ndmsv гулькевичирайгаз.ndmsv гурьевскремтехпред.ndmsv гусевмежрайгаз.ndmsv гусевремтехпред.ndmsv даггаз.ndmsv 
-дагестанавтодор.ndmsv дагестанавтотранс.ndmsv дагестангазпром.ndmsv дагестантурист.ndmsv дагестанхлебопродукт.ndmsv дагнефтепродукт.ndmsv 
-дагогнигаз.ndmsv дагпотребсоюз.ndmsv дагрыбхолодфлот.ndmsv дагсвязьинформ.ndmsv дальводстрой-холдинг.ndmsv дальвостоксиблес.ndmsv 
-дальгипротранс.ndmsv дальзавод.ndmsv дальинторг.ndmsv дальинфонд.ndmsv далькиноцентр.ndmsv дальлес.ndmsv 
-дальлеспром.ndmsv дальлестехцентр.ndmsv дальлесторг.ndmsv дальморепродукт.ndmsv дальнереченскагропромтранс.ndmsv дальнереченскмежрайгаз.ndmsv 
-дальорглестехмонтаж.ndmsv дальполиметалл.ndmsv дальпресс.ndmsv дальприбор.ndmsv дальрыбвтуз.ndmsv дальсельэнергопроект.ndmsv 
-дальэлектромонтаж.ndmsv дальэлектрон.ndmsv дальэнергомонтаж.ndmsv дальэнергосетьпроект.ndmsv даниловмежрайгаз.ndmsv данковбытсервис.ndmsv 
-двиносплав.ndmsv демидовагропромснаб.ndmsv дербентгаз.ndmsv дергачиагропроммехмонтаж.ndmsv дзержинскмежрайгаз.ndmsv дзержинскхолод.ndmsv 
-дизельпром.ndmsv динскаярайгаз.ndmsv дмитриевагропромснаб.ndmsv дмитровагропромснаб.ndmsv дмитровлес.ndmsv домодедовоагросервис.ndmsv 
-донагрохимсервис.ndmsv донгазпром.ndmsv донецкгоргаз.ndmsv донецкмежрайгаз.ndmsv донречфлот.ndmsv донтелефильм.ndmsv 
-донэлектромонтаж.ndmsv дорасфальт.ndmsv доринвест.ndmsv дорпрофсоюз.ndmsv досааф.ndmsv дубнаагросервис.ndmsv 
-дубовкамежрайгаз.ndmsv дубовскагропромтранс.ndmsv дубовскмежрайгаз.ndmsv дудинкабыт.ndmsv духовницкагропромтранс.ndmsv дятьковорайгаз.ndmsv 
-европол.ndmsv евростандарт.ndmsv егорлыкмежрайгаз.ndmsv егорьевскагропромснаб.ndmsv егорьевскагропромтранс.ndmsv ейскагросервис.ndmsv 
-ейскгоргаз.ndmsv екатеринбургархпроект.ndmsv екатеринбургнефтепродукт.ndmsv екатеринбургпроект.ndmsv екатериновкаагропромснаб.ndmsv екатериновкаагропромтранс.ndmsv 
-елаз.ndmsv елаз-инвест.ndmsv ельняагропромснаб.ndmsv енисейлес.ndmsv енисейлесоэкспорт.ndmsv ермакагроавтотранс.ndmsv 
-ершичиагропромснаб.ndmsv ершовагропроммехмонтажкомплект.ndmsv ершовагропромтранс.ndmsv ершовмежрайгаз.ndmsv ефремовмежрайгаз.ndmsv желдорпроект.ndmsv 
-желдорэкспорт.ndmsv железноводсккурорт.ndmsv железногорскмежрайгаз.ndmsv жердевкаагропромснаб.ndmsv жердевкаремтехпред.ndmsv жилкоммункомплект.ndmsv 
-жиркиагропромснаб.ndmsv жирновскмежрайгаз.ndmsv жуковкамежрайгаз.ndmsv жуковорайгаз.ndmsv забайкалводпроект.ndmsv забайкаллес.ndmsv 
-забайкалредмет.ndmsv забайкалэлектромонтаж.ndmsv заводоуковскрайгаз.ndmsv завьяловскремтехпред.ndmsv заграноргстроймонтаж.ndmsv запкаспрыбвод.ndmsv 
-запсибгазпром.ndmsv запсибдорстройсервис.ndmsv запсибкомбанк.ndmsv запсибнефтехиммонтаж.ndmsv запсибремонт.ndmsv запсибсельэнергопроект.ndmsv 
-запсибэнергоспецмонтаж.ndmsv запчастьоптторг.ndmsv запэнерголегпром.ndmsv зарайскремтехпред.ndmsv зарайскхлебопродукт.ndmsv заринскмежрайгаз.ndmsv 
-зарубежцветмет.ndmsv зарубежэнергопроект.ndmsv зауралэнергопроект.ndmsv здравмед.ndmsv здравмедпром.ndmsv зеленецоптторг.ndmsv 
-зеленоградводоканал.ndmsv зеленоградскремтехпред.ndmsv зерноградмежрайгаз.ndmsv зил.ndmsv зимовникимежрайгаз.ndmsv зимторг.ndmsv 
-златоустмежрайгаз.ndmsv знаменкаагропромснаб.ndmsv золотухиноагропромснаб.ndmsv зооветснаб.ndmsv зорнинскагропромснаб.ndmsv ивановоавтотранс.ndmsv 
-ивановогоргаз.ndmsv ивановоконцерт.ndmsv ивановомежрайгаз.ndmsv ивановооблгаз.ndmsv ивановорыбпромсбыт.ndmsv ивановостройкомплекс.ndmsv 
-ивановоторф.ndmsv ивантеевкаагропромснаб.ndmsv ивантеевкаагропромтранс.ndmsv игримэнергогаз.ndmsv ижводоканал.ndmsv ижевскмежрайгаз.ndmsv 
-ижметаллургмонтаж.ndmsv ижобщепит.ndmsv избербашгаз.ndmsv иловляремтехпред.ndmsv импэкс-банк.ndmsv инвалтех.ndmsv 
-инвентарьторг.ndmsv инвест.ndmsv инвесткредит.ndmsv инвестнафт.ndmsv инвестэнергоцентр.ndmsv ингосстрах.ndmsv 
-индустройпроект.ndmsv инжсервис.ndmsv инкомбанк.ndmsv инкомторг.ndmsv инносоюз.ndmsv иннофонд.ndmsv 
-инрыбпром.ndmsv интас.ndmsv интаугольсбыт.ndmsv интерагрофонд.ndmsv интероптторг.ndmsv интерпол.ndmsv 
-интерпром.ndmsv интерросимпэкс.ndmsv интерсервис.ndmsv интертрест.ndmsv интерхимпром.ndmsv интерцентр.ndmsv 
-интерэвм.ndmsv интурбанк.ndmsv интурмедсервис.ndmsv интурсервис.ndmsv интуртранс.ndmsv интурцентр.ndmsv 
-информ.ndmsv информ-автотранс.ndmsv информгаз.ndmsv информсервис.ndmsv информторгтовар.ndmsv информцентр.ndmsv 
-инфосервис.ndmsv инфотранс.ndmsv инфоцентр.ndmsv иркутсклестоппром.ndmsv иркутскмашхимоптторг.ndmsv иркутскметаллоптторг.ndmsv 
-иркутскнефтепродукт.ndmsv иркутскоблгаз.ndmsv иркутскптицепром.ndmsv иркутскстройоптторг.ndmsv исилькульмежрайгаз.ndmsv истраагропромтранс.ndmsv 
-истраремтехпред.ndmsv истрахлебопродукт.ndmsv ишимагропромснаб.ndmsv ишиммежрайгаз.ndmsv каббалкальпинист.ndmsv каббалквтормет.ndmsv 
-каббалкгаз.ndmsv каббалкмолпром.ndmsv каббалкнефтепродукт.ndmsv каббалктоппром.ndmsv каббалктурист.ndmsv кавалеровомежрайгаз.ndmsv 
-кавказскагропромснаб.ndmsv кавказтрансгаз.ndmsv кавказцемент.ndmsv кадоммежрайгаз.ndmsv калачинскмежрайгаз.ndmsv калачмежрайгаз.ndmsv 
-калиниградснабэкспорт.ndmsv калининградавтотранс.ndmsv калининградагропром.ndmsv калининградагропромкомплект.ndmsv калининградагропромлегтранс.ndmsv калининградагропромснаб.ndmsv 
-калининградагропромтранс.ndmsv калининградгоргаз.ndmsv калининградгражданпроект.ndmsv калининградлегпром.ndmsv калининградморнефтегаз.ndmsv калининграднефтепродукт.ndmsv 
-калининградпромпроект.ndmsv калининградремтехпред.ndmsv калининградрыбпром.ndmsv калининградторгморнефтегаз.ndmsv калининградтранс.ndmsv калининскаярайгаз.ndmsv 
-калитвамежрайгаз.ndmsv калмыкнефтепродукт.ndmsv калугаоблгаз.ndmsv калугметаллторг.ndmsv камазавтоцентр.ndmsv камазжилбыт.ndmsv 
-камазимпорт.ndmsv камазинструмент.ndmsv камазмонтаж.ndmsv камазпроект.ndmsv каменкамежрайгаз.ndmsv каменскмежрайгаз.ndmsv 
-каменьмежрайгаз.ndmsv камчаткоммунпроект.ndmsv камчатлес.ndmsv камчатнефтепродукт.ndmsv камышинмежрайгаз.ndmsv камэнергоремонт.ndmsv 
-камэнергостройпром.ndmsv канашмежрайгаз.ndmsv кандалакшарайгаз.ndmsv кандалакшаремтехагропромснаб.ndmsv каневскаярайгаз.ndmsv капьяргаз.ndmsv 
-карабулакагропромтранс.ndmsv карабулакмежрайгаз.ndmsv каргопольрайгаз.ndmsv карелкоммунжилпроект.ndmsv карелнефтепродукт.ndmsv карталымежрайгаз.ndmsv 
-касимовгоргаз.ndmsv каспийскгаз.ndmsv каспрыбпроект.ndmsv катавмежрайгаз.ndmsv кемеровогоргаз.ndmsv кемеровомежрайгаз.ndmsv 
-кемеровооблгаз.ndmsv кзот.ndmsv кизилюртгаз.ndmsv кизляргаз.ndmsv кинельгоргаз.ndmsv кинешмарайгаз.ndmsv 
-киновидеотеатр.ndmsv кинотехпром.ndmsv кинофотоинститут.ndmsv киржачремтехпред.ndmsv киришинефтеоргсинтез.ndmsv кировагровод.ndmsv 
-кировгипроводхоз.ndmsv кировнефтепродукт.ndmsv кировоблгаз.ndmsv кировоградмежрайгаз.ndmsv кисловодсккурорт.ndmsv клепикирайгаз.ndmsv 
-клинагропромтранс.ndmsv клинцымежрайгаз.ndmsv ключгоргаз.ndmsv клявлинорайгаз.ndmsv книгоэкспорт.ndmsv ковровремтехпред.ndmsv 
-ковровхлебопродукт.ndmsv когалымгоргаз.ndmsv когалымнефтегаз.ndmsv когалымнефтепрогресс.ndmsv когалымторгнефтегаз.ndmsv кожзавод.ndmsv 
-коларайгаз.ndmsv коломнаагропромтранс.ndmsv коломнаремтехпред.ndmsv кольчугиноремтехпред.ndmsv комигаз.ndmsv комигипрониилеспром.ndmsv 
-коминефтедорстройремонт.ndmsv коминтерн.ndmsv комипермяцкагропромавтотранс.ndmsv комипермяцкагропромтехснаб.ndmsv коммунавтоматсервис.ndmsv коммунбытоптторг.ndmsv 
-коммунмонтаж.ndmsv коммунотдел.ndmsv комсомольскмежрайгаз.ndmsv комсомольскрайгаз.ndmsv конверсбанк.ndmsv кондровобумпром.ndmsv 
-коношарайгаз.ndmsv константиновскмежрайгаз.ndmsv консультантплюс.ndmsv конышевкаагропромснаб.ndmsv копейскмежрайгаз.ndmsv кораблинорайгаз.ndmsv 
-кореновскрайгаз.ndmsv коркиномежрайгаз.ndmsv костромаавтотранс.ndmsv костромаагропромпроект.ndmsv костромагоргаз.ndmsv костромакоммунсервис.ndmsv 
-костроманефтепродукт.ndmsv костромаоблбгаз.ndmsv костромаоблгаз.ndmsv котельниковомежрайгаз.ndmsv котласагропромснаб.ndmsv котласлес.ndmsv 
-котласмежрайгаз.ndmsv котовомежрайгаз.ndmsv котовскхлеб.ndmsv кошкинскагропромтранс.ndmsv кошкирайгаз.ndmsv крайагроснаб.ndmsv 
-крайбыткомплект.ndmsv крайгосплемсоюз.ndmsv крайкоммунводкомплекс.ndmsv крайкоопсоюз.ndmsv крайпотребсоюз.ndmsv крайремстройбыт.ndmsv 
-крайтрикотажбыт.ndmsv красмашзавод.ndmsv красноармейскагропромснаб.ndmsv красноармейскмежрайгаз.ndmsv красноармейскрайгаз.ndmsv красноборскремтехпредснаб.ndmsv 
-красногорскагропромтранс.ndmsv краснодарбланкиздат.ndmsv краснодаргипродревпром.ndmsv краснодарглавснаб.ndmsv краснодаргоргаз.ndmsv краснодаргражданпроект.ndmsv 
-краснодаркрайгаз.ndmsv краснодарнефтегаз.ndmsv краснодарнефтеоргсинтез.ndmsv краснодарорггаз.ndmsv краснодарсельэнергопроект.ndmsv краснокутагропроммехмонтаж.ndmsv 
-краснокутагропромснаб.ndmsv краснокутагропромтранс.ndmsv красноленинскнефтегаз.ndmsv краснотурьинскмежрайгаз.ndmsv красноуральскмежрайгаз.ndmsv красноярскавтодор.ndmsv 
-красноярскавтосалон.ndmsv красноярскагролеспром.ndmsv красноярскагропроммехмонтаж.ndmsv красноярскагропромтехпроект.ndmsv красноярскгидропроект.ndmsv красноярскмежхозлес.ndmsv 
-красноярскметаллоопторг.ndmsv красноярскметаллооптторг.ndmsv красноярскметаллоптторг.ndmsv красноярскнефтепродукт.ndmsv красноярскобщемашопторг.ndmsv красноярскполимеркерамик.ndmsv 
-красноярскстройматериал.ndmsv красноярскхлебопродукт.ndmsv красноярскхлебпром.ndmsv красноярскэнергопром.ndmsv красноярскэнергосетьпроект.ndmsv кредитпромбанк.ndmsv 
-кредобанк.ndmsv кропоткингоргаз.ndmsv крыловскаярайгаз.ndmsv крымскрайгаз.ndmsv кубаньвинпром.ndmsv кубаньводтраст.ndmsv 
-кубаньгазпром.ndmsv кубаньконсервпром.ndmsv кубаньлестоппром.ndmsv кубаньспецэнергоремонт.ndmsv кубаньхлебопродукт.ndmsv кузбассавтотранс.ndmsv 
-кузбассзернопродукт.ndmsv кузбасскомплект.ndmsv кузбассмясопром.ndmsv кузбассполиграфиздат.ndmsv кузбассхлеб.ndmsv кузбассхолод.ndmsv 
-кузбассшахтостроймонтаж.ndmsv кузнецкмежрайгаз.ndmsv куйбышевагропромтранс.ndmsv куйбышевазот.ndmsv куйбышевнефтемашремонт.ndmsv куйбышевнефтеоргсинтез.ndmsv 
-куйбышнефтеоргсинтез.ndmsv кулебакимежрайгаз.ndmsv культторг.ndmsv куминсклес.ndmsv кумскремтехпред.ndmsv курганагропромтехпроект.ndmsv 
-кургангоргаз.ndmsv курганинскрайгаз.ndmsv курганмашзавод.ndmsv курганнефтепродукт.ndmsv курганоблгаз.ndmsv курганприбор.ndmsv 
-курганхлеб.ndmsv курскавторемонт.ndmsv курскагропромкомплектснаб.ndmsv курскгоргаз.ndmsv курсккиновидеопрокат.ndmsv курскоблгаз.ndmsv 
-курсксахарагропром.ndmsv курсктурбоатомэнергоремонт.ndmsv курскхлеб.ndmsv курскхлебопродукт.ndmsv курскхлебпром.ndmsv кушвамежрайгаз.ndmsv 
-кущевскаярайгаз.ndmsv кшеньмежрайгаз.ndmsv кыштыммежрайгаз.ndmsv лабинскагропромснаб.ndmsv лабинскрайгаз.ndmsv лангепаснефтегаз.ndmsv 
-легкомплектснаб.ndmsv легпром.ndmsv легпромэкспорт.ndmsv ленаагролеспром.ndmsv ленагропромсервис.ndmsv ленвзрывпром.ndmsv 
-ленгидропроект.ndmsv ленгипронефтехим.ndmsv ленгипротранс.ndmsv ленгорисполком.ndmsv ленгражданпроект.ndmsv лензнииэп.ndmsv 
-лениздат.ndmsv ленинградскаярайгаз.ndmsv ленинскагроснаб.ndmsv ленинтерфонд.ndmsv ленком.ndmsv ленконцерт.ndmsv 
-ленлес.ndmsv ленлесбумстройоптторг.ndmsv ленлестоппром.ndmsv ленмашоптторг.ndmsv ленметаллоптторг.ndmsv леннаучфильм.ndmsv 
-леннефтехим.ndmsv леноблгаз.ndmsv леноблпассажиравтотранс.ndmsv ленотделкомплект.ndmsv ленпромлес.ndmsv ленремтехприбор.ndmsv 
-ленрыбпром.ndmsv ленсвет.ndmsv ленстройкомитет.ndmsv ленстройкор.ndmsv ленторф.ndmsv лентрансгаз.ndmsv 
-ленфильм.ndmsv ленхимоптторг.ndmsv ленэнергоремонт.ndmsv лесбумоптторг.ndmsv лесдревмонтаж.ndmsv лесинформ.ndmsv 
-лескомснабсбыт.ndmsv лескомцентр.ndmsv лесогорсклес.ndmsv лесозаводскагропромтранс.ndmsv лесоптторг.ndmsv леспефлан.ndmsv 
-леспроект.ndmsv леспромсервис.ndmsv леспромцентр.ndmsv лесснаб.ndmsv лестоппром.ndmsv лесторг.ndmsv 
-лешуконскремтехпредхимснаб.ndmsv липецкагромехживцентр.ndmsv липецкдорпроект.ndmsv липецкмонтаж.ndmsv липецкнефтепродукт.ndmsv липецкоблгаз.ndmsv 
-липецкрыбхоз.ndmsv липецксахар.ndmsv липецктоппром.ndmsv липецкхлебмакаронпром.ndmsv липецкцемент.ndmsv лифтремонт.ndmsv 
-логоваз.ndmsv локтевскремтехпред.ndmsv ломовмежрайгаз.ndmsv лукимежрайгаз.ndmsv лукойл.ndmsv луховицыагропромснаб.ndmsv 
-лысогорскагропромснаб.ndmsv льговагропромснаб.ndmsv льговмежрайгаз.ndmsv магаданавтотранс.ndmsv магаданпромстройниипроект.ndmsv магаданрыбпром.ndmsv 
-магадансвязьинформ.ndmsv магаданспецэнергомонтаж.ndmsv магаданстройтранс.ndmsv магаданхимлесстройторг.ndmsv магнитогорскмежрайгаз.ndmsv майскийрайгаз.ndmsv 
-макдональдс.ndmsv малгобекмежрайгаз.ndmsv мансийскмежрайгаз.ndmsv мансийскнефтегаз.ndmsv мантуровоагропромснаб.ndmsv мариинскмежрайгаз.ndmsv 
-марийнефтепродукт.ndmsv марийскавтотранс.ndmsv марксрайгаз.ndmsv маррайгаз.ndmsv марспецмонтаж.ndmsv масложиркомбинат.ndmsv 
-масложирпром.ndmsv маслосыркомбинат.ndmsv маслосырокомбинат.ndmsv матвеевкурганхлебопродукт.ndmsv махачкалагаз.ndmsv машзавод.ndmsv 
-машоптторг.ndmsv машприборинторг.ndmsv машхимторг.ndmsv мбм-банк.ndmsv мегионгазсервис.ndmsv мегионнефтегаз.ndmsv 
-медвенкаагропромснаб.ndmsv мединвестор.ndmsv медпром.ndmsv медснабсбытторг.ndmsv медсоцэкономинформ.ndmsv медтехснаб.ndmsv 
-медфизприбор.ndmsv межлесхоз.ndmsv межрайагропромснаб.ndmsv межэкономсбербанк.ndmsv мезеньремтехпредхимснаб.ndmsv менатеп.ndmsv 
-металлооптторг.ndmsv металлоптторг.ndmsv металлосервис.ndmsv металлторг.ndmsv металлургмеханомонтаж.ndmsv металлургпрокатмонтаж.ndmsv 
-металлургпром.ndmsv метрогипротранс.ndmsv миассмежрайгаз.ndmsv микомс.ndmsv миллеровомежрайгаз.ndmsv минавиапром.ndmsv 
-минавтопром.ndmsv минатом.ndmsv минатомэнергопром.ndmsv минвнешторг.ndmsv мингаз.ndmsv минздрав.ndmsv 
-минздравмед.ndmsv минздравмедпром.ndmsv минздравпроект.ndmsv минзравмедпром.ndmsv минлесбумпром.ndmsv минлесхоз.ndmsv 
-минмедпром.ndmsv миноборонпром.ndmsv минпром.ndmsv минрыбхоз.ndmsv минсельхоз.ndmsv минсельхозпрод.ndmsv 
-минстанкопром.ndmsv минсудпром.ndmsv минторг.ndmsv минтранс.ndmsv минтраст.ndmsv минтруд.ndmsv 
-минуглепром.ndmsv минусинскагроавтотранс.ndmsv минусинскагропромснаб.ndmsv минусинскмежрайгаз.ndmsv минфин.ndmsv минхимнефтепром.ndmsv 
-минхлебопродукт.ndmsv минцветмет.ndmsv минэлектронпром.ndmsv минэлектротехприбор.ndmsv минюст.ndmsv мирныймежрайгаз.ndmsv 
-михайловкамежрайгаз.ndmsv михайловмежрайгаз.ndmsv михайловцемент.ndmsv мичуринскагропромснаб.ndmsv можайскагропромснаб.ndmsv можгамежрайгаз.ndmsv 
-моздокрайгаз.ndmsv молагропром.ndmsv молококомбинат.ndmsv монастырщинаагропромснаб.ndmsv монголбанк.ndmsv монтажпроект.ndmsv 
-монтажспецбанк.ndmsv монтажстройсервис.ndmsv моргаушскрайгаз.ndmsv мордовгаз.ndmsv мордовнефтепродукт.ndmsv мордовобувьбыт.ndmsv 
-мордовспирт.ndmsv морнефтегаз.ndmsv морозовскмежрайгаз.ndmsv морозовскхлебопродукт.ndmsv моррыбтехникум.ndmsv морсвязьспутник.ndmsv 
-морфизприбор.ndmsv моршанскагропромснаб.ndmsv мосавтосантранс.ndmsv мосавтотранс.ndmsv мосагрокомплект.ndmsv мосагропромснаб.ndmsv 
-мосасботермокомбинат.ndmsv мосбизнесбанк.ndmsv мосводоканал.ndmsv мосводопровод.ndmsv мосгаз.ndmsv мосгипротранс.ndmsv 
-мосгорархив.ndmsv мосгорисполком.ndmsv мосгорремстройтрест.ndmsv мосгорсвет.ndmsv мосгортранс.ndmsv мосгортрансниипроект.ndmsv 
-мосгорхлебопродукт.ndmsv мосгорэлектроприбороптторг.ndmsv мосжилкомитет.ndmsv мосинжбетон.ndmsv мосинжпроект.ndmsv мосинжпромстройкомплект.ndmsv 
-мосинжстройкомплект.ndmsv москабельмет.ndmsv москабельсетьмонтаж.ndmsv москапстройкомплект.ndmsv москирпич.ndmsv москоммунбытпром.ndmsv 
-москонцерт.ndmsv мослес.ndmsv мослесопарк.ndmsv мослифт.ndmsv мослифтмонтаж.ndmsv мосметротранскомплект.ndmsv 
-моснефтепродукт.ndmsv мособлавтотранс.ndmsv мособлгаз.ndmsv мособлгеотрест.ndmsv мособлгидропроект.ndmsv мособлжилкомхоз.ndmsv 
-мособлкооппром.ndmsv мособлмедтранс.ndmsv мособлобщепит.ndmsv мособлсовет.ndmsv мособлстройкомитет.ndmsv мособлстройтранс.ndmsv 
-мособлсуд.ndmsv мосотделпром.ndmsv моспроект.ndmsv моспромгаз.ndmsv моспромжелезобетон.ndmsv моспроммонтаж.ndmsv 
-моспромпроект.ndmsv моспромстройкомплект.ndmsv моспромтехмонтаж.ndmsv моспромтранспроект.ndmsv мосрентген.ndmsv мосрыбхоз.ndmsv 
-моссантехпром.ndmsv моссанэлектропром.ndmsv моссовет.ndmsv мосспецатомэнергомонтаж.ndmsv мосспецжелезобетон.ndmsv мосспецмонтаж.ndmsv 
-мосспецпромпроект.ndmsv мосстройкомитет.ndmsv мосстройпрогресс.ndmsv мосстройснаб.ndmsv мосстройтранс.ndmsv мост-банк.ndmsv 
-мостелефон.ndmsv мостовскаярайгаз.ndmsv мостотрест.ndmsv мострансгаз.ndmsv мосфильм.ndmsv мосхладокомбинат.ndmsv 
-мосхолод.ndmsv мосэлектромонтаж.ndmsv мосэлектроприбор.ndmsv мосэнергомонтаж.ndmsv мосэнергоремонт.ndmsv мурмангоробщепит.ndmsv 
-мурманрыбпром.ndmsv мурмансервис.ndmsv мурманскавтосервис.ndmsv мурманскавтотранс.ndmsv мурманскагропромавтотранс.ndmsv мурманскагропромснабсервис.ndmsv 
-мурманскгоргаз.ndmsv мурманскгражданпроект.ndmsv мурманскжилкоммунпроект.ndmsv мурманскнефтепродукт.ndmsv мурманскпромпроект.ndmsv мурманскстройтранс.ndmsv 
-мурмансктурист.ndmsv мурмантоппром.ndmsv муромагропромснаб.ndmsv муромтепловоз.ndmsv мучкапагропромснаб.ndmsv мучкапремтехпред.ndmsv 
-мхат.ndmsv мышкинмежрайгаз.ndmsv мясомолторг.ndmsv мясотехносервис.ndmsv надвоицыагроснаб.ndmsv надеждинскагроснаб.ndmsv 
-надеждинскремтехпред.ndmsv надымгазпром.ndmsv надымгазснабкомплект.ndmsv надымгазэнергоремонт.ndmsv надыммежрайгаз.ndmsv надымэнергогаз.ndmsv 
-назаровоагроавтотранс.ndmsv назаровоагропромснаб.ndmsv назаровомежрайгаз.ndmsv назаровомехмонтаж.ndmsv назраньрайгаз.ndmsv нальчикгаз.ndmsv 
-наркомздрав.ndmsv наркомзем.ndmsv наркомлегпром.ndmsv наркомпрос.ndmsv нарымлес.ndmsv научдревпром.ndmsv 
-научлесдревпром.ndmsv научлеспром.ndmsv находкагоргаз.ndmsv находкалес.ndmsv находканефтепродукт.ndmsv невельмежрайгаз.ndmsv 
-невинномысскремтехпред.ndmsv невьянскмежрайгаз.ndmsv неманремтехпред.ndmsv нерехтамежрайгаз.ndmsv нерюнгригоргаз.ndmsv несветайрайгаз.ndmsv 
-нестеровремтехпред.ndmsv нефтегаз.ndmsv нефтегазмонтаж.ndmsv нефтегазснаб.ndmsv нефтегазстройкомплект.ndmsv нефтегеофизприбор.ndmsv 
-нефтегорскмежрайгаз.ndmsv нефтемаркет.ndmsv нефтемаслозавод.ndmsv нефтемашремонт.ndmsv нефтепродуктснабкомплект.ndmsv нефтепроект.ndmsv 
-нефтепром.ndmsv нефтепромсервис.ndmsv нефтесервис.ndmsv нефтестройремонт.ndmsv нефтехиммонтаж.ndmsv нефтеэкспортер.ndmsv 
-нефтеюганскгаз.ndmsv нечерноземагропроект.ndmsv нечерноземагроспецпром.ndmsv нечерноземпроекттехцентр.ndmsv нечерноземсельхозпроект.ndmsv нижегородавтодор.ndmsv 
-нижегородавтотранс.ndmsv нижегородгоргаз.ndmsv нижегородгражданпроект.ndmsv нижегородлестоппром.ndmsv нижегородмежхозлес.ndmsv нижегороднефтеоргсинтез.ndmsv 
-нижегороднефтепродукт.ndmsv нижегородоблгаз.ndmsv нижегородоптхозторг.ndmsv нижегородпассажиравтотранс.ndmsv нижегородсахар.ndmsv нижегородскийэнергосетьпроект.ndmsv 
-нижегородскнефтепродукт.ndmsv нижегородскоблгаз.ndmsv нижегородсксельэнергопроект.ndmsv нижневартовскжилкомхоз.ndmsv нижневартовскмежрайгаз.ndmsv нижневартовскнефтегаз.ndmsv 
-нижневартовскнефтепрогресс.ndmsv нижневартовскстройтранс.ndmsv нижнегородниинефтепроект.ndmsv нижнедевицкагропромтранс.ndmsv нижнекамскнефтехим.ndmsv нижполиграф.ndmsv 
-нииавтопром.ndmsv ниинаучприбор.ndmsv ниитрактор.ndmsv ниичаспром.ndmsv нииэлектроаппарат.ndmsv нииэлектропривод.ndmsv 
-никифоровкаагропромснаб.ndmsv никифоровкаремтехпред.ndmsv николаевскагропромснаб.ndmsv николаевскмежрайгаз.ndmsv никольскмежрайгаз.ndmsv новгородавтодор.ndmsv 
-новгородавтотранс.ndmsv новгородагропромснаб.ndmsv новгородагросервис.ndmsv новгородагростройзаказчик.ndmsv новгороджилкоммунсервис.ndmsv новгородлесстройсервис.ndmsv 
-новгородлестопром.ndmsv новгородмежрайгаз.ndmsv новгородмолпром.ndmsv новгороднефтепродукт.ndmsv новгороднефтесервис.ndmsv новгородоблгаз.ndmsv 
-новгородпищепром.ndmsv новгородрыбхоз.ndmsv новгородсельхозмонтаж.ndmsv новгородснаб.ndmsv новгородхлеб.ndmsv новгородхлебопродукт.ndmsv 
-новгородхлебпром.ndmsv новжилкоммунпроект.ndmsv новжилкоммунсервис.ndmsv ново-вязникиремтехпред.ndmsv новоалтайскмежрайгаз.ndmsv новоаннинскмежрайгаз.ndmsv 
-новоблместпром.ndmsv новобурасскагропроммехмонтаж.ndmsv новобурасскагропромтранс.ndmsv нововоронежхлеб.ndmsv новодугиноагропромснаб.ndmsv новозыбковмежрайгаз.ndmsv 
-новокубанскрайгаз.ndmsv новокузнецкгоргаз.ndmsv новокузнецкметаллооптторг.ndmsv новокуйбышевскгоргаз.ndmsv новопокровскаярайгаз.ndmsv новорослесэкспорт.ndmsv 
-новороссийскгоргаз.ndmsv новороссийскрыбпром.ndmsv новоросхлебкондитер.ndmsv новоросцемент.ndmsv новосибгражданпроект.ndmsv новосибирскжилкомхоз.ndmsv 
-новосибирсккиновидеосервис.ndmsv новосибирскнефтепродукт.ndmsv новосибирскпищепром.ndmsv новосибирскрыбхоз.ndmsv новосибирсктеплоэлектропроект.ndmsv новосиблестоппром.ndmsv 
-новосибмашоптторг.ndmsv новосибметалл.ndmsv новосибметаллооптторг.ndmsv новосибхимлегоптторг.ndmsv новосибхлеб.ndmsv новосибхозторг.ndmsv 
-новосибхолод.ndmsv новоспасскавтотранс.ndmsv новотроицкмежрайгаз.ndmsv новоузенскагропромснаб.ndmsv новоузенскагропромтранс.ndmsv новоузенскмежрайгаз.ndmsv 
-новоуренгоймежрайгаз.ndmsv новоусманьагропромтранс.ndmsv новохоперскагропромтранс.ndmsv новочебоксарскмежрайгаз.ndmsv новочеркасскгоргаз.ndmsv новошахтинскмежрайгаз.ndmsv 
-новошахтинсхлебопродукт.ndmsv ногинскагропромтранс.ndmsv норильскбыт.ndmsv норильскгазпром.ndmsv норильскпроект.ndmsv норильскреммонтаж.ndmsv 
-норильскснаб.ndmsv норильскторг.ndmsv норильсктрансремонт.ndmsv норильскэнергоремонт.ndmsv ноябрьскгазсервис.ndmsv ноябрьскнефтегаз.ndmsv 
-ноябрьскнефтедорстройремонт.ndmsv няганьнефтепрогресс.ndmsv няндомалес.ndmsv няндомамежрайгаз.ndmsv няндомаремтехпредснаб.ndmsv облбытсервис.ndmsv 
-облводоканал.ndmsv облжилкомхоз.ndmsv обливскрайгаз.ndmsv облкинопрокат.ndmsv облкоммунпроект.ndmsv облкоммунремстройпроект.ndmsv 
-облкоммунсервис.ndmsv облремстройсбыт.ndmsv облрыболовпотребсоюз.ndmsv облснаб.ndmsv облсовет.ndmsv облторг.ndmsv 
-обнинскархпроект.ndmsv обоззавод.ndmsv оборонкомплекс.ndmsv оборонконтракт.ndmsv оборонпром.ndmsv оборонпромкомплекс.ndmsv 
-оборонэкспорт.ndmsv обояньагропромснаб.ndmsv обояньмежрайгаз.ndmsv обояньхлеб.ndmsv обувьбыт.ndmsv общепит.ndmsv 
-общепитсоюз.ndmsv обьнефтегаз.ndmsv обьполимер.ndmsv обьэлектромонтаж.ndmsv овцекомплекс.ndmsv овцепром.ndmsv 
-огнеупорпром.ndmsv одоевагросервис.ndmsv озерскремтехпред.ndmsv озинкиагропромснаб.ndmsv океанрыбфлот.ndmsv окрпотребсоюз.ndmsv 
-октябрьагропромснаб.ndmsv октябрьрайгаз.ndmsv октябрьскагропромснаб.ndmsv октябрьскийрайгаз.ndmsv олонецагросервис.ndmsv ольгаагропромтранс.ndmsv 
-ольгалес.ndmsv омон.ndmsv омскавиапроект.ndmsv омскавтодор.ndmsv омскавтотранс.ndmsv омскагрегат.ndmsv 
-омскгаз.ndmsv омскгидропривод.ndmsv омскгоргаз.ndmsv омскгражданпроект.ndmsv омсккоммунпроект.ndmsv омсклеспром.ndmsv 
-омсклестоппром.ndmsv омскнефтеоргсинтез.ndmsv омскнефтепродукт.ndmsv омскнефтехимпроект.ndmsv омскоблгаз.ndmsv омскпромстройбанк.ndmsv 
-омсксервис.ndmsv омскстроймост.ndmsv омскхлебопродукт.ndmsv омутинкарайгаз.ndmsv омэлектромонтаж.ndmsv онегарайгаз.ndmsv 
-онегаремтехпредхимснаб.ndmsv опочкамежрайгаз.ndmsv оптопром.ndmsv оптторг.ndmsv оптторгимпэкс.ndmsv орбита-сервис.ndmsv 
-орглестехмонтаж.ndmsv оргмонтажпроект.ndmsv оргмонтехпроект.ndmsv оргнефтехимзавод.ndmsv оргпримтвердосплав.ndmsv оргсинтез.ndmsv 
-оргстройниипроект.ndmsv оргстройпроект.ndmsv оргэнергогаз.ndmsv орелавтодор.ndmsv орелавтотранс.ndmsv орелводоканал.ndmsv 
-орелглавснаб.ndmsv орелгоргаз.ndmsv орелнефтепродукт.ndmsv орелоблгаз.ndmsv орелоблстройзаказчик.ndmsv орелхолод.ndmsv 
-оренбургавтодор.ndmsv оренбургавтотранс.ndmsv оренбургазпром.ndmsv оренбургасбест.ndmsv оренбургбургаз.ndmsv оренбурггазпром.ndmsv 
-оренбурггоргражданин.ndmsv оренбургкомплектмонтаж.ndmsv оренбурглифт.ndmsv оренбургмежрайгаз.ndmsv оренбургмонтажгаззавод.ndmsv оренбургнефтепродукт.ndmsv 
-оренбургоблгаз.ndmsv оренбургпромстройпроект.ndmsv оренбургптицепром.ndmsv оренбургсантехмонтаж.ndmsv оренбургснаб.ndmsv оренбургстройтранс.ndmsv 
-оренбургтоппром.ndmsv ореховоторф.ndmsv орловскрайгаз.ndmsv орскмежрайгаз.ndmsv орскнефтеоргсинтез.ndmsv осетиннефтепродукт.ndmsv 
-островмежрайгаз.ndmsv острогожскагропромтранс.ndmsv откормсовхоз.ndmsv отраднаярайгаз.ndmsv отрадноемежрайгаз.ndmsv охотскрыбвод.ndmsv 
-павловскаярайгаз.ndmsv павлодарнефтекомбинат.ndmsv павлодартрактор.ndmsv палласовкамежрайгаз.ndmsv пангодыэнергогаз.ndmsv паниноагропромтранс.ndmsv 
-парклесхоз.ndmsv партизанскмежрайгаз.ndmsv пассажиравтотранс.ndmsv пельгорторф.ndmsv пензаавтотранс.ndmsv пензагоргаз.ndmsv 
-пензалеспром.ndmsv пензалестоппром.ndmsv пензамежрайгаз.ndmsv пензанефтепродукт.ndmsv пензаорггаз.ndmsv пензаплодоовощпром.ndmsv 
-пензаспиртпром.ndmsv пензастройтранс.ndmsv пензаэнергоремонт.ndmsv пенькозавод.ndmsv первомайскагропромснаб.ndmsv первомайскремтехпред.ndmsv 
-первоуральскмежрайгаз.ndmsv перелюбагропромтранс.ndmsv переславльрайгаз.ndmsv пермавтотранс.ndmsv пермагропромпроект.ndmsv пермгипромашпром.ndmsv 
-пермглавснаб.ndmsv перммашоптторг.ndmsv перммежхозлес.ndmsv пермметалл.ndmsv пермметаллоопторг.ndmsv пермметаллооптторг.ndmsv 
-пермметаллоптторг.ndmsv пермнефтемашремонт.ndmsv пермнефтеоргсинтез.ndmsv пермооптторг.ndmsv пермпромжелдортранс.ndmsv пермстройоптторг.ndmsv 
-пермтрансгаз.ndmsv пермтрансжелезобетон.ndmsv пермтурист.ndmsv пермхимоптторг.ndmsv пермьнефтепродукт.ndmsv пестовомежрайгаз.ndmsv 
-пестравкаагропромтранс.ndmsv пестравкарайгаз.ndmsv петербургнефтеснаб.ndmsv петергоф-агропродсервис.ndmsv петроагропромбанк.ndmsv петровкаагропромснаб.ndmsv 
-петровскагропромснаб.ndmsv петровскагропромтранс.ndmsv петровскмежрайгаз.ndmsv петрозаводскагропроммонтаж.ndmsv петрозаводскагросервис.ndmsv петрозаводскнефтепродукт.ndmsv 
-петрокомерцбанк.ndmsv петролеспорт.ndmsv петроснаб.ndmsv петрофлот.ndmsv петрохимоптторг.ndmsv петрохлеб.ndmsv 
-петрохолод.ndmsv петушкиинтерлес.ndmsv петушкиремтехпред.ndmsv печорыагропромсервис.ndmsv питеркаагропромснаб.ndmsv питеркаагропромтранс.ndmsv 
-питкярантаагросервис.ndmsv пичаевоагропромснаб.ndmsv пичаеворемтехпред.ndmsv плавмагазин.ndmsv пластполимер.ndmsv племконезавод.ndmsv 
-племовцезавод.ndmsv плесецкремтехпредснаб.ndmsv плитспичпром.ndmsv поволжсельэнергопроект.ndmsv повориноагропромтранс.ndmsv погрузтранс.ndmsv 
-подгоренскагропромтранс.ndmsv подольскагропромсервис.ndmsv подольскагропромснаб.ndmsv подольскагропромтранс.ndmsv полевскоймежрайгаз.ndmsv полесскремтехпред.ndmsv 
-полиграфкомбинат.ndmsv полиграфприбор.ndmsv полимерсинтез.ndmsv политсовет.ndmsv полянамежрайгаз.ndmsv понт.ndmsv 
-поныриагропромснаб.ndmsv портнадзор.ndmsv портопункт.ndmsv порховмежрайгаз.ndmsv посадрайгаз.ndmsv поспелихамежрайгаз.ndmsv 
-поспелихинскремтехпред.ndmsv посылторг.ndmsv похвистневоагропромтранс.ndmsv похвистневомежрайгаз.ndmsv почепрайгаз.ndmsv починокагропромснаб.ndmsv 
-правдинскремтехпред.ndmsv приволжскагропромтранс.ndmsv приволжскрайгаз.ndmsv приволжсктехкомплект.ndmsv прикамлес.ndmsv прикумскагропромснаб.ndmsv 
-приморавтодор.ndmsv приморавтотранс.ndmsv приморводоканал.ndmsv приморгражданпроект.ndmsv приморкрайгаз.ndmsv приморлеспром.ndmsv 
-приморнефтепродукт.ndmsv приморрыбпром.ndmsv приморскавтотранс.ndmsv приморскагропромремонт.ndmsv приморскагропромснаб.ndmsv приморскагропромтранс.ndmsv 
-приморсклеспром.ndmsv приморсклестоппром.ndmsv приморскметаллснаб.ndmsv приморскнефтепродукт.ndmsv приморско-ахтарскрайгаз.ndmsv приморскопткомплектприбор.ndmsv 
-приморскоптхимполимер.ndmsv приморскремтехпредхимснаб.ndmsv приморскстройтранс.ndmsv приморсктурист.ndmsv примснабконтракт.ndmsv приоблес.ndmsv 
-приокскремтехпред.ndmsv прионежскагропромснаб.ndmsv приполярбургаз.ndmsv пристеньагропромснаб.ndmsv пробизнессбанк.ndmsv провиденремтехснаб.ndmsv 
-продинторг.ndmsv проектмашприбор.ndmsv пролетарскрайгаз.ndmsv промбурвод.ndmsv промгаз.ndmsv промжелдортранс.ndmsv 
-промзернопроект.ndmsv проминвест.ndmsv проминформбизнес.ndmsv промкомбинат.ndmsv промкомплект.ndmsv проммеханомонтаж.ndmsv 
-проммонтаж.ndmsv промприбор.ndmsv промрадтехбанк.ndmsv промсвязьмонтаж.ndmsv промсвязьпроект.ndmsv промсервис.ndmsv 
-промснаб.ndmsv промстройбанк.ndmsv промстройниипроект.ndmsv промтрактор.ndmsv промтрансниипроект.ndmsv промтранспроект.ndmsv 
-промышленнаярайгаз.ndmsv промэкспорт.ndmsv пронскрайгаз.ndmsv профиздат.ndmsv профинкадр.ndmsv прохладныйгоррайгаз.ndmsv 
-псковавтотранс.ndmsv псковагропромпроект.ndmsv псковлестоппром.ndmsv псковмежрайгаз.ndmsv псковнефтепродукт.ndmsv псковоблгаз.ndmsv 
-псковрыбхоз.ndmsv псковхлеб.ndmsv птицекомбинат.ndmsv птицепром.ndmsv пугачевагропромтранс.ndmsv пугачевмежрайгаз.ndmsv 
-пудожагросервис.ndmsv пурнефтегаз.ndmsv пурнефтепрогресс.ndmsv пушкиноагросервис.ndmsv пчелопром.ndmsv пятигорсксельэнергопроект.ndmsv 
-равмедпром.ndmsv радиокомплекссервис.ndmsv радиометеоцентр.ndmsv радиосервис.ndmsv радиостройкомплекс.ndmsv радиотелецентр.ndmsv 
-радиофармпрепарат.ndmsv радченкоторф.ndmsv разнооптторг.ndmsv райагропромснаб.ndmsv райагроснаб.ndmsv райбытсервис.ndmsv 
-райводхоз.ndmsv райжилкомхоз.ndmsv райпромкомбинат.ndmsv райтопсбыт.ndmsv райчихинскгаз.ndmsv рамоньагропромтранс.ndmsv 
-рассказовоагропромснаб.ndmsv ребрихамежрайгаз.ndmsv ребрихинскремтехпред.ndmsv ревдамежрайгаз.ndmsv резинооптторг.ndmsv резиноптторг.ndmsv 
-ремагропром.ndmsv реммонтажгаззавод.ndmsv ремсервис.ndmsv ремстройпищепром.ndmsv ремстройсервис.ndmsv репьевкаагропромтранс.ndmsv 
-ресурс-банк.ndmsv ржаксаагропромснаб.ndmsv ровноеагропромснаб.ndmsv ровноеагропромтранс.ndmsv родникирайгаз.ndmsv романовкаагропромснаб.ndmsv 
-романовкаагропромтранс.ndmsv росагробиопром.ndmsv росагропромтехпроект.ndmsv росагроснаб.ndmsv росагрохим.ndmsv росархив.ndmsv 
-росасутпроект.ndmsv росбланкиздат.ndmsv росбумоптоторг.ndmsv росбумоптторг.ndmsv росбытсоюз.ndmsv росвиноградвинпром.ndmsv 
-росвиноградпром.ndmsv росвнешторг.ndmsv росводоканалпроект.ndmsv росвосток.ndmsv росгазпром.ndmsv росгазспецпром.ndmsv 
-росгеоинформ.ndmsv росгидромет.ndmsv росгипроводхоз.ndmsv росгипролес.ndmsv росглавкоопрыбсевероторг.ndmsv росгорэлектротранс.ndmsv 
-росгосстрах.ndmsv росгосцирк.ndmsv росжелдорснаб.ndmsv росживсоюз.ndmsv росзарубежцентр.ndmsv росзембанк.ndmsv 
-росзооветснаб.ndmsv росзооветснабпром.ndmsv росинвалютторг.ndmsv росинформресурс.ndmsv росинфраинвест.ndmsv роскомархив.ndmsv 
-роскомбытооптторг.ndmsv роскомвод.ndmsv роскомводхоз.ndmsv роскомгидромет.ndmsv роскомдрагмет.ndmsv роскомзем.ndmsv 
-роскоминформ.ndmsv роскоммунхоз.ndmsv роскомнефтепром.ndmsv роскомнефтехимпром.ndmsv роскомоборонпром.ndmsv роскомпищепром.ndmsv 
-роскомплект.ndmsv роскомрезерв.ndmsv роскомсевер.ndmsv роскомторг.ndmsv роскомтуризм.ndmsv роскомхимнефтепром.ndmsv 
-росконтракт.ndmsv роскультторг.ndmsv рославльагропромснаб.ndmsv рослегимпекс.ndmsv рослегпром.ndmsv рослеспром.ndmsv 
-рослесхоз.ndmsv росмежавтотранс.ndmsv росместпром.ndmsv росминфин.ndmsv росморфлот.ndmsv росмузпром.ndmsv 
-росмясомолпром.ndmsv росмясомолторг.ndmsv роснефтегаз.ndmsv роснефтеимпекс.ndmsv роснефтекомплект.ndmsv роснефтепродукт.ndmsv 
-роснииземпроект.ndmsv росниипрогресс.ndmsv рособувьторг.ndmsv росовощплодопром.ndmsv росоптимед.ndmsv росоптпродторг.ndmsv 
-росохотрыболовсоюз.ndmsv роспищепром.ndmsv роспищеснабсбыт.ndmsv росплодоовощхоз.ndmsv роспосылторг.ndmsv роспотребрезерв.ndmsv 
-роспродторг.ndmsv росразноснабсбыт.ndmsv росречфлот.ndmsv росрудпром.ndmsv росрыбколхозсоюз.ndmsv росрыбпромсбыт.ndmsv 
-росрыбхоз.ndmsv россвязьинформ.ndmsv россвязьпромкомплект.ndmsv россвязьстройкомплект.ndmsv россевзапсельэнергопроект.ndmsv россельхозбанк.ndmsv 
-россоюзместпром.ndmsv росспецэнергомонтаж.ndmsv росстанкоинструмент.ndmsv росстрахнадзор.ndmsv росстройимпекс.ndmsv росстром.ndmsv 
-ростекстильпром.ndmsv ростелеком.ndmsv ростехэкспорт.ndmsv ростоблремстройсбыт.ndmsv ростовавтотранс.ndmsv ростовгоргаз.ndmsv 
-ростовгражданпроект.ndmsv ростовдонресурс.ndmsv ростовмежрайгаз.ndmsv ростовметаллооптторг.ndmsv ростовнефтепродукт.ndmsv ростовнефтехимпроект.ndmsv 
-ростовоблгаз.ndmsv ростовоблспецремстройгаз.ndmsv ростовсельэнергопроект.ndmsv ростовтеплоэлектропроект.ndmsv ростовтурист.ndmsv ростовхлебпром.ndmsv 
-ростовэлектротранс.ndmsv ростовэнергоремонт.ndmsv ростоппром.ndmsv ростопсбыт.ndmsv росторгречтранс.ndmsv рострубпласт.ndmsv 
-росуглепрофсоюз.ndmsv росурал.ndmsv росуралсиб.ndmsv росфарфор.ndmsv росхимнефтепром.ndmsv росхлеб.ndmsv 
-росхлебопродукт.ndmsv росхлебпродукт.ndmsv росхозторг.ndmsv росцветмет.ndmsv росцементоптторг.ndmsv росцентробанк.ndmsv 
-росэлектроприбороптторг.ndmsv росэлтранс.ndmsv росэнергоатом.ndmsv росюгпром.ndmsv ртищевоагропромснаб.ndmsv ртищевоагропромтранс.ndmsv 
-ртищевомежрайгаз.ndmsv рубобанк.ndmsv рубторг.ndmsv рубцовскмежрайгаз.ndmsv рудняагропромснаб.ndmsv рузаремтехпред.ndmsv 
-русьлифт.ndmsv русьхлеб.ndmsv рыбакколхозсоюз.ndmsv рыбинскагроавтотранс.ndmsv рыбинскагропромснаб.ndmsv рыбинскмежрайгаз.ndmsv 
-рыбинскэнергожелезобетон.ndmsv рыбнадзор.ndmsv рыбноерайгаз.ndmsv рыбсовхоз.ndmsv рыльскагропромснаб.ndmsv рыльскмежрайгаз.ndmsv 
-рыльскхлебопродукт.ndmsv ряжскмежрайгаз.ndmsv рязаньавтосервис.ndmsv рязаньавтотранс.ndmsv рязаньвест.ndmsv рязаньгоргаз.ndmsv 
-рязаньнефтепродукт.ndmsv рязаньнефтехимпродукт.ndmsv рязаньоблгаз.ndmsv рязаньоблпродторг.ndmsv рязаньрайгаз.ndmsv рязаньспиртпром.ndmsv 
-рязаньхлеб.ndmsv рязаньхлебпром.ndmsv рязаньэлеватор.ndmsv рязаньэнергоремонт.ndmsv рязнефтехимпродукт.ndmsv рязоргстанкинпром.ndmsv 
-рязцветмет.ndmsv салаватгипронефтехим.ndmsv салаватенфтеоргсинтез.ndmsv салаватнефтеоргсинтез.ndmsv салехардмежрайгаз.ndmsv сальскмежрайгаз.ndmsv 
-самараавтодор.ndmsv самараавтоконтейнер.ndmsv самараавтосервис.ndmsv самараавтотранс.ndmsv самараагропромтранс.ndmsv самарагаз.ndmsv 
-самарагидропроект.ndmsv самараглавснаб.ndmsv самарагражданпроект.ndmsv самаралестоппром.ndmsv самарамашэлектроторг.ndmsv самаранефтегаз.ndmsv 
-самаранефтепродукт.ndmsv самаранефтехимпроект.ndmsv самараоблгаз.ndmsv самараоблснаб.ndmsv самарастройтранс.ndmsv самаратрансгаз.ndmsv 
-самарахимоптоторг.ndmsv самарахлебпром.ndmsv самойловкаагропромтранс.ndmsv сампурагропромснаб.ndmsv сампурагросервис.ndmsv самтрест.ndmsv 
-сантехмонтаж.ndmsv сантехниипроект.ndmsv сантехэлектромонтаж.ndmsv санэпиднадзор.ndmsv сапожокгаз.ndmsv сараимежрайгаз.ndmsv 
-саранскстройзаказчик.ndmsv саранскэлектротранс.ndmsv сарапулмежрайгаз.ndmsv саратовавторемонт.ndmsv саратовавтотранс.ndmsv саратовагропромснаб.ndmsv 
-саратовагропромтранс.ndmsv саратовбашняагропром.ndmsv саратовгаз.ndmsv саратовгазавторемонт.ndmsv саратовгазэнергоремонт.ndmsv саратовгоргаз.ndmsv 
-саратовдизельаппарат.ndmsv саратовмясопром.ndmsv саратовнефтегаз.ndmsv саратовнефтепродукт.ndmsv саратовоблгаз.ndmsv саратовоблремстройбыт.ndmsv 
-саратоворггаз.ndmsv саратовплодовощпром.ndmsv саратовплодовощтранс.ndmsv саратовсельмелиоводхоз.ndmsv саратовсельстройтранс.ndmsv саратовснабсбыт.ndmsv 
-саратовспецмонтаж.ndmsv саратовстройкомплект.ndmsv саратовстройтранс.ndmsv саратовтехсервис.ndmsv саратовторгнефтегаз.ndmsv саратовэнергоремонт.ndmsv 
-саровгидромонтаж.ndmsv сароптмясомолторг.ndmsv сасовоагропромсервис.ndmsv сасовомежрайгаз.ndmsv саткамежрайгаз.ndmsv сафоновоагропромснаб.ndmsv 
-саха-газ.ndmsv сахаконцерт.ndmsv сахалинавтотранс.ndmsv сахалинглавснаб.ndmsv сахалинлеспром.ndmsv сахалинморнефтегаз.ndmsv 
-сахалинморнефтемонтаж.ndmsv сахалиннефтепродукт.ndmsv сахалиноблгаз.ndmsv сахалинхлеб.ndmsv сахаполиграфиздат.ndmsv саянскагроавтотранс.ndmsv 
-саянскхимпром.ndmsv свердлеспром.ndmsv свердловскавтодор.ndmsv свердловскавтотранс.ndmsv свердловскгоргаз.ndmsv свердловскгражданпроект.ndmsv 
-свердловскнефтепродукт.ndmsv свердловскоблводхоз.ndmsv свердловскоблгаз.ndmsv свердловскстройматериал.ndmsv свердловскстройтранс.ndmsv свердловскторф.ndmsv 
-свердловэлектроремонт.ndmsv сверлифтремонт.ndmsv светлогорскмежрайгаз.ndmsv светлоградремтехпред.ndmsv свинокомплекс.ndmsv связьинвест.ndmsv 
-связьинформ.ndmsv связьморпроект.ndmsv связьэлектромонтаж.ndmsv севатомремонт.ndmsv севгипрорыбфлот.ndmsv севдорпроект.ndmsv 
-северавтодор.ndmsv северавтотранс.ndmsv севералмаз.ndmsv севератомкомплекс.ndmsv севергазпром.ndmsv севернефтепродукт.ndmsv 
-севернефтесервис.ndmsv северо-осетиннефтепродукт.ndmsv северовостокэлектромонтаж.ndmsv северодвинскмежрайгаз.ndmsv северозападорггаз.ndmsv северолесоэкспорт.ndmsv 
-североморскрайгаз.ndmsv североторг.ndmsv североэнергоремонт.ndmsv северскаярайгаз.ndmsv северскремтехпред.ndmsv севзапгипрозем.ndmsv 
-севзаптранслеспром.ndmsv севзапэлектромонтаж.ndmsv севзапэнергомонтаж.ndmsv севзапэнергомонтажпроект.ndmsv севзапэнергопром.ndmsv севзапэнергосетьпроект.ndmsv 
-севкавгипроцветмет.ndmsv севкавмежавтотранс.ndmsv севкавниигаз.ndmsv севкавниигипс.ndmsv севкавнипиагропром.ndmsv севкавнипигаз.ndmsv 
-севкавторгпроект.ndmsv севкавэнергомонтаж.ndmsv севосгаз.ndmsv севосгорсельстройпроект.ndmsv севречфлот.ndmsv севрыбсбыт.ndmsv 
-севрыбхолодфлот.ndmsv севсантехмонтаж.ndmsv севтюменьавтотранс.ndmsv севэнергостройпром.ndmsv сегежабумпром.ndmsv селенгалес.ndmsv 
-селивановоремтехпред.ndmsv сельхоз.ndmsv сельхозавтотранс.ndmsv сельхозбанк.ndmsv сельхозинститут.ndmsv сельхозкооператив.ndmsv 
-сельхозлес.ndmsv сельхозполимер.ndmsv сельхозпромэкспорт.ndmsv сельхозтранс.ndmsv сельэлектроснаб.ndmsv сельэнергопроект.ndmsv 
-сельэнергопромпроект.ndmsv семикаракорскмежрайгаз.ndmsv семилукиагропромтранс.ndmsv семилукихлеб.ndmsv серафимовичмежрайгаз.ndmsv сервискомплект.ndmsv 
-сервиспищепром.ndmsv сервисэлектронполиграф.ndmsv сергиевскагропромтранс.ndmsv сергиевскмежрайгаз.ndmsv сердобскмежрайгаз.ndmsv серовмежрайгаз.ndmsv 
-сибавтостройсервис.ndmsv сибагропромтехпроект.ndmsv сиббиофарм.ndmsv сибвнипиэнергопром.ndmsv сибгазснаб.ndmsv сибгазтранс.ndmsv 
-сибгеоинформ.ndmsv сибгипробиосинтез.ndmsv сибгипромез.ndmsv сибгипронефтетранс.ndmsv сибгипронииавиапром.ndmsv сибгипротранс.ndmsv 
-сибзавод.ndmsv сибимпэкс.ndmsv сибирьгазсервис.ndmsv сибкомплектмонтаж.ndmsv сибконтакт.ndmsv сибметаллургмонтаж.ndmsv 
-сибнефтепровод.ndmsv сибнефтесервис.ndmsv сибнефтетранспроект.ndmsv сибнефтехиммонтаж.ndmsv сибнефтькомплектмонтаж.ndmsv сиборггаз.ndmsv 
-сибпродмонтаж.ndmsv сибсантехмонтаж.ndmsv сибспецмонтаж.ndmsv сибспецэнергомонтаж.ndmsv сибстанкоэлектропривод.ndmsv сибторгнефтепровод.ndmsv 
-сибторгпроект.ndmsv сибхиммонтаж.ndmsv сибхимремонт.ndmsv сибцветметремонт.ndmsv сибэкспоцентр.ndmsv сибэлектромонтаж.ndmsv 
-сибэнергокомплект.ndmsv сибэнергомонтаж.ndmsv сибэнергоремонт.ndmsv сибэнергосетьпроект.ndmsv сибэнергоцветмет.ndmsv симбирскспирт.ndmsv 
-сименс.ndmsv скбприбор.ndmsv скопинмежрайгаз.ndmsv славгородмежрайгаз.ndmsv славскремтехпред.ndmsv славянскаярайгаз.ndmsv 
-смоленскавтотранс.ndmsv смоленскагрокомплект.ndmsv смоленскагропромснаб.ndmsv смоленскагропромтранс.ndmsv смоленскагросервис.ndmsv смоленскглавснаб.ndmsv 
-смоленскленагропром.ndmsv смоленсклестоппром.ndmsv смоленскмежрайгаз.ndmsv смоленскмолсырпром.ndmsv смоленскмясоагропром.ndmsv смоленскнефтепродукт.ndmsv 
-смоленскоблгаз.ndmsv смоленскоблобувьбыт.ndmsv смоленскоблразнобыт.ndmsv смоленскоблснаб.ndmsv смоленскоблтрикотажбыт.ndmsv смоленскремтехпред.ndmsv 
-смоленсксвязьинформ.ndmsv смоленскспиртпищеагропром.ndmsv смоленскстройзаказчик.ndmsv смоленскстройматериал.ndmsv смоленскторф.ndmsv смоленсктрубопровод.ndmsv 
-смоленскшвейбыт.ndmsv собинкаремтехпред.ndmsv совавто-термез.ndmsv совгаваньмежрайгаз.ndmsv советскагропромснаб.ndmsv советскмежрайгаз.ndmsv 
-советскоемежрайгаз.ndmsv советскремтехпред.ndmsv совинтеравтосервис.ndmsv совинтерспорт.ndmsv совинтерфест.ndmsv совинторг.ndmsv 
-совинцентр.ndmsv совкомфлот.ndmsv совремстройматериал.ndmsv соврыбфлот.ndmsv совтелеэкспорт.ndmsv совфрахт.ndmsv 
-совэкспортфильм.ndmsv соликамскбумпром.ndmsv солнцевоагропромснаб.ndmsv солодчагазсервис.ndmsv сольпром.ndmsv сольцымежрайгаз.ndmsv 
-сортавалаагросервис.ndmsv сосновкаагропромснаб.ndmsv сосновкаремтехпред.ndmsv сосновоборэлектромонтаж.ndmsv соцкомбыт.ndmsv соцкультбыт.ndmsv 
-соцпроф.ndmsv соцэкономинформ.ndmsv сочиавтотранс.ndmsv сочиглавснаб.ndmsv сочигоргаз.ndmsv союзагропром.ndmsv 
-союзантисептик.ndmsv союзвзрывпром.ndmsv союзвнешстройимпорт.ndmsv союзвнештранс.ndmsv союзвтормет.ndmsv союзгосцирк.ndmsv 
-союздорпроект.ndmsv союзздравэкспорт.ndmsv союзинтерпром.ndmsv союзкиносервис.ndmsv союзкинотехпрокат.ndmsv союзкинофонд.ndmsv 
-союзконтракт.ndmsv союзлесмонтаж.ndmsv союзлифтмонтаж.ndmsv союзметаллургпром.ndmsv союзморниипроект.ndmsv союзмультфильм.ndmsv 
-союзмясомолмонтаж.ndmsv союзнефтеэкспорт.ndmsv союзпарфюмерпром.ndmsv союзпатент.ndmsv союзплодимпорт.ndmsv союзплодоимпорт.ndmsv 
-союзпром.ndmsv союзпроммонтаж.ndmsv союзпромэкспорт.ndmsv союзросместпром.ndmsv союзстекломонтаж.ndmsv союзстройматериал.ndmsv 
-союзтелерадиосервис.ndmsv союзтелефильм.ndmsv союзтранзит.ndmsv союзфоринвест.ndmsv спасскмежрайгаз.ndmsv спасскрайгаз.ndmsv 
-спасскцемент.ndmsv спецавтотранспорт.ndmsv спецавтоцентр.ndmsv спецатоммонтаж.ndmsv спецгазавтотранс.ndmsv спецдор.ndmsv 
-спецдормост.ndmsv спецканаттранс.ndmsv спецкомбинат.ndmsv спецмашмонтаж.ndmsv спецметаллопроект.ndmsv спецодеждаоптторг.ndmsv 
-спецпроект.ndmsv спецстройбетон.ndmsv спецстройремтрест.ndmsv спецтеплохиммонтаж.ndmsv спецтранс.ndmsv спецфакультет.ndmsv 
-спецхиммонтаж.ndmsv спецэлектромонтаж.ndmsv спецэнергомонтаж.ndmsv спецэнергоремонт.ndmsv спортинвест.ndmsv спортинтерпром.ndmsv 
-спорткомплекс.ndmsv средневолжсклифтремонт.ndmsv ставропольавтодор.ndmsv ставропольавтотранс.ndmsv ставропольвиноградпром.ndmsv ставропольгоргаз.ndmsv 
-ставропольимпэкс.ndmsv ставрополькоммунпроект.ndmsv ставрополькрайагрокомплекс.ndmsv ставрополькрайгаз.ndmsv ставропольлифтремонт.ndmsv ставропольместпром.ndmsv 
-ставропольнефтегаз.ndmsv ставропольнефтепродукт.ndmsv ставропольорггаз.ndmsv ставропольремагропром.ndmsv ставропольресурс.ndmsv ставропольснаб.ndmsv 
-ставропольстройматериал.ndmsv ставропольстройтранс.ndmsv ставропольтоппром.ndmsv ставропольторгпроект.ndmsv ставропольтурист.ndmsv стальмонтаж.ndmsv 
-стальпроект.ndmsv станкин.ndmsv станкобизнес.ndmsv станкоинструментоптторг.ndmsv станкомэз.ndmsv станкоэлектрон.ndmsv 
-старожиловорайгаз.ndmsv староминскаярайгаз.ndmsv старопохвистневоагропромтранс.ndmsv старорусприбор.ndmsv староруссмежрайгаз.ndmsv староюрьевоагропромснаб.ndmsv 
-статкомитет.ndmsv стройбизнес.ndmsv стройгаз.ndmsv стройдеталькомплект.ndmsv стройдормашсервис.ndmsv стройиздат.ndmsv 
-стройинвест.ndmsv стройинсервис.ndmsv стройинструмент.ndmsv стройкомбинат.ndmsv стройкомплекс.ndmsv стройкомплект.ndmsv 
-стройкомплектэкспорт.ndmsv стройлес.ndmsv стройлессервис.ndmsv стройматериалинторг.ndmsv строймехкомплект.ndmsv строймехсервис.ndmsv 
-строймонтажгаз.ndmsv строймонтажсервис.ndmsv стройоптторг.ndmsv стройпластполимер.ndmsv стройпрогресс.ndmsv стройпромторг.ndmsv 
-стройресурс.ndmsv стройсвязьпроект.ndmsv стройсервис.ndmsv стройсинтез.ndmsv стройснаб.ndmsv стройтехсервис.ndmsv 
-стройтранс.ndmsv стройтрансгаз.ndmsv стройтрест.ndmsv стройфарфор.ndmsv стройэлектромонтаж.ndmsv стромкомпозит.ndmsv 
-строммашполимер.ndmsv стромфонд.ndmsv ступиноремтехпред.ndmsv судбытсервис.ndmsv суджаагропромснаб.ndmsv суджамежрайгаз.ndmsv 
-судогдаремтехпред.ndmsv судотрансрыбфлот.ndmsv судоэкспорт.ndmsv суздальремтехпред.ndmsv сулинмежрайгаз.ndmsv сунжамежрайгаз.ndmsv 
-сургутгазпром.ndmsv сургутжилкомхоз.ndmsv сургутнефтегаз.ndmsv сургутнефтегазбанк.ndmsv сургутрайгаз.ndmsv суровикиномежрайгаз.ndmsv 
-сухоложскцемент.ndmsv сызраньагропромтранс.ndmsv сызраньмежрайгаз.ndmsv сычевкаагропромснаб.ndmsv табакпром.ndmsv табунскремтехпред.ndmsv 
-таганрогмежрайгаз.ndmsv тагиллес.ndmsv тагилмежрайгаз.ndmsv тагилмясопром.ndmsv таймырагроснаб.ndmsv таймырнефтегаз.ndmsv 
-талнахспецшахтремонт.ndmsv таловаяагропромтранс.ndmsv тамбовавтотранс.ndmsv тамбовагроинформ.ndmsv тамбовагропромкомплект.ndmsv тамбовагропромсервис.ndmsv 
-тамбовагропромснаб.ndmsv тамбовагростройпроект.ndmsv тамбовагрохимтранс.ndmsv тамбовгражданпроект.ndmsv тамбовжилколхоз.ndmsv тамбовкоммунпроект.ndmsv 
-тамбовконтракт.ndmsv тамбовместпром.ndmsv тамбовмолпром.ndmsv тамбовмясопродукт.ndmsv тамбовмясопром.ndmsv тамбовнефтепродукт.ndmsv 
-тамбовоблгаз.ndmsv тамбовоблснаб.ndmsv тамбовпассажироавтосервис.ndmsv тамбовпищепром.ndmsv тамбовплодоовощхоз.ndmsv тамбовптицепром.ndmsv 
-тамбоврыбхоз.ndmsv тамбовсахарсервис.ndmsv тамбовстройпроект.ndmsv тамбовстройтранс.ndmsv тамбовтоппром.ndmsv тамбовхлебпром.ndmsv 
-тарамежрайгаз.ndmsv таркосаленефтегаз.ndmsv тасс.ndmsv татавтотранс.ndmsv татагрохимсервис.ndmsv татищевоагропромснаб.ndmsv 
-татищевоагропромтранс.ndmsv татнефтебитум.ndmsv татнефтемашремонт.ndmsv татнефтепродукт.ndmsv татойлгаз.ndmsv татпромстройбанк.ndmsv 
-таттрансгаз.ndmsv тбилисскаярайгаз.ndmsv тв-информ.ndmsv тверьавтодор.ndmsv тверьавтотранс.ndmsv тверькурорт.ndmsv 
-тверьлеспром.ndmsv тверьлеспром-холдинг.ndmsv тверьлестоппром.ndmsv тверьнефтепродукт.ndmsv тверьоблгаз.ndmsv тверьоборонпромкомплекс.ndmsv 
-тверьсвинопром.ndmsv тверьторф.ndmsv тверьхлебпром.ndmsv тейковомежрайгаз.ndmsv текстильпром.ndmsv телеком.ndmsv 
-телерадиокомитет.ndmsv темкиноагропромснаб.ndmsv темрюкрайгаз.ndmsv тенгизнефтегаз.ndmsv теплопроект.ndmsv теплоэлектропроект.ndmsv 
-термнефтепроект.ndmsv техинвест.ndmsv техмашимпорт.ndmsv техмашкомплекс.ndmsv техмашэкспорт.ndmsv технимпорт.ndmsv 
-технобанк.ndmsv техноимпорт.ndmsv техноинторг.ndmsv технополис.ndmsv техноприбор.ndmsv технопромимпорт.ndmsv 
-технопромэкспорт.ndmsv техносервис.ndmsv техностройпром.ndmsv техностройэкспорт.ndmsv техноторгсервис.ndmsv технохим.ndmsv 
-техноэкополис.ndmsv техноэкспорт.ndmsv техпромэкспорт.ndmsv техснабэкспорт.ndmsv тимагропромснаб.ndmsv тимашевскрайгаз.ndmsv 
-тиммежрайгаз.ndmsv тисульрайгаз.ndmsv тихорецкгоргаз.ndmsv тобольсклес.ndmsv токаревкаавтотранс.ndmsv токаревкаагропромснаб.ndmsv 
-токобанк.ndmsv тольяттиазот.ndmsv тольяттигоргаз.ndmsv тольяттиоптторг.ndmsv тольяттистройтранс.ndmsv тольяттиторгтранс.ndmsv 
-томскавтотранс.ndmsv томскнефтепродукт.ndmsv томскоблгаз.ndmsv томсктеплоэлектропроект.ndmsv томсктрансгаз.ndmsv томсктранспроект.ndmsv 
-томскхлебопродукт.ndmsv томскэнергосетьпроект.ndmsv торгмортранс.ndmsv торгпроект.ndmsv торгречтранс.ndmsv торгсервис.ndmsv 
-торгтехстройсервис.ndmsv точприбор.ndmsv трактороэкспорт.ndmsv трансвзрывпром.ndmsv трансмашпроект.ndmsv транснефтепродукт.ndmsv 
-транспроект.ndmsv трансресторансервис.ndmsv транссервис.ndmsv трансфорум-интерсервис.ndmsv трансэлектропроект.ndmsv трубооптторг.ndmsv 
-трубоптторг.ndmsv трубчевскмежрайгаз.ndmsv туапсегоргаз.ndmsv туапсенефтепродукт.ndmsv туваавтодор.ndmsv туваавтотранс.ndmsv 
-туваагросервис.ndmsv туваагроснаб.ndmsv туваасбест.ndmsv тувазаготпродпром.ndmsv тувалестоппром.ndmsv туванефтепродукт.ndmsv 
-тувапрокатавтосервис.ndmsv туварыбхоз.ndmsv тувастройматериал.ndmsv туватурист.ndmsv тувахлебпром.ndmsv тувгаз.ndmsv 
-тулаавтотранс.ndmsv тулаагроводпроект.ndmsv тулакондитерагропром.ndmsv туламашзавод.ndmsv туламашпроект.ndmsv туланефтепродукт.ndmsv 
-тулаоблгаз.ndmsv туласпирт.ndmsv тулатоппром.ndmsv тулачермет.ndmsv тулачерметпроект.ndmsv тулаэлектропривод.ndmsv 
-тулаэнергосетьпроект.ndmsv тулоблавтотранс.ndmsv тульскгражданпроект.ndmsv турбоатом.ndmsv тындалес.ndmsv тюкалинскмежрайгаз.ndmsv 
-тюменбургаз.ndmsv тюменгазснабкомплект.ndmsv тюменнефтегаз.ndmsv тюменнефтепродукт.ndmsv тюменнефтеспецтранс.ndmsv тюменниигипрогаз.ndmsv 
-тюменоблгаз.ndmsv тюментрансгаз.ndmsv тюментрансгазремонт.ndmsv тюменьавиатранс.ndmsv тюменьавтотранс.ndmsv тюменьагролеспром.ndmsv 
-тюменьглавснаб.ndmsv тюменьгражданпроект.ndmsv тюменьлес.ndmsv тюменьмежрайгаз.ndmsv тюменьмясомолторг.ndmsv тюменьремстройпроект.ndmsv 
-тюменьрыбхоз.ndmsv тюменьторф.ndmsv тюменьтрансгаз.ndmsv тюменьтурист.ndmsv тяжмашоптторг.ndmsv тяжмехпресс.ndmsv 
-тяжпром.ndmsv тяжпромэкспорт.ndmsv тяжпромэлектропроект.ndmsv тяжстанкогидропресс.ndmsv угличмежрайгаз.ndmsv уграагропромснаб.ndmsv 
-удмуртавтотранс.ndmsv удмуртагропромсервис.ndmsv удмуртагроснаб.ndmsv удмуртгаз.ndmsv удмуртлес.ndmsv удмуртнефтепродукт.ndmsv 
-ульяновскавтосервис.ndmsv ульяновскавтотранс.ndmsv ульяновскагроснаб.ndmsv ульяновскводпроект.ndmsv ульяновскжилкоммунпроект.ndmsv ульяновскжилкомхоз.ndmsv 
-ульяновсккурорт.ndmsv ульяновскнефтепродукт.ndmsv ульяновскхлебпром.ndmsv ульяновскцемент.ndmsv умбасельхозсервис.ndmsv унечарайгаз.ndmsv 
-универсалпром.ndmsv университетобщепит.ndmsv уникомбанк.ndmsv упоровоспецгазсервис.ndmsv ураймежрайгаз.ndmsv урайнефтегаз.ndmsv 
-урал-центр.ndmsv уралавнипиэнергопром.ndmsv уралавтоприцеп.ndmsv ураласбест.ndmsv уралвагонзавод.ndmsv уралгазсервис.ndmsv 
-уралгазэнергоремонт.ndmsv уралгипромез.ndmsv уралгипротранс.ndmsv уралдомнаремонт.ndmsv ураллеспроект.ndmsv уралмашзавод.ndmsv 
-уралмрамор.ndmsv уралниистромпроект.ndmsv уралорггаз.ndmsv уралпромпроект.ndmsv уралсвязьинформ.ndmsv уралсельэнергопроект.ndmsv 
-уралтеплоэлектропроект.ndmsv уралторгпроект.ndmsv уралторфпроект.ndmsv уралтрансгаз.ndmsv уралтрубпром.ndmsv уралхимпласт.ndmsv 
-уралцемент.ndmsv уралчермет.ndmsv уралэнергомонтаж.ndmsv уралэнергомонтажпроект.ndmsv уралэнергоремонт.ndmsv уралэнергосетьпроект.ndmsv 
-урансервис.ndmsv урваньмежрайгаз.ndmsv ургаллес.ndmsv уренгойгазпром.ndmsv уренгойстройгаз.ndmsv уржумводспирт.ndmsv 
-урюпинскавтотранс.ndmsv урюпинскмежрайгаз.ndmsv усольехимпром.ndmsv усольскмежрайгаз.ndmsv усольхимпром.ndmsv успенскоерайгаз.ndmsv 
-уссурийскагропромкомплект.ndmsv уссурийскмежрайгаз.ndmsv уссурийскремтехпредснаб.ndmsv усть-катавмежрайгаз.ndmsv усть-лабинскрайгаз.ndmsv уфаавиапроект.ndmsv 
-уфамолагропром.ndmsv уфаоргсинтез.ndmsv учколлектор.ndmsv учхоз.ndmsv фатежмежрайгаз.ndmsv ферейн.ndmsv 
-физтех.ndmsv фильмэкспорт.ndmsv фроловомежрайгаз.ndmsv фурмановрайгаз.ndmsv хабаровскавтодор.ndmsv хабаровскавтотранс.ndmsv 
-хабаровскагропромснаб.ndmsv хабаровскгражданпроект.ndmsv хабаровсккрайгаз.ndmsv хабаровсклестоппром.ndmsv хабаровскместпром.ndmsv хабаровскнефтепродукт.ndmsv 
-хабаровскрайгаз.ndmsv хабаровскстройтранс.ndmsv хабаровсктурист.ndmsv хакасавтотранс.ndmsv хакасгаз.ndmsv хакаслес.ndmsv 
-хакаснефтепродукт.ndmsv хакасхлебопродукт.ndmsv хантымансийсклес.ndmsv харбор.ndmsv хасавюртгаз.ndmsv хвалынскагропромтранс.ndmsv 
-хворостянкарайгаз.ndmsv химбытпром.ndmsv химзавод.ndmsv химкомбинат.ndmsv химмашсервис.ndmsv химнефтепром.ndmsv 
-химоптоторг.ndmsv химоптторг.ndmsv химпищеоптторг.ndmsv химпром.ndmsv химснаб.ndmsv химфармкомбинат.ndmsv 
-хинипэк.ndmsv хладокомбинат.ndmsv хозмебельстройсервис.ndmsv холмогорымежрайгаз.ndmsv холмогорыремтехпредхимснаб.ndmsv хорольмежрайгаз.ndmsv 
-цветмет.ndmsv цветметинвест.ndmsv цветметконтракт.ndmsv цветметоптторг.ndmsv цветметэкспорт.ndmsv целинхлебопродукт.ndmsv 
-цементоптторг.ndmsv цемзавод.ndmsv центрагроавтотранс.ndmsv центрагропромснаб.ndmsv центргаз.ndmsv центризбирком.ndmsv 
-центрметаллургремонт.ndmsv центрнаучфильм.ndmsv центробанк.ndmsv центролит.ndmsv центросоюз.ndmsv центросоюзпроект.ndmsv 
-центротрансжелезобетон.ndmsv центроэнергомонтаж.ndmsv центрпродсервис.ndmsv центрремтехпредснаб.ndmsv центррыбвод.ndmsv центрторг.ndmsv 
-центрчерноземмежавтотранс.ndmsv центрчерноземорггаз.ndmsv цивильскмежрайгаз.ndmsv цимлянскрыбвод.ndmsv цкбточприбор.ndmsv цнииатоминформ.ndmsv 
-цниибыт.ndmsv цниилесосплав.ndmsv цниипроект.ndmsv цниичермет.ndmsv цсхбанк.ndmsv чапаевскгоргаз.ndmsv 
-чебаркульмежрайгаз.ndmsv чебоксарыгоргаз.ndmsv чебуламежрайгаз.ndmsv чегемрайгаз.ndmsv чекфондконтур.ndmsv челно-вершинырайгаз.ndmsv 
-челябинскавтодор.ndmsv челябинскавтотранс.ndmsv челябинскгоргаз.ndmsv челябинсккурорт.ndmsv челябинскнефтепродукт.ndmsv челябинскоблгаз.ndmsv 
-челябинскспиртпром.ndmsv челябмашоптторг.ndmsv челябнефтепродукт.ndmsv челябоблтоппром.ndmsv челябспецтранс.ndmsv челябстройзаказчик.ndmsv 
-челябтехоптторг.ndmsv челябхимоптторг.ndmsv черемховомежрайгаз.ndmsv череповецгоргаз.ndmsv череповецлессервис.ndmsv черкассыагропромтранс.ndmsv 
-черкассымежрайгаз.ndmsv черкеснефтепродукт.ndmsv черкесскавтодор.ndmsv черкесскавтотранс.ndmsv черкесскагропромпроект.ndmsv черкесскнефтепродукт.ndmsv 
-чертковорайгаз.ndmsv чечинггаз.ndmsv чимкентнефтеоргсинтез.ndmsv читаглавснаб.ndmsv читалес-холдинг.ndmsv читалестоппром.ndmsv 
-читанефтепродукт.ndmsv читаоблгаз.ndmsv читатурист.ndmsv чувашавтотранс.ndmsv чувашгаз.ndmsv чувашкредитпромбанк.ndmsv 
-чувашнефтепродукт.ndmsv чудовомежрайгаз.ndmsv чукотагропромпроект.ndmsv чукотгоспроект.ndmsv чукотнефтепродукт.ndmsv шадринскмежрайгаз.ndmsv 
-шарьямежрайгаз.ndmsv шатурторф.ndmsv шахтостройкомпозит.ndmsv шахтымежрайгаз.ndmsv шацкмежрайгаз.ndmsv швейпром.ndmsv 
-шелеховмежрайгаз.ndmsv шенталамежрайгаз.ndmsv шиловорайгаз.ndmsv шумерлямежрайгаз.ndmsv шуямежрайгаз.ndmsv щербиновскаярайгаз.ndmsv 
-щигрымежрайгаз.ndmsv экономбанк.ndmsv экоресурс.ndmsv экспо-центр.ndmsv экспортлес.ndmsv экспортподшипник.ndmsv 
-экспортхлеб.ndmsv экспоцентр.ndmsv элеватормелькомплект.ndmsv электроавтомат.ndmsv электроагрегат.ndmsv электроаппарат.ndmsv 
-электрогаз.ndmsv электрозапсибмонтаж.ndmsv электрометприбор.ndmsv электромонтаж.ndmsv электронприбор.ndmsv электронпроект.ndmsv 
-электронстандарт.ndmsv электрооптторг.ndmsv электроприбороптторг.ndmsv электропроект.ndmsv электропромремонт.ndmsv электропрофсоюз.ndmsv 
-электросевкавмонтаж.ndmsv электросетьстройпроект.ndmsv электросибмонтаж.ndmsv электростальгражданпроект.ndmsv электростандарт.ndmsv электротехоптторг.ndmsv 
-электроточприбор.ndmsv электроуралмонтаж.ndmsv электрохимприбор.ndmsv электроцентромонтаж.ndmsv электроцех.ndmsv эльбрустурист.ndmsv 
-эльф-нефтегаз.ndmsv энгельсагропромтранс.ndmsv энгельсмежрайгаз.ndmsv энергоатомиздат.ndmsv энергожилиндустрпроект.ndmsv энергозавод.ndmsv 
-энергокомплект.ndmsv энергомашэкспорт.ndmsv энергомехавтотранс.ndmsv энергомехпрогресс.ndmsv энергомонтаж.ndmsv энергомонтажпроект.ndmsv 
-энергонадзор.ndmsv энергопроект.ndmsv энергоремонт.ndmsv энергосетьпроект.ndmsv энергостальпроект.ndmsv энергостройкомплект.ndmsv 
-энергостройпром.ndmsv энерготехкомплект.ndmsv энерготехпром.ndmsv энергоцех.ndmsv энимс.ndmsv эпиднадзор.ndmsv 
-ювелирпром.ndmsv юганскнефтегаз.ndmsv юганскнефтедорстройремонт.ndmsv югранефтепрогресс.ndmsv югтрансгаз.ndmsv южамежрайгаз.ndmsv 
-южноуральскмежрайгаз.ndmsv южэнергожилпроект.ndmsv южэнергосетьпроект.ndmsv юргарайгаз.ndmsv юрьевецмежрайгаз.ndmsv ядринрайгаз.ndmsv 
-якутавиатранс.ndmsv якутавтотранс.ndmsv якутгаз.ndmsv якутгазпром.ndmsv якутлес.ndmsv якутнефтепродукт.ndmsv 
-якутнипроалмаз.ndmsv якутснаб.ndmsv якуттурист.ndmsv ялуторовскспецгазсервис.ndmsv ямалнефтегазжелезобетон.ndmsv ямалнефтепродукт.ndmsv 
-ямрайгаз.ndmsv яроблснабсбыт.ndmsv ярославльавтотранс.ndmsv ярославльагростройтранс.ndmsv ярославльгоргаз.ndmsv ярославлькондитер.ndmsv 
-ярославльоблгаз.ndmsv ярославльсельлес.ndmsv ярославльхлебпром.ndmsv ярославнефтеоргсинтез.ndmsv ярославнефтепродукт.ndmsv ярославхлеб.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
 
 абалгаз.ndmsi абанагроавтотранс.ndmsi абатскспецгазсервис.ndmsi абинскрайгаз.ndmsi авиабанк.ndmsi авиаприбор-холдинг.ndmsi 
 авиаприборпроект.ndmsi авиаприборхолдинг.ndmsi авиапром.ndmsi авиапромсервис.ndmsi авиаремонт.ndmsi авиаспецмонтаж.ndmsi 
@@ -13401,6 +12863,542 @@
 ярославльоблгаз.ndmsi ярославльсельлес.ndmsi ярославльхлебпром.ndmsi ярославнефтеоргсинтез.ndmsi ярославнефтепродукт.ndmsi ярославхлеб.ndmsi 
 :  <morph-С,мр,но,ед,им>;
 
+абалгаз.ndmsv абанагроавтотранс.ndmsv абатскспецгазсервис.ndmsv абинскрайгаз.ndmsv авиабанк.ndmsv авиаприбор-холдинг.ndmsv 
+авиаприборпроект.ndmsv авиаприборхолдинг.ndmsv авиапром.ndmsv авиапромсервис.ndmsv авиаремонт.ndmsv авиаспецмонтаж.ndmsv 
+авиаспецснабсбыт.ndmsv авиастар.ndmsv автобанк.ndmsv автобытсервис.ndmsv автоваз.ndmsv автовазагрегат.ndmsv 
+автовазбанк.ndmsv автовазтранс.ndmsv автовокзалсервис.ndmsv автогаз.ndmsv автодеталь-сервис.ndmsv автодорресурс.ndmsv 
+автозаз.ndmsv автозазсервис.ndmsv автоимпорт.ndmsv автокраз.ndmsv автоприбор.ndmsv автопромимпорт.ndmsv 
+автопромматериал.ndmsv автосельхозмаш-холдинг.ndmsv автосельхозмашхолдинг.ndmsv автосельхозторг.ndmsv автосервис.ndmsv автоснабсбыт.ndmsv 
+автостройпроект.ndmsv автотехтранс.ndmsv автотракторооптторг.ndmsv автотрактороптторг.ndmsv автотранссервис.ndmsv автоэкспорт.ndmsv 
+автрокон-холдинг.ndmsv агробизнесцентр.ndmsv агродорсервис.ndmsv агроинкомбанк.ndmsv агроинторг.ndmsv агрокурорт.ndmsv 
+агроландшафт.ndmsv агромашимпорт.ndmsv агромехмонтаж.ndmsv агромонтаж.ndmsv агромостожелезобетон.ndmsv агропищепром.ndmsv 
+агроплемзавод.ndmsv агроприбор.ndmsv агропродсервис.ndmsv агропроект.ndmsv агропром.ndmsv агропромавтотранс.ndmsv 
+агропромбанк.ndmsv агропромкомбинат.ndmsv агропромкомплекс.ndmsv агропромкомплект.ndmsv агропроммехмонтаж.ndmsv агропромпрогресс.ndmsv 
+агропромремонт.ndmsv агропромсервис.ndmsv агропромснаб.ndmsv агропромсоюз.ndmsv агропромспецстроймонтаж.ndmsv агропромстандарт.ndmsv 
+агропромстройматериал.ndmsv агропромстройтранс.ndmsv агропромтехнопол.ndmsv агропромтехпроект.ndmsv агропромтехсервис.ndmsv агропромтранс.ndmsv 
+агрос.ndmsv агросевер.ndmsv агросиб.ndmsv агроснаб.ndmsv агроснабкомплект.ndmsv агроспецмонтаж.ndmsv 
+агротехпром.ndmsv агротехсервис.ndmsv агротехцентр.ndmsv агроторг.ndmsv агротранс.ndmsv агрофермероргснаб.ndmsv 
+агрохим.ndmsv агрохимполимер.ndmsv агрохимцентр.ndmsv агрохолод.ndmsv агрохолодпром.ndmsv адыггаз.ndmsv 
+адыгейнефтепродукт.ndmsv адыгеяавтотранс.ndmsv адыгеяагроснаб.ndmsv азовмежрайгаз.ndmsv айрекс.ndmsv академинвест.ndmsv 
+аксаймежрайгаз.ndmsv алагиррайгаз.ndmsv алатырьгоргаз.ndmsv алгайагропромтранс.ndmsv алдангоргаз.ndmsv алейскмежрайгаз.ndmsv 
+алейскхлебопродукт.ndmsv александровагропромснаб.ndmsv александровогайагропромснаб.ndmsv александровремтехпред.ndmsv алексеевкарайгаз.ndmsv алексеевскагропромтранс.ndmsv 
+алексеевскремтехпред.ndmsv алмаздортранс.ndmsv алмазэкспорт.ndmsv алмазювелир.ndmsv алмазювелир-экспорт.ndmsv алмазювелирэкспорт.ndmsv 
+алтайавтодор.ndmsv алтайавтотранс.ndmsv алтайагрокоопмолпром.ndmsv алтайагрокоопмясопром.ndmsv алтайагропромпроект.ndmsv алтайагропромснаб.ndmsv 
+алтайагропромтранс.ndmsv алтайагросервис.ndmsv алтайагроспецмонтаж.ndmsv алтайагротранс.ndmsv алтайвинагропром.ndmsv алтайвитамин.ndmsv 
+алтайгаз.ndmsv алтайкрайгаз.ndmsv алтайкрайгазсервис.ndmsv алтайлестоппром.ndmsv алтаймедпрепарат.ndmsv алтаймежхозлес.ndmsv 
+алтаймрамор.ndmsv алтайнефтепродукт.ndmsv алтайовощхоз.ndmsv алтайполиметалл.ndmsv алтайптицеводкомплект.ndmsv алтайремстройбыт.ndmsv 
+алтайремстроймонтаж.ndmsv алтайсахарагропром.ndmsv алтайсельхозводопровод.ndmsv алтайскагропромавтотранс.ndmsv алтайскагропромснаб.ndmsv алтайскремтехпред.ndmsv 
+алтайстройкомплект.ndmsv алтайстройматериал.ndmsv алтайстройтранс.ndmsv алтайтурист.ndmsv алтайхимпром.ndmsv алтайхлебопродукт.ndmsv 
+алтайэнергоремонт.ndmsv альфа-банк.ndmsv амур-порт.ndmsv амуравтотранс.ndmsv амурагроснаб.ndmsv амурагротехсервис.ndmsv 
+амурагроэлектроремонт.ndmsv амургаз.ndmsv амуржилкомхоз.ndmsv амурлес.ndmsv амурлеспром.ndmsv амурнефтепродукт.ndmsv 
+амуроблгаз.ndmsv амурремпроект.ndmsv амурскмежрайгаз.ndmsv амурэлектромонтаж.ndmsv амурэнергоремонт.ndmsv анадырьремтехснаб.ndmsv 
+аналитприбор.ndmsv анапагоргаз.ndmsv ангаралес.ndmsv ангарскгоргаз.ndmsv ангарскнефтеоргсинтез.ndmsv ангарскнефтехимпроект.ndmsv 
+ангарсктеплохиммонтаж.ndmsv ангарскхимнефтеремонт.ndmsv анилпром.ndmsv анлагенбау-инжиниринг.ndmsv апатитгражданпроект.ndmsv апатитсельхозсервис.ndmsv 
+апатитырайгаз.ndmsv апшеронскрайгаз.ndmsv ардонмежрайгаз.ndmsv арзамасспирт.ndmsv аркадакагропроммехмонтажкомплект.ndmsv аркадакагропромснаб.ndmsv 
+аркадакагропромтранс.ndmsv аркадакмежрайгаз.ndmsv аркадакхлебопродукт.ndmsv арктикснаб.ndmsv армавиргоргаз.ndmsv армавироптторг.ndmsv 
+армконтракт.ndmsv арсеньевагропромтранс.ndmsv арсеньевмежрайгаз.ndmsv артикком.ndmsv архангельскавтодор.ndmsv архангельскавтотранс.ndmsv 
+архангельскагропром.ndmsv архангельскагропромснаб.ndmsv архангельскгаз.ndmsv архангельскгоргаз.ndmsv архангельскконтракт.ndmsv архангельсклессбыт.ndmsv 
+архангельсклестоппром.ndmsv архангельскнефтепродукт.ndmsv архангельскоблснаб.ndmsv архангельскоптторг.ndmsv архангельскрыбпром.ndmsv архангельсктурист.ndmsv 
+архптицепромснабсбыт.ndmsv архрыбсбыт.ndmsv архстройматериал.ndmsv архстройтранс.ndmsv асткиновидеопрокат.ndmsv астраханьавтодор.ndmsv 
+астраханьавтотранс.ndmsv астраханьагропромпроект.ndmsv астраханьбумпром.ndmsv астраханьгазпром.ndmsv астраханьмежрайгаз.ndmsv астраханьнефтепродукт.ndmsv 
+астраханьоблгаз.ndmsv астраханьпромстройпроект.ndmsv астраханьптицепром.ndmsv астро-гермес.ndmsv астробанк.ndmsv асуавтотранс.ndmsv 
+аткарскагропромснаб.ndmsv аткарскагропромтранс.ndmsv атомзащитаинформ.ndmsv атоминформ.ndmsv атомпром.ndmsv атомпромкомплекс.ndmsv 
+атомрудмет.ndmsv атомфлот.ndmsv атомэнергокомплект.ndmsv атомэнергопроект.ndmsv атомэнергоремонт.ndmsv атомэнергоэкспорт.ndmsv 
+ахтарскрайгаз.ndmsv ачинскагроавтотранс.ndmsv ачинскагропромснаб.ndmsv аэроприбор.ndmsv аэропроект.ndmsv багратионовскремтехпред.ndmsv 
+байкаллес.ndmsv байкалпротеин.ndmsv бакалеяоптторг.ndmsv бакпрепарат.ndmsv баксанрайгаз.ndmsv балаковоагропроммехмонтаж.ndmsv 
+балаковоагропромснаб.ndmsv балаковоагропромтранс.ndmsv балаковомежрайгаз.ndmsv балаковотурбоатомэнергоремонт.ndmsv балашовагропроммехмонтаж.ndmsv балашовагропромснаб.ndmsv 
+балашовмежрайгаз.ndmsv балкар-трейдинг.ndmsv балтайагропромтранс.ndmsv балтийскмежрайгаз.ndmsv балткран.ndmsv балтмонтаж.ndmsv 
+балтсудопроект.ndmsv бамнефтепродукт.ndmsv бамтрансвзрывпром.ndmsv бамтранстехмонтаж.ndmsv барнаулагропромснаб.ndmsv барнаулгоргаз.ndmsv 
+барнаулметаллоптторг.ndmsv батайскгоргаз.ndmsv башавтотранс.ndmsv башгипронефтехим.ndmsv башкортостантурист.ndmsv башкран.ndmsv 
+башлеспром.ndmsv башнефтепродукт.ndmsv башнефтехимзавод.ndmsv башпромбанк.ndmsv башстройтранс.ndmsv баштрансгаз.ndmsv 
+башэлектромонтаж.ndmsv безенчукагропромснаб.ndmsv безенчукагроремтехпред.ndmsv безенчукмежрайгаз.ndmsv безымянкаагропромтранс.ndmsv белавтомаз.ndmsv 
+белан.ndmsv белвитамин.ndmsv белгородавтотранс.ndmsv белгородагропромсервис.ndmsv белгороднефтепродукт.ndmsv белгородоблгаз.ndmsv 
+белгородорггаз.ndmsv белгородтоппром.ndmsv белгородэнергоремонт.ndmsv белкомхлебпрод.ndmsv беловомежрайгаз.ndmsv беловопогрузтранс.ndmsv 
+белогорскгаз.ndmsv белореченскрайгаз.ndmsv белоярскгаз.ndmsv белпласт.ndmsv белторгпроект.ndmsv бельсклес.ndmsv 
+березоворайгаз.ndmsv беринговремтехснаб.ndmsv бесланрайгаз.ndmsv бизнес-парк.ndmsv бизнес-центр.ndmsv бийскмежрайгаз.ndmsv 
+бийсктехноторг.ndmsv билибиноремтехснаб.ndmsv биомашприбор.ndmsv биомед.ndmsv биомедпрепарат.ndmsv биопрепарат-центр.ndmsv 
+биоснабсбыт.ndmsv биотехпрогресс.ndmsv биохимзавод.ndmsv биохиммашпроект.ndmsv биохимпром.ndmsv биробиджаноблгаз.ndmsv 
+биробиджанхлеб.ndmsv биробиджанхлебопродукт.ndmsv благовещенскмежрайгаз.ndmsv благсантехмонтаж.ndmsv бобровагропромснаб.ndmsv богатовскагропромтранс.ndmsv 
+богородскрайгаз.ndmsv боготолагропромснаб.ndmsv богучанлес.ndmsv богучарагропромтранс.ndmsv большаковремтехпред.ndmsv большеглушицкагпропромтранс.ndmsv 
+большеречьемежрайгаз.ndmsv большесолдатскагропромснаб.ndmsv большечерниговскагропромтранс.ndmsv бомонт.ndmsv бондариагропромснаб.ndmsv бондариремтехпред.ndmsv 
+боровичимежрайгаз.ndmsv борскагропромтранс.ndmsv брасовомежрайгаз.ndmsv братскгидропроект.ndmsv братскжелезобетон.ndmsv братсклес.ndmsv 
+братскпромэнергокомплект.ndmsv братскстройкомплект.ndmsv братскэнергопроект.ndmsv братскэнергостройтранс.ndmsv брюховецкаярайгаз.ndmsv брянскавтотранс.ndmsv 
+брянскгазпроект.ndmsv брянскгорстройзаказчик.ndmsv брянсккомплект.ndmsv брянскмежрайгаз.ndmsv брянскнефтепродукт.ndmsv брянскоблгаз.ndmsv 
+брянскпромбетон.ndmsv брянсксантехмонтаж.ndmsv брянсксвязьинформ.ndmsv брянскспиртпром.ndmsv брянскстройтранс.ndmsv брянсктоппром.ndmsv 
+брянскхолод.ndmsv брянскцемент.ndmsv брянскчернобыльстройзаказчик.ndmsv бугурусланмежрайгаз.ndmsv будимекс.ndmsv бузулукмежрайгаз.ndmsv 
+буйнакскгаз.ndmsv бумлесоптторг.ndmsv бумоптторг.ndmsv бургазгеотерм.ndmsv буржелезобетон.ndmsv бурятавтотранс.ndmsv 
+бурятавтотранссервис.ndmsv бурятагропроммехмонтаж.ndmsv бурятагропромпроект.ndmsv бурятагропромремонт.ndmsv бурятгаз.ndmsv бурятгражданпроект.ndmsv 
+бурятлестоппром.ndmsv бурятматтехресурс.ndmsv бурятнефтепродукт.ndmsv бурятпромстройпроект.ndmsv бурятрыбпром.ndmsv бурятскагропромснаб.ndmsv 
+бурятскагропромстандарт.ndmsv бурятскмолагропром.ndmsv бурятскпищепром.ndmsv бурятспирт.ndmsv бурятстройматериал.ndmsv бурятхлебпром.ndmsv 
+бутурлиновкаагропромтранс.ndmsv быковорайгаз.ndmsv быковоремтехпред.ndmsv валдаймежрайгаз.ndmsv ванинолесоэкспорт.ndmsv варитекс.ndmsv 
+варьеганнефтегаз.ndmsv варьеганнефтеснаб.ndmsv васхнил.ndmsv велижагропромснаб.ndmsv велижагропромтехмонтаж.ndmsv велижагропромтранс.ndmsv 
+вельскагропромснаб.ndmsv вельсклес.ndmsv вельскмежрайгаз.ndmsv вельскремтехпред.ndmsv верхнебуреинскрайгаз.ndmsv верхневолгоэлектромонтаж.ndmsv 
+верхнекамсклес.ndmsv верхнемамонагропромтранс.ndmsv верхнетоемскремтехпредхимснаб.ndmsv верхнехаваагропромтранс.ndmsv вершинскагропромтранс.ndmsv вершинырайгаз.ndmsv 
+ветсанутильзавод.ndmsv вешенскмежрайгаз.ndmsv викуловоагропромтранс.ndmsv виноагропром.ndmsv виноградовскремтехпредхимснаб.ndmsv виноградпром.ndmsv 
+вичугамежрайгаз.ndmsv владивостокагропромснаб.ndmsv владивостокмежрайгаз.ndmsv владивостокоптснаб.ndmsv владивостокстройкомплект.ndmsv владикавказ-газоаппарат.ndmsv 
+владикавказгоргаз.ndmsv владимиравтосервис.ndmsv владимиравтотранс.ndmsv владимирагроинформ.ndmsv владимирагропищепром.ndmsv владимирагропромпроект.ndmsv 
+владимирагропромснаб.ndmsv владимирагропромтранс.ndmsv владимиргазпроект.ndmsv владимирглавснаб.ndmsv владимиргоргаз.ndmsv владимирнефтепродукт.ndmsv 
+владимироблгаз.ndmsv владимироптторг.ndmsv владимирпищепроект.ndmsv владимирптицепром.ndmsv владимирремтехпред.ndmsv владимирстройматериал.ndmsv 
+владимирторф.ndmsv владимирэкогаз.ndmsv владимирэлектроникаагропром.ndmsv владимирэнергомонтаж.ndmsv владинтерлес.ndmsv владинтерлес-центр.ndmsv 
+владстройтранс.ndmsv внешагропромсервис.ndmsv внешинторг.ndmsv внешконсульт.ndmsv внешлес.ndmsv внешпромтехобмен.ndmsv 
+внешстройимпорт.ndmsv внешторгбанк.ndmsv внешторгиздат.ndmsv внештрейдинвест.ndmsv внииалмаз.ndmsv вниибиохимпрепарат.ndmsv 
+вниигаз.ndmsv вниигеоцветмет.ndmsv вниижелезобетон.ndmsv внииинструмент.ndmsv вниимотопром.ndmsv вниинаучприбор.ndmsv 
+вниинефтехим.ndmsv вниипигидротрубопровод.ndmsv вниипиморнефтегаз.ndmsv вниипиэт.ndmsv вниипромгаз.ndmsv вниистандарт.ndmsv 
+вниистройполимер.ndmsv внииэгазпром.ndmsv внииэлектротранспорт.ndmsv внииэпрант.ndmsv внипигидротрубопровод.ndmsv внипиморнефтегаз.ndmsv 
+внипистройполимер.ndmsv внипиэнергопром.ndmsv водтрансприбор.ndmsv воентех.ndmsv волгаэнергомонтаж.ndmsv волгаэнергоремонт.ndmsv 
+волгаэнергоснабкомплект.ndmsv волгаэнергостройпром.ndmsv волгобиосинтез.ndmsv волговзрывпром.ndmsv волговятмашэлектроснабсбыт.ndmsv волгогаз.ndmsv 
+волгоградавтодор.ndmsv волгоградавтотранс.ndmsv волгоградагропроект.ndmsv волгоградагропромтранс.ndmsv волгоградгоргаз.ndmsv волгоградметаллоторг.ndmsv 
+волгограднефтепродукт.ndmsv волгоградоблгаз.ndmsv волгоградтоппром.ndmsv волгоградтрансгаз.ndmsv волгоградэлектротранс.ndmsv волгоградэнергосетьпроект.ndmsv 
+волгодизельаппарат.ndmsv волгодонскмежрайгаз.ndmsv волгокамподводтрубопровод.ndmsv волгонефтехиммонтаж.ndmsv волгоспецмонтаж.ndmsv волгостальмонтаж.ndmsv 
+волготанкер.ndmsv волготрансгаз.ndmsv волгоэлектромонтаж.ndmsv волгоэнергомонтаж.ndmsv волгоэнергопромстройпроект.ndmsv волгоэнергостройпром.ndmsv 
+волжскагропромтранс.ndmsv волжскиймежрайгаз.ndmsv волжскийрайгаз.ndmsv вологдаавтотранс.ndmsv вологдаагроавтотранс.ndmsv вологдаагропроект.ndmsv 
+вологдаагропромавтотранс.ndmsv вологдаагростройсервис.ndmsv вологдаагрохим.ndmsv вологдагоргаз.ndmsv вологдаленпромэкспорт.ndmsv вологдалестоппром.ndmsv 
+вологдалесторг.ndmsv вологдамежхозлес.ndmsv вологдаметаллоптторг.ndmsv вологдамонтажпроект.ndmsv вологдамясопром.ndmsv вологданефтепродукт.ndmsv 
+вологдаоблагропромснаб.ndmsv вологдаоблбыт.ndmsv вологдаоблгаз.ndmsv вологдапроект.ndmsv вологдаптицепром.ndmsv вологдасвинопром.ndmsv 
+вологдасвинпром.ndmsv вологдаснаб.ndmsv вологдаторф.ndmsv вологдахлебпром.ndmsv вологодавтодор.ndmsv вологодметаллопторг.ndmsv 
+волоколамскагропромснаб.ndmsv волховторг.ndmsv волчихинскремтехпред.ndmsv вольскмежрайгаз.ndmsv воробьевкаагропромтранс.ndmsv воронежавтодор.ndmsv 
+воронежавторемонт.ndmsv воронежавтотранс.ndmsv воронежагроконтракт.ndmsv воронежагропромкомплект.ndmsv воронежагропромснаб.ndmsv воронежагропромстройматериал.ndmsv 
+воронежагропромтранс.ndmsv воронежагроснаб.ndmsv воронежагроспецмонтаж.ndmsv воронежгоргаз.ndmsv воронежгорсвет.ndmsv воронежконсервпром.ndmsv 
+воронежмасложирагропром.ndmsv воронежмолпром.ndmsv воронежнефтепродукт.ndmsv воронежоблавтобыттранс.ndmsv воронежоблавтотрансгаз.ndmsv воронежоблбытсоюз.ndmsv 
+воронежоблгаз.ndmsv воронежоблмебельбыт.ndmsv воронежоблремстройпроект.ndmsv воронежоблснаб.ndmsv воронежпищепром.ndmsv воронежрыбхоз.ndmsv 
+воронежсадпитомник.ndmsv воронежсахарагропром.ndmsv воронежсахарпром.ndmsv воронежсвязьинформ.ndmsv воронежсинтезкаучук.ndmsv воронежстрой-холдинг.ndmsv 
+воронежтранссервис.ndmsv воскозавод.ndmsv воскресенскагропромтранс.ndmsv воскресенскцемент.ndmsv востокгидромонтаж.ndmsv востокгипрозем.ndmsv 
+востокметаллургмонтаж.ndmsv востокмонтажгаз.ndmsv востокнефтегазсантехмонтаж.ndmsv востокнефтезаводмонтаж.ndmsv востоксантехмонтаж.ndmsv востоксиб.ndmsv 
+востоксибрыбниипроект.ndmsv востоксибсантехмонтаж.ndmsv востоксибсельэнергопроект.ndmsv востоксибсельэнергопром.ndmsv востоктехмонтаж.ndmsv востокэнергомонтаж.ndmsv 
+востокэнерготехнадзор.ndmsv востсибгипроспецагропром.ndmsv востсибнефтегаз.ndmsv востсибэлемент.ndmsv воткинскмежрайгаз.ndmsv вторметинвест.ndmsv 
+вторметресурс.ndmsv вторнефтепродукт.ndmsv вторцветмет.ndmsv вторчермет.ndmsv вузцентр.ndmsv выксалес.ndmsv 
+выселкирайгаз.ndmsv вычегдалес.ndmsv вяземскагропром.ndmsv вяземскагропромтранс.ndmsv вяземскмежрайгаз.ndmsv вязникиагропромснаб.ndmsv 
+вязникиремтехпред.ndmsv вязьмаагропромснаб.ndmsv вязьмазернопродукт.ndmsv вятводспирт.ndmsv вятлесосплав.ndmsv гаврилов-ямрайгаз.ndmsv 
+гавриловкаагропромснаб.ndmsv гаврилово-посадрайгаз.ndmsv гагаринагропромснаб.ndmsv газавтосбыт.ndmsv газавтосервис.ndmsv газкомплектимпэкс.ndmsv 
+газмашаппарат.ndmsv газнадзор.ndmsv газпром.ndmsv газсантехмонтаж.ndmsv газтранссервис.ndmsv газэкспорт.ndmsv 
+газэнергосервис.ndmsv гвардейскмежрайгаз.ndmsv гвардейскремтехпред.ndmsv гексаметилендиаминсебацинат.ndmsv геленджикавтоснаб.ndmsv геленджикгоргаз.ndmsv 
+геосервис.ndmsv геосинтез.ndmsv геоцентр.ndmsv гермес-союз.ndmsv гивцнефтегаз.ndmsv гидродормост.ndmsv 
+гидрометприбор.ndmsv гидрометцентр.ndmsv гидромонтаж.ndmsv гидроприбор.ndmsv гидропроект.ndmsv гидроспецпроект.ndmsv 
+гидроцветмет.ndmsv гидроэлектромонтаж.ndmsv гидроэнергоснаб.ndmsv гипроавтотранс.ndmsv гипробиосинтез.ndmsv гипрогазцентр.ndmsv 
+гипрокоммунводоканал.ndmsv гипрокоммундортранс.ndmsv гипроленпром.ndmsv гипролестранс.ndmsv гипролесхим.ndmsv гипромашпром.ndmsv 
+гипронииавиапром.ndmsv гипрониигаз.ndmsv гипрониимедпром.ndmsv гипрониинефтетранс.ndmsv гипрониисельхоз.ndmsv гипропищепром.ndmsv 
+гипрополимер.ndmsv гипроречтранс.ndmsv гипрорыбфлот.ndmsv гипросахар.ndmsv гипросельпром.ndmsv гипроспецгаз.ndmsv 
+гипростроймост.ndmsv гипротранс.ndmsv гипротрансмост.ndmsv гипротюменнефтегаз.ndmsv гипротюменьнефтегаз.ndmsv гипрохолод.ndmsv 
+гипроцветмет.ndmsv гипроцемент.ndmsv гипроэнергоремонт.ndmsv главгостехнадзор.ndmsv главгосэнергонадзор.ndmsv главдорресторан.ndmsv 
+главинтурист.ndmsv главкомат.ndmsv главкосмос.ndmsv главлесхоз.ndmsv главнефтепродукт.ndmsv главплан.ndmsv 
+главпочтамт.ndmsv главснаб.ndmsv главтабак.ndmsv глазовмежрайгаз.ndmsv глинарайгаз.ndmsv глинкаагропромснаб.ndmsv 
+глушицамежрайгаз.ndmsv глушковоагропромснаб.ndmsv гнииэлектроагрегат.ndmsv говорковолес.ndmsv гознак.ndmsv гольшмановомежрайгаз.ndmsv 
+горбачев-фонд.ndmsv горжилобмен.ndmsv горкомсервис.ndmsv гормолзавод.ndmsv гормолкомбинат.ndmsv гормост.ndmsv 
+горно-алтайгаз.ndmsv горнозаводскцемент.ndmsv гороховецремтехпред.ndmsv горпищекомбинат.ndmsv горпищеторг.ndmsv горплодоовощторг.ndmsv 
+горпроект.ndmsv горпромкомбинат.ndmsv горпромторг.ndmsv горрайлинорган.ndmsv гортехнадзор.ndmsv гортопсбыт.ndmsv 
+горторг.ndmsv горшечноеагропромснаб.ndmsv горькнефтеоргсинтез.ndmsv горэлектротранс.ndmsv госагропром.ndmsv госархив.ndmsv 
+госархстройнадзор.ndmsv госатомнадзор.ndmsv госгазнадзор.ndmsv госгидромет.ndmsv госгортехнадзор.ndmsv госземзапас.ndmsv 
+госкомвуз.ndmsv госкомзем.ndmsv госкомиздат.ndmsv госкоминтурист.ndmsv госкомконтракт.ndmsv госкомлегпром.ndmsv 
+госкомоборонпром.ndmsv госкомпром.ndmsv госкомрезерв.ndmsv госкомсанэпидемнадзор.ndmsv госкомсанэпиднадзор.ndmsv госкомсанэпидназдор.ndmsv 
+госкомсевер.ndmsv госкомстат.ndmsv госкомстатат.ndmsv госкомтруд.ndmsv госкомэпиднадзор.ndmsv госконтракт.ndmsv 
+госконцерт.ndmsv гослесфонд.ndmsv госметр.ndmsv госмкомвуз.ndmsv госниибиоприбор.ndmsv госниикарбамидпроект.ndmsv 
+госниимедполимер.ndmsv госниинефтехим.ndmsv госнииэлектроагрегат.ndmsv госплемзавод.ndmsv госплемконезавод.ndmsv госплемптицезавод.ndmsv 
+госплемсовхоз.ndmsv госпроматомнадзор.ndmsv госрезерв.ndmsv госсанэпидемнадзор.ndmsv госсанэпиднадзор.ndmsv госсовет.ndmsv 
+госстрахнадзор.ndmsv гостехнадзор.ndmsv госфильмофонд.ndmsv госэкономплан.ndmsv грибановкаагропромтранс.ndmsv гринкомплекс.ndmsv 
+грозгипронефтехим.ndmsv грозгоргаз.ndmsv грознефтегаз.ndmsv грознефтеоргсинтез.ndmsv грязовецлес.ndmsv гудермесмежрайгаз.ndmsv 
+гуковогоргаз.ndmsv гулькевичирайгаз.ndmsv гурьевскремтехпред.ndmsv гусевмежрайгаз.ndmsv гусевремтехпред.ndmsv даггаз.ndmsv 
+дагестанавтодор.ndmsv дагестанавтотранс.ndmsv дагестангазпром.ndmsv дагестантурист.ndmsv дагестанхлебопродукт.ndmsv дагнефтепродукт.ndmsv 
+дагогнигаз.ndmsv дагпотребсоюз.ndmsv дагрыбхолодфлот.ndmsv дагсвязьинформ.ndmsv дальводстрой-холдинг.ndmsv дальвостоксиблес.ndmsv 
+дальгипротранс.ndmsv дальзавод.ndmsv дальинторг.ndmsv дальинфонд.ndmsv далькиноцентр.ndmsv дальлес.ndmsv 
+дальлеспром.ndmsv дальлестехцентр.ndmsv дальлесторг.ndmsv дальморепродукт.ndmsv дальнереченскагропромтранс.ndmsv дальнереченскмежрайгаз.ndmsv 
+дальорглестехмонтаж.ndmsv дальполиметалл.ndmsv дальпресс.ndmsv дальприбор.ndmsv дальрыбвтуз.ndmsv дальсельэнергопроект.ndmsv 
+дальэлектромонтаж.ndmsv дальэлектрон.ndmsv дальэнергомонтаж.ndmsv дальэнергосетьпроект.ndmsv даниловмежрайгаз.ndmsv данковбытсервис.ndmsv 
+двиносплав.ndmsv демидовагропромснаб.ndmsv дербентгаз.ndmsv дергачиагропроммехмонтаж.ndmsv дзержинскмежрайгаз.ndmsv дзержинскхолод.ndmsv 
+дизельпром.ndmsv динскаярайгаз.ndmsv дмитриевагропромснаб.ndmsv дмитровагропромснаб.ndmsv дмитровлес.ndmsv домодедовоагросервис.ndmsv 
+донагрохимсервис.ndmsv донгазпром.ndmsv донецкгоргаз.ndmsv донецкмежрайгаз.ndmsv донречфлот.ndmsv донтелефильм.ndmsv 
+донэлектромонтаж.ndmsv дорасфальт.ndmsv доринвест.ndmsv дорпрофсоюз.ndmsv досааф.ndmsv дубнаагросервис.ndmsv 
+дубовкамежрайгаз.ndmsv дубовскагропромтранс.ndmsv дубовскмежрайгаз.ndmsv дудинкабыт.ndmsv духовницкагропромтранс.ndmsv дятьковорайгаз.ndmsv 
+европол.ndmsv евростандарт.ndmsv егорлыкмежрайгаз.ndmsv егорьевскагропромснаб.ndmsv егорьевскагропромтранс.ndmsv ейскагросервис.ndmsv 
+ейскгоргаз.ndmsv екатеринбургархпроект.ndmsv екатеринбургнефтепродукт.ndmsv екатеринбургпроект.ndmsv екатериновкаагропромснаб.ndmsv екатериновкаагропромтранс.ndmsv 
+елаз.ndmsv елаз-инвест.ndmsv ельняагропромснаб.ndmsv енисейлес.ndmsv енисейлесоэкспорт.ndmsv ермакагроавтотранс.ndmsv 
+ершичиагропромснаб.ndmsv ершовагропроммехмонтажкомплект.ndmsv ершовагропромтранс.ndmsv ершовмежрайгаз.ndmsv ефремовмежрайгаз.ndmsv желдорпроект.ndmsv 
+желдорэкспорт.ndmsv железноводсккурорт.ndmsv железногорскмежрайгаз.ndmsv жердевкаагропромснаб.ndmsv жердевкаремтехпред.ndmsv жилкоммункомплект.ndmsv 
+жиркиагропромснаб.ndmsv жирновскмежрайгаз.ndmsv жуковкамежрайгаз.ndmsv жуковорайгаз.ndmsv забайкалводпроект.ndmsv забайкаллес.ndmsv 
+забайкалредмет.ndmsv забайкалэлектромонтаж.ndmsv заводоуковскрайгаз.ndmsv завьяловскремтехпред.ndmsv заграноргстроймонтаж.ndmsv запкаспрыбвод.ndmsv 
+запсибгазпром.ndmsv запсибдорстройсервис.ndmsv запсибкомбанк.ndmsv запсибнефтехиммонтаж.ndmsv запсибремонт.ndmsv запсибсельэнергопроект.ndmsv 
+запсибэнергоспецмонтаж.ndmsv запчастьоптторг.ndmsv запэнерголегпром.ndmsv зарайскремтехпред.ndmsv зарайскхлебопродукт.ndmsv заринскмежрайгаз.ndmsv 
+зарубежцветмет.ndmsv зарубежэнергопроект.ndmsv зауралэнергопроект.ndmsv здравмед.ndmsv здравмедпром.ndmsv зеленецоптторг.ndmsv 
+зеленоградводоканал.ndmsv зеленоградскремтехпред.ndmsv зерноградмежрайгаз.ndmsv зил.ndmsv зимовникимежрайгаз.ndmsv зимторг.ndmsv 
+златоустмежрайгаз.ndmsv знаменкаагропромснаб.ndmsv золотухиноагропромснаб.ndmsv зооветснаб.ndmsv зорнинскагропромснаб.ndmsv ивановоавтотранс.ndmsv 
+ивановогоргаз.ndmsv ивановоконцерт.ndmsv ивановомежрайгаз.ndmsv ивановооблгаз.ndmsv ивановорыбпромсбыт.ndmsv ивановостройкомплекс.ndmsv 
+ивановоторф.ndmsv ивантеевкаагропромснаб.ndmsv ивантеевкаагропромтранс.ndmsv игримэнергогаз.ndmsv ижводоканал.ndmsv ижевскмежрайгаз.ndmsv 
+ижметаллургмонтаж.ndmsv ижобщепит.ndmsv избербашгаз.ndmsv иловляремтехпред.ndmsv импэкс-банк.ndmsv инвалтех.ndmsv 
+инвентарьторг.ndmsv инвест.ndmsv инвесткредит.ndmsv инвестнафт.ndmsv инвестэнергоцентр.ndmsv ингосстрах.ndmsv 
+индустройпроект.ndmsv инжсервис.ndmsv инкомбанк.ndmsv инкомторг.ndmsv инносоюз.ndmsv иннофонд.ndmsv 
+инрыбпром.ndmsv интас.ndmsv интаугольсбыт.ndmsv интерагрофонд.ndmsv интероптторг.ndmsv интерпол.ndmsv 
+интерпром.ndmsv интерросимпэкс.ndmsv интерсервис.ndmsv интертрест.ndmsv интерхимпром.ndmsv интерцентр.ndmsv 
+интерэвм.ndmsv интурбанк.ndmsv интурмедсервис.ndmsv интурсервис.ndmsv интуртранс.ndmsv интурцентр.ndmsv 
+информ.ndmsv информ-автотранс.ndmsv информгаз.ndmsv информсервис.ndmsv информторгтовар.ndmsv информцентр.ndmsv 
+инфосервис.ndmsv инфотранс.ndmsv инфоцентр.ndmsv иркутсклестоппром.ndmsv иркутскмашхимоптторг.ndmsv иркутскметаллоптторг.ndmsv 
+иркутскнефтепродукт.ndmsv иркутскоблгаз.ndmsv иркутскптицепром.ndmsv иркутскстройоптторг.ndmsv исилькульмежрайгаз.ndmsv истраагропромтранс.ndmsv 
+истраремтехпред.ndmsv истрахлебопродукт.ndmsv ишимагропромснаб.ndmsv ишиммежрайгаз.ndmsv каббалкальпинист.ndmsv каббалквтормет.ndmsv 
+каббалкгаз.ndmsv каббалкмолпром.ndmsv каббалкнефтепродукт.ndmsv каббалктоппром.ndmsv каббалктурист.ndmsv кавалеровомежрайгаз.ndmsv 
+кавказскагропромснаб.ndmsv кавказтрансгаз.ndmsv кавказцемент.ndmsv кадоммежрайгаз.ndmsv калачинскмежрайгаз.ndmsv калачмежрайгаз.ndmsv 
+калиниградснабэкспорт.ndmsv калининградавтотранс.ndmsv калининградагропром.ndmsv калининградагропромкомплект.ndmsv калининградагропромлегтранс.ndmsv калининградагропромснаб.ndmsv 
+калининградагропромтранс.ndmsv калининградгоргаз.ndmsv калининградгражданпроект.ndmsv калининградлегпром.ndmsv калининградморнефтегаз.ndmsv калининграднефтепродукт.ndmsv 
+калининградпромпроект.ndmsv калининградремтехпред.ndmsv калининградрыбпром.ndmsv калининградторгморнефтегаз.ndmsv калининградтранс.ndmsv калининскаярайгаз.ndmsv 
+калитвамежрайгаз.ndmsv калмыкнефтепродукт.ndmsv калугаоблгаз.ndmsv калугметаллторг.ndmsv камазавтоцентр.ndmsv камазжилбыт.ndmsv 
+камазимпорт.ndmsv камазинструмент.ndmsv камазмонтаж.ndmsv камазпроект.ndmsv каменкамежрайгаз.ndmsv каменскмежрайгаз.ndmsv 
+каменьмежрайгаз.ndmsv камчаткоммунпроект.ndmsv камчатлес.ndmsv камчатнефтепродукт.ndmsv камышинмежрайгаз.ndmsv камэнергоремонт.ndmsv 
+камэнергостройпром.ndmsv канашмежрайгаз.ndmsv кандалакшарайгаз.ndmsv кандалакшаремтехагропромснаб.ndmsv каневскаярайгаз.ndmsv капьяргаз.ndmsv 
+карабулакагропромтранс.ndmsv карабулакмежрайгаз.ndmsv каргопольрайгаз.ndmsv карелкоммунжилпроект.ndmsv карелнефтепродукт.ndmsv карталымежрайгаз.ndmsv 
+касимовгоргаз.ndmsv каспийскгаз.ndmsv каспрыбпроект.ndmsv катавмежрайгаз.ndmsv кемеровогоргаз.ndmsv кемеровомежрайгаз.ndmsv 
+кемеровооблгаз.ndmsv кзот.ndmsv кизилюртгаз.ndmsv кизляргаз.ndmsv кинельгоргаз.ndmsv кинешмарайгаз.ndmsv 
+киновидеотеатр.ndmsv кинотехпром.ndmsv кинофотоинститут.ndmsv киржачремтехпред.ndmsv киришинефтеоргсинтез.ndmsv кировагровод.ndmsv 
+кировгипроводхоз.ndmsv кировнефтепродукт.ndmsv кировоблгаз.ndmsv кировоградмежрайгаз.ndmsv кисловодсккурорт.ndmsv клепикирайгаз.ndmsv 
+клинагропромтранс.ndmsv клинцымежрайгаз.ndmsv ключгоргаз.ndmsv клявлинорайгаз.ndmsv книгоэкспорт.ndmsv ковровремтехпред.ndmsv 
+ковровхлебопродукт.ndmsv когалымгоргаз.ndmsv когалымнефтегаз.ndmsv когалымнефтепрогресс.ndmsv когалымторгнефтегаз.ndmsv кожзавод.ndmsv 
+коларайгаз.ndmsv коломнаагропромтранс.ndmsv коломнаремтехпред.ndmsv кольчугиноремтехпред.ndmsv комигаз.ndmsv комигипрониилеспром.ndmsv 
+коминефтедорстройремонт.ndmsv коминтерн.ndmsv комипермяцкагропромавтотранс.ndmsv комипермяцкагропромтехснаб.ndmsv коммунавтоматсервис.ndmsv коммунбытоптторг.ndmsv 
+коммунмонтаж.ndmsv коммунотдел.ndmsv комсомольскмежрайгаз.ndmsv комсомольскрайгаз.ndmsv конверсбанк.ndmsv кондровобумпром.ndmsv 
+коношарайгаз.ndmsv константиновскмежрайгаз.ndmsv консультантплюс.ndmsv конышевкаагропромснаб.ndmsv копейскмежрайгаз.ndmsv кораблинорайгаз.ndmsv 
+кореновскрайгаз.ndmsv коркиномежрайгаз.ndmsv костромаавтотранс.ndmsv костромаагропромпроект.ndmsv костромагоргаз.ndmsv костромакоммунсервис.ndmsv 
+костроманефтепродукт.ndmsv костромаоблбгаз.ndmsv костромаоблгаз.ndmsv котельниковомежрайгаз.ndmsv котласагропромснаб.ndmsv котласлес.ndmsv 
+котласмежрайгаз.ndmsv котовомежрайгаз.ndmsv котовскхлеб.ndmsv кошкинскагропромтранс.ndmsv кошкирайгаз.ndmsv крайагроснаб.ndmsv 
+крайбыткомплект.ndmsv крайгосплемсоюз.ndmsv крайкоммунводкомплекс.ndmsv крайкоопсоюз.ndmsv крайпотребсоюз.ndmsv крайремстройбыт.ndmsv 
+крайтрикотажбыт.ndmsv красмашзавод.ndmsv красноармейскагропромснаб.ndmsv красноармейскмежрайгаз.ndmsv красноармейскрайгаз.ndmsv красноборскремтехпредснаб.ndmsv 
+красногорскагропромтранс.ndmsv краснодарбланкиздат.ndmsv краснодаргипродревпром.ndmsv краснодарглавснаб.ndmsv краснодаргоргаз.ndmsv краснодаргражданпроект.ndmsv 
+краснодаркрайгаз.ndmsv краснодарнефтегаз.ndmsv краснодарнефтеоргсинтез.ndmsv краснодарорггаз.ndmsv краснодарсельэнергопроект.ndmsv краснокутагропроммехмонтаж.ndmsv 
+краснокутагропромснаб.ndmsv краснокутагропромтранс.ndmsv красноленинскнефтегаз.ndmsv краснотурьинскмежрайгаз.ndmsv красноуральскмежрайгаз.ndmsv красноярскавтодор.ndmsv 
+красноярскавтосалон.ndmsv красноярскагролеспром.ndmsv красноярскагропроммехмонтаж.ndmsv красноярскагропромтехпроект.ndmsv красноярскгидропроект.ndmsv красноярскмежхозлес.ndmsv 
+красноярскметаллоопторг.ndmsv красноярскметаллооптторг.ndmsv красноярскметаллоптторг.ndmsv красноярскнефтепродукт.ndmsv красноярскобщемашопторг.ndmsv красноярскполимеркерамик.ndmsv 
+красноярскстройматериал.ndmsv красноярскхлебопродукт.ndmsv красноярскхлебпром.ndmsv красноярскэнергопром.ndmsv красноярскэнергосетьпроект.ndmsv кредитпромбанк.ndmsv 
+кредобанк.ndmsv кропоткингоргаз.ndmsv крыловскаярайгаз.ndmsv крымскрайгаз.ndmsv кубаньвинпром.ndmsv кубаньводтраст.ndmsv 
+кубаньгазпром.ndmsv кубаньконсервпром.ndmsv кубаньлестоппром.ndmsv кубаньспецэнергоремонт.ndmsv кубаньхлебопродукт.ndmsv кузбассавтотранс.ndmsv 
+кузбассзернопродукт.ndmsv кузбасскомплект.ndmsv кузбассмясопром.ndmsv кузбассполиграфиздат.ndmsv кузбассхлеб.ndmsv кузбассхолод.ndmsv 
+кузбассшахтостроймонтаж.ndmsv кузнецкмежрайгаз.ndmsv куйбышевагропромтранс.ndmsv куйбышевазот.ndmsv куйбышевнефтемашремонт.ndmsv куйбышевнефтеоргсинтез.ndmsv 
+куйбышнефтеоргсинтез.ndmsv кулебакимежрайгаз.ndmsv культторг.ndmsv куминсклес.ndmsv кумскремтехпред.ndmsv курганагропромтехпроект.ndmsv 
+кургангоргаз.ndmsv курганинскрайгаз.ndmsv курганмашзавод.ndmsv курганнефтепродукт.ndmsv курганоблгаз.ndmsv курганприбор.ndmsv 
+курганхлеб.ndmsv курскавторемонт.ndmsv курскагропромкомплектснаб.ndmsv курскгоргаз.ndmsv курсккиновидеопрокат.ndmsv курскоблгаз.ndmsv 
+курсксахарагропром.ndmsv курсктурбоатомэнергоремонт.ndmsv курскхлеб.ndmsv курскхлебопродукт.ndmsv курскхлебпром.ndmsv кушвамежрайгаз.ndmsv 
+кущевскаярайгаз.ndmsv кшеньмежрайгаз.ndmsv кыштыммежрайгаз.ndmsv лабинскагропромснаб.ndmsv лабинскрайгаз.ndmsv лангепаснефтегаз.ndmsv 
+легкомплектснаб.ndmsv легпром.ndmsv легпромэкспорт.ndmsv ленаагролеспром.ndmsv ленагропромсервис.ndmsv ленвзрывпром.ndmsv 
+ленгидропроект.ndmsv ленгипронефтехим.ndmsv ленгипротранс.ndmsv ленгорисполком.ndmsv ленгражданпроект.ndmsv лензнииэп.ndmsv 
+лениздат.ndmsv ленинградскаярайгаз.ndmsv ленинскагроснаб.ndmsv ленинтерфонд.ndmsv ленком.ndmsv ленконцерт.ndmsv 
+ленлес.ndmsv ленлесбумстройоптторг.ndmsv ленлестоппром.ndmsv ленмашоптторг.ndmsv ленметаллоптторг.ndmsv леннаучфильм.ndmsv 
+леннефтехим.ndmsv леноблгаз.ndmsv леноблпассажиравтотранс.ndmsv ленотделкомплект.ndmsv ленпромлес.ndmsv ленремтехприбор.ndmsv 
+ленрыбпром.ndmsv ленсвет.ndmsv ленстройкомитет.ndmsv ленстройкор.ndmsv ленторф.ndmsv лентрансгаз.ndmsv 
+ленфильм.ndmsv ленхимоптторг.ndmsv ленэнергоремонт.ndmsv лесбумоптторг.ndmsv лесдревмонтаж.ndmsv лесинформ.ndmsv 
+лескомснабсбыт.ndmsv лескомцентр.ndmsv лесогорсклес.ndmsv лесозаводскагропромтранс.ndmsv лесоптторг.ndmsv леспефлан.ndmsv 
+леспроект.ndmsv леспромсервис.ndmsv леспромцентр.ndmsv лесснаб.ndmsv лестоппром.ndmsv лесторг.ndmsv 
+лешуконскремтехпредхимснаб.ndmsv липецкагромехживцентр.ndmsv липецкдорпроект.ndmsv липецкмонтаж.ndmsv липецкнефтепродукт.ndmsv липецкоблгаз.ndmsv 
+липецкрыбхоз.ndmsv липецксахар.ndmsv липецктоппром.ndmsv липецкхлебмакаронпром.ndmsv липецкцемент.ndmsv лифтремонт.ndmsv 
+логоваз.ndmsv локтевскремтехпред.ndmsv ломовмежрайгаз.ndmsv лукимежрайгаз.ndmsv лукойл.ndmsv луховицыагропромснаб.ndmsv 
+лысогорскагропромснаб.ndmsv льговагропромснаб.ndmsv льговмежрайгаз.ndmsv магаданавтотранс.ndmsv магаданпромстройниипроект.ndmsv магаданрыбпром.ndmsv 
+магадансвязьинформ.ndmsv магаданспецэнергомонтаж.ndmsv магаданстройтранс.ndmsv магаданхимлесстройторг.ndmsv магнитогорскмежрайгаз.ndmsv майскийрайгаз.ndmsv 
+макдональдс.ndmsv малгобекмежрайгаз.ndmsv мансийскмежрайгаз.ndmsv мансийскнефтегаз.ndmsv мантуровоагропромснаб.ndmsv мариинскмежрайгаз.ndmsv 
+марийнефтепродукт.ndmsv марийскавтотранс.ndmsv марксрайгаз.ndmsv маррайгаз.ndmsv марспецмонтаж.ndmsv масложиркомбинат.ndmsv 
+масложирпром.ndmsv маслосыркомбинат.ndmsv маслосырокомбинат.ndmsv матвеевкурганхлебопродукт.ndmsv махачкалагаз.ndmsv машзавод.ndmsv 
+машоптторг.ndmsv машприборинторг.ndmsv машхимторг.ndmsv мбм-банк.ndmsv мегионгазсервис.ndmsv мегионнефтегаз.ndmsv 
+медвенкаагропромснаб.ndmsv мединвестор.ndmsv медпром.ndmsv медснабсбытторг.ndmsv медсоцэкономинформ.ndmsv медтехснаб.ndmsv 
+медфизприбор.ndmsv межлесхоз.ndmsv межрайагропромснаб.ndmsv межэкономсбербанк.ndmsv мезеньремтехпредхимснаб.ndmsv менатеп.ndmsv 
+металлооптторг.ndmsv металлоптторг.ndmsv металлосервис.ndmsv металлторг.ndmsv металлургмеханомонтаж.ndmsv металлургпрокатмонтаж.ndmsv 
+металлургпром.ndmsv метрогипротранс.ndmsv миассмежрайгаз.ndmsv микомс.ndmsv миллеровомежрайгаз.ndmsv минавиапром.ndmsv 
+минавтопром.ndmsv минатом.ndmsv минатомэнергопром.ndmsv минвнешторг.ndmsv мингаз.ndmsv минздрав.ndmsv 
+минздравмед.ndmsv минздравмедпром.ndmsv минздравпроект.ndmsv минзравмедпром.ndmsv минлесбумпром.ndmsv минлесхоз.ndmsv 
+минмедпром.ndmsv миноборонпром.ndmsv минпром.ndmsv минрыбхоз.ndmsv минсельхоз.ndmsv минсельхозпрод.ndmsv 
+минстанкопром.ndmsv минсудпром.ndmsv минторг.ndmsv минтранс.ndmsv минтраст.ndmsv минтруд.ndmsv 
+минуглепром.ndmsv минусинскагроавтотранс.ndmsv минусинскагропромснаб.ndmsv минусинскмежрайгаз.ndmsv минфин.ndmsv минхимнефтепром.ndmsv 
+минхлебопродукт.ndmsv минцветмет.ndmsv минэлектронпром.ndmsv минэлектротехприбор.ndmsv минюст.ndmsv мирныймежрайгаз.ndmsv 
+михайловкамежрайгаз.ndmsv михайловмежрайгаз.ndmsv михайловцемент.ndmsv мичуринскагропромснаб.ndmsv можайскагропромснаб.ndmsv можгамежрайгаз.ndmsv 
+моздокрайгаз.ndmsv молагропром.ndmsv молококомбинат.ndmsv монастырщинаагропромснаб.ndmsv монголбанк.ndmsv монтажпроект.ndmsv 
+монтажспецбанк.ndmsv монтажстройсервис.ndmsv моргаушскрайгаз.ndmsv мордовгаз.ndmsv мордовнефтепродукт.ndmsv мордовобувьбыт.ndmsv 
+мордовспирт.ndmsv морнефтегаз.ndmsv морозовскмежрайгаз.ndmsv морозовскхлебопродукт.ndmsv моррыбтехникум.ndmsv морсвязьспутник.ndmsv 
+морфизприбор.ndmsv моршанскагропромснаб.ndmsv мосавтосантранс.ndmsv мосавтотранс.ndmsv мосагрокомплект.ndmsv мосагропромснаб.ndmsv 
+мосасботермокомбинат.ndmsv мосбизнесбанк.ndmsv мосводоканал.ndmsv мосводопровод.ndmsv мосгаз.ndmsv мосгипротранс.ndmsv 
+мосгорархив.ndmsv мосгорисполком.ndmsv мосгорремстройтрест.ndmsv мосгорсвет.ndmsv мосгортранс.ndmsv мосгортрансниипроект.ndmsv 
+мосгорхлебопродукт.ndmsv мосгорэлектроприбороптторг.ndmsv мосжилкомитет.ndmsv мосинжбетон.ndmsv мосинжпроект.ndmsv мосинжпромстройкомплект.ndmsv 
+мосинжстройкомплект.ndmsv москабельмет.ndmsv москабельсетьмонтаж.ndmsv москапстройкомплект.ndmsv москирпич.ndmsv москоммунбытпром.ndmsv 
+москонцерт.ndmsv мослес.ndmsv мослесопарк.ndmsv мослифт.ndmsv мослифтмонтаж.ndmsv мосметротранскомплект.ndmsv 
+моснефтепродукт.ndmsv мособлавтотранс.ndmsv мособлгаз.ndmsv мособлгеотрест.ndmsv мособлгидропроект.ndmsv мособлжилкомхоз.ndmsv 
+мособлкооппром.ndmsv мособлмедтранс.ndmsv мособлобщепит.ndmsv мособлсовет.ndmsv мособлстройкомитет.ndmsv мособлстройтранс.ndmsv 
+мособлсуд.ndmsv мосотделпром.ndmsv моспроект.ndmsv моспромгаз.ndmsv моспромжелезобетон.ndmsv моспроммонтаж.ndmsv 
+моспромпроект.ndmsv моспромстройкомплект.ndmsv моспромтехмонтаж.ndmsv моспромтранспроект.ndmsv мосрентген.ndmsv мосрыбхоз.ndmsv 
+моссантехпром.ndmsv моссанэлектропром.ndmsv моссовет.ndmsv мосспецатомэнергомонтаж.ndmsv мосспецжелезобетон.ndmsv мосспецмонтаж.ndmsv 
+мосспецпромпроект.ndmsv мосстройкомитет.ndmsv мосстройпрогресс.ndmsv мосстройснаб.ndmsv мосстройтранс.ndmsv мост-банк.ndmsv 
+мостелефон.ndmsv мостовскаярайгаз.ndmsv мостотрест.ndmsv мострансгаз.ndmsv мосфильм.ndmsv мосхладокомбинат.ndmsv 
+мосхолод.ndmsv мосэлектромонтаж.ndmsv мосэлектроприбор.ndmsv мосэнергомонтаж.ndmsv мосэнергоремонт.ndmsv мурмангоробщепит.ndmsv 
+мурманрыбпром.ndmsv мурмансервис.ndmsv мурманскавтосервис.ndmsv мурманскавтотранс.ndmsv мурманскагропромавтотранс.ndmsv мурманскагропромснабсервис.ndmsv 
+мурманскгоргаз.ndmsv мурманскгражданпроект.ndmsv мурманскжилкоммунпроект.ndmsv мурманскнефтепродукт.ndmsv мурманскпромпроект.ndmsv мурманскстройтранс.ndmsv 
+мурмансктурист.ndmsv мурмантоппром.ndmsv муромагропромснаб.ndmsv муромтепловоз.ndmsv мучкапагропромснаб.ndmsv мучкапремтехпред.ndmsv 
+мхат.ndmsv мышкинмежрайгаз.ndmsv мясомолторг.ndmsv мясотехносервис.ndmsv надвоицыагроснаб.ndmsv надеждинскагроснаб.ndmsv 
+надеждинскремтехпред.ndmsv надымгазпром.ndmsv надымгазснабкомплект.ndmsv надымгазэнергоремонт.ndmsv надыммежрайгаз.ndmsv надымэнергогаз.ndmsv 
+назаровоагроавтотранс.ndmsv назаровоагропромснаб.ndmsv назаровомежрайгаз.ndmsv назаровомехмонтаж.ndmsv назраньрайгаз.ndmsv нальчикгаз.ndmsv 
+наркомздрав.ndmsv наркомзем.ndmsv наркомлегпром.ndmsv наркомпрос.ndmsv нарымлес.ndmsv научдревпром.ndmsv 
+научлесдревпром.ndmsv научлеспром.ndmsv находкагоргаз.ndmsv находкалес.ndmsv находканефтепродукт.ndmsv невельмежрайгаз.ndmsv 
+невинномысскремтехпред.ndmsv невьянскмежрайгаз.ndmsv неманремтехпред.ndmsv нерехтамежрайгаз.ndmsv нерюнгригоргаз.ndmsv несветайрайгаз.ndmsv 
+нестеровремтехпред.ndmsv нефтегаз.ndmsv нефтегазмонтаж.ndmsv нефтегазснаб.ndmsv нефтегазстройкомплект.ndmsv нефтегеофизприбор.ndmsv 
+нефтегорскмежрайгаз.ndmsv нефтемаркет.ndmsv нефтемаслозавод.ndmsv нефтемашремонт.ndmsv нефтепродуктснабкомплект.ndmsv нефтепроект.ndmsv 
+нефтепром.ndmsv нефтепромсервис.ndmsv нефтесервис.ndmsv нефтестройремонт.ndmsv нефтехиммонтаж.ndmsv нефтеэкспортер.ndmsv 
+нефтеюганскгаз.ndmsv нечерноземагропроект.ndmsv нечерноземагроспецпром.ndmsv нечерноземпроекттехцентр.ndmsv нечерноземсельхозпроект.ndmsv нижегородавтодор.ndmsv 
+нижегородавтотранс.ndmsv нижегородгоргаз.ndmsv нижегородгражданпроект.ndmsv нижегородлестоппром.ndmsv нижегородмежхозлес.ndmsv нижегороднефтеоргсинтез.ndmsv 
+нижегороднефтепродукт.ndmsv нижегородоблгаз.ndmsv нижегородоптхозторг.ndmsv нижегородпассажиравтотранс.ndmsv нижегородсахар.ndmsv нижегородскийэнергосетьпроект.ndmsv 
+нижегородскнефтепродукт.ndmsv нижегородскоблгаз.ndmsv нижегородсксельэнергопроект.ndmsv нижневартовскжилкомхоз.ndmsv нижневартовскмежрайгаз.ndmsv нижневартовскнефтегаз.ndmsv 
+нижневартовскнефтепрогресс.ndmsv нижневартовскстройтранс.ndmsv нижнегородниинефтепроект.ndmsv нижнедевицкагропромтранс.ndmsv нижнекамскнефтехим.ndmsv нижполиграф.ndmsv 
+нииавтопром.ndmsv ниинаучприбор.ndmsv ниитрактор.ndmsv ниичаспром.ndmsv нииэлектроаппарат.ndmsv нииэлектропривод.ndmsv 
+никифоровкаагропромснаб.ndmsv никифоровкаремтехпред.ndmsv николаевскагропромснаб.ndmsv николаевскмежрайгаз.ndmsv никольскмежрайгаз.ndmsv новгородавтодор.ndmsv 
+новгородавтотранс.ndmsv новгородагропромснаб.ndmsv новгородагросервис.ndmsv новгородагростройзаказчик.ndmsv новгороджилкоммунсервис.ndmsv новгородлесстройсервис.ndmsv 
+новгородлестопром.ndmsv новгородмежрайгаз.ndmsv новгородмолпром.ndmsv новгороднефтепродукт.ndmsv новгороднефтесервис.ndmsv новгородоблгаз.ndmsv 
+новгородпищепром.ndmsv новгородрыбхоз.ndmsv новгородсельхозмонтаж.ndmsv новгородснаб.ndmsv новгородхлеб.ndmsv новгородхлебопродукт.ndmsv 
+новгородхлебпром.ndmsv новжилкоммунпроект.ndmsv новжилкоммунсервис.ndmsv ново-вязникиремтехпред.ndmsv новоалтайскмежрайгаз.ndmsv новоаннинскмежрайгаз.ndmsv 
+новоблместпром.ndmsv новобурасскагропроммехмонтаж.ndmsv новобурасскагропромтранс.ndmsv нововоронежхлеб.ndmsv новодугиноагропромснаб.ndmsv новозыбковмежрайгаз.ndmsv 
+новокубанскрайгаз.ndmsv новокузнецкгоргаз.ndmsv новокузнецкметаллооптторг.ndmsv новокуйбышевскгоргаз.ndmsv новопокровскаярайгаз.ndmsv новорослесэкспорт.ndmsv 
+новороссийскгоргаз.ndmsv новороссийскрыбпром.ndmsv новоросхлебкондитер.ndmsv новоросцемент.ndmsv новосибгражданпроект.ndmsv новосибирскжилкомхоз.ndmsv 
+новосибирсккиновидеосервис.ndmsv новосибирскнефтепродукт.ndmsv новосибирскпищепром.ndmsv новосибирскрыбхоз.ndmsv новосибирсктеплоэлектропроект.ndmsv новосиблестоппром.ndmsv 
+новосибмашоптторг.ndmsv новосибметалл.ndmsv новосибметаллооптторг.ndmsv новосибхимлегоптторг.ndmsv новосибхлеб.ndmsv новосибхозторг.ndmsv 
+новосибхолод.ndmsv новоспасскавтотранс.ndmsv новотроицкмежрайгаз.ndmsv новоузенскагропромснаб.ndmsv новоузенскагропромтранс.ndmsv новоузенскмежрайгаз.ndmsv 
+новоуренгоймежрайгаз.ndmsv новоусманьагропромтранс.ndmsv новохоперскагропромтранс.ndmsv новочебоксарскмежрайгаз.ndmsv новочеркасскгоргаз.ndmsv новошахтинскмежрайгаз.ndmsv 
+новошахтинсхлебопродукт.ndmsv ногинскагропромтранс.ndmsv норильскбыт.ndmsv норильскгазпром.ndmsv норильскпроект.ndmsv норильскреммонтаж.ndmsv 
+норильскснаб.ndmsv норильскторг.ndmsv норильсктрансремонт.ndmsv норильскэнергоремонт.ndmsv ноябрьскгазсервис.ndmsv ноябрьскнефтегаз.ndmsv 
+ноябрьскнефтедорстройремонт.ndmsv няганьнефтепрогресс.ndmsv няндомалес.ndmsv няндомамежрайгаз.ndmsv няндомаремтехпредснаб.ndmsv облбытсервис.ndmsv 
+облводоканал.ndmsv облжилкомхоз.ndmsv обливскрайгаз.ndmsv облкинопрокат.ndmsv облкоммунпроект.ndmsv облкоммунремстройпроект.ndmsv 
+облкоммунсервис.ndmsv облремстройсбыт.ndmsv облрыболовпотребсоюз.ndmsv облснаб.ndmsv облсовет.ndmsv облторг.ndmsv 
+обнинскархпроект.ndmsv обоззавод.ndmsv оборонкомплекс.ndmsv оборонконтракт.ndmsv оборонпром.ndmsv оборонпромкомплекс.ndmsv 
+оборонэкспорт.ndmsv обояньагропромснаб.ndmsv обояньмежрайгаз.ndmsv обояньхлеб.ndmsv обувьбыт.ndmsv общепит.ndmsv 
+общепитсоюз.ndmsv обьнефтегаз.ndmsv обьполимер.ndmsv обьэлектромонтаж.ndmsv овцекомплекс.ndmsv овцепром.ndmsv 
+огнеупорпром.ndmsv одоевагросервис.ndmsv озерскремтехпред.ndmsv озинкиагропромснаб.ndmsv океанрыбфлот.ndmsv окрпотребсоюз.ndmsv 
+октябрьагропромснаб.ndmsv октябрьрайгаз.ndmsv октябрьскагропромснаб.ndmsv октябрьскийрайгаз.ndmsv олонецагросервис.ndmsv ольгаагропромтранс.ndmsv 
+ольгалес.ndmsv омон.ndmsv омскавиапроект.ndmsv омскавтодор.ndmsv омскавтотранс.ndmsv омскагрегат.ndmsv 
+омскгаз.ndmsv омскгидропривод.ndmsv омскгоргаз.ndmsv омскгражданпроект.ndmsv омсккоммунпроект.ndmsv омсклеспром.ndmsv 
+омсклестоппром.ndmsv омскнефтеоргсинтез.ndmsv омскнефтепродукт.ndmsv омскнефтехимпроект.ndmsv омскоблгаз.ndmsv омскпромстройбанк.ndmsv 
+омсксервис.ndmsv омскстроймост.ndmsv омскхлебопродукт.ndmsv омутинкарайгаз.ndmsv омэлектромонтаж.ndmsv онегарайгаз.ndmsv 
+онегаремтехпредхимснаб.ndmsv опочкамежрайгаз.ndmsv оптопром.ndmsv оптторг.ndmsv оптторгимпэкс.ndmsv орбита-сервис.ndmsv 
+орглестехмонтаж.ndmsv оргмонтажпроект.ndmsv оргмонтехпроект.ndmsv оргнефтехимзавод.ndmsv оргпримтвердосплав.ndmsv оргсинтез.ndmsv 
+оргстройниипроект.ndmsv оргстройпроект.ndmsv оргэнергогаз.ndmsv орелавтодор.ndmsv орелавтотранс.ndmsv орелводоканал.ndmsv 
+орелглавснаб.ndmsv орелгоргаз.ndmsv орелнефтепродукт.ndmsv орелоблгаз.ndmsv орелоблстройзаказчик.ndmsv орелхолод.ndmsv 
+оренбургавтодор.ndmsv оренбургавтотранс.ndmsv оренбургазпром.ndmsv оренбургасбест.ndmsv оренбургбургаз.ndmsv оренбурггазпром.ndmsv 
+оренбурггоргражданин.ndmsv оренбургкомплектмонтаж.ndmsv оренбурглифт.ndmsv оренбургмежрайгаз.ndmsv оренбургмонтажгаззавод.ndmsv оренбургнефтепродукт.ndmsv 
+оренбургоблгаз.ndmsv оренбургпромстройпроект.ndmsv оренбургптицепром.ndmsv оренбургсантехмонтаж.ndmsv оренбургснаб.ndmsv оренбургстройтранс.ndmsv 
+оренбургтоппром.ndmsv ореховоторф.ndmsv орловскрайгаз.ndmsv орскмежрайгаз.ndmsv орскнефтеоргсинтез.ndmsv осетиннефтепродукт.ndmsv 
+островмежрайгаз.ndmsv острогожскагропромтранс.ndmsv откормсовхоз.ndmsv отраднаярайгаз.ndmsv отрадноемежрайгаз.ndmsv охотскрыбвод.ndmsv 
+павловскаярайгаз.ndmsv павлодарнефтекомбинат.ndmsv павлодартрактор.ndmsv палласовкамежрайгаз.ndmsv пангодыэнергогаз.ndmsv паниноагропромтранс.ndmsv 
+парклесхоз.ndmsv партизанскмежрайгаз.ndmsv пассажиравтотранс.ndmsv пельгорторф.ndmsv пензаавтотранс.ndmsv пензагоргаз.ndmsv 
+пензалеспром.ndmsv пензалестоппром.ndmsv пензамежрайгаз.ndmsv пензанефтепродукт.ndmsv пензаорггаз.ndmsv пензаплодоовощпром.ndmsv 
+пензаспиртпром.ndmsv пензастройтранс.ndmsv пензаэнергоремонт.ndmsv пенькозавод.ndmsv первомайскагропромснаб.ndmsv первомайскремтехпред.ndmsv 
+первоуральскмежрайгаз.ndmsv перелюбагропромтранс.ndmsv переславльрайгаз.ndmsv пермавтотранс.ndmsv пермагропромпроект.ndmsv пермгипромашпром.ndmsv 
+пермглавснаб.ndmsv перммашоптторг.ndmsv перммежхозлес.ndmsv пермметалл.ndmsv пермметаллоопторг.ndmsv пермметаллооптторг.ndmsv 
+пермметаллоптторг.ndmsv пермнефтемашремонт.ndmsv пермнефтеоргсинтез.ndmsv пермооптторг.ndmsv пермпромжелдортранс.ndmsv пермстройоптторг.ndmsv 
+пермтрансгаз.ndmsv пермтрансжелезобетон.ndmsv пермтурист.ndmsv пермхимоптторг.ndmsv пермьнефтепродукт.ndmsv пестовомежрайгаз.ndmsv 
+пестравкаагропромтранс.ndmsv пестравкарайгаз.ndmsv петербургнефтеснаб.ndmsv петергоф-агропродсервис.ndmsv петроагропромбанк.ndmsv петровкаагропромснаб.ndmsv 
+петровскагропромснаб.ndmsv петровскагропромтранс.ndmsv петровскмежрайгаз.ndmsv петрозаводскагропроммонтаж.ndmsv петрозаводскагросервис.ndmsv петрозаводскнефтепродукт.ndmsv 
+петрокомерцбанк.ndmsv петролеспорт.ndmsv петроснаб.ndmsv петрофлот.ndmsv петрохимоптторг.ndmsv петрохлеб.ndmsv 
+петрохолод.ndmsv петушкиинтерлес.ndmsv петушкиремтехпред.ndmsv печорыагропромсервис.ndmsv питеркаагропромснаб.ndmsv питеркаагропромтранс.ndmsv 
+питкярантаагросервис.ndmsv пичаевоагропромснаб.ndmsv пичаеворемтехпред.ndmsv плавмагазин.ndmsv пластполимер.ndmsv племконезавод.ndmsv 
+племовцезавод.ndmsv плесецкремтехпредснаб.ndmsv плитспичпром.ndmsv поволжсельэнергопроект.ndmsv повориноагропромтранс.ndmsv погрузтранс.ndmsv 
+подгоренскагропромтранс.ndmsv подольскагропромсервис.ndmsv подольскагропромснаб.ndmsv подольскагропромтранс.ndmsv полевскоймежрайгаз.ndmsv полесскремтехпред.ndmsv 
+полиграфкомбинат.ndmsv полиграфприбор.ndmsv полимерсинтез.ndmsv политсовет.ndmsv полянамежрайгаз.ndmsv понт.ndmsv 
+поныриагропромснаб.ndmsv портнадзор.ndmsv портопункт.ndmsv порховмежрайгаз.ndmsv посадрайгаз.ndmsv поспелихамежрайгаз.ndmsv 
+поспелихинскремтехпред.ndmsv посылторг.ndmsv похвистневоагропромтранс.ndmsv похвистневомежрайгаз.ndmsv почепрайгаз.ndmsv починокагропромснаб.ndmsv 
+правдинскремтехпред.ndmsv приволжскагропромтранс.ndmsv приволжскрайгаз.ndmsv приволжсктехкомплект.ndmsv прикамлес.ndmsv прикумскагропромснаб.ndmsv 
+приморавтодор.ndmsv приморавтотранс.ndmsv приморводоканал.ndmsv приморгражданпроект.ndmsv приморкрайгаз.ndmsv приморлеспром.ndmsv 
+приморнефтепродукт.ndmsv приморрыбпром.ndmsv приморскавтотранс.ndmsv приморскагропромремонт.ndmsv приморскагропромснаб.ndmsv приморскагропромтранс.ndmsv 
+приморсклеспром.ndmsv приморсклестоппром.ndmsv приморскметаллснаб.ndmsv приморскнефтепродукт.ndmsv приморско-ахтарскрайгаз.ndmsv приморскопткомплектприбор.ndmsv 
+приморскоптхимполимер.ndmsv приморскремтехпредхимснаб.ndmsv приморскстройтранс.ndmsv приморсктурист.ndmsv примснабконтракт.ndmsv приоблес.ndmsv 
+приокскремтехпред.ndmsv прионежскагропромснаб.ndmsv приполярбургаз.ndmsv пристеньагропромснаб.ndmsv пробизнессбанк.ndmsv провиденремтехснаб.ndmsv 
+продинторг.ndmsv проектмашприбор.ndmsv пролетарскрайгаз.ndmsv промбурвод.ndmsv промгаз.ndmsv промжелдортранс.ndmsv 
+промзернопроект.ndmsv проминвест.ndmsv проминформбизнес.ndmsv промкомбинат.ndmsv промкомплект.ndmsv проммеханомонтаж.ndmsv 
+проммонтаж.ndmsv промприбор.ndmsv промрадтехбанк.ndmsv промсвязьмонтаж.ndmsv промсвязьпроект.ndmsv промсервис.ndmsv 
+промснаб.ndmsv промстройбанк.ndmsv промстройниипроект.ndmsv промтрактор.ndmsv промтрансниипроект.ndmsv промтранспроект.ndmsv 
+промышленнаярайгаз.ndmsv промэкспорт.ndmsv пронскрайгаз.ndmsv профиздат.ndmsv профинкадр.ndmsv прохладныйгоррайгаз.ndmsv 
+псковавтотранс.ndmsv псковагропромпроект.ndmsv псковлестоппром.ndmsv псковмежрайгаз.ndmsv псковнефтепродукт.ndmsv псковоблгаз.ndmsv 
+псковрыбхоз.ndmsv псковхлеб.ndmsv птицекомбинат.ndmsv птицепром.ndmsv пугачевагропромтранс.ndmsv пугачевмежрайгаз.ndmsv 
+пудожагросервис.ndmsv пурнефтегаз.ndmsv пурнефтепрогресс.ndmsv пушкиноагросервис.ndmsv пчелопром.ndmsv пятигорсксельэнергопроект.ndmsv 
+равмедпром.ndmsv радиокомплекссервис.ndmsv радиометеоцентр.ndmsv радиосервис.ndmsv радиостройкомплекс.ndmsv радиотелецентр.ndmsv 
+радиофармпрепарат.ndmsv радченкоторф.ndmsv разнооптторг.ndmsv райагропромснаб.ndmsv райагроснаб.ndmsv райбытсервис.ndmsv 
+райводхоз.ndmsv райжилкомхоз.ndmsv райпромкомбинат.ndmsv райтопсбыт.ndmsv райчихинскгаз.ndmsv рамоньагропромтранс.ndmsv 
+рассказовоагропромснаб.ndmsv ребрихамежрайгаз.ndmsv ребрихинскремтехпред.ndmsv ревдамежрайгаз.ndmsv резинооптторг.ndmsv резиноптторг.ndmsv 
+ремагропром.ndmsv реммонтажгаззавод.ndmsv ремсервис.ndmsv ремстройпищепром.ndmsv ремстройсервис.ndmsv репьевкаагропромтранс.ndmsv 
+ресурс-банк.ndmsv ржаксаагропромснаб.ndmsv ровноеагропромснаб.ndmsv ровноеагропромтранс.ndmsv родникирайгаз.ndmsv романовкаагропромснаб.ndmsv 
+романовкаагропромтранс.ndmsv росагробиопром.ndmsv росагропромтехпроект.ndmsv росагроснаб.ndmsv росагрохим.ndmsv росархив.ndmsv 
+росасутпроект.ndmsv росбланкиздат.ndmsv росбумоптоторг.ndmsv росбумоптторг.ndmsv росбытсоюз.ndmsv росвиноградвинпром.ndmsv 
+росвиноградпром.ndmsv росвнешторг.ndmsv росводоканалпроект.ndmsv росвосток.ndmsv росгазпром.ndmsv росгазспецпром.ndmsv 
+росгеоинформ.ndmsv росгидромет.ndmsv росгипроводхоз.ndmsv росгипролес.ndmsv росглавкоопрыбсевероторг.ndmsv росгорэлектротранс.ndmsv 
+росгосстрах.ndmsv росгосцирк.ndmsv росжелдорснаб.ndmsv росживсоюз.ndmsv росзарубежцентр.ndmsv росзембанк.ndmsv 
+росзооветснаб.ndmsv росзооветснабпром.ndmsv росинвалютторг.ndmsv росинформресурс.ndmsv росинфраинвест.ndmsv роскомархив.ndmsv 
+роскомбытооптторг.ndmsv роскомвод.ndmsv роскомводхоз.ndmsv роскомгидромет.ndmsv роскомдрагмет.ndmsv роскомзем.ndmsv 
+роскоминформ.ndmsv роскоммунхоз.ndmsv роскомнефтепром.ndmsv роскомнефтехимпром.ndmsv роскомоборонпром.ndmsv роскомпищепром.ndmsv 
+роскомплект.ndmsv роскомрезерв.ndmsv роскомсевер.ndmsv роскомторг.ndmsv роскомтуризм.ndmsv роскомхимнефтепром.ndmsv 
+росконтракт.ndmsv роскультторг.ndmsv рославльагропромснаб.ndmsv рослегимпекс.ndmsv рослегпром.ndmsv рослеспром.ndmsv 
+рослесхоз.ndmsv росмежавтотранс.ndmsv росместпром.ndmsv росминфин.ndmsv росморфлот.ndmsv росмузпром.ndmsv 
+росмясомолпром.ndmsv росмясомолторг.ndmsv роснефтегаз.ndmsv роснефтеимпекс.ndmsv роснефтекомплект.ndmsv роснефтепродукт.ndmsv 
+роснииземпроект.ndmsv росниипрогресс.ndmsv рособувьторг.ndmsv росовощплодопром.ndmsv росоптимед.ndmsv росоптпродторг.ndmsv 
+росохотрыболовсоюз.ndmsv роспищепром.ndmsv роспищеснабсбыт.ndmsv росплодоовощхоз.ndmsv роспосылторг.ndmsv роспотребрезерв.ndmsv 
+роспродторг.ndmsv росразноснабсбыт.ndmsv росречфлот.ndmsv росрудпром.ndmsv росрыбколхозсоюз.ndmsv росрыбпромсбыт.ndmsv 
+росрыбхоз.ndmsv россвязьинформ.ndmsv россвязьпромкомплект.ndmsv россвязьстройкомплект.ndmsv россевзапсельэнергопроект.ndmsv россельхозбанк.ndmsv 
+россоюзместпром.ndmsv росспецэнергомонтаж.ndmsv росстанкоинструмент.ndmsv росстрахнадзор.ndmsv росстройимпекс.ndmsv росстром.ndmsv 
+ростекстильпром.ndmsv ростелеком.ndmsv ростехэкспорт.ndmsv ростоблремстройсбыт.ndmsv ростовавтотранс.ndmsv ростовгоргаз.ndmsv 
+ростовгражданпроект.ndmsv ростовдонресурс.ndmsv ростовмежрайгаз.ndmsv ростовметаллооптторг.ndmsv ростовнефтепродукт.ndmsv ростовнефтехимпроект.ndmsv 
+ростовоблгаз.ndmsv ростовоблспецремстройгаз.ndmsv ростовсельэнергопроект.ndmsv ростовтеплоэлектропроект.ndmsv ростовтурист.ndmsv ростовхлебпром.ndmsv 
+ростовэлектротранс.ndmsv ростовэнергоремонт.ndmsv ростоппром.ndmsv ростопсбыт.ndmsv росторгречтранс.ndmsv рострубпласт.ndmsv 
+росуглепрофсоюз.ndmsv росурал.ndmsv росуралсиб.ndmsv росфарфор.ndmsv росхимнефтепром.ndmsv росхлеб.ndmsv 
+росхлебопродукт.ndmsv росхлебпродукт.ndmsv росхозторг.ndmsv росцветмет.ndmsv росцементоптторг.ndmsv росцентробанк.ndmsv 
+росэлектроприбороптторг.ndmsv росэлтранс.ndmsv росэнергоатом.ndmsv росюгпром.ndmsv ртищевоагропромснаб.ndmsv ртищевоагропромтранс.ndmsv 
+ртищевомежрайгаз.ndmsv рубобанк.ndmsv рубторг.ndmsv рубцовскмежрайгаз.ndmsv рудняагропромснаб.ndmsv рузаремтехпред.ndmsv 
+русьлифт.ndmsv русьхлеб.ndmsv рыбакколхозсоюз.ndmsv рыбинскагроавтотранс.ndmsv рыбинскагропромснаб.ndmsv рыбинскмежрайгаз.ndmsv 
+рыбинскэнергожелезобетон.ndmsv рыбнадзор.ndmsv рыбноерайгаз.ndmsv рыбсовхоз.ndmsv рыльскагропромснаб.ndmsv рыльскмежрайгаз.ndmsv 
+рыльскхлебопродукт.ndmsv ряжскмежрайгаз.ndmsv рязаньавтосервис.ndmsv рязаньавтотранс.ndmsv рязаньвест.ndmsv рязаньгоргаз.ndmsv 
+рязаньнефтепродукт.ndmsv рязаньнефтехимпродукт.ndmsv рязаньоблгаз.ndmsv рязаньоблпродторг.ndmsv рязаньрайгаз.ndmsv рязаньспиртпром.ndmsv 
+рязаньхлеб.ndmsv рязаньхлебпром.ndmsv рязаньэлеватор.ndmsv рязаньэнергоремонт.ndmsv рязнефтехимпродукт.ndmsv рязоргстанкинпром.ndmsv 
+рязцветмет.ndmsv салаватгипронефтехим.ndmsv салаватенфтеоргсинтез.ndmsv салаватнефтеоргсинтез.ndmsv салехардмежрайгаз.ndmsv сальскмежрайгаз.ndmsv 
+самараавтодор.ndmsv самараавтоконтейнер.ndmsv самараавтосервис.ndmsv самараавтотранс.ndmsv самараагропромтранс.ndmsv самарагаз.ndmsv 
+самарагидропроект.ndmsv самараглавснаб.ndmsv самарагражданпроект.ndmsv самаралестоппром.ndmsv самарамашэлектроторг.ndmsv самаранефтегаз.ndmsv 
+самаранефтепродукт.ndmsv самаранефтехимпроект.ndmsv самараоблгаз.ndmsv самараоблснаб.ndmsv самарастройтранс.ndmsv самаратрансгаз.ndmsv 
+самарахимоптоторг.ndmsv самарахлебпром.ndmsv самойловкаагропромтранс.ndmsv сампурагропромснаб.ndmsv сампурагросервис.ndmsv самтрест.ndmsv 
+сантехмонтаж.ndmsv сантехниипроект.ndmsv сантехэлектромонтаж.ndmsv санэпиднадзор.ndmsv сапожокгаз.ndmsv сараимежрайгаз.ndmsv 
+саранскстройзаказчик.ndmsv саранскэлектротранс.ndmsv сарапулмежрайгаз.ndmsv саратовавторемонт.ndmsv саратовавтотранс.ndmsv саратовагропромснаб.ndmsv 
+саратовагропромтранс.ndmsv саратовбашняагропром.ndmsv саратовгаз.ndmsv саратовгазавторемонт.ndmsv саратовгазэнергоремонт.ndmsv саратовгоргаз.ndmsv 
+саратовдизельаппарат.ndmsv саратовмясопром.ndmsv саратовнефтегаз.ndmsv саратовнефтепродукт.ndmsv саратовоблгаз.ndmsv саратовоблремстройбыт.ndmsv 
+саратоворггаз.ndmsv саратовплодовощпром.ndmsv саратовплодовощтранс.ndmsv саратовсельмелиоводхоз.ndmsv саратовсельстройтранс.ndmsv саратовснабсбыт.ndmsv 
+саратовспецмонтаж.ndmsv саратовстройкомплект.ndmsv саратовстройтранс.ndmsv саратовтехсервис.ndmsv саратовторгнефтегаз.ndmsv саратовэнергоремонт.ndmsv 
+саровгидромонтаж.ndmsv сароптмясомолторг.ndmsv сасовоагропромсервис.ndmsv сасовомежрайгаз.ndmsv саткамежрайгаз.ndmsv сафоновоагропромснаб.ndmsv 
+саха-газ.ndmsv сахаконцерт.ndmsv сахалинавтотранс.ndmsv сахалинглавснаб.ndmsv сахалинлеспром.ndmsv сахалинморнефтегаз.ndmsv 
+сахалинморнефтемонтаж.ndmsv сахалиннефтепродукт.ndmsv сахалиноблгаз.ndmsv сахалинхлеб.ndmsv сахаполиграфиздат.ndmsv саянскагроавтотранс.ndmsv 
+саянскхимпром.ndmsv свердлеспром.ndmsv свердловскавтодор.ndmsv свердловскавтотранс.ndmsv свердловскгоргаз.ndmsv свердловскгражданпроект.ndmsv 
+свердловскнефтепродукт.ndmsv свердловскоблводхоз.ndmsv свердловскоблгаз.ndmsv свердловскстройматериал.ndmsv свердловскстройтранс.ndmsv свердловскторф.ndmsv 
+свердловэлектроремонт.ndmsv сверлифтремонт.ndmsv светлогорскмежрайгаз.ndmsv светлоградремтехпред.ndmsv свинокомплекс.ndmsv связьинвест.ndmsv 
+связьинформ.ndmsv связьморпроект.ndmsv связьэлектромонтаж.ndmsv севатомремонт.ndmsv севгипрорыбфлот.ndmsv севдорпроект.ndmsv 
+северавтодор.ndmsv северавтотранс.ndmsv севералмаз.ndmsv севератомкомплекс.ndmsv севергазпром.ndmsv севернефтепродукт.ndmsv 
+севернефтесервис.ndmsv северо-осетиннефтепродукт.ndmsv северовостокэлектромонтаж.ndmsv северодвинскмежрайгаз.ndmsv северозападорггаз.ndmsv северолесоэкспорт.ndmsv 
+североморскрайгаз.ndmsv североторг.ndmsv североэнергоремонт.ndmsv северскаярайгаз.ndmsv северскремтехпред.ndmsv севзапгипрозем.ndmsv 
+севзаптранслеспром.ndmsv севзапэлектромонтаж.ndmsv севзапэнергомонтаж.ndmsv севзапэнергомонтажпроект.ndmsv севзапэнергопром.ndmsv севзапэнергосетьпроект.ndmsv 
+севкавгипроцветмет.ndmsv севкавмежавтотранс.ndmsv севкавниигаз.ndmsv севкавниигипс.ndmsv севкавнипиагропром.ndmsv севкавнипигаз.ndmsv 
+севкавторгпроект.ndmsv севкавэнергомонтаж.ndmsv севосгаз.ndmsv севосгорсельстройпроект.ndmsv севречфлот.ndmsv севрыбсбыт.ndmsv 
+севрыбхолодфлот.ndmsv севсантехмонтаж.ndmsv севтюменьавтотранс.ndmsv севэнергостройпром.ndmsv сегежабумпром.ndmsv селенгалес.ndmsv 
+селивановоремтехпред.ndmsv сельхоз.ndmsv сельхозавтотранс.ndmsv сельхозбанк.ndmsv сельхозинститут.ndmsv сельхозкооператив.ndmsv 
+сельхозлес.ndmsv сельхозполимер.ndmsv сельхозпромэкспорт.ndmsv сельхозтранс.ndmsv сельэлектроснаб.ndmsv сельэнергопроект.ndmsv 
+сельэнергопромпроект.ndmsv семикаракорскмежрайгаз.ndmsv семилукиагропромтранс.ndmsv семилукихлеб.ndmsv серафимовичмежрайгаз.ndmsv сервискомплект.ndmsv 
+сервиспищепром.ndmsv сервисэлектронполиграф.ndmsv сергиевскагропромтранс.ndmsv сергиевскмежрайгаз.ndmsv сердобскмежрайгаз.ndmsv серовмежрайгаз.ndmsv 
+сибавтостройсервис.ndmsv сибагропромтехпроект.ndmsv сиббиофарм.ndmsv сибвнипиэнергопром.ndmsv сибгазснаб.ndmsv сибгазтранс.ndmsv 
+сибгеоинформ.ndmsv сибгипробиосинтез.ndmsv сибгипромез.ndmsv сибгипронефтетранс.ndmsv сибгипронииавиапром.ndmsv сибгипротранс.ndmsv 
+сибзавод.ndmsv сибимпэкс.ndmsv сибирьгазсервис.ndmsv сибкомплектмонтаж.ndmsv сибконтакт.ndmsv сибметаллургмонтаж.ndmsv 
+сибнефтепровод.ndmsv сибнефтесервис.ndmsv сибнефтетранспроект.ndmsv сибнефтехиммонтаж.ndmsv сибнефтькомплектмонтаж.ndmsv сиборггаз.ndmsv 
+сибпродмонтаж.ndmsv сибсантехмонтаж.ndmsv сибспецмонтаж.ndmsv сибспецэнергомонтаж.ndmsv сибстанкоэлектропривод.ndmsv сибторгнефтепровод.ndmsv 
+сибторгпроект.ndmsv сибхиммонтаж.ndmsv сибхимремонт.ndmsv сибцветметремонт.ndmsv сибэкспоцентр.ndmsv сибэлектромонтаж.ndmsv 
+сибэнергокомплект.ndmsv сибэнергомонтаж.ndmsv сибэнергоремонт.ndmsv сибэнергосетьпроект.ndmsv сибэнергоцветмет.ndmsv симбирскспирт.ndmsv 
+сименс.ndmsv скбприбор.ndmsv скопинмежрайгаз.ndmsv славгородмежрайгаз.ndmsv славскремтехпред.ndmsv славянскаярайгаз.ndmsv 
+смоленскавтотранс.ndmsv смоленскагрокомплект.ndmsv смоленскагропромснаб.ndmsv смоленскагропромтранс.ndmsv смоленскагросервис.ndmsv смоленскглавснаб.ndmsv 
+смоленскленагропром.ndmsv смоленсклестоппром.ndmsv смоленскмежрайгаз.ndmsv смоленскмолсырпром.ndmsv смоленскмясоагропром.ndmsv смоленскнефтепродукт.ndmsv 
+смоленскоблгаз.ndmsv смоленскоблобувьбыт.ndmsv смоленскоблразнобыт.ndmsv смоленскоблснаб.ndmsv смоленскоблтрикотажбыт.ndmsv смоленскремтехпред.ndmsv 
+смоленсксвязьинформ.ndmsv смоленскспиртпищеагропром.ndmsv смоленскстройзаказчик.ndmsv смоленскстройматериал.ndmsv смоленскторф.ndmsv смоленсктрубопровод.ndmsv 
+смоленскшвейбыт.ndmsv собинкаремтехпред.ndmsv совавто-термез.ndmsv совгаваньмежрайгаз.ndmsv советскагропромснаб.ndmsv советскмежрайгаз.ndmsv 
+советскоемежрайгаз.ndmsv советскремтехпред.ndmsv совинтеравтосервис.ndmsv совинтерспорт.ndmsv совинтерфест.ndmsv совинторг.ndmsv 
+совинцентр.ndmsv совкомфлот.ndmsv совремстройматериал.ndmsv соврыбфлот.ndmsv совтелеэкспорт.ndmsv совфрахт.ndmsv 
+совэкспортфильм.ndmsv соликамскбумпром.ndmsv солнцевоагропромснаб.ndmsv солодчагазсервис.ndmsv сольпром.ndmsv сольцымежрайгаз.ndmsv 
+сортавалаагросервис.ndmsv сосновкаагропромснаб.ndmsv сосновкаремтехпред.ndmsv сосновоборэлектромонтаж.ndmsv соцкомбыт.ndmsv соцкультбыт.ndmsv 
+соцпроф.ndmsv соцэкономинформ.ndmsv сочиавтотранс.ndmsv сочиглавснаб.ndmsv сочигоргаз.ndmsv союзагропром.ndmsv 
+союзантисептик.ndmsv союзвзрывпром.ndmsv союзвнешстройимпорт.ndmsv союзвнештранс.ndmsv союзвтормет.ndmsv союзгосцирк.ndmsv 
+союздорпроект.ndmsv союзздравэкспорт.ndmsv союзинтерпром.ndmsv союзкиносервис.ndmsv союзкинотехпрокат.ndmsv союзкинофонд.ndmsv 
+союзконтракт.ndmsv союзлесмонтаж.ndmsv союзлифтмонтаж.ndmsv союзметаллургпром.ndmsv союзморниипроект.ndmsv союзмультфильм.ndmsv 
+союзмясомолмонтаж.ndmsv союзнефтеэкспорт.ndmsv союзпарфюмерпром.ndmsv союзпатент.ndmsv союзплодимпорт.ndmsv союзплодоимпорт.ndmsv 
+союзпром.ndmsv союзпроммонтаж.ndmsv союзпромэкспорт.ndmsv союзросместпром.ndmsv союзстекломонтаж.ndmsv союзстройматериал.ndmsv 
+союзтелерадиосервис.ndmsv союзтелефильм.ndmsv союзтранзит.ndmsv союзфоринвест.ndmsv спасскмежрайгаз.ndmsv спасскрайгаз.ndmsv 
+спасскцемент.ndmsv спецавтотранспорт.ndmsv спецавтоцентр.ndmsv спецатоммонтаж.ndmsv спецгазавтотранс.ndmsv спецдор.ndmsv 
+спецдормост.ndmsv спецканаттранс.ndmsv спецкомбинат.ndmsv спецмашмонтаж.ndmsv спецметаллопроект.ndmsv спецодеждаоптторг.ndmsv 
+спецпроект.ndmsv спецстройбетон.ndmsv спецстройремтрест.ndmsv спецтеплохиммонтаж.ndmsv спецтранс.ndmsv спецфакультет.ndmsv 
+спецхиммонтаж.ndmsv спецэлектромонтаж.ndmsv спецэнергомонтаж.ndmsv спецэнергоремонт.ndmsv спортинвест.ndmsv спортинтерпром.ndmsv 
+спорткомплекс.ndmsv средневолжсклифтремонт.ndmsv ставропольавтодор.ndmsv ставропольавтотранс.ndmsv ставропольвиноградпром.ndmsv ставропольгоргаз.ndmsv 
+ставропольимпэкс.ndmsv ставрополькоммунпроект.ndmsv ставрополькрайагрокомплекс.ndmsv ставрополькрайгаз.ndmsv ставропольлифтремонт.ndmsv ставропольместпром.ndmsv 
+ставропольнефтегаз.ndmsv ставропольнефтепродукт.ndmsv ставропольорггаз.ndmsv ставропольремагропром.ndmsv ставропольресурс.ndmsv ставропольснаб.ndmsv 
+ставропольстройматериал.ndmsv ставропольстройтранс.ndmsv ставропольтоппром.ndmsv ставропольторгпроект.ndmsv ставропольтурист.ndmsv стальмонтаж.ndmsv 
+стальпроект.ndmsv станкин.ndmsv станкобизнес.ndmsv станкоинструментоптторг.ndmsv станкомэз.ndmsv станкоэлектрон.ndmsv 
+старожиловорайгаз.ndmsv староминскаярайгаз.ndmsv старопохвистневоагропромтранс.ndmsv старорусприбор.ndmsv староруссмежрайгаз.ndmsv староюрьевоагропромснаб.ndmsv 
+статкомитет.ndmsv стройбизнес.ndmsv стройгаз.ndmsv стройдеталькомплект.ndmsv стройдормашсервис.ndmsv стройиздат.ndmsv 
+стройинвест.ndmsv стройинсервис.ndmsv стройинструмент.ndmsv стройкомбинат.ndmsv стройкомплекс.ndmsv стройкомплект.ndmsv 
+стройкомплектэкспорт.ndmsv стройлес.ndmsv стройлессервис.ndmsv стройматериалинторг.ndmsv строймехкомплект.ndmsv строймехсервис.ndmsv 
+строймонтажгаз.ndmsv строймонтажсервис.ndmsv стройоптторг.ndmsv стройпластполимер.ndmsv стройпрогресс.ndmsv стройпромторг.ndmsv 
+стройресурс.ndmsv стройсвязьпроект.ndmsv стройсервис.ndmsv стройсинтез.ndmsv стройснаб.ndmsv стройтехсервис.ndmsv 
+стройтранс.ndmsv стройтрансгаз.ndmsv стройтрест.ndmsv стройфарфор.ndmsv стройэлектромонтаж.ndmsv стромкомпозит.ndmsv 
+строммашполимер.ndmsv стромфонд.ndmsv ступиноремтехпред.ndmsv судбытсервис.ndmsv суджаагропромснаб.ndmsv суджамежрайгаз.ndmsv 
+судогдаремтехпред.ndmsv судотрансрыбфлот.ndmsv судоэкспорт.ndmsv суздальремтехпред.ndmsv сулинмежрайгаз.ndmsv сунжамежрайгаз.ndmsv 
+сургутгазпром.ndmsv сургутжилкомхоз.ndmsv сургутнефтегаз.ndmsv сургутнефтегазбанк.ndmsv сургутрайгаз.ndmsv суровикиномежрайгаз.ndmsv 
+сухоложскцемент.ndmsv сызраньагропромтранс.ndmsv сызраньмежрайгаз.ndmsv сычевкаагропромснаб.ndmsv табакпром.ndmsv табунскремтехпред.ndmsv 
+таганрогмежрайгаз.ndmsv тагиллес.ndmsv тагилмежрайгаз.ndmsv тагилмясопром.ndmsv таймырагроснаб.ndmsv таймырнефтегаз.ndmsv 
+талнахспецшахтремонт.ndmsv таловаяагропромтранс.ndmsv тамбовавтотранс.ndmsv тамбовагроинформ.ndmsv тамбовагропромкомплект.ndmsv тамбовагропромсервис.ndmsv 
+тамбовагропромснаб.ndmsv тамбовагростройпроект.ndmsv тамбовагрохимтранс.ndmsv тамбовгражданпроект.ndmsv тамбовжилколхоз.ndmsv тамбовкоммунпроект.ndmsv 
+тамбовконтракт.ndmsv тамбовместпром.ndmsv тамбовмолпром.ndmsv тамбовмясопродукт.ndmsv тамбовмясопром.ndmsv тамбовнефтепродукт.ndmsv 
+тамбовоблгаз.ndmsv тамбовоблснаб.ndmsv тамбовпассажироавтосервис.ndmsv тамбовпищепром.ndmsv тамбовплодоовощхоз.ndmsv тамбовптицепром.ndmsv 
+тамбоврыбхоз.ndmsv тамбовсахарсервис.ndmsv тамбовстройпроект.ndmsv тамбовстройтранс.ndmsv тамбовтоппром.ndmsv тамбовхлебпром.ndmsv 
+тарамежрайгаз.ndmsv таркосаленефтегаз.ndmsv тасс.ndmsv татавтотранс.ndmsv татагрохимсервис.ndmsv татищевоагропромснаб.ndmsv 
+татищевоагропромтранс.ndmsv татнефтебитум.ndmsv татнефтемашремонт.ndmsv татнефтепродукт.ndmsv татойлгаз.ndmsv татпромстройбанк.ndmsv 
+таттрансгаз.ndmsv тбилисскаярайгаз.ndmsv тв-информ.ndmsv тверьавтодор.ndmsv тверьавтотранс.ndmsv тверькурорт.ndmsv 
+тверьлеспром.ndmsv тверьлеспром-холдинг.ndmsv тверьлестоппром.ndmsv тверьнефтепродукт.ndmsv тверьоблгаз.ndmsv тверьоборонпромкомплекс.ndmsv 
+тверьсвинопром.ndmsv тверьторф.ndmsv тверьхлебпром.ndmsv тейковомежрайгаз.ndmsv текстильпром.ndmsv телеком.ndmsv 
+телерадиокомитет.ndmsv темкиноагропромснаб.ndmsv темрюкрайгаз.ndmsv тенгизнефтегаз.ndmsv теплопроект.ndmsv теплоэлектропроект.ndmsv 
+термнефтепроект.ndmsv техинвест.ndmsv техмашимпорт.ndmsv техмашкомплекс.ndmsv техмашэкспорт.ndmsv технимпорт.ndmsv 
+технобанк.ndmsv техноимпорт.ndmsv техноинторг.ndmsv технополис.ndmsv техноприбор.ndmsv технопромимпорт.ndmsv 
+технопромэкспорт.ndmsv техносервис.ndmsv техностройпром.ndmsv техностройэкспорт.ndmsv техноторгсервис.ndmsv технохим.ndmsv 
+техноэкополис.ndmsv техноэкспорт.ndmsv техпромэкспорт.ndmsv техснабэкспорт.ndmsv тимагропромснаб.ndmsv тимашевскрайгаз.ndmsv 
+тиммежрайгаз.ndmsv тисульрайгаз.ndmsv тихорецкгоргаз.ndmsv тобольсклес.ndmsv токаревкаавтотранс.ndmsv токаревкаагропромснаб.ndmsv 
+токобанк.ndmsv тольяттиазот.ndmsv тольяттигоргаз.ndmsv тольяттиоптторг.ndmsv тольяттистройтранс.ndmsv тольяттиторгтранс.ndmsv 
+томскавтотранс.ndmsv томскнефтепродукт.ndmsv томскоблгаз.ndmsv томсктеплоэлектропроект.ndmsv томсктрансгаз.ndmsv томсктранспроект.ndmsv 
+томскхлебопродукт.ndmsv томскэнергосетьпроект.ndmsv торгмортранс.ndmsv торгпроект.ndmsv торгречтранс.ndmsv торгсервис.ndmsv 
+торгтехстройсервис.ndmsv точприбор.ndmsv трактороэкспорт.ndmsv трансвзрывпром.ndmsv трансмашпроект.ndmsv транснефтепродукт.ndmsv 
+транспроект.ndmsv трансресторансервис.ndmsv транссервис.ndmsv трансфорум-интерсервис.ndmsv трансэлектропроект.ndmsv трубооптторг.ndmsv 
+трубоптторг.ndmsv трубчевскмежрайгаз.ndmsv туапсегоргаз.ndmsv туапсенефтепродукт.ndmsv туваавтодор.ndmsv туваавтотранс.ndmsv 
+туваагросервис.ndmsv туваагроснаб.ndmsv туваасбест.ndmsv тувазаготпродпром.ndmsv тувалестоппром.ndmsv туванефтепродукт.ndmsv 
+тувапрокатавтосервис.ndmsv туварыбхоз.ndmsv тувастройматериал.ndmsv туватурист.ndmsv тувахлебпром.ndmsv тувгаз.ndmsv 
+тулаавтотранс.ndmsv тулаагроводпроект.ndmsv тулакондитерагропром.ndmsv туламашзавод.ndmsv туламашпроект.ndmsv туланефтепродукт.ndmsv 
+тулаоблгаз.ndmsv туласпирт.ndmsv тулатоппром.ndmsv тулачермет.ndmsv тулачерметпроект.ndmsv тулаэлектропривод.ndmsv 
+тулаэнергосетьпроект.ndmsv тулоблавтотранс.ndmsv тульскгражданпроект.ndmsv турбоатом.ndmsv тындалес.ndmsv тюкалинскмежрайгаз.ndmsv 
+тюменбургаз.ndmsv тюменгазснабкомплект.ndmsv тюменнефтегаз.ndmsv тюменнефтепродукт.ndmsv тюменнефтеспецтранс.ndmsv тюменниигипрогаз.ndmsv 
+тюменоблгаз.ndmsv тюментрансгаз.ndmsv тюментрансгазремонт.ndmsv тюменьавиатранс.ndmsv тюменьавтотранс.ndmsv тюменьагролеспром.ndmsv 
+тюменьглавснаб.ndmsv тюменьгражданпроект.ndmsv тюменьлес.ndmsv тюменьмежрайгаз.ndmsv тюменьмясомолторг.ndmsv тюменьремстройпроект.ndmsv 
+тюменьрыбхоз.ndmsv тюменьторф.ndmsv тюменьтрансгаз.ndmsv тюменьтурист.ndmsv тяжмашоптторг.ndmsv тяжмехпресс.ndmsv 
+тяжпром.ndmsv тяжпромэкспорт.ndmsv тяжпромэлектропроект.ndmsv тяжстанкогидропресс.ndmsv угличмежрайгаз.ndmsv уграагропромснаб.ndmsv 
+удмуртавтотранс.ndmsv удмуртагропромсервис.ndmsv удмуртагроснаб.ndmsv удмуртгаз.ndmsv удмуртлес.ndmsv удмуртнефтепродукт.ndmsv 
+ульяновскавтосервис.ndmsv ульяновскавтотранс.ndmsv ульяновскагроснаб.ndmsv ульяновскводпроект.ndmsv ульяновскжилкоммунпроект.ndmsv ульяновскжилкомхоз.ndmsv 
+ульяновсккурорт.ndmsv ульяновскнефтепродукт.ndmsv ульяновскхлебпром.ndmsv ульяновскцемент.ndmsv умбасельхозсервис.ndmsv унечарайгаз.ndmsv 
+универсалпром.ndmsv университетобщепит.ndmsv уникомбанк.ndmsv упоровоспецгазсервис.ndmsv ураймежрайгаз.ndmsv урайнефтегаз.ndmsv 
+урал-центр.ndmsv уралавнипиэнергопром.ndmsv уралавтоприцеп.ndmsv ураласбест.ndmsv уралвагонзавод.ndmsv уралгазсервис.ndmsv 
+уралгазэнергоремонт.ndmsv уралгипромез.ndmsv уралгипротранс.ndmsv уралдомнаремонт.ndmsv ураллеспроект.ndmsv уралмашзавод.ndmsv 
+уралмрамор.ndmsv уралниистромпроект.ndmsv уралорггаз.ndmsv уралпромпроект.ndmsv уралсвязьинформ.ndmsv уралсельэнергопроект.ndmsv 
+уралтеплоэлектропроект.ndmsv уралторгпроект.ndmsv уралторфпроект.ndmsv уралтрансгаз.ndmsv уралтрубпром.ndmsv уралхимпласт.ndmsv 
+уралцемент.ndmsv уралчермет.ndmsv уралэнергомонтаж.ndmsv уралэнергомонтажпроект.ndmsv уралэнергоремонт.ndmsv уралэнергосетьпроект.ndmsv 
+урансервис.ndmsv урваньмежрайгаз.ndmsv ургаллес.ndmsv уренгойгазпром.ndmsv уренгойстройгаз.ndmsv уржумводспирт.ndmsv 
+урюпинскавтотранс.ndmsv урюпинскмежрайгаз.ndmsv усольехимпром.ndmsv усольскмежрайгаз.ndmsv усольхимпром.ndmsv успенскоерайгаз.ndmsv 
+уссурийскагропромкомплект.ndmsv уссурийскмежрайгаз.ndmsv уссурийскремтехпредснаб.ndmsv усть-катавмежрайгаз.ndmsv усть-лабинскрайгаз.ndmsv уфаавиапроект.ndmsv 
+уфамолагропром.ndmsv уфаоргсинтез.ndmsv учколлектор.ndmsv учхоз.ndmsv фатежмежрайгаз.ndmsv ферейн.ndmsv 
+физтех.ndmsv фильмэкспорт.ndmsv фроловомежрайгаз.ndmsv фурмановрайгаз.ndmsv хабаровскавтодор.ndmsv хабаровскавтотранс.ndmsv 
+хабаровскагропромснаб.ndmsv хабаровскгражданпроект.ndmsv хабаровсккрайгаз.ndmsv хабаровсклестоппром.ndmsv хабаровскместпром.ndmsv хабаровскнефтепродукт.ndmsv 
+хабаровскрайгаз.ndmsv хабаровскстройтранс.ndmsv хабаровсктурист.ndmsv хакасавтотранс.ndmsv хакасгаз.ndmsv хакаслес.ndmsv 
+хакаснефтепродукт.ndmsv хакасхлебопродукт.ndmsv хантымансийсклес.ndmsv харбор.ndmsv хасавюртгаз.ndmsv хвалынскагропромтранс.ndmsv 
+хворостянкарайгаз.ndmsv химбытпром.ndmsv химзавод.ndmsv химкомбинат.ndmsv химмашсервис.ndmsv химнефтепром.ndmsv 
+химоптоторг.ndmsv химоптторг.ndmsv химпищеоптторг.ndmsv химпром.ndmsv химснаб.ndmsv химфармкомбинат.ndmsv 
+хинипэк.ndmsv хладокомбинат.ndmsv хозмебельстройсервис.ndmsv холмогорымежрайгаз.ndmsv холмогорыремтехпредхимснаб.ndmsv хорольмежрайгаз.ndmsv 
+цветмет.ndmsv цветметинвест.ndmsv цветметконтракт.ndmsv цветметоптторг.ndmsv цветметэкспорт.ndmsv целинхлебопродукт.ndmsv 
+цементоптторг.ndmsv цемзавод.ndmsv центрагроавтотранс.ndmsv центрагропромснаб.ndmsv центргаз.ndmsv центризбирком.ndmsv 
+центрметаллургремонт.ndmsv центрнаучфильм.ndmsv центробанк.ndmsv центролит.ndmsv центросоюз.ndmsv центросоюзпроект.ndmsv 
+центротрансжелезобетон.ndmsv центроэнергомонтаж.ndmsv центрпродсервис.ndmsv центрремтехпредснаб.ndmsv центррыбвод.ndmsv центрторг.ndmsv 
+центрчерноземмежавтотранс.ndmsv центрчерноземорггаз.ndmsv цивильскмежрайгаз.ndmsv цимлянскрыбвод.ndmsv цкбточприбор.ndmsv цнииатоминформ.ndmsv 
+цниибыт.ndmsv цниилесосплав.ndmsv цниипроект.ndmsv цниичермет.ndmsv цсхбанк.ndmsv чапаевскгоргаз.ndmsv 
+чебаркульмежрайгаз.ndmsv чебоксарыгоргаз.ndmsv чебуламежрайгаз.ndmsv чегемрайгаз.ndmsv чекфондконтур.ndmsv челно-вершинырайгаз.ndmsv 
+челябинскавтодор.ndmsv челябинскавтотранс.ndmsv челябинскгоргаз.ndmsv челябинсккурорт.ndmsv челябинскнефтепродукт.ndmsv челябинскоблгаз.ndmsv 
+челябинскспиртпром.ndmsv челябмашоптторг.ndmsv челябнефтепродукт.ndmsv челябоблтоппром.ndmsv челябспецтранс.ndmsv челябстройзаказчик.ndmsv 
+челябтехоптторг.ndmsv челябхимоптторг.ndmsv черемховомежрайгаз.ndmsv череповецгоргаз.ndmsv череповецлессервис.ndmsv черкассыагропромтранс.ndmsv 
+черкассымежрайгаз.ndmsv черкеснефтепродукт.ndmsv черкесскавтодор.ndmsv черкесскавтотранс.ndmsv черкесскагропромпроект.ndmsv черкесскнефтепродукт.ndmsv 
+чертковорайгаз.ndmsv чечинггаз.ndmsv чимкентнефтеоргсинтез.ndmsv читаглавснаб.ndmsv читалес-холдинг.ndmsv читалестоппром.ndmsv 
+читанефтепродукт.ndmsv читаоблгаз.ndmsv читатурист.ndmsv чувашавтотранс.ndmsv чувашгаз.ndmsv чувашкредитпромбанк.ndmsv 
+чувашнефтепродукт.ndmsv чудовомежрайгаз.ndmsv чукотагропромпроект.ndmsv чукотгоспроект.ndmsv чукотнефтепродукт.ndmsv шадринскмежрайгаз.ndmsv 
+шарьямежрайгаз.ndmsv шатурторф.ndmsv шахтостройкомпозит.ndmsv шахтымежрайгаз.ndmsv шацкмежрайгаз.ndmsv швейпром.ndmsv 
+шелеховмежрайгаз.ndmsv шенталамежрайгаз.ndmsv шиловорайгаз.ndmsv шумерлямежрайгаз.ndmsv шуямежрайгаз.ndmsv щербиновскаярайгаз.ndmsv 
+щигрымежрайгаз.ndmsv экономбанк.ndmsv экоресурс.ndmsv экспо-центр.ndmsv экспортлес.ndmsv экспортподшипник.ndmsv 
+экспортхлеб.ndmsv экспоцентр.ndmsv элеватормелькомплект.ndmsv электроавтомат.ndmsv электроагрегат.ndmsv электроаппарат.ndmsv 
+электрогаз.ndmsv электрозапсибмонтаж.ndmsv электрометприбор.ndmsv электромонтаж.ndmsv электронприбор.ndmsv электронпроект.ndmsv 
+электронстандарт.ndmsv электрооптторг.ndmsv электроприбороптторг.ndmsv электропроект.ndmsv электропромремонт.ndmsv электропрофсоюз.ndmsv 
+электросевкавмонтаж.ndmsv электросетьстройпроект.ndmsv электросибмонтаж.ndmsv электростальгражданпроект.ndmsv электростандарт.ndmsv электротехоптторг.ndmsv 
+электроточприбор.ndmsv электроуралмонтаж.ndmsv электрохимприбор.ndmsv электроцентромонтаж.ndmsv электроцех.ndmsv эльбрустурист.ndmsv 
+эльф-нефтегаз.ndmsv энгельсагропромтранс.ndmsv энгельсмежрайгаз.ndmsv энергоатомиздат.ndmsv энергожилиндустрпроект.ndmsv энергозавод.ndmsv 
+энергокомплект.ndmsv энергомашэкспорт.ndmsv энергомехавтотранс.ndmsv энергомехпрогресс.ndmsv энергомонтаж.ndmsv энергомонтажпроект.ndmsv 
+энергонадзор.ndmsv энергопроект.ndmsv энергоремонт.ndmsv энергосетьпроект.ndmsv энергостальпроект.ndmsv энергостройкомплект.ndmsv 
+энергостройпром.ndmsv энерготехкомплект.ndmsv энерготехпром.ndmsv энергоцех.ndmsv энимс.ndmsv эпиднадзор.ndmsv 
+ювелирпром.ndmsv юганскнефтегаз.ndmsv юганскнефтедорстройремонт.ndmsv югранефтепрогресс.ndmsv югтрансгаз.ndmsv южамежрайгаз.ndmsv 
+южноуральскмежрайгаз.ndmsv южэнергожилпроект.ndmsv южэнергосетьпроект.ndmsv юргарайгаз.ndmsv юрьевецмежрайгаз.ndmsv ядринрайгаз.ndmsv 
+якутавиатранс.ndmsv якутавтотранс.ndmsv якутгаз.ndmsv якутгазпром.ndmsv якутлес.ndmsv якутнефтепродукт.ndmsv 
+якутнипроалмаз.ndmsv якутснаб.ndmsv якуттурист.ndmsv ялуторовскспецгазсервис.ndmsv ямалнефтегазжелезобетон.ndmsv ямалнефтепродукт.ndmsv 
+ямрайгаз.ndmsv яроблснабсбыт.ndmsv ярославльавтотранс.ndmsv ярославльагростройтранс.ndmsv ярославльгоргаз.ndmsv ярославлькондитер.ndmsv 
+ярославльоблгаз.ndmsv ярославльсельлес.ndmsv ярославльхлебпром.ndmsv ярославнефтеоргсинтез.ndmsv ярославнефтепродукт.ndmsv ярославхлеб.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
+
 ед.= :
   LLAGL+ or LLBSX+;
 
@@ -13425,9 +13423,9 @@
 еж.= :
   LLAAJ+ or LLACF+ or LLBHJ+ or LLBMV+ or LLCKS+;
 
-еж.nlmsi :  <morph-С,мр,од,ед,им>;
-
 еж.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+еж.nlmsi :  <morph-С,мр,од,ед,им>;
 
 еж.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -13462,13 +13460,13 @@
 ер.= :
   LLAAQ+ or LLAEY+ or LLDML+;
 
-ер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ер.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-ер.ndmsi :  <morph-С,мр,но,ед,им>;
+ер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ер.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+ер.ndmsi :  <morph-С,мр,но,ед,им>;
 
 ерепен.= кобен.= хорохор.= :
   LLBNU+;
@@ -13482,11 +13480,11 @@
 ерш.= :
   LLAAJ+ or LLACF+ or LLBHE+ or LLBMS+;
 
+ерш.ndmsi :  <morph-С,мр,но,ед,им>;
+
 ерш.nlmsi :  <morph-С,мр,од,ед,им>;
 
 ерш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-ерш.ndmsi :  <morph-С,мр,но,ед,им>;
 
 апоничищ.= ершич.= кобеляк.= кулебак.= мытищ.= прилук.= 
 семилук.= :
@@ -13500,11 +13498,11 @@
 
 ершов.amss :  <morph-П,мр,ед,кр>;
 
+ершов.ndmsi :  <morph-С,мр,но,ед,им>;
+
 ершов.nlmsi :  <morph-С,мр,од,ед,им>;
 
 ершов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-ершов.ndmsi :  <morph-С,мр,но,ед,им>;
 
 ессентук.= :
   LLBCC+ or LLDYM+;
@@ -13523,18 +13521,18 @@
 
 ехид.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-ехид.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 ехид.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 ехид.nlfpv :  <morph-С,жр,од,мн,вн>;
 
+ехид.nlmpv :  <morph-С,мр,од,мн,вн>;
+
 ж.= :
   LLDTM+ or LLFQI+ or LLAKD+ or LLENZ+ or LLATL+ or LLAYM+ or LLAYQ+;
 
-ж.i :  <morph-СОЮЗ,0>;
-
 ж.p :  <morph-ЧАСТ,0>;
+
+ж.i :  <morph-СОЮЗ,0>;
 
 жаб.= :
   LLAFX+ or LLAGT+ or LLBFF+ or LLBRK+ or LLBYZ+;
@@ -13604,24 +13602,24 @@
 :
   LLDTM+;
 
-абы.i аж.i будто.i все-таки.i даже.i же.i 
-или.i кабы.i либо.i лишь.i нешто.i пускай.i 
-пусть.i словно.i только.i чтоб.i чтобы.i якобы.i 
-:  <morph-СОЮЗ,0>;
-
 абы.p аж.p будто.p все-таки.p даже.p же.p 
 или.p кабы.p либо.p лишь.p нешто.p пускай.p 
 пусть.p словно.p только.p чтоб.p чтобы.p якобы.p 
 :  <morph-ЧАСТ,0>;
 
+абы.i аж.i будто.i все-таки.i даже.i же.i 
+или.i кабы.i либо.i лишь.i нешто.i пускай.i 
+пусть.i словно.i только.i чтоб.i чтобы.i якобы.i 
+:  <morph-СОЮЗ,0>;
+
 желатин.= :
   LLAAO+ or LLAFX+ or LLBYU+;
-
-желатин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 желатин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 желатин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+желатин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 желе.= купе.= реле.= :
   LLADL+ or LLBQK+;
@@ -13631,9 +13629,9 @@
 желез.= :
   LLAFX+ or LLBRK+ or LLBTI+ or LLBYU+ or LLCAG+;
 
-желез.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 желез.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+желез.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 желоб.= :
   LLABM+ or LLBZE+ or LLCJW+;
@@ -13666,9 +13664,9 @@
 жен.= :
   LLAGT+ or LLBHS+ or LLFWV+ or LLBNP+ or LLFWW+ or LLFHL+ or LLBRO+;
 
-жен.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 жен.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+жен.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 женоубийц.= :
   LLAEW+;
@@ -13693,9 +13691,9 @@
 жернов.= :
   LLABM+ or LLCJC+ or LLCJW+;
 
-жернов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 жернов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+жернов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 жертв.= :
   LLAFX+ or LLAGT+ or LLCCZ+ or LLCGW+;
@@ -13747,11 +13745,11 @@
 
 животин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-животин.ndmpg :  <morph-С,мр,но,мн,рд>;
+животин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 животин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-животин.ndfpg :  <morph-С,жр,но,мн,рд>;
+животин.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 жвачн.= животн.= копытн.= насеком.= рукокрыл.= :
   LLCIL+;
@@ -13797,22 +13795,22 @@
 жил.= :
   LLAFH+ or LLAFX+ or LLAYL+ or LLFTC+ or LLFAN+ or LLBNU+ or LLBRK+ or LLCJC+ or LLDOO+;
 
-жил.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 жил.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 жил.ndfpg :  <morph-С,жр,но,мн,рд>;
 
+жил.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 жил.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-жил.nlfpv :  <morph-С,жр,од,мн,вн>;
+жил.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 жилищ.= :
   LLAFM+ or LLARS+ or LLBYZ+;
 
-жилищ.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 жилищ.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+жилищ.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 жилпло.= :
   LLDJP+;
@@ -13844,9 +13842,9 @@
 жнив.= титл.= :
   LLAFX+ or LLCAG+;
 
-жнив.ndnpg титл.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 жнив.ndfpg титл.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+жнив.ndnpg титл.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 брюзгн.= волгн.= горкн.= жолкн.= склизн.= терпн.= 
 :
@@ -13866,9 +13864,9 @@
 журавель.= :
   LLAAC+ or LLACB+;
 
-журавель.nlmsi :  <morph-С,мр,од,ед,им>;
-
 журавель.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+журавель.nlmsi :  <morph-С,мр,од,ед,им>;
 
 журавель.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -13878,9 +13876,9 @@
 журавлев.= плетнев.= :
   LLFQF+ or LLFJN+ or LLDKJ+;
 
-журавлев.amss плетнев.amss :  <morph-П,мр,ед,кр>;
-
 журавлев.nlmsi плетнев.nlmsi :  <morph-С,мр,од,ед,им>;
+
+журавлев.amss плетнев.amss :  <morph-П,мр,ед,кр>;
 
 журавуш.= :
   LLBRE+ or LLBRM+;
@@ -13924,11 +13922,11 @@
 заберег.= ичиг.= черевик.= :
   LLAAM+ or LLBCA+;
 
-заберег.ndmsv ичиг.ndmsv черевик.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 заберег.ndmsi ичиг.ndmsi черевик.ndmsi :  <morph-С,мр,но,ед,им>;
 
 заберег.npg ичиг.npg черевик.npg :  <morph-С,мн,мн,рд>;
+
+заберег.ndmsv ичиг.ndmsv черевик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 забеспоко.= самоуспоко.= :
   LLFCX+;
@@ -13965,9 +13963,9 @@
 заброс.= разброс.= :
   LLAAQ+ or LLFWS+ or LLBRK+;
 
-заброс.ndmsv разброс.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 заброс.ndmsi разброс.ndmsi :  <morph-С,мр,но,ед,им>;
+
+заброс.ndmsv разброс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 забыть.= полузабыть.= :
   LLARX+;
@@ -14039,9 +14037,9 @@
 завоз.= перевоз.= сход.= :
   LLAAQ+ or LLBRK+ or LLBYZ+ or LLBZO+;
 
-завоз.ndmsv перевоз.ndmsv сход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 завоз.ndmsi перевоз.ndmsi сход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+завоз.ndmsv перевоз.ndmsv сход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 заворотн.= :
   LLEDW+ or LLDLO+;
@@ -14156,9 +14154,9 @@
 задор.= :
   LLAAO+ or LLBNU+ or LLBYU+;
 
-задор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 задор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+задор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 задрем.= подрем.= продрем.= :
   LLGIQ+;
@@ -14193,11 +14191,11 @@
 зазноб.= :
   LLAFX+ or LLAGT+ or LLFWK+;
 
-зазноб.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 зазноб.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 зазноб.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+зазноб.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 зазуммер.= :
   LLBJM+;
@@ -14301,20 +14299,20 @@
 закут.= :
   LLAAQ+ or LLAFX+ or LLBRK+ or LLCJW+;
 
-закут.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 закут.ndmsi :  <morph-С,мр,но,ед,им>;
+
+закут.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 закут.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 зал.= :
   LLAAQ+ or LLAFX+ or LLGJE+ or LLGAY+ or LLGDA+ or LLGDB+ or LLCAI+ or LLDOO+ or LLDPD+;
 
-зал.ndnpg :  <morph-С,ср,но,мн,рд>;
+зал.ndmsi :  <morph-С,мр,но,ед,им>;
 
 зал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-зал.ndmsi :  <morph-С,мр,но,ед,им>;
+зал.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 зал.ndfpg :  <morph-С,жр,но,мн,рд>;
 
@@ -14495,26 +14493,26 @@
 заноз.= :
   LLAFH+ or LLAFX+ or LLBRK+;
 
+заноз.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 заноз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 заноз.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 заноз.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-заноз.nlmpg :  <morph-С,мр,од,мн,рд>;
-
 заноз.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 зануд.= надоед.= обжор.= паскуд.= :
   LLAFH+ or LLBYU+;
 
-зануд.nlfpg надоед.nlfpg обжор.nlfpg паскуд.nlfpg :  <morph-С,жр,од,мн,рд>;
+зануд.nlfpv надоед.nlfpv обжор.nlfpv паскуд.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 зануд.nlmpv надоед.nlmpv обжор.nlmpv паскуд.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-зануд.nlmpg надоед.nlmpg обжор.nlmpg паскуд.nlmpg :  <morph-С,мр,од,мн,рд>;
+зануд.nlfpg надоед.nlfpg обжор.nlfpg паскуд.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-зануд.nlfpv надоед.nlfpv обжор.nlfpv паскуд.nlfpv :  <morph-С,жр,од,мн,вн>;
+зануд.nlmpg надоед.nlmpg обжор.nlmpg паскуд.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 занюха.= :
   LLFRI+ or LLFWU+;
@@ -14530,9 +14528,9 @@
 запад.= :
   LLAAQ+ or LLDWW+ or LLBYU+;
 
-запад.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 запад.ndmsi :  <morph-С,мр,но,ед,им>;
+
+запад.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 закрепо.= запако.= испако.= перекре.= перепако.= повычи.= 
 :
@@ -14607,9 +14605,9 @@
 запор.= :
   LLAAQ+ or LLBRK+ or LLBYU+ or LLGAA+ or LLGFC+ or LLFTE+;
 
-запор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 запор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+запор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 броненос.= запорож.= :
   LLAXZ+ or LLAYI+;
@@ -14809,9 +14807,9 @@
 засос.= :
   LLAAQ+ or LLFZJ+;
 
-засос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 засос.ndmsi :  <morph-С,мр,но,ед,им>;
+
+засос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 заспор.= :
   LLGHS+ or LLGEO+;
@@ -14997,9 +14995,9 @@
 
 звезд.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-звезд.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 звезд.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+звезд.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 звен.= :
   LLAWR+ or LLCAN+;
@@ -15015,13 +15013,13 @@
 зверин.= :
   LLAFH+ or LLAXZ+ or LLDKJ+;
 
+зверин.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 зверин.amss :  <morph-П,мр,ед,кр>;
 
 зверин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 зверин.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-зверин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 зверин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
@@ -15031,9 +15029,9 @@
 звон.= :
   LLAAO+ or LLAYB+ or LLBGI+ or LLBNP+ or LLBSX+ or LLCJW+;
 
-звон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 звон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+звон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 звонар.= :
   LLBZO+ or LLDMT+;
@@ -15052,27 +15050,40 @@
 здорово.= :
   LLAEK+ or LLAEL+ or LLDTP+;
 
-здорово.xn :  <morph-ПРЕДК,нст>;
-
 здорово.e :  <morph-Н,0>;
+
+здорово.xn :  <morph-ПРЕДК,нст>;
 
 зев.= :
   LLAAQ+ or LLAFH+ or LLCJW+;
 
 зев.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-зев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-зев.nlmpv :  <morph-С,мр,од,мн,вн>;
+зев.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 зев.ndmsi :  <morph-С,мр,но,ед,им>;
 
-зев.nlmpg :  <morph-С,мр,од,мн,рд>;
-
 зев.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+зев.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+зев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.78:
   LLAFG+;
+
+бедняг.nlmpg бедолаг.nlmpg бродяг.nlmpg брюзг.nlmpg бумагомарак.nlmpg ворюг.nlmpg 
+выпивох.nlmpg горемык.nlmpg гуляк.nlmpg деляг.nlmpg доходяг.nlmpg жаднюг.nlmpg 
+жадюг.nlmpg забияк.nlmpg задавак.nlmpg заик.nlmpg замарах.nlmpg запивох.nlmpg 
+зверюг.nlmpg здоровяг.nlmpg зевак.nlmpg злюк.nlmpg калек.nlmpg калик.nlmpg 
+коллег.nlmpg кочевряг.nlmpg кривляк.nlmpg кусак.nlmpg ломак.nlmpg миляг.nlmpg 
+молодчаг.nlmpg мурлык.nlmpg недотык.nlmpg нерях.nlmpg нескладех.nlmpg обирох.nlmpg 
+опивох.nlmpg писак.nlmpg побирах.nlmpg побирух.nlmpg побродяг.nlmpg подлюг.nlmpg 
+подлюк.nlmpg прожиг.nlmpg пройдох.nlmpg прощелыг.nlmpg пьянчуг.nlmpg работяг.nlmpg 
+раскоряк.nlmpg распустех.nlmpg растерях.nlmpg сердяг.nlmpg симпатяг.nlmpg сквалыг.nlmpg 
+скряг.nlmpg скупердяг.nlmpg стиляг.nlmpg сутяг.nlmpg тварюг.nlmpg торопыг.nlmpg 
+трудяг.nlmpg тюх.nlmpg фордыбак.nlmpg хапуг.nlmpg хитрюг.nlmpg шаромыг.nlmpg 
+:  <morph-С,мр,од,мн,рд>;
 
 бедняг.nlfpg бедолаг.nlfpg бродяг.nlfpg брюзг.nlfpg бумагомарак.nlfpg ворюг.nlfpg 
 выпивох.nlfpg горемык.nlfpg гуляк.nlfpg деляг.nlfpg доходяг.nlfpg жаднюг.nlfpg 
@@ -15099,19 +15110,6 @@
 скряг.nlmpv скупердяг.nlmpv стиляг.nlmpv сутяг.nlmpv тварюг.nlmpv торопыг.nlmpv 
 трудяг.nlmpv тюх.nlmpv фордыбак.nlmpv хапуг.nlmpv хитрюг.nlmpv шаромыг.nlmpv 
 :  <morph-С,мр,од,мн,вн>;
-
-бедняг.nlmpg бедолаг.nlmpg бродяг.nlmpg брюзг.nlmpg бумагомарак.nlmpg ворюг.nlmpg 
-выпивох.nlmpg горемык.nlmpg гуляк.nlmpg деляг.nlmpg доходяг.nlmpg жаднюг.nlmpg 
-жадюг.nlmpg забияк.nlmpg задавак.nlmpg заик.nlmpg замарах.nlmpg запивох.nlmpg 
-зверюг.nlmpg здоровяг.nlmpg зевак.nlmpg злюк.nlmpg калек.nlmpg калик.nlmpg 
-коллег.nlmpg кочевряг.nlmpg кривляк.nlmpg кусак.nlmpg ломак.nlmpg миляг.nlmpg 
-молодчаг.nlmpg мурлык.nlmpg недотык.nlmpg нерях.nlmpg нескладех.nlmpg обирох.nlmpg 
-опивох.nlmpg писак.nlmpg побирах.nlmpg побирух.nlmpg побродяг.nlmpg подлюг.nlmpg 
-подлюк.nlmpg прожиг.nlmpg пройдох.nlmpg прощелыг.nlmpg пьянчуг.nlmpg работяг.nlmpg 
-раскоряк.nlmpg распустех.nlmpg растерях.nlmpg сердяг.nlmpg симпатяг.nlmpg сквалыг.nlmpg 
-скряг.nlmpg скупердяг.nlmpg стиляг.nlmpg сутяг.nlmpg тварюг.nlmpg торопыг.nlmpg 
-трудяг.nlmpg тюх.nlmpg фордыбак.nlmpg хапуг.nlmpg хитрюг.nlmpg шаромыг.nlmpg 
-:  <morph-С,мр,од,мн,рд>;
 
 бедняг.nlfpv бедолаг.nlfpv бродяг.nlfpv брюзг.nlfpv бумагомарак.nlfpv ворюг.nlfpv 
 выпивох.nlfpv горемык.nlfpv гуляк.nlfpv деляг.nlfpv доходяг.nlfpv жаднюг.nlfpv 
@@ -15212,9 +15210,9 @@
 златоуст.= :
   LLACI+ or LLDWW+ or LLDLO+;
 
-златоуст.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 златоуст.nlmsi :  <morph-С,мр,од,ед,им>;
+
+златоуст.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 златоуст.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -15299,9 +15297,9 @@
 
 золотухин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-золотухин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 золотухин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+золотухин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 /ru/words/words.80:
   LLARQ+;
@@ -15312,11 +15310,11 @@
 зорин.= :
   LLFQF+ or LLFIN+;
 
-зорин.nlfpg :  <morph-С,жр,од,мн,рд>;
+зорин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 зорин.nlmsi :  <morph-С,мр,од,ед,им>;
 
-зорин.nlfpv :  <morph-С,жр,од,мн,вн>;
+зорин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 зрел.= :
   LLDKF+ or LLDOZ+;
@@ -15334,9 +15332,9 @@
 зуб.= :
   LLAAR+ or LLAYB+ or LLCKB+;
 
-зуб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 зуб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+зуб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выходн.= губн.= зубн.= :
   LLCIP+ or LLCJC+;
@@ -15354,30 +15352,30 @@
 зубрил.= :
   LLAFH+ or LLBRH+ or LLCAG+ or LLDOK+;
 
-зубрил.ndnpg :  <morph-С,ср,но,мн,рд>;
-
-зубрил.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 зубрил.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-зубрил.nlmpg :  <morph-С,мр,од,мн,рд>;
+зубрил.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 зубрил.nlfpv :  <morph-С,жр,од,мн,вн>;
 
+зубрил.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+зубрил.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 зуд.= :
   LLAAQ+ or LLAFH+ or LLAVM+;
-
-зуд.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 зуд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 зуд.nlmpv :  <morph-С,мр,од,мн,вн>;
 
+зуд.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 зуд.ndmsi :  <morph-С,мр,но,ед,им>;
 
 зуд.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-зуд.nlfpv :  <morph-С,жр,од,мн,вн>;
+зуд.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 зуммер.= :
   LLAAQ+ or LLBGR+;
@@ -15403,25 +15401,23 @@
 и.= :
   LLDTK+ or LLGKX+ or LLEOU+ or LLEOV+ or LLGLB+ or LLGLE+ or LLGLF+ or LLGLG+;
 
-:  <morph-СОЮЗ,0>;
-
 и.p :  <morph-ЧАСТ,0>;
 
 иванов.= :
   LLFJG+ or LLFUO+ or LLFOU+ or LLDZR+;
 
-иванов.amsi :  <morph-П,мр,ед,им>;
+иванов.admsv :  <morph-П,мр,ед,вн,но>;
 
 иванов.nlmsi :  <morph-С,мр,од,ед,им>;
 
-иванов.admsv :  <morph-П,мр,ед,вн,но>;
+иванов.amsi :  <morph-П,мр,ед,им>;
 
 ивановск.= :
   LLDWW+ or LLBEL+ or LLDZV+;
 
-ивановск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ивановск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ивановск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 анадыр.= аньшан.= ивдел.= суздал.= :
   LLEAT+ or LLEAU+;
@@ -15461,18 +15457,18 @@
 /ru/words/words.82:
   LLAFH+;
 
-балд.nlfpg бузил.nlfpg верзил.nlfpg воображал.nlfpg выжимал.nlfpg выпивал.nlfpg 
-гомоз.nlfpg грымз.nlfpg деревенщин.nlfpg доставал.nlfpg дурынд.nlfpg дылд.nlfpg 
-егоз.nlfpg ехидин.nlfpg жадин.nlfpg жадоб.nlfpg заводил.nlfpg задир.nlfpg 
-задирал.nlfpg зазывал.nlfpg запевал.nlfpg зудил.nlfpg идиотин.nlfpg ловчил.nlfpg 
-молодчин.nlfpg мудрил.nlfpg надоедал.nlfpg надувал.nlfpg насекал.nlfpg невежд.nlfpg 
-недотеп.nlfpg непосед.nlfpg обдирал.nlfpg обдувал.nlfpg обжигал.nlfpg обжирал.nlfpg 
-обирал.nlfpg объедал.nlfpg опивал.nlfpg остолопин.nlfpg плакс.nlfpg подгонял.nlfpg 
-поддавал.nlfpg подлиз.nlfpg подлипал.nlfpg подметал.nlfpg подпевал.nlfpg подхалюз.nlfpg 
-приверед.nlfpg приставал.nlfpg притворял.nlfpg прихлебал.nlfpg прожор.nlfpg пройд.nlfpg 
-прокуд.nlfpg проныр.nlfpg растяп.nlfpg скулил.nlfpg сластен.nlfpg сорвиголов.nlfpg 
-строчил.nlfpg тарант.nlfpg уродин.nlfpg хныкал.nlfpg хныкс.nlfpg чудил.nlfpg 
-шленд.nlfpg шлендр.nlfpg :  <morph-С,жр,од,мн,рд>;
+балд.nlfpv бузил.nlfpv верзил.nlfpv воображал.nlfpv выжимал.nlfpv выпивал.nlfpv 
+гомоз.nlfpv грымз.nlfpv деревенщин.nlfpv доставал.nlfpv дурынд.nlfpv дылд.nlfpv 
+егоз.nlfpv ехидин.nlfpv жадин.nlfpv жадоб.nlfpv заводил.nlfpv задир.nlfpv 
+задирал.nlfpv зазывал.nlfpv запевал.nlfpv зудил.nlfpv идиотин.nlfpv ловчил.nlfpv 
+молодчин.nlfpv мудрил.nlfpv надоедал.nlfpv надувал.nlfpv насекал.nlfpv невежд.nlfpv 
+недотеп.nlfpv непосед.nlfpv обдирал.nlfpv обдувал.nlfpv обжигал.nlfpv обжирал.nlfpv 
+обирал.nlfpv объедал.nlfpv опивал.nlfpv остолопин.nlfpv плакс.nlfpv подгонял.nlfpv 
+поддавал.nlfpv подлиз.nlfpv подлипал.nlfpv подметал.nlfpv подпевал.nlfpv подхалюз.nlfpv 
+приверед.nlfpv приставал.nlfpv притворял.nlfpv прихлебал.nlfpv прожор.nlfpv пройд.nlfpv 
+прокуд.nlfpv проныр.nlfpv растяп.nlfpv скулил.nlfpv сластен.nlfpv сорвиголов.nlfpv 
+строчил.nlfpv тарант.nlfpv уродин.nlfpv хныкал.nlfpv хныкс.nlfpv чудил.nlfpv 
+шленд.nlfpv шлендр.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 балд.nlmpv бузил.nlmpv верзил.nlmpv воображал.nlmpv выжимал.nlmpv выпивал.nlmpv 
 гомоз.nlmpv грымз.nlmpv деревенщин.nlmpv доставал.nlmpv дурынд.nlmpv дылд.nlmpv 
@@ -15487,6 +15483,19 @@
 строчил.nlmpv тарант.nlmpv уродин.nlmpv хныкал.nlmpv хныкс.nlmpv чудил.nlmpv 
 шленд.nlmpv шлендр.nlmpv :  <morph-С,мр,од,мн,вн>;
 
+балд.nlfpg бузил.nlfpg верзил.nlfpg воображал.nlfpg выжимал.nlfpg выпивал.nlfpg 
+гомоз.nlfpg грымз.nlfpg деревенщин.nlfpg доставал.nlfpg дурынд.nlfpg дылд.nlfpg 
+егоз.nlfpg ехидин.nlfpg жадин.nlfpg жадоб.nlfpg заводил.nlfpg задир.nlfpg 
+задирал.nlfpg зазывал.nlfpg запевал.nlfpg зудил.nlfpg идиотин.nlfpg ловчил.nlfpg 
+молодчин.nlfpg мудрил.nlfpg надоедал.nlfpg надувал.nlfpg насекал.nlfpg невежд.nlfpg 
+недотеп.nlfpg непосед.nlfpg обдирал.nlfpg обдувал.nlfpg обжигал.nlfpg обжирал.nlfpg 
+обирал.nlfpg объедал.nlfpg опивал.nlfpg остолопин.nlfpg плакс.nlfpg подгонял.nlfpg 
+поддавал.nlfpg подлиз.nlfpg подлипал.nlfpg подметал.nlfpg подпевал.nlfpg подхалюз.nlfpg 
+приверед.nlfpg приставал.nlfpg притворял.nlfpg прихлебал.nlfpg прожор.nlfpg пройд.nlfpg 
+прокуд.nlfpg проныр.nlfpg растяп.nlfpg скулил.nlfpg сластен.nlfpg сорвиголов.nlfpg 
+строчил.nlfpg тарант.nlfpg уродин.nlfpg хныкал.nlfpg хныкс.nlfpg чудил.nlfpg 
+шленд.nlfpg шлендр.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 балд.nlmpg бузил.nlmpg верзил.nlmpg воображал.nlmpg выжимал.nlmpg выпивал.nlmpg 
 гомоз.nlmpg грымз.nlmpg деревенщин.nlmpg доставал.nlmpg дурынд.nlmpg дылд.nlmpg 
 егоз.nlmpg ехидин.nlmpg жадин.nlmpg жадоб.nlmpg заводил.nlmpg задир.nlmpg 
@@ -15499,19 +15508,6 @@
 прокуд.nlmpg проныр.nlmpg растяп.nlmpg скулил.nlmpg сластен.nlmpg сорвиголов.nlmpg 
 строчил.nlmpg тарант.nlmpg уродин.nlmpg хныкал.nlmpg хныкс.nlmpg чудил.nlmpg 
 шленд.nlmpg шлендр.nlmpg :  <morph-С,мр,од,мн,рд>;
-
-балд.nlfpv бузил.nlfpv верзил.nlfpv воображал.nlfpv выжимал.nlfpv выпивал.nlfpv 
-гомоз.nlfpv грымз.nlfpv деревенщин.nlfpv доставал.nlfpv дурынд.nlfpv дылд.nlfpv 
-егоз.nlfpv ехидин.nlfpv жадин.nlfpv жадоб.nlfpv заводил.nlfpv задир.nlfpv 
-задирал.nlfpv зазывал.nlfpv запевал.nlfpv зудил.nlfpv идиотин.nlfpv ловчил.nlfpv 
-молодчин.nlfpv мудрил.nlfpv надоедал.nlfpv надувал.nlfpv насекал.nlfpv невежд.nlfpv 
-недотеп.nlfpv непосед.nlfpv обдирал.nlfpv обдувал.nlfpv обжигал.nlfpv обжирал.nlfpv 
-обирал.nlfpv объедал.nlfpv опивал.nlfpv остолопин.nlfpv плакс.nlfpv подгонял.nlfpv 
-поддавал.nlfpv подлиз.nlfpv подлипал.nlfpv подметал.nlfpv подпевал.nlfpv подхалюз.nlfpv 
-приверед.nlfpv приставал.nlfpv притворял.nlfpv прихлебал.nlfpv прожор.nlfpv пройд.nlfpv 
-прокуд.nlfpv проныр.nlfpv растяп.nlfpv скулил.nlfpv сластен.nlfpv сорвиголов.nlfpv 
-строчил.nlfpv тарант.nlfpv уродин.nlfpv хныкал.nlfpv хныкс.nlfpv чудил.nlfpv 
-шленд.nlfpv шлендр.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 из.= :
   LLDTD+ or LLFWP+ or LLFYE+ or LLFXH+ or LLFYN+ or LLGKS+ or LLGKT+ or LLGAD+ or LLGAE+ or LLGAG+ or LLGAH+ or LLFZG+ or LLFZH+ or LLGLA+;
@@ -15553,9 +15549,9 @@
 изверг.= :
   LLACG+ or LLGKP+ or LLGKQ+;
 
-изверг.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
-
 изверг.nlmsi :  <morph-С,мр,од,ед,им>;
+
+изверг.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 извест.= связ.= :
   LLBRK+ or LLBYU+ or LLDNF+;
@@ -15678,16 +15674,16 @@
 икр.= :
   LLAFX+ or LLBNP+ or LLDJS+;
 
-икр.npg :  <morph-С,мн,мн,рд>;
-
 икр.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+икр.npg :  <morph-С,мн,мн,рд>;
 
 ил.= :
   LLAAO+ or LLDNX+ or LLDNY+ or LLDOO+;
 
-ил.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ил.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ил.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 иллюстрир.= :
   LLEOR+ or LLCGD+ or LLEOS+;
@@ -15735,20 +15731,20 @@
 ин-фолио.= :
   LLABZ+ or LLADL+ or LLAEG+ or LLAEK+;
 
-ин-фолио.ndn :  <morph-С,ср,но,0>;
-
 ин-фолио.a :  <morph-П,0>;
 
-ин-фолио.e :  <morph-Н,0>;
-
 ин-фолио.ndm :  <morph-С,мр,но,0>;
+
+ин-фолио.ndn :  <morph-С,ср,но,0>;
+
+ин-фолио.e :  <morph-Н,0>;
 
 доколе.= иначе.= :
   LLDTI+ or LLAEK+;
 
-доколе.i иначе.i :  <morph-СОЮЗ,0>;
-
 доколе.e иначе.e :  <morph-Н,0>;
+
+доколе.i иначе.i :  <morph-СОЮЗ,0>;
 
 ингул.= :
   LLDWW+ or LLDYI+;
@@ -15781,9 +15777,9 @@
 инкогнито.= :
   LLACZ+ or LLADL+ or LLAEK+;
 
-инкогнито.ndn :  <morph-С,ср,но,0>;
-
 инкогнито.e :  <morph-Н,0>;
+
+инкогнито.ndn :  <morph-С,ср,но,0>;
 
 инкрустир.= :
   LLCGL+;
@@ -15868,9 +15864,9 @@
 иордан.= :
   LLAAQ+ or LLAYI+ or LLBRO+ or LLDNF+;
 
-иордан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 иордан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+иордан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ален.= ипат.= :
   LLFKO+ or LLFIH+ or LLBRO+;
@@ -15890,20 +15886,6 @@
 /ru/words/words.86:
   LLFUS+;
 
-анютин.amsi ариаднин.amsi бабусин.amsi барынин.amsi братнин.amsi валькин.amsi 
-внучкин.amsi гулькин.amsi девицын.amsi дедушкин.amsi димин.amsi дочерин.amsi 
-дочернин.amsi дочкин.amsi дядин.amsi дядюшкин.amsi женин.amsi иринкин.amsi 
-иришкин.amsi калинкин.amsi карлушин.amsi клавкин.amsi колин.amsi колькин.amsi 
-курицын.amsi кутькин.amsi кухаркин.amsi ларисин.amsi ласточкин.amsi любочкин.amsi 
-люськин.amsi мамашин.amsi маменькин.amsi мамин.amsi мамкин.amsi маринкин.amsi 
-мартышкин.amsi материн.amsi матушкин.amsi мачехин.amsi мишкин.amsi морковкин.amsi 
-мужнин.amsi наташкин.amsi невестин.amsi нинкин.amsi нянечкин.amsi нянин.amsi 
-нянькин.amsi нянюшкин.amsi олин.amsi папашин.amsi папенькин.amsi папин.amsi 
-прабабкин.amsi свекровин.amsi светланин.amsi сестрин.amsi сестрицын.amsi старухин.amsi 
-сукин.amsi танькин.amsi тетин.amsi тетушкин.amsi тещин.amsi толькин.amsi 
-тришкин.amsi троицын.amsi тятькин.amsi филькин.amsi хозяйкин.amsi юлин.amsi 
-юркин.amsi :  <morph-П,мр,ед,им>;
-
 анютин.admsv ариаднин.admsv бабусин.admsv барынин.admsv братнин.admsv валькин.admsv 
 внучкин.admsv гулькин.admsv девицын.admsv дедушкин.admsv димин.admsv дочерин.admsv 
 дочернин.admsv дочкин.admsv дядин.admsv дядюшкин.admsv женин.admsv иринкин.admsv 
@@ -15917,6 +15899,20 @@
 сукин.admsv танькин.admsv тетин.admsv тетушкин.admsv тещин.admsv толькин.admsv 
 тришкин.admsv троицын.admsv тятькин.admsv филькин.admsv хозяйкин.admsv юлин.admsv 
 юркин.admsv :  <morph-П,мр,ед,вн,но>;
+
+анютин.amsi ариаднин.amsi бабусин.amsi барынин.amsi братнин.amsi валькин.amsi 
+внучкин.amsi гулькин.amsi девицын.amsi дедушкин.amsi димин.amsi дочерин.amsi 
+дочернин.amsi дочкин.amsi дядин.amsi дядюшкин.amsi женин.amsi иринкин.amsi 
+иришкин.amsi калинкин.amsi карлушин.amsi клавкин.amsi колин.amsi колькин.amsi 
+курицын.amsi кутькин.amsi кухаркин.amsi ларисин.amsi ласточкин.amsi любочкин.amsi 
+люськин.amsi мамашин.amsi маменькин.amsi мамин.amsi мамкин.amsi маринкин.amsi 
+мартышкин.amsi материн.amsi матушкин.amsi мачехин.amsi мишкин.amsi морковкин.amsi 
+мужнин.amsi наташкин.amsi невестин.amsi нинкин.amsi нянечкин.amsi нянин.amsi 
+нянькин.amsi нянюшкин.amsi олин.amsi папашин.amsi папенькин.amsi папин.amsi 
+прабабкин.amsi свекровин.amsi светланин.amsi сестрин.amsi сестрицын.amsi старухин.amsi 
+сукин.amsi танькин.amsi тетин.amsi тетушкин.amsi тещин.amsi толькин.amsi 
+тришкин.amsi троицын.amsi тятькин.amsi филькин.amsi хозяйкин.amsi юлин.amsi 
+юркин.amsi :  <morph-П,мр,ед,им>;
 
 ирм.= :
   LLETM+;
@@ -15942,9 +15938,9 @@
 всего.= исключительно.= прямо.= там.= токмо.= :
   LLAEK+ or LLDTS+;
 
-всего.e исключительно.e прямо.e там.e токмо.e :  <morph-Н,0>;
-
 всего.p исключительно.p прямо.p там.p токмо.p :  <morph-ЧАСТ,0>;
+
+всего.e исключительно.e прямо.e там.e токмо.e :  <morph-Н,0>;
 
 дневн.= исков.= :
   LLCJC+ or LLDLP+;
@@ -16024,9 +16020,9 @@
 иссык.= :
   LLAEG+ or LLDWW+;
 
-иссык.a :  <morph-П,0>;
-
 иссык.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+иссык.a :  <morph-П,0>;
 
 иссык.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -16116,9 +16112,9 @@
 кабан.= :
   LLAAQ+ or LLACI+ or LLAVH+ or LLBFF+;
 
-кабан.nlmsi :  <morph-С,мр,од,ед,им>;
-
 кабан.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+кабан.nlmsi :  <morph-С,мр,од,ед,им>;
 
 кабан.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -16171,9 +16167,9 @@
 казан.= :
   LLAAQ+ or LLCJW+ or LLEAU+;
 
-казан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 казан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+казан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 казач.= :
   LLBFF+ or LLBRM+ or LLCJW+ or LLCKD+ or LLCKS+;
@@ -16184,9 +16180,9 @@
 кайл.= :
   LLAFX+ or LLBHS+ or LLBNP+ or LLCAG+;
 
-кайл.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 кайл.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+кайл.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 кайф.= :
   LLAAY+ or LLCBK+;
@@ -16199,8 +16195,6 @@
   LLDTM+ or LLAEK+ or LLDVN+ or LLCJP+ or LLCJQ+ or LLCJR+;
 
 как.i :  <morph-СОЮЗ,0>;
-
-:  <morph-Н,0>;
 
 как.p :  <morph-ЧАСТ,0>;
 
@@ -16218,9 +16212,9 @@
 кал.= :
   LLAAQ+ or LLEOW+ or LLATN+ or LLBHS+ or LLBNP+ or LLDNX+;
 
-кал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 каламбур.= :
   LLAAQ+ or LLBGW+;
@@ -16240,9 +16234,9 @@
 кайман.= кальмар.= палаван.= :
   LLACI+ or LLDWW+;
 
-кайман.ndmsv кальмар.ndmsv палаван.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кайман.nlmsi кальмар.nlmsi палаван.nlmsi :  <morph-С,мр,од,ед,им>;
+
+кайман.ndmsv кальмар.ndmsv палаван.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кайман.ndmsi кальмар.ndmsi палаван.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -16269,11 +16263,11 @@
 светлан.= татьян.= :
   LLFIQ+ or LLFHX+;
 
-аманд.nlfpg барбар.nlfpg илон.nlfpg камилл.nlfpg кассандр.nlfpg клав.nlfpg 
-светлан.nlfpg татьян.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 аманд.nlfpv барбар.nlfpv илон.nlfpv камилл.nlfpv кассандр.nlfpv клав.nlfpv 
 светлан.nlfpv татьян.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+аманд.nlfpg барбар.nlfpg илон.nlfpg камилл.nlfpg кассандр.nlfpg клав.nlfpg 
+светлан.nlfpg татьян.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кампани.= :
   LLDQL+ or LLEBA+;
@@ -16374,9 +16368,9 @@
 кан.= :
   LLDWW+ or LLGBL+;
 
-кан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 аргентин.= канад.= палестин.= уганд.= украин.= :
   LLDXR+ or LLAYI+ or LLBRO+;
@@ -16391,11 +16385,11 @@
 канаш.= :
   LLDWV+ or LLDWY+ or LLEEL+;
 
-канаш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 канаш.ndmsi :  <morph-С,мр,но,ед,им>;
 
 канаш.ndm :  <morph-С,мр,но,0>;
+
+канаш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кандал.= :
   LLDJV+ or LLDOO+;
@@ -16421,22 +16415,22 @@
 канюк.= лежебок.= :
   LLACG+ or LLAFG+;
 
-канюк.nlfpg лежебок.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 канюк.nlmsi лежебок.nlmsi :  <morph-С,мр,од,ед,им>;
 
 канюк.nlmpv лежебок.nlmpv :  <morph-С,мр,од,мн,вн>;
 
+канюк.nlfpv лежебок.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 канюк.nlmpg лежебок.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-канюк.nlfpv лежебок.nlfpv :  <morph-С,жр,од,мн,вн>;
+канюк.nlfpg лежебок.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кап.= :
   LLAAQ+ or LLAHT+ or LLBTV+ or LLBUI+ or LLCJW+;
 
-кап.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кап.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кап.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 капитал.= :
   LLAAO+ or LLAYE+ or LLDML+;
@@ -16474,9 +16468,9 @@
 каракол.= :
   LLDWW+ or LLDNF+;
 
-каракол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 каракол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+каракол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 каракул.= :
   LLDML+ or LLDQH+;
@@ -16496,9 +16490,9 @@
 караул.= :
   LLAAQ+ or LLBIA+ or LLBNU+ or LLBRK+ or LLDOK+ or LLDOZ+;
 
-караул.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 караул.ndmsi :  <morph-С,мр,но,ед,им>;
+
+караул.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вольн.= караульн.= отвальн.= :
   LLAKS+ or LLDJZ+;
@@ -16526,18 +16520,18 @@
 карл.= :
   LLFKQ+ or LLFHQ+ or LLAEY+;
 
+карл.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 карл.nlmsi :  <morph-С,мр,од,ед,им>;
 
 карл.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-карл.nlmpg :  <morph-С,мр,од,мн,рд>;
-
 ангар.= карман.= :
   LLAAQ+ or LLDXR+ or LLBYZ+;
 
-ангар.ndmsv карман.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ангар.ndmsi карман.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ангар.ndmsv карман.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 алабам.= бухар.= верон.= ган.= женев.= каролин.= 
 полтав.= тоскан.= :
@@ -16557,16 +16551,16 @@
 картуш.= клич.= плюш.= :
   LLAAH+ or LLBRI+;
 
-картуш.ndmsv клич.ndmsv плюш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 картуш.ndmsi клич.ndmsi плюш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+картуш.ndmsv клич.ndmsv плюш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 карч.= :
   LLAAH+ or LLAGC+;
 
-карч.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 карч.ndmsi :  <morph-С,мр,но,ед,им>;
+
+карч.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 воронк.= гнедк.= карьк.= серк.= сивк.= :
   LLCAB+;
@@ -16601,15 +16595,15 @@
 кат.= :
   LLAAQ+ or LLACI+ or LLFIR+ or LLBSW+ or LLCJW+ or LLFKY+;
 
-кат.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-кат.nlmsi :  <morph-С,мр,од,ед,им>;
+кат.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 кат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-кат.ndmsi :  <morph-С,мр,но,ед,им>;
+кат.nlmsi :  <morph-С,мр,од,ед,им>;
 
-кат.nlfpv :  <morph-С,жр,од,мн,вн>;
+кат.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+кат.ndmsi :  <morph-С,мр,но,ед,им>;
 
 катал.= :
   LLBRL+ or LLDMT+ or LLDOO+ or LLDOZ+;
@@ -16626,16 +16620,16 @@
 катер.= хутор.= :
   LLABM+ or LLBYZ+ or LLCJW+;
 
-катер.ndmsv хутор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 катер.ndmsi хутор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+катер.ndmsv хутор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 катыш.= :
   LLAAH+ or LLAUG+;
 
-катыш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 катыш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+катыш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 булан.= каур.= :
   LLBRH+ or LLDKF+;
@@ -16676,9 +16670,9 @@
 кб.= :
   LLABZ+ or LLEER+;
 
-кб.ndn :  <morph-С,ср,но,0>;
-
 кб.ndm :  <morph-С,мр,но,0>;
+
+кб.ndn :  <morph-С,ср,но,0>;
 
 ква.= :
   LLACA+ or LLCOH+ or LLCPA+;
@@ -16686,9 +16680,9 @@
 квант.= контракт.= центр.= :
   LLAAQ+ or LLFRF+ or LLFAK+;
 
-квант.ndmsv контракт.ndmsv центр.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 квант.ndmsi контракт.ndmsi центр.ndmsi :  <morph-С,мр,но,ед,им>;
+
+квант.ndmsv контракт.ndmsv центр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.94:
   LLAGL+;
@@ -16707,9 +16701,9 @@
 квит.= :
   LLAAQ+ or LLAEL+ or LLCJW+;
 
-квит.xn :  <morph-ПРЕДК,нст>;
-
 квит.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+квит.xn :  <morph-ПРЕДК,нст>;
 
 квит.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -17115,9 +17109,9 @@
 кечуа.= травести.= :
   LLADB+ or LLADL+ or LLAEG+;
 
-кечуа.ndn травести.ndn :  <morph-С,ср,но,0>;
-
 кечуа.a травести.a :  <morph-П,0>;
+
+кечуа.ndn травести.ndn :  <morph-С,ср,но,0>;
 
 античастиц.= водолечебниц.= кеш-таблиц.= клубнелуковиц.= фритюрниц.= :
   LLAFR+;
@@ -17130,32 +17124,32 @@
 кивер.= :
   LLABM+ or LLEAH+;
 
-кивер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кивер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кивер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кизил.= :
   LLAAO+ or LLDML+ or LLDOO+;
 
-кизил.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кизил.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кизил.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 камышин.= кас.= кизляр.= рабат.= :
   LLDWW+ or LLBRK+;
 
-камышин.ndmsv кас.ndmsv кизляр.ndmsv рабат.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 камышин.ndmsi кас.ndmsi кизляр.ndmsi рабат.ndmsi :  <morph-С,мр,но,ед,им>;
+
+камышин.ndmsv кас.ndmsv кизляр.ndmsv рабат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кил.= :
   LLAAQ+ or LLAFX+ or LLEOW+ or LLATN+ or LLDML+ or LLEAT+ or LLDNX+ or LLDNY+;
 
 кил.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-кил.ndmsi :  <morph-С,мр,но,ед,им>;
-
 кил.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+кил.ndmsi :  <morph-С,мр,но,ед,им>;
 
 кила.= :
   LLBRA+;
@@ -17166,11 +17160,11 @@
 килогерц.= мегагерц.= :
   LLABR+;
 
+килогерц.ndmpg мегагерц.ndmpg :  <morph-С,мр,но,мн,рд>;
+
 килогерц.ndmsv мегагерц.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 килогерц.ndmsi мегагерц.ndmsi :  <morph-С,мр,но,ед,им>;
-
-килогерц.ndmpg мегагерц.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 кин.= :
   LLAFX+ or LLFXS+ or LLFXT+;
@@ -17180,19 +17174,19 @@
 кино.= :
   LLADH+ or LLADL+;
 
-кино.ndn :  <morph-С,ср,но,0>;
+кино.ndnsp :  <morph-С,ср,но,ед,пр>;
 
-кино.ndnsd :  <morph-С,ср,но,ед,дт>;
+кино.ndnst :  <morph-С,ср,но,ед,тв>;
 
 кино.ndnsi :  <morph-С,ср,но,ед,им>;
 
-кино.ndnsp :  <morph-С,ср,но,ед,пр>;
+кино.ndnsg :  <morph-С,ср,но,ед,рд>;
+
+кино.ndnsd :  <morph-С,ср,но,ед,дт>;
 
 кино.ndnsv :  <morph-С,ср,но,ед,вн>;
 
-кино.ndnsg :  <morph-С,ср,но,ед,рд>;
-
-кино.ndnst :  <morph-С,ср,но,ед,тв>;
+кино.ndn :  <morph-С,ср,но,0>;
 
 /ru/words/words.97:
   LLDQL+;
@@ -17211,9 +17205,9 @@
 кинотовар.= :
   LLAAY+ or LLDJV+;
 
-кинотовар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кинотовар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кинотовар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кип.= :
   LLAFX+ or LLAWQ+;
@@ -17236,11 +17230,11 @@
 кис.= :
   LLAGE+ or LLAGT+ or LLBRO+ or LLBUG+ or LLBVZ+;
 
+кис.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 кис.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 кис.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-кис.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 кисел.= :
   LLAUH+ or LLDMK+ or LLDOK+;
@@ -17250,18 +17244,6 @@
 
 /ru/words/words.98:
   LLDWW+ or LLBEP+;
-
-актюбинск.ndmsv аральск.ndmsv ачинск.ndmsv батайск.ndmsv беднодемьянск.ndmsv беломорск.ndmsv 
-бирюсинск.ndmsv верхнеднепровск.ndmsv витебск.ndmsv волоколамск.ndmsv высоковск.ndmsv георгиевск.ndmsv 
-горноалтайск.ndmsv горноправдинск.ndmsv гусиноозерск.ndmsv дальнегорск.ndmsv дегтярск.ndmsv дивногорск.ndmsv 
-днепропетровск.ndmsv докучаевск.ndmsv еманжелинск.ndmsv заводоуковск.ndmsv карачаевск.ndmsv кировск.ndmsv 
-кисловодск.ndmsv кодинск.ndmsv красногорск.ndmsv красноуральск.ndmsv лесосибирск.ndmsv луганск.ndmsv 
-медногорск.ndmsv михайловск.ndmsv невинномысск.ndmsv нефтекамск.ndmsv нижневолжск.ndmsv нижнекамск.ndmsv 
-новинск.ndmsv новоаганск.ndmsv новоенисейск.ndmsv новозаводск.ndmsv новоильинск.ndmsv новомосковск.ndmsv 
-новотроицк.ndmsv новоульяновск.ndmsv новочебоксарск.ndmsv новочеркасск.ndmsv новошахтинск.ndmsv норильск.ndmsv 
-обнинск.ndmsv первоуральск.ndmsv печерск.ndmsv подольск.ndmsv пронск.ndmsv рубцовск.ndmsv 
-рыбинск.ndmsv саяногорск.ndmsv свердловск.ndmsv серебрянск.ndmsv среднеуральск.ndmsv тихорецк.ndmsv 
-тобольск.ndmsv томск.ndmsv усинск.ndmsv южноуральск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 актюбинск.ndmsi аральск.ndmsi ачинск.ndmsi батайск.ndmsi беднодемьянск.ndmsi беломорск.ndmsi 
 бирюсинск.ndmsi верхнеднепровск.ndmsi витебск.ndmsi волоколамск.ndmsi высоковск.ndmsi георгиевск.ndmsi 
@@ -17274,6 +17256,18 @@
 обнинск.ndmsi первоуральск.ndmsi печерск.ndmsi подольск.ndmsi пронск.ndmsi рубцовск.ndmsi 
 рыбинск.ndmsi саяногорск.ndmsi свердловск.ndmsi серебрянск.ndmsi среднеуральск.ndmsi тихорецк.ndmsi 
 тобольск.ndmsi томск.ndmsi усинск.ndmsi южноуральск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+актюбинск.ndmsv аральск.ndmsv ачинск.ndmsv батайск.ndmsv беднодемьянск.ndmsv беломорск.ndmsv 
+бирюсинск.ndmsv верхнеднепровск.ndmsv витебск.ndmsv волоколамск.ndmsv высоковск.ndmsv георгиевск.ndmsv 
+горноалтайск.ndmsv горноправдинск.ndmsv гусиноозерск.ndmsv дальнегорск.ndmsv дегтярск.ndmsv дивногорск.ndmsv 
+днепропетровск.ndmsv докучаевск.ndmsv еманжелинск.ndmsv заводоуковск.ndmsv карачаевск.ndmsv кировск.ndmsv 
+кисловодск.ndmsv кодинск.ndmsv красногорск.ndmsv красноуральск.ndmsv лесосибирск.ndmsv луганск.ndmsv 
+медногорск.ndmsv михайловск.ndmsv невинномысск.ndmsv нефтекамск.ndmsv нижневолжск.ndmsv нижнекамск.ndmsv 
+новинск.ndmsv новоаганск.ndmsv новоенисейск.ndmsv новозаводск.ndmsv новоильинск.ndmsv новомосковск.ndmsv 
+новотроицк.ndmsv новоульяновск.ndmsv новочебоксарск.ndmsv новочеркасск.ndmsv новошахтинск.ndmsv норильск.ndmsv 
+обнинск.ndmsv первоуральск.ndmsv печерск.ndmsv подольск.ndmsv пронск.ndmsv рубцовск.ndmsv 
+рыбинск.ndmsv саяногорск.ndmsv свердловск.ndmsv серебрянск.ndmsv среднеуральск.ndmsv тихорецк.ndmsv 
+тобольск.ndmsv томск.ndmsv усинск.ndmsv южноуральск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кита.= :
   LLAYG+ or LLDZD+ or LLBPW+;
@@ -17297,9 +17291,9 @@
 кишмиш.= :
   LLAAI+;
 
-кишмиш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кишмиш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кишмиш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кл.= :
   LLASW+ or LLATN+;
@@ -17315,11 +17309,11 @@
 клавиш.= :
   LLAAH+ or LLAFM+ or LLBYZ+;
 
-клавиш.ndmsv :  <morph-С,мр,но,ед,вн>;
+клавиш.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 клавиш.ndmsi :  <morph-С,мр,но,ед,им>;
 
-клавиш.ndfpg :  <morph-С,жр,но,мн,рд>;
+клавиш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кладов.= :
   LLAKS+ or LLBRK+;
@@ -17327,50 +17321,12 @@
 классик.= :
   LLACG+ or LLAFU+ or LLBCC+;
 
-классик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 классик.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+классик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 /ru/words/words.99:
   LLAAQ+ or LLACI+;
-
-автохтон.nlmsi агент.nlmsi аллохтон.nlmsi аммонит.nlmsi апостол.nlmsi атлант.nlmsi 
-бактероид.nlmsi балабан.nlmsi белемнит.nlmsi брандахлыст.nlmsi бройлер.nlmsi вибрион.nlmsi 
-водолюб.nlmsi вулканизатор.nlmsi газификатор.nlmsi гаплонт.nlmsi гастрозоид.nlmsi гастроном.nlmsi 
-геркулес.nlmsi гигант.nlmsi гидрометр.nlmsi гнотобионт.nlmsi горлодер.nlmsi гриф.nlmsi 
-дегазатор.nlmsi детектив.nlmsi дохлец.nlmsi жупан.nlmsi иллюминатор.nlmsi интерпретатор.nlmsi 
-кермес.nlmsi кинематографист.nlmsi классификатор.nlmsi коллектор.nlmsi колосс.nlmsi корнет.nlmsi 
-лаз.nlmsi манекен.nlmsi манипулятор.nlmsi маркер.nlmsi медиум.nlmsi меринос.nlmsi 
-метр.nlmsi мигрант.nlmsi моветон.nlmsi молоковоз.nlmsi мутант.nlmsi нутрец.nlmsi 
-оператор.nlmsi оракул.nlmsi оригинатор.nlmsi пеон.nlmsi плакун.nlmsi полипоид.nlmsi 
-примат.nlmsi протектор.nlmsi протобионт.nlmsi проэмбрион.nlmsi пустоцвет.nlmsi радикал.nlmsi 
-реципиент.nlmsi розан.nlmsi розмысл.nlmsi рыскун.nlmsi самострел.nlmsi сардар.nlmsi 
-сателлит.nlmsi селенит.nlmsi симбионт.nlmsi солитер.nlmsi стартер.nlmsi стеклорез.nlmsi 
-сублицензиат.nlmsi субститут.nlmsi теплолюб.nlmsi термофил.nlmsi термофоб.nlmsi типограф.nlmsi 
-титан.nlmsi топтун.nlmsi триангулятор.nlmsi туз.nlmsi углевоз.nlmsi уникум.nlmsi 
-утилизатор.nlmsi фараон.nlmsi ферт.nlmsi фиксатор.nlmsi флагман.nlmsi флотатор.nlmsi 
-фофан.nlmsi фриз.nlmsi фрукт.nlmsi фурштат.nlmsi хлыст.nlmsi хлюст.nlmsi 
-чертогон.nlmsi чурбан.nlmsi шпингалет.nlmsi экзот.nlmsi экспонент.nlmsi эфармон.nlmsi 
-:  <morph-С,мр,од,ед,им>;
-
-автохтон.ndmsv агент.ndmsv аллохтон.ndmsv аммонит.ndmsv апостол.ndmsv атлант.ndmsv 
-бактероид.ndmsv балабан.ndmsv белемнит.ndmsv брандахлыст.ndmsv бройлер.ndmsv вибрион.ndmsv 
-водолюб.ndmsv вулканизатор.ndmsv газификатор.ndmsv гаплонт.ndmsv гастрозоид.ndmsv гастроном.ndmsv 
-геркулес.ndmsv гигант.ndmsv гидрометр.ndmsv гнотобионт.ndmsv горлодер.ndmsv гриф.ndmsv 
-дегазатор.ndmsv детектив.ndmsv дохлец.ndmsv жупан.ndmsv иллюминатор.ndmsv интерпретатор.ndmsv 
-кермес.ndmsv кинематографист.ndmsv классификатор.ndmsv коллектор.ndmsv колосс.ndmsv корнет.ndmsv 
-лаз.ndmsv манекен.ndmsv манипулятор.ndmsv маркер.ndmsv медиум.ndmsv меринос.ndmsv 
-метр.ndmsv мигрант.ndmsv моветон.ndmsv молоковоз.ndmsv мутант.ndmsv нутрец.ndmsv 
-оператор.ndmsv оракул.ndmsv оригинатор.ndmsv пеон.ndmsv плакун.ndmsv полипоид.ndmsv 
-примат.ndmsv протектор.ndmsv протобионт.ndmsv проэмбрион.ndmsv пустоцвет.ndmsv радикал.ndmsv 
-реципиент.ndmsv розан.ndmsv розмысл.ndmsv рыскун.ndmsv самострел.ndmsv сардар.ndmsv 
-сателлит.ndmsv селенит.ndmsv симбионт.ndmsv солитер.ndmsv стартер.ndmsv стеклорез.ndmsv 
-сублицензиат.ndmsv субститут.ndmsv теплолюб.ndmsv термофил.ndmsv термофоб.ndmsv типограф.ndmsv 
-титан.ndmsv топтун.ndmsv триангулятор.ndmsv туз.ndmsv углевоз.ndmsv уникум.ndmsv 
-утилизатор.ndmsv фараон.ndmsv ферт.ndmsv фиксатор.ndmsv флагман.ndmsv флотатор.ndmsv 
-фофан.ndmsv фриз.ndmsv фрукт.ndmsv фурштат.ndmsv хлыст.ndmsv хлюст.ndmsv 
-чертогон.ndmsv чурбан.ndmsv шпингалет.ndmsv экзот.ndmsv экспонент.ndmsv эфармон.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
 
 автохтон.ndmsi агент.ndmsi аллохтон.ndmsi аммонит.ndmsi апостол.ndmsi атлант.ndmsi 
 бактероид.ndmsi балабан.ndmsi белемнит.ndmsi брандахлыст.ndmsi бройлер.ndmsi вибрион.ndmsi 
@@ -17391,17 +17347,55 @@
 чертогон.ndmsi чурбан.ndmsi шпингалет.ndmsi экзот.ndmsi экспонент.ndmsi эфармон.ndmsi 
 :  <morph-С,мр,но,ед,им>;
 
+автохтон.ndmsv агент.ndmsv аллохтон.ndmsv аммонит.ndmsv апостол.ndmsv атлант.ndmsv 
+бактероид.ndmsv балабан.ndmsv белемнит.ndmsv брандахлыст.ndmsv бройлер.ndmsv вибрион.ndmsv 
+водолюб.ndmsv вулканизатор.ndmsv газификатор.ndmsv гаплонт.ndmsv гастрозоид.ndmsv гастроном.ndmsv 
+геркулес.ndmsv гигант.ndmsv гидрометр.ndmsv гнотобионт.ndmsv горлодер.ndmsv гриф.ndmsv 
+дегазатор.ndmsv детектив.ndmsv дохлец.ndmsv жупан.ndmsv иллюминатор.ndmsv интерпретатор.ndmsv 
+кермес.ndmsv кинематографист.ndmsv классификатор.ndmsv коллектор.ndmsv колосс.ndmsv корнет.ndmsv 
+лаз.ndmsv манекен.ndmsv манипулятор.ndmsv маркер.ndmsv медиум.ndmsv меринос.ndmsv 
+метр.ndmsv мигрант.ndmsv моветон.ndmsv молоковоз.ndmsv мутант.ndmsv нутрец.ndmsv 
+оператор.ndmsv оракул.ndmsv оригинатор.ndmsv пеон.ndmsv плакун.ndmsv полипоид.ndmsv 
+примат.ndmsv протектор.ndmsv протобионт.ndmsv проэмбрион.ndmsv пустоцвет.ndmsv радикал.ndmsv 
+реципиент.ndmsv розан.ndmsv розмысл.ndmsv рыскун.ndmsv самострел.ndmsv сардар.ndmsv 
+сателлит.ndmsv селенит.ndmsv симбионт.ndmsv солитер.ndmsv стартер.ndmsv стеклорез.ndmsv 
+сублицензиат.ndmsv субститут.ndmsv теплолюб.ndmsv термофил.ndmsv термофоб.ndmsv типограф.ndmsv 
+титан.ndmsv топтун.ndmsv триангулятор.ndmsv туз.ndmsv углевоз.ndmsv уникум.ndmsv 
+утилизатор.ndmsv фараон.ndmsv ферт.ndmsv фиксатор.ndmsv флагман.ndmsv флотатор.ndmsv 
+фофан.ndmsv фриз.ndmsv фрукт.ndmsv фурштат.ndmsv хлыст.ndmsv хлюст.ndmsv 
+чертогон.ndmsv чурбан.ndmsv шпингалет.ndmsv экзот.ndmsv экспонент.ndmsv эфармон.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
+
+автохтон.nlmsi агент.nlmsi аллохтон.nlmsi аммонит.nlmsi апостол.nlmsi атлант.nlmsi 
+бактероид.nlmsi балабан.nlmsi белемнит.nlmsi брандахлыст.nlmsi бройлер.nlmsi вибрион.nlmsi 
+водолюб.nlmsi вулканизатор.nlmsi газификатор.nlmsi гаплонт.nlmsi гастрозоид.nlmsi гастроном.nlmsi 
+геркулес.nlmsi гигант.nlmsi гидрометр.nlmsi гнотобионт.nlmsi горлодер.nlmsi гриф.nlmsi 
+дегазатор.nlmsi детектив.nlmsi дохлец.nlmsi жупан.nlmsi иллюминатор.nlmsi интерпретатор.nlmsi 
+кермес.nlmsi кинематографист.nlmsi классификатор.nlmsi коллектор.nlmsi колосс.nlmsi корнет.nlmsi 
+лаз.nlmsi манекен.nlmsi манипулятор.nlmsi маркер.nlmsi медиум.nlmsi меринос.nlmsi 
+метр.nlmsi мигрант.nlmsi моветон.nlmsi молоковоз.nlmsi мутант.nlmsi нутрец.nlmsi 
+оператор.nlmsi оракул.nlmsi оригинатор.nlmsi пеон.nlmsi плакун.nlmsi полипоид.nlmsi 
+примат.nlmsi протектор.nlmsi протобионт.nlmsi проэмбрион.nlmsi пустоцвет.nlmsi радикал.nlmsi 
+реципиент.nlmsi розан.nlmsi розмысл.nlmsi рыскун.nlmsi самострел.nlmsi сардар.nlmsi 
+сателлит.nlmsi селенит.nlmsi симбионт.nlmsi солитер.nlmsi стартер.nlmsi стеклорез.nlmsi 
+сублицензиат.nlmsi субститут.nlmsi теплолюб.nlmsi термофил.nlmsi термофоб.nlmsi типограф.nlmsi 
+титан.nlmsi топтун.nlmsi триангулятор.nlmsi туз.nlmsi углевоз.nlmsi уникум.nlmsi 
+утилизатор.nlmsi фараон.nlmsi ферт.nlmsi фиксатор.nlmsi флагман.nlmsi флотатор.nlmsi 
+фофан.nlmsi фриз.nlmsi фрукт.nlmsi фурштат.nlmsi хлыст.nlmsi хлюст.nlmsi 
+чертогон.nlmsi чурбан.nlmsi шпингалет.nlmsi экзот.nlmsi экспонент.nlmsi эфармон.nlmsi 
+:  <morph-С,мр,од,ед,им>;
+
 кластериз.= :
   LLCDD+ or LLCFX+ or LLCGW+;
 
 клаш.= :
   LLFIL+ or LLFIR+ or LLFKZ+;
 
-клаш.nlfpg :  <morph-С,жр,од,мн,рд>;
+клаш.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 клаш.nlmsi :  <morph-С,мр,од,ед,им>;
 
-клаш.nlfpv :  <morph-С,жр,од,мн,вн>;
+клаш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кле.= :
   LLBHY+ or LLBNR+ or LLBPI+ or LLBPW+ or LLBQC+;
@@ -17409,9 +17403,9 @@
 клев.= :
   LLAAQ+ or LLDYE+ or LLCJW+;
 
-клев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 клев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+клев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 клеве.= роп.= скреже.= :
   LLCUM+;
@@ -17443,9 +17437,9 @@
 клеш.= :
   LLAAH+ or LLAEG+;
 
-клеш.a :  <morph-П,0>;
-
 клеш.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+клеш.a :  <morph-П,0>;
 
 клеш.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -17475,9 +17469,9 @@
 бункер.= клинкер.= :
   LLABM+ or LLBYZ+ or LLFRF+ or LLEUU+;
 
-бункер.ndmsv клинкер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бункер.ndmsi клинкер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бункер.ndmsv клинкер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кло.= :
   LLACA+ or LLBRB+;
@@ -17490,9 +17484,9 @@
 клон.= :
   LLAAQ+ or LLBHS+ or LLBNP+;
 
-клон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 клон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+клон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 клуб.= :
   LLAAQ+ or LLAVL+ or LLBIJ+ or LLBNN+ or LLBYZ+ or LLCJW+;
@@ -17535,18 +17529,18 @@
 кобр.= сайд.= :
   LLAGT+ or LLDXR+;
 
-кобр.nlfpg сайд.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 кобр.nlfpv сайд.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+кобр.nlfpg сайд.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кобыл.= :
   LLAFX+ or LLAGT+ or LLBFF+ or LLBRK+ or LLBRO+;
 
-кобыл.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 кобыл.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 кобыл.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+кобыл.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 ков.= :
   LLDXR+ or LLAVQ+ or LLBRK+ or LLBSW+ or LLDJS+;
@@ -17558,249 +17552,6 @@
 
 /ru/words/words.102:
   LLDWW+;
-
-абадан.ndmsv абазашт.ndmsv абакан.ndmsv абердин.ndmsv абиджан.ndmsv абкайк.ndmsv 
-абовян.ndmsv авилес.ndmsv авиньон.ndmsv авчелуп.ndmsv агадир.ndmsv аган.ndmsv 
-агдам.ndmsv агджакенд.ndmsv агрыз.ndmsv агуаскальентес.ndmsv адайхох.ndmsv адак.ndmsv 
-аден.ndmsv аджман.ndmsv аджмир.ndmsv адирондак.ndmsv адлер.ndmsv адрар-ифорас.ndmsv 
-адур.ndmsv азас.ndmsv азов.ndmsv айдар.ndmsv айлэнд.ndmsv айон.ndmsv 
-ак-довурак.ndmsv акалах.ndmsv аккурган.ndmsv аклинс.ndmsv аксенгир.ndmsv аксуат.ndmsv 
-акшийрак.ndmsv акъяб.ndmsv алагез.ndmsv алагир.ndmsv аламедин.ndmsv алат.ndmsv 
-алгабас.ndmsv алгобас.ndmsv алдан.ndmsv алигарх.ndmsv аликазган.ndmsv алитус.ndmsv 
-алкмар.ndmsv алмалык.ndmsv альбервилл.ndmsv альтаир.ndmsv амазар.ndmsv аманауз.ndmsv 
-амбарчик.ndmsv амман.ndmsv аморгос.ndmsv амритсар.ndmsv амстердам.ndmsv амьен.ndmsv 
-анабар.ndmsv ангкор.ndmsv ангрен.ndmsv анджелес.ndmsv андижан.ndmsv андреас.ndmsv 
-анжеро-судженск.ndmsv анст.ndmsv антарес.ndmsv антверпен.ndmsv антиливан.ndmsv аншулем.ndmsv 
-апелдорн.ndmsv апшерон.ndmsv арагон.ndmsv арад.ndmsv аракс.ndmsv аралсор.ndmsv 
-аранхуэс.ndmsv арарат.ndmsv арбат.ndmsv арбор.ndmsv аргаяш.ndmsv аргут.ndmsv 
-ардатов.ndmsv ардон.ndmsv арендал.ndmsv арзамас.ndmsv арзев.ndmsv аркадак.ndmsv 
-аркалык.ndmsv арктур.ndmsv арлавир.ndmsv арлон.ndmsv армавир.ndmsv арнем.ndmsv 
-арнемленд.ndmsv аррас.ndmsv арсамак.ndmsv арташат.ndmsv артек.ndmsv артик.ndmsv 
-арциз.ndmsv аскиз.ndmsv асуан.ndmsv асунсьон.ndmsv атаман-нюр.ndmsv атрек.ndmsv 
-афар.ndmsv афганистан.ndmsv афон.ndmsv ахангаран.ndmsv ахваз.ndmsv ахмвдабад.ndmsv 
-ахунбабаев.ndmsv ачикулак.ndmsv ачхой-мартан.ndmsv ашгабад.ndmsv ашгабат.ndmsv ашдод.ndmsv 
-аштарак.ndmsv ашхабад.ndmsv аюдаг.ndmsv аягуз.ndmsv аят.ndmsv баба-юрт.ndmsv 
-бабадаг.ndmsv бабитес.ndmsv багдад.ndmsv баглан.ndmsv бадахшан.ndmsv баден.ndmsv 
-бадхыз.ndmsv бай-хаак.ndmsv байгажак.ndmsv байкал.ndmsv байканд.ndmsv байсун.ndmsv 
-бакал.ndmsv баканас.ndmsv баксан.ndmsv балатон.ndmsv баликпапан.ndmsv балчуг.ndmsv 
-бангкок.ndmsv банджул.ndmsv бандунг.ndmsv банияс.ndmsv банкс.ndmsv барнаул.ndmsv 
-барсакельмес.ndmsv баскунчак.ndmsv бастер.ndmsv батакоюрт.ndmsv батангас.ndmsv баттамбанг.ndmsv 
-баудуков.ndmsv баунт.ndmsv бахилов.ndmsv бахмач.ndmsv бахрейн.ndmsv бахт.ndmsv 
-бачхаз.ndmsv башкортостан.ndmsv бегаван.ndmsv безансон.ndmsv безенчук.ndmsv безмеин.ndmsv 
-бейлаган.ndmsv бейрут.ndmsv бейсуг.ndmsv бекабад.ndmsv белгород.ndmsv белград.ndmsv 
-белз.ndmsv белокаменск.ndmsv белолуцк.ndmsv белосток.ndmsv белуджистан.ndmsv белфаст.ndmsv 
-бенин.ndmsv берген.ndmsv бердичев.ndmsv берислав.ndmsv берн.ndmsv беслан.ndmsv 
-бешар.ndmsv бешарык.ndmsv бешкент.ndmsv биканер.ndmsv бирмингем.ndmsv биробиджан.ndmsv 
-бирштонас.ndmsv битуг.ndmsv бихар.ndmsv бишкек.ndmsv блумфонтейн.ndmsv бобруйск.ndmsv 
-богодуховлес.ndmsv боготол.ndmsv болград.ndmsv болехов.ndmsv болтвар.ndmsv болхов.ndmsv 
-борислав.ndmsv борнмут.ndmsv борнхольм.ndmsv брабант.ndmsv бранденбург.ndmsv браслав.ndmsv 
-брауншвайг.ndmsv брашов.ndmsv бременхафен.ndmsv брест.ndmsv бриежуциемс.ndmsv брокленд.ndmsv 
-бугуруслан.ndmsv будапешт.ndmsv бузан.ndmsv бузулук.ndmsv буксунд.ndmsv буогас.ndmsv 
-бургенлад.ndmsv бурунгулак.ndmsv буск.ndmsv бустан.ndmsv бустах.ndmsv бутут.ndmsv 
-бухарест.ndmsv бучач.ndmsv бушир.ndmsv буэнос.ndmsv буэнос-айрес.ndmsv бхопал.ndmsv 
-бырлад.ndmsv бытом.ndmsv быхов.ndmsv бьюекен.ndmsv вабальнинкас.ndmsv вабкент.ndmsv 
-вад.ndmsv вайгач.ndmsv валаам.ndmsv валдемарпилс.ndmsv вальдолид.ndmsv ванадзор.ndmsv 
-ванино-холмск.ndmsv ванкувер.ndmsv ваннинск.ndmsv варберг.ndmsv варташен.ndmsv варьеган.ndmsv 
-ватикан.ndmsv вах.ndmsv ваховск.ndmsv вевис.ndmsv великоустюг.ndmsv веллингтон.ndmsv 
-венерн.ndmsv вентспилс.ndmsv вентьян.ndmsv веракрус.ndmsv верден.ndmsv верхне-благовещенск.ndmsv 
-верхнедвинск.ndmsv веспрем.ndmsv вестерас.ndmsv вестервик.ndmsv веттерн.ndmsv видин.ndmsv 
-вилькавишкис.ndmsv вильнюс.ndmsv виннипег.ndmsv виннипегосис.ndmsv винтертур.ndmsv вирбалис.ndmsv 
-висим.ndmsv висман.ndmsv висмар.ndmsv витим.ndmsv владивосток.ndmsv владикавказ.ndmsv 
-воклюз.ndmsv волгоград.ndmsv волгореченск.ndmsv воложин.ndmsv волоф.ndmsv волочиск.ndmsv 
-волхов.ndmsv вольногорск.ndmsv вольнянск.ndmsv вонсан.ndmsv воротан.ndmsv вроцлав.ndmsv 
-вуктыл.ndmsv вулвергемптон.ndmsv выборг.ndmsv вышгород.ndmsv вьентьян.ndmsv вюртемберг.ndmsv 
-вюрцбург.ndmsv габон.ndmsv гавр.ndmsv газалкент.ndmsv гайворон.ndmsv галифакс.ndmsv 
-галляарал.ndmsv гамбург.ndmsv ганг.ndmsv ганновер.ndmsv гардез.ndmsv гвадалквивир.ndmsv 
-гданьск.ndmsv гдов.ndmsv гелдерланд.ndmsv геленджик.ndmsv геленждик.ndmsv геническ.ndmsv 
-гент.ndmsv герат.ndmsv гессен.ndmsv гетеборг.ndmsv геттинген.ndmsv гибралтар.ndmsv 
-гиждуван.ndmsv гизиантеп.ndmsv гонконг.ndmsv горис.ndmsv горнореченск.ndmsv горячинск.ndmsv 
-готланд.ndmsv гохран.ndmsv грайворон.ndmsv грибов.ndmsv гросглокнер.ndmsv гуадалканал.ndmsv 
-гуам.ndmsv гудермес.ndmsv гуджарат.ndmsv гузар.ndmsv гулистан.ndmsv гуниб.ndmsv 
-гунт.ndmsv гурон.ndmsv дагомыс.ndmsv далат.ndmsv даллас.ndmsv дальнореченск.ndmsv 
-дамар.ndmsv даммам.ndmsv дамодар.ndmsv дананг.ndmsv данбар.ndmsv дар-эс-салам.ndmsv 
-дарлинг.ndmsv даруссалам.ndmsv дархан.ndmsv дарьял.ndmsv датч-харбор.ndmsv даугавпилс.ndmsv 
-дашкесан.ndmsv дебрецен.ndmsv дейтон.ndmsv делфт.ndmsv демавенд.ndmsv дербент.ndmsv 
-деркул.ndmsv десногорск.ndmsv детройт.ndmsv джайпур.ndmsv джалилабад.ndmsv джамалпур.ndmsv 
-джамбул.ndmsv джамбыл.ndmsv джамшедпур.ndmsv джаркурган.ndmsv джарылгач.ndmsv джебраил.ndmsv 
-джелалабад.ndmsv джермук.ndmsv джетым.ndmsv джизак.ndmsv джилонг.ndmsv джинал.ndmsv 
-джорджтаун.ndmsv джугдыр.ndmsv джуджид-яг.ndmsv дзабхан.ndmsv дижон.ndmsv диксон.ndmsv 
-дилижан.ndmsv димитровград.ndmsv диснейленд.ndmsv диярбакыр.ndmsv дмитров.ndmsv дмитровград.ndmsv 
-днепр.ndmsv днестр.ndmsv довурак.ndmsv донбасс.ndmsv донузлав.ndmsv дортмунд.ndmsv 
-дрезден.ndmsv дрогичин.ndmsv дублин.ndmsv дубчес.ndmsv дувр.ndmsv дуйсбург.ndmsv 
-дукштас.ndmsv думьят.ndmsv дурбан.ndmsv дуррес.ndmsv дусетос.ndmsv дустлик.ndmsv 
-дьеп.ndmsv дьер.ndmsv дюльтыдаг.ndmsv дюнкерк.ndmsv дюпкун.ndmsv дюссельдорф.ndmsv 
-евлах.ndmsv евфрат.ndmsv егорлык.ndmsv езнас.ndmsv екабпилс.ndmsv екатеринбург.ndmsv 
-ельск.ndmsv ереван.ndmsv ермелан.ndmsv еруслан.ndmsv жанатас.ndmsv жашков.ndmsv 
-жесканган.ndmsv жидачов.ndmsv жирекен.ndmsv житомир.ndmsv жлобин.ndmsv жостов.ndmsv 
-забид.ndmsv загребин.ndmsv загрос.ndmsv зайсан.ndmsv закинф.ndmsv зальцбург.ndmsv 
-зангелан.ndmsv зарафшан.ndmsv зардоб.ndmsv зборов.ndmsv звенигород.ndmsv здолбунов.ndmsv 
-зеленоборск.ndmsv зеленоград.ndmsv зеленокумск.ndmsv зеньков.ndmsv зеравшан.ndmsv зерноград.ndmsv 
-зиган.ndmsv зильмердак.ndmsv змиев.ndmsv золочев.ndmsv зонгулдак.ndmsv зубцов.ndmsv 
-зугрэс.ndmsv зунд.ndmsv зыряновск.ndmsv ивангород.ndmsv ивано-франковск.ndmsv иджеван.ndmsv 
-иерусалим.ndmsv изар.ndmsv изер.ndmsv измаил.ndmsv измир.ndmsv измит.ndmsv 
-изяслав.ndmsv илек.ndmsv илим.ndmsv иллер.ndmsv иловайск.ndmsv ильяк.ndmsv 
-иман.ndmsv имроз.ndmsv ингольштадт.ndmsv инд.ndmsv индаур.ndmsv индур.ndmsv 
-инсар.ndmsv инсбрук.ndmsv инчхон.ndmsv ионишкелис.ndmsv ипох.ndmsv ирбит.ndmsv 
-иргыз.ndmsv ирендак.ndmsv иркут.ndmsv иртяш.ndmsv искендерун.ndmsv искитим.ndmsv 
-искыр.ndmsv исламабад.ndmsv истад.ndmsv исфахан.ndmsv итуруп.ndmsv ишерим.ndmsv 
-ишим.ndmsv иштыхан.ndmsv йезд.ndmsv йелл.ndmsv йоханесбург.ndmsv каварскас.ndmsv 
-кагальник.ndmsv кагарлык.ndmsv каджаран.ndmsv кадис.ndmsv казалинск.ndmsv казатин.ndmsv 
-казым.ndmsv каир.ndmsv кайеркан.ndmsv кайраккум.ndmsv кайшадорис.ndmsv калакан.ndmsv 
-калар.ndmsv калат.ndmsv калаус.ndmsv калимантан.ndmsv калинин.ndmsv калининград.ndmsv 
-калтан.ndmsv калунборг.ndmsv калязин.ndmsv каменник.ndmsv каменногорск.ndmsv камерун.ndmsv 
-кампогсаом.ndmsv камызяк.ndmsv камышлов.ndmsv кандагар.ndmsv канев.ndmsv канзас.ndmsv 
-канибадам.ndmsv канпур.ndmsv кантегир.ndmsv капошвар.ndmsv кара-богаз-гол.ndmsv карабах.ndmsv 
-карабулак.ndmsv карадаг.ndmsv каражал.ndmsv каракас.ndmsv каракорум.ndmsv карасор.ndmsv 
-караулбазар.ndmsv карачев.ndmsv каргат.ndmsv кардифф.ndmsv каркаралинск.ndmsv карлсборг.ndmsv 
-карлстад.ndmsv карокорум.ndmsv карпатос.ndmsv касан.ndmsv касимов.ndmsv каскелен.ndmsv 
-каттакурган.ndmsv каттегат.ndmsv каунас.ndmsv кафан.ndmsv качканар.ndmsv кашин.ndmsv 
-квебек.ndmsv кевлар.ndmsv кеген.ndmsv кейптаун.ndmsv кекемерен.ndmsv келес.ndmsv 
-кельбаджар.ndmsv кельн.ndmsv кемчуг.ndmsv кенсингтон.ndmsv керман.ndmsv керманшахр.ndmsv 
-керулен.ndmsv кивач.ndmsv киев.ndmsv кизел.ndmsv кизилюрт.ndmsv кильдин.ndmsv 
-кингисепп.ndmsv кингстаун.ndmsv киномир.ndmsv кипр.ndmsv киргизстан.ndmsv киржач.ndmsv 
-кириллов.ndmsv киркук.ndmsv кировград.ndmsv кировоград.ndmsv кирс.ndmsv кирсанов.ndmsv 
-киселевск.ndmsv китаб.ndmsv китнос.ndmsv кишинев.ndmsv кишн.ndmsv кишпинач.ndmsv 
-клагенфурт.ndmsv клайд.ndmsv кланг.ndmsv клецк.ndmsv кливленд.ndmsv княж-погост.ndmsv 
-ковдор.ndmsv когалым.ndmsv кодакан.ndmsv кожимиз.ndmsv козьмодемьянск.ndmsv койбагар.ndmsv 
-коканд.ndmsv кокарал.ndmsv колгуев.ndmsv колл.ndmsv колобжег.ndmsv коломак.ndmsv 
-комрат.ndmsv коннектикут.ndmsv конотоп.ndmsv консепсьон.ndmsv копейск.ndmsv копенгаген.ndmsv 
-копетдаг.ndmsv коринф.ndmsv коркодон.ndmsv коркоран.ndmsv корнат.ndmsv коростышев.ndmsv 
-корткерос.ndmsv кот-д-ивуар.ndmsv котбус.ndmsv котлас.ndmsv котлин.ndmsv кочечум.ndmsv 
-краков.ndmsv красилов.ndmsv краснодар.ndmsv краснозаводск.ndmsv краснотурьинск.ndmsv кременчуг.ndmsv 
-кристиансанн.ndmsv кристианстад.ndmsv крит.ndmsv крк.ndmsv кронштадт.ndmsv крым.ndmsv 
-крюгерсдорп.ndmsv кувандык.ndmsv кудымкар.ndmsv кузбасс.ndmsv кузнецовск.ndmsv куйбышев.ndmsv 
-кукунор.ndmsv кульеган.ndmsv кумак.ndmsv кумкурган.ndmsv кунашак.ndmsv кунашир.ndmsv 
-кунград.ndmsv кунгур.ndmsv кундос.ndmsv купишкис.ndmsv купянск.ndmsv куткашен.ndmsv 
-кушум.ndmsv кызыл.ndmsv кызылкум.ndmsv кыргызстан.ndmsv кыштым.ndmsv кэт.ndmsv 
-кюрдамир.ndmsv кюстендил.ndmsv лабрадор.ndmsv ладушкин.ndmsv ладыжин.ndmsv лакинск.ndmsv 
-лаклан.ndmsv лангепас.ndmsv лачин.ndmsv лаялпур.ndmsv лейден.ndmsv лейпциг.ndmsv 
-лемнос.ndmsv ленгер.ndmsv ленинакан.ndmsv лентварис.ndmsv лептон.ndmsv лесбос.ndmsv 
-лестер.ndmsv лидс.ndmsv лиллехаммер.ndmsv лимасол.ndmsv лимбург.ndmsv линарес.ndmsv 
-линчепинг.ndmsv лисаковск.ndmsv лисичанск.ndmsv лиссабон.ndmsv лихтенштейн.ndmsv ловеч.ndmsv 
-лоддон.ndmsv локчим.ndmsv лонг-айленд.ndmsv лос-аламос.ndmsv лос-анджелес.ndmsv луганчик.ndmsv 
-лукоянов.ndmsv луксор.ndmsv лумпур.ndmsv лух.ndmsv лучегорск.ndmsv львов.ndmsv 
-льгов.ndmsv льюис.ndmsv любек.ndmsv люботин.ndmsv люксембург.ndmsv лямин.ndmsv 
-маадыр.ndmsv маас.ndmsv магадан.ndmsv магдебург.ndmsv мадагаскар.ndmsv мадрас.ndmsv 
-мадрид.ndmsv мажалык.ndmsv майкоп.ndmsv макран.ndmsv маланг.ndmsv мальмбергет.ndmsv 
-мамадышенск.ndmsv мамакан.ndmsv манас.ndmsv манаус.ndmsv мангейм.ndmsv мангит.ndmsv 
-мангышлак.ndmsv манипур.ndmsv манчестер.ndmsv маргилан.ndmsv мардакерт.ndmsv марджанбулак.ndmsv 
-мариестад.ndmsv мархамат.ndmsv маршалл.ndmsv маскат.ndmsv массачусетс.ndmsv матрах.ndmsv 
-машук.ndmsv мглин.ndmsv мегион.ndmsv медан.ndmsv мейнленд.ndmsv мекнес.ndmsv 
-меконг.ndmsv меларен.ndmsv мелвилл.ndmsv мелеуз.ndmsv мельбурн.ndmsv мепл-уайт.ndmsv 
-мерир.ndmsv мерсин.ndmsv мешхед.ndmsv миасс.ndmsv миконос.ndmsv милос.ndmsv 
-мингечаур.ndmsv миньяр.ndmsv миргород.ndmsv миусинск.ndmsv миусс.ndmsv михайловград.ndmsv 
-мичиган.ndmsv млет.ndmsv могилев.ndmsv мозамбик.ndmsv моламьяйн.ndmsv молл.ndmsv 
-молочанск.ndmsv монс.ndmsv монтсерат.ndmsv монтсеррат.ndmsv моркам.ndmsv мосул.ndmsv 
-мубарек.ndmsv муйнак.ndmsv мукур.ndmsv мултан.ndmsv мургаб.ndmsv мурэн.ndmsv 
-мухаррак.ndmsv мьюинджан.ndmsv мэн.ndmsv мэриленд.ndmsv мюнстер.ndmsv мюнхен.ndmsv 
-наблус.ndmsv наварин.ndmsv назарет.ndmsv назым.ndmsv наксос.ndmsv нальчик.ndmsv 
-наманган.ndmsv намюр.ndmsv нанкин.ndmsv нант.ndmsv наньлин.ndmsv нарбутов.ndmsv 
-наргин.ndmsv нариманов.ndmsv нарофоминск.ndmsv нарын.ndmsv нарьян-мар.ndmsv нафталан.ndmsv 
-невис.ndmsv негрос.ndmsv неджеф.ndmsv нежин.ndmsv неккар.ndmsv неман.ndmsv 
-немиров.ndmsv нептун.ndmsv нетешин.ndmsv нигер.ndmsv нижнеянск.ndmsv нил.ndmsv 
-новоазовск.ndmsv нововолынск.ndmsv новодружеск.ndmsv новозыбков.ndmsv новомиргород.ndmsv новомичуринск.ndmsv 
-новопавловск.ndmsv новопетровск.ndmsv новополоцк.ndmsv новоржев.ndmsv новосад.ndmsv новоуральск.ndmsv 
-новохованск.ndmsv нордвик.ndmsv нордкап.ndmsv нордкин.ndmsv норчеппинг.ndmsv ноттингем.ndmsv 
-ноушехр.ndmsv нуакшот.ndmsv нукус.ndmsv нунивак.ndmsv нурабад.ndmsv нурлат.ndmsv 
-нью-йорк.ndmsv ньюфаундленд.ndmsv нюк.ndmsv нюрнберг.ndmsv нярис.ndmsv нячанг.ndmsv 
-оверейселл.ndmsv овстуг.ndmsv окленд.ndmsv оксфорд.ndmsv олимп.ndmsv ольборг.ndmsv 
-ольхон.ndmsv ольштын.ndmsv оман.ndmsv омолон.ndmsv онекотан.ndmsv онемен.ndmsv 
-онон.ndmsv оргеев.ndmsv ордубад.ndmsv оренбург.ndmsv ортолык.ndmsv орхус.ndmsv 
-осмуссар.ndmsv оснабрюкк.ndmsv осташков.ndmsv остер.ndmsv осым.ndmsv очаков.ndmsv 
-павлоград.ndmsv павлодар.ndmsv паг.ndmsv пазарджик.ndmsv пайер.ndmsv пайтуг.ndmsv 
-пакруойис.ndmsv палембанг.ndmsv памир.ndmsv панделис.ndmsv паневежис.ndmsv парамушир.ndmsv 
-парджуман.ndmsv паркент.ndmsv пасвалис.ndmsv пахтаабад.ndmsv пахтакор.ndmsv педжикент.ndmsv 
-пелопоннес.ndmsv пелым.ndmsv перевальск.ndmsv перелюб.ndmsv перник.ndmsv перпиньон.ndmsv 
-перт.ndmsv першотравенск.ndmsv песяков.ndmsv петербург.ndmsv петергоф.ndmsv петриков.ndmsv 
-пешавар.ndmsv пешт.ndmsv пиелинен.ndmsv пинд.ndmsv пирятин.ndmsv питермарицбург.ndmsv 
-питляр.ndmsv питтсбург.ndmsv плевен.ndmsv плимут.ndmsv пловдив.ndmsv плоцк.ndmsv 
-плутон.ndmsv плявиняс.ndmsv поважск.ndmsv подбельск.ndmsv помаран.ndmsv порт-александр.ndmsv 
-порт-оф-пренс.ndmsv порт-оф-спэйн.ndmsv портленд.ndmsv портсмут.ndmsv порхов.ndmsv потомак.ndmsv 
-потсдам.ndmsv поусат.ndmsv почеп.ndmsv праслен.ndmsv прикумск.ndmsv прованс.ndmsv 
-псел.ndmsv пскент.ndmsv псков.ndmsv пунг.ndmsv пунтаренас.ndmsv пусан.ndmsv 
-путалов.ndmsv пхеньян.ndmsv пхукет.ndmsv пыталов.ndmsv пыть-ях.ndmsv пыщуг.ndmsv 
-пьетрос.ndmsv пятигорск.ndmsv пятиморск.ndmsv радвилишкис.ndmsv радехов.ndmsv раджастхан.ndmsv 
-радом.ndmsv разград.ndmsv раздан.ndmsv раздолинск.ndmsv рангун.ndmsv раттен.ndmsv 
-раудатайн.ndmsv регенсбург.ndmsv редант.ndmsv рединг.ndmsv рейкьявик.ndmsv реймс.ndmsv 
-рейн.ndmsv ретавас.ndmsv реут.ndmsv реюньон.ndmsv ржев.ndmsv рим.ndmsv 
-ринггит.ndmsv риштан.ndmsv роанн.ndmsv родос.ndmsv роздол.ndmsv рокишкис.ndmsv 
-рокстон.ndmsv ромитан.ndmsv росток.ndmsv роттердам.ndmsv роудс.ndmsv рохас.ndmsv 
-руан.ndmsv рур.ndmsv рэдан.ndmsv рюген.ndmsv саар.ndmsv сабирабад.ndmsv 
-саган-нур.ndmsv сайвун.ndmsv сайгон.ndmsv сайхут.ndmsv салават.ndmsv салаир.ndmsv 
-салгир.ndmsv салдус.ndmsv салем.ndmsv салехард.ndmsv сальвадор.ndmsv самарканд.ndmsv 
-самбор.ndmsv самос.ndmsv сампур.ndmsv самсун.ndmsv самур.ndmsv сандакан.ndmsv 
-сандвиксен.ndmsv сандерленд.ndmsv санкт-петебрург.ndmsv санкт-петербург.ndmsv сантус.ndmsv сарапул.ndmsv 
-саривон.ndmsv сарканд.ndmsv сарлан.ndmsv саров.ndmsv сартанг.ndmsv сарыагач.ndmsv 
-сарыг-сеп.ndmsv сарыджаз.ndmsv саскатун.ndmsv саскачеван.ndmsv сасык.ndmsv саттахип.ndmsv 
-сатурн.ndmsv саур.ndmsv саутгемптон.ndmsv сахалин.ndmsv свердруп.ndmsv светан.ndmsv 
-светловодск.ndmsv светлоград.ndmsv севан.ndmsv северин.ndmsv северн.ndmsv северо-уральск.ndmsv 
-северобайкальск.ndmsv северодонецк.ndmsv сегед.ndmsv секешфехервар.ndmsv селигдар.ndmsv селигер.ndmsv 
-семаранг.ndmsv семикаракорск.ndmsv семипалатинск.ndmsv семхоз.ndmsv сент-винсент.ndmsv сент-джеймс-стрит.ndmsv 
-сент-китс.ndmsv сентарен.ndmsv серам.ndmsv сергач.ndmsv серет.ndmsv серифос.ndmsv 
-серпухов.ndmsv сескар.ndmsv сестрорецк.ndmsv сетиф.ndmsv сетубал.ndmsv сеул.ndmsv 
-сивас.ndmsv сигуам.ndmsv сикар.ndmsv сикким.ndmsv силхет.ndmsv сильян.ndmsv 
-сим.ndmsv симнас.ndmsv симушир.ndmsv сингапур.ndmsv сирет.ndmsv сирос.ndmsv 
-сисиан.ndmsv сисим.ndmsv сифнос.ndmsv сицзян.ndmsv сиэтл.ndmsv сиялкот.ndmsv 
-скаген.ndmsv скагеррак.ndmsv скадовск.ndmsv скалат.ndmsv скирос.ndmsv скопин.ndmsv 
-скуодас.ndmsv славгород.ndmsv славяногорск.ndmsv сливен.ndmsv слуцк.ndmsv снежинск.ndmsv 
-снятын.ndmsv солигорск.ndmsv сорск.ndmsv спитак.ndmsv сплит.ndmsv спрингс.ndmsv 
-среднекан.ndmsv сринагар.ndmsv старобельск.ndmsv староуткинск.ndmsv староюрьев.ndmsv стаффорд.ndmsv 
-стебник.ndmsv степанаван.ndmsv степанакерт.ndmsv стерлитамак.ndmsv стернхейм.ndmsv стокгольм.ndmsv 
-столин.ndmsv стоход.ndmsv страсбург.ndmsv стремсунд.ndmsv стрижамент.ndmsv стуруван.ndmsv 
-суглан.ndmsv суккур.ndmsv сулак.ndmsv сумгаит.ndmsv сургут.ndmsv сусуман.ndmsv 
-суходольск.ndmsv сухэ-батор.ndmsv сфакс.ndmsv сыктывкар.ndmsv сым.ndmsv сьенфуэгос.ndmsv 
-таврийск.ndmsv таганрог.ndmsv тагил.ndmsv таджикистан.ndmsv таждикистан.ndmsv таймыр.ndmsv 
-тайшет.ndmsv талакан.ndmsv талас.ndmsv талгар.ndmsv талдом.ndmsv талды-курган.ndmsv 
-талдык.ndmsv талимарджан.ndmsv таллин.ndmsv таллинн.ndmsv талнах.ndmsv тамбов.ndmsv 
-тамилнад.ndmsv танджунгприорк.ndmsv танжер.ndmsv тарим.ndmsv тарнув.ndmsv тартус.ndmsv 
-тасос.ndmsv татарстан.ndmsv тауз.ndmsv ташкент.ndmsv таштагол.ndmsv таштып.ndmsv 
-тебриз.ndmsv тегеран.ndmsv теджен.ndmsv тель-авив.ndmsv тельпосиз.ndmsv темир.ndmsv 
-темрюк.ndmsv тенис.ndmsv теплогорск.ndmsv терек.ndmsv терен.ndmsv термаикос.ndmsv 
-термез.ndmsv тертер.ndmsv тетиев.ndmsv тетуан.ndmsv теужеск.ndmsv тилбург.ndmsv 
-тилос.ndmsv тим.ndmsv тимптон.ndmsv тинос.ndmsv тихвин.ndmsv тлумач.ndmsv 
-тогучин.ndmsv токмак.ndmsv толочин.ndmsv томмот.ndmsv тонлесап.ndmsv торренс.ndmsv 
-трабзон.ndmsv треллеборг.ndmsv трент.ndmsv триест.ndmsv тринидад.ndmsv трир.ndmsv 
-троллхетан.ndmsv трубачевск.ndmsv туггурт.ndmsv тукумс.ndmsv тулон.ndmsv тулос.ndmsv 
-тулун.ndmsv тульчин.ndmsv тумэн.ndmsv туракурган.ndmsv туран.ndmsv турин.ndmsv 
-туркечиан.ndmsv туркменистан.ndmsv туртас.ndmsv турухан.ndmsv тхаб.ndmsv тюкян.ndmsv 
-тюнг.ndmsv тясмин.ndmsv тячев.ndmsv убаган.ndmsv угнев.ndmsv уджунгпанданг.ndmsv 
-ужвентис.ndmsv ужгород.ndmsv ужур.ndmsv узбекистан.ndmsv узген.ndmsv улавун.ndmsv 
-улан-батор.ndmsv улуюл.ndmsv ульм.ndmsv ульсан.ndmsv умнак.ndmsv унимак.ndmsv 
-урак.ndmsv ургал.ndmsv ургут.ndmsv уржум.ndmsv урузган.ndmsv уруп.ndmsv 
-урух.ndmsv урюп.ndmsv устилуг.ndmsv усть-абакан.ndmsv усть-катав.ndmsv усть-кут.ndmsv 
-усть-омчуг.ndmsv устюг.ndmsv учарал.ndmsv учкекен.ndmsv учкудук.ndmsv учкурган.ndmsv 
-учур.ndmsv ушишир.ndmsv уэйк.ndmsv уяр.ndmsv файзабад.ndmsv фастов.ndmsv 
-фаял.ndmsv фемарн.ndmsv фишт.ndmsv флорес.ndmsv форарльберг.ndmsv франкфурт.ndmsv 
-фредериксхавн.ndmsv фредрикстад.ndmsv фрейзер.ndmsv фрибур.ndmsv фритаун.ndmsv хаджидер.ndmsv 
-хадыженск.ndmsv хайдарабад.ndmsv хайфон.ndmsv хаккулабад.ndmsv халал.ndmsv халеб.ndmsv 
-халкабад.ndmsv халл.ndmsv хальмстад.ndmsv хамадан.ndmsv хамхын.ndmsv ханабад.ndmsv 
-ханлар.ndmsv харагун.ndmsv харбин.ndmsv харлем.ndmsv харпер.ndmsv харцызск.ndmsv 
-харьков.ndmsv хасавюрт.ndmsv хасан.ndmsv хасселт.ndmsv хачмас.ndmsv хвар.ndmsv 
-хельсингборг.ndmsv хемчик.ndmsv хернестад.ndmsv хиос.ndmsv ходжаабад.ndmsv ходоров.ndmsv 
-холбон.ndmsv холихед.ndmsv хомс.ndmsv хопер.ndmsv хорог.ndmsv хорол.ndmsv 
-хоростков.ndmsv хорремшехр.ndmsv хотин.ndmsv хубсугул.ndmsv худат.ndmsv худжанд.ndmsv 
-хуст.ndmsv хыров.ndmsv хьюстон.ndmsv цахкадзор.ndmsv цесис.ndmsv црес.ndmsv 
-цэцэрлэг.ndmsv цюрих.ndmsv цюрупинск.ndmsv чаган.ndmsv чадан.ndmsv чандпур.ndmsv 
-чаохч.ndmsv чаренцаван.ndmsv чарикар.ndmsv чарск.ndmsv чартак.ndmsv чаткал.ndmsv 
-чатырдаг.ndmsv чаун.ndmsv чахчаран.ndmsv челек.ndmsv челекен.ndmsv челкар.ndmsv 
-чен.ndmsv червоноград.ndmsv чериков.ndmsv чермоз.ndmsv чернигов.ndmsv чечерск.ndmsv 
-чигирин.ndmsv чимкент.ndmsv чиназ.ndmsv чирчик.ndmsv чистоп.ndmsv читтагонг.ndmsv 
-чичкаюл.ndmsv чкалов.ndmsv чойбалсан.ndmsv чондон.ndmsv чоп.ndmsv чорох.ndmsv 
-чортков.ndmsv чугуев.ndmsv чулым.ndmsv чуст.ndmsv чхонджин.ndmsv шагол.ndmsv 
-шагонар.ndmsv шалкар.ndmsv шаргород.ndmsv шарлоттаун.ndmsv шартр.ndmsv шат-эль-араб.ndmsv 
-шахрисабз.ndmsv шахрихан.ndmsv швенченис.ndmsv шверин.ndmsv шеньян.ndmsv шерабад.ndmsv 
-шербур.ndmsv шерхан.ndmsv шеффилд.ndmsv шехркорд.ndmsv шиашкотан.ndmsv шибарган.ndmsv 
-шикотан.ndmsv шимкент.ndmsv шираз.ndmsv ширвинтос.ndmsv шклов.ndmsv шлиссельбург.ndmsv 
-шляйн.ndmsv шопоков.ndmsv шпицберген.ndmsv штральзунд.ndmsv штутгарт.ndmsv шумен.ndmsv 
-шураб.ndmsv щагонар.ndmsv щецин.ndmsv эверест.ndmsv эгер.ndmsv эдинбург.ndmsv 
-эдмонтон.ndmsv эйзенштадт.ndmsv эйлат.ndmsv эйндховен.ndmsv эйр.ndmsv эйшишкес.ndmsv 
-экибастуз.ndmsv эланд.ndmsv элегест.ndmsv электрогорск.ndmsv элефисис.ndmsv элсмир.ndmsv 
-эль-кувейт.ndmsv эль-сальвадор.ndmsv эльбрус.ndmsv эльтон.ndmsv элязыг.ndmsv энергодар.ndmsv 
-энмор-парк.ndmsv эрдек.ndmsv эрджияс.ndmsv эресунн.ndmsv эрзурум.ndmsv эрфурт.ndmsv 
-эсбьерг.ndmsv эстерсунд.ndmsv эчмиадзин.ndmsv юганск.ndmsv южносухокумск.ndmsv юкон.ndmsv 
-юкос.ndmsv юрбаркас.ndmsv юхнов.ndmsv яготин.ndmsv ядрин.ndmsv язгулем.ndmsv 
-яйпан.ndmsv яккабаг.ndmsv ялпуг.ndmsv ямал.ndmsv ямбол.ndmsv янаул.ndmsv 
-янгиабад.ndmsv янгиер.ndmsv янгстаун.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 абадан.ndmsi абазашт.ndmsi абакан.ndmsi абердин.ndmsi абиджан.ndmsi абкайк.ndmsi 
 абовян.ndmsi авилес.ndmsi авиньон.ndmsi авчелуп.ndmsi агадир.ndmsi аган.ndmsi 
@@ -18045,14 +17796,257 @@
 яйпан.ndmsi яккабаг.ndmsi ялпуг.ndmsi ямал.ndmsi ямбол.ndmsi янаул.ndmsi 
 янгиабад.ndmsi янгиер.ndmsi янгстаун.ndmsi :  <morph-С,мр,но,ед,им>;
 
+абадан.ndmsv абазашт.ndmsv абакан.ndmsv абердин.ndmsv абиджан.ndmsv абкайк.ndmsv 
+абовян.ndmsv авилес.ndmsv авиньон.ndmsv авчелуп.ndmsv агадир.ndmsv аган.ndmsv 
+агдам.ndmsv агджакенд.ndmsv агрыз.ndmsv агуаскальентес.ndmsv адайхох.ndmsv адак.ndmsv 
+аден.ndmsv аджман.ndmsv аджмир.ndmsv адирондак.ndmsv адлер.ndmsv адрар-ифорас.ndmsv 
+адур.ndmsv азас.ndmsv азов.ndmsv айдар.ndmsv айлэнд.ndmsv айон.ndmsv 
+ак-довурак.ndmsv акалах.ndmsv аккурган.ndmsv аклинс.ndmsv аксенгир.ndmsv аксуат.ndmsv 
+акшийрак.ndmsv акъяб.ndmsv алагез.ndmsv алагир.ndmsv аламедин.ndmsv алат.ndmsv 
+алгабас.ndmsv алгобас.ndmsv алдан.ndmsv алигарх.ndmsv аликазган.ndmsv алитус.ndmsv 
+алкмар.ndmsv алмалык.ndmsv альбервилл.ndmsv альтаир.ndmsv амазар.ndmsv аманауз.ndmsv 
+амбарчик.ndmsv амман.ndmsv аморгос.ndmsv амритсар.ndmsv амстердам.ndmsv амьен.ndmsv 
+анабар.ndmsv ангкор.ndmsv ангрен.ndmsv анджелес.ndmsv андижан.ndmsv андреас.ndmsv 
+анжеро-судженск.ndmsv анст.ndmsv антарес.ndmsv антверпен.ndmsv антиливан.ndmsv аншулем.ndmsv 
+апелдорн.ndmsv апшерон.ndmsv арагон.ndmsv арад.ndmsv аракс.ndmsv аралсор.ndmsv 
+аранхуэс.ndmsv арарат.ndmsv арбат.ndmsv арбор.ndmsv аргаяш.ndmsv аргут.ndmsv 
+ардатов.ndmsv ардон.ndmsv арендал.ndmsv арзамас.ndmsv арзев.ndmsv аркадак.ndmsv 
+аркалык.ndmsv арктур.ndmsv арлавир.ndmsv арлон.ndmsv армавир.ndmsv арнем.ndmsv 
+арнемленд.ndmsv аррас.ndmsv арсамак.ndmsv арташат.ndmsv артек.ndmsv артик.ndmsv 
+арциз.ndmsv аскиз.ndmsv асуан.ndmsv асунсьон.ndmsv атаман-нюр.ndmsv атрек.ndmsv 
+афар.ndmsv афганистан.ndmsv афон.ndmsv ахангаран.ndmsv ахваз.ndmsv ахмвдабад.ndmsv 
+ахунбабаев.ndmsv ачикулак.ndmsv ачхой-мартан.ndmsv ашгабад.ndmsv ашгабат.ndmsv ашдод.ndmsv 
+аштарак.ndmsv ашхабад.ndmsv аюдаг.ndmsv аягуз.ndmsv аят.ndmsv баба-юрт.ndmsv 
+бабадаг.ndmsv бабитес.ndmsv багдад.ndmsv баглан.ndmsv бадахшан.ndmsv баден.ndmsv 
+бадхыз.ndmsv бай-хаак.ndmsv байгажак.ndmsv байкал.ndmsv байканд.ndmsv байсун.ndmsv 
+бакал.ndmsv баканас.ndmsv баксан.ndmsv балатон.ndmsv баликпапан.ndmsv балчуг.ndmsv 
+бангкок.ndmsv банджул.ndmsv бандунг.ndmsv банияс.ndmsv банкс.ndmsv барнаул.ndmsv 
+барсакельмес.ndmsv баскунчак.ndmsv бастер.ndmsv батакоюрт.ndmsv батангас.ndmsv баттамбанг.ndmsv 
+баудуков.ndmsv баунт.ndmsv бахилов.ndmsv бахмач.ndmsv бахрейн.ndmsv бахт.ndmsv 
+бачхаз.ndmsv башкортостан.ndmsv бегаван.ndmsv безансон.ndmsv безенчук.ndmsv безмеин.ndmsv 
+бейлаган.ndmsv бейрут.ndmsv бейсуг.ndmsv бекабад.ndmsv белгород.ndmsv белград.ndmsv 
+белз.ndmsv белокаменск.ndmsv белолуцк.ndmsv белосток.ndmsv белуджистан.ndmsv белфаст.ndmsv 
+бенин.ndmsv берген.ndmsv бердичев.ndmsv берислав.ndmsv берн.ndmsv беслан.ndmsv 
+бешар.ndmsv бешарык.ndmsv бешкент.ndmsv биканер.ndmsv бирмингем.ndmsv биробиджан.ndmsv 
+бирштонас.ndmsv битуг.ndmsv бихар.ndmsv бишкек.ndmsv блумфонтейн.ndmsv бобруйск.ndmsv 
+богодуховлес.ndmsv боготол.ndmsv болград.ndmsv болехов.ndmsv болтвар.ndmsv болхов.ndmsv 
+борислав.ndmsv борнмут.ndmsv борнхольм.ndmsv брабант.ndmsv бранденбург.ndmsv браслав.ndmsv 
+брауншвайг.ndmsv брашов.ndmsv бременхафен.ndmsv брест.ndmsv бриежуциемс.ndmsv брокленд.ndmsv 
+бугуруслан.ndmsv будапешт.ndmsv бузан.ndmsv бузулук.ndmsv буксунд.ndmsv буогас.ndmsv 
+бургенлад.ndmsv бурунгулак.ndmsv буск.ndmsv бустан.ndmsv бустах.ndmsv бутут.ndmsv 
+бухарест.ndmsv бучач.ndmsv бушир.ndmsv буэнос.ndmsv буэнос-айрес.ndmsv бхопал.ndmsv 
+бырлад.ndmsv бытом.ndmsv быхов.ndmsv бьюекен.ndmsv вабальнинкас.ndmsv вабкент.ndmsv 
+вад.ndmsv вайгач.ndmsv валаам.ndmsv валдемарпилс.ndmsv вальдолид.ndmsv ванадзор.ndmsv 
+ванино-холмск.ndmsv ванкувер.ndmsv ваннинск.ndmsv варберг.ndmsv варташен.ndmsv варьеган.ndmsv 
+ватикан.ndmsv вах.ndmsv ваховск.ndmsv вевис.ndmsv великоустюг.ndmsv веллингтон.ndmsv 
+венерн.ndmsv вентспилс.ndmsv вентьян.ndmsv веракрус.ndmsv верден.ndmsv верхне-благовещенск.ndmsv 
+верхнедвинск.ndmsv веспрем.ndmsv вестерас.ndmsv вестервик.ndmsv веттерн.ndmsv видин.ndmsv 
+вилькавишкис.ndmsv вильнюс.ndmsv виннипег.ndmsv виннипегосис.ndmsv винтертур.ndmsv вирбалис.ndmsv 
+висим.ndmsv висман.ndmsv висмар.ndmsv витим.ndmsv владивосток.ndmsv владикавказ.ndmsv 
+воклюз.ndmsv волгоград.ndmsv волгореченск.ndmsv воложин.ndmsv волоф.ndmsv волочиск.ndmsv 
+волхов.ndmsv вольногорск.ndmsv вольнянск.ndmsv вонсан.ndmsv воротан.ndmsv вроцлав.ndmsv 
+вуктыл.ndmsv вулвергемптон.ndmsv выборг.ndmsv вышгород.ndmsv вьентьян.ndmsv вюртемберг.ndmsv 
+вюрцбург.ndmsv габон.ndmsv гавр.ndmsv газалкент.ndmsv гайворон.ndmsv галифакс.ndmsv 
+галляарал.ndmsv гамбург.ndmsv ганг.ndmsv ганновер.ndmsv гардез.ndmsv гвадалквивир.ndmsv 
+гданьск.ndmsv гдов.ndmsv гелдерланд.ndmsv геленджик.ndmsv геленждик.ndmsv геническ.ndmsv 
+гент.ndmsv герат.ndmsv гессен.ndmsv гетеборг.ndmsv геттинген.ndmsv гибралтар.ndmsv 
+гиждуван.ndmsv гизиантеп.ndmsv гонконг.ndmsv горис.ndmsv горнореченск.ndmsv горячинск.ndmsv 
+готланд.ndmsv гохран.ndmsv грайворон.ndmsv грибов.ndmsv гросглокнер.ndmsv гуадалканал.ndmsv 
+гуам.ndmsv гудермес.ndmsv гуджарат.ndmsv гузар.ndmsv гулистан.ndmsv гуниб.ndmsv 
+гунт.ndmsv гурон.ndmsv дагомыс.ndmsv далат.ndmsv даллас.ndmsv дальнореченск.ndmsv 
+дамар.ndmsv даммам.ndmsv дамодар.ndmsv дананг.ndmsv данбар.ndmsv дар-эс-салам.ndmsv 
+дарлинг.ndmsv даруссалам.ndmsv дархан.ndmsv дарьял.ndmsv датч-харбор.ndmsv даугавпилс.ndmsv 
+дашкесан.ndmsv дебрецен.ndmsv дейтон.ndmsv делфт.ndmsv демавенд.ndmsv дербент.ndmsv 
+деркул.ndmsv десногорск.ndmsv детройт.ndmsv джайпур.ndmsv джалилабад.ndmsv джамалпур.ndmsv 
+джамбул.ndmsv джамбыл.ndmsv джамшедпур.ndmsv джаркурган.ndmsv джарылгач.ndmsv джебраил.ndmsv 
+джелалабад.ndmsv джермук.ndmsv джетым.ndmsv джизак.ndmsv джилонг.ndmsv джинал.ndmsv 
+джорджтаун.ndmsv джугдыр.ndmsv джуджид-яг.ndmsv дзабхан.ndmsv дижон.ndmsv диксон.ndmsv 
+дилижан.ndmsv димитровград.ndmsv диснейленд.ndmsv диярбакыр.ndmsv дмитров.ndmsv дмитровград.ndmsv 
+днепр.ndmsv днестр.ndmsv довурак.ndmsv донбасс.ndmsv донузлав.ndmsv дортмунд.ndmsv 
+дрезден.ndmsv дрогичин.ndmsv дублин.ndmsv дубчес.ndmsv дувр.ndmsv дуйсбург.ndmsv 
+дукштас.ndmsv думьят.ndmsv дурбан.ndmsv дуррес.ndmsv дусетос.ndmsv дустлик.ndmsv 
+дьеп.ndmsv дьер.ndmsv дюльтыдаг.ndmsv дюнкерк.ndmsv дюпкун.ndmsv дюссельдорф.ndmsv 
+евлах.ndmsv евфрат.ndmsv егорлык.ndmsv езнас.ndmsv екабпилс.ndmsv екатеринбург.ndmsv 
+ельск.ndmsv ереван.ndmsv ермелан.ndmsv еруслан.ndmsv жанатас.ndmsv жашков.ndmsv 
+жесканган.ndmsv жидачов.ndmsv жирекен.ndmsv житомир.ndmsv жлобин.ndmsv жостов.ndmsv 
+забид.ndmsv загребин.ndmsv загрос.ndmsv зайсан.ndmsv закинф.ndmsv зальцбург.ndmsv 
+зангелан.ndmsv зарафшан.ndmsv зардоб.ndmsv зборов.ndmsv звенигород.ndmsv здолбунов.ndmsv 
+зеленоборск.ndmsv зеленоград.ndmsv зеленокумск.ndmsv зеньков.ndmsv зеравшан.ndmsv зерноград.ndmsv 
+зиган.ndmsv зильмердак.ndmsv змиев.ndmsv золочев.ndmsv зонгулдак.ndmsv зубцов.ndmsv 
+зугрэс.ndmsv зунд.ndmsv зыряновск.ndmsv ивангород.ndmsv ивано-франковск.ndmsv иджеван.ndmsv 
+иерусалим.ndmsv изар.ndmsv изер.ndmsv измаил.ndmsv измир.ndmsv измит.ndmsv 
+изяслав.ndmsv илек.ndmsv илим.ndmsv иллер.ndmsv иловайск.ndmsv ильяк.ndmsv 
+иман.ndmsv имроз.ndmsv ингольштадт.ndmsv инд.ndmsv индаур.ndmsv индур.ndmsv 
+инсар.ndmsv инсбрук.ndmsv инчхон.ndmsv ионишкелис.ndmsv ипох.ndmsv ирбит.ndmsv 
+иргыз.ndmsv ирендак.ndmsv иркут.ndmsv иртяш.ndmsv искендерун.ndmsv искитим.ndmsv 
+искыр.ndmsv исламабад.ndmsv истад.ndmsv исфахан.ndmsv итуруп.ndmsv ишерим.ndmsv 
+ишим.ndmsv иштыхан.ndmsv йезд.ndmsv йелл.ndmsv йоханесбург.ndmsv каварскас.ndmsv 
+кагальник.ndmsv кагарлык.ndmsv каджаран.ndmsv кадис.ndmsv казалинск.ndmsv казатин.ndmsv 
+казым.ndmsv каир.ndmsv кайеркан.ndmsv кайраккум.ndmsv кайшадорис.ndmsv калакан.ndmsv 
+калар.ndmsv калат.ndmsv калаус.ndmsv калимантан.ndmsv калинин.ndmsv калининград.ndmsv 
+калтан.ndmsv калунборг.ndmsv калязин.ndmsv каменник.ndmsv каменногорск.ndmsv камерун.ndmsv 
+кампогсаом.ndmsv камызяк.ndmsv камышлов.ndmsv кандагар.ndmsv канев.ndmsv канзас.ndmsv 
+канибадам.ndmsv канпур.ndmsv кантегир.ndmsv капошвар.ndmsv кара-богаз-гол.ndmsv карабах.ndmsv 
+карабулак.ndmsv карадаг.ndmsv каражал.ndmsv каракас.ndmsv каракорум.ndmsv карасор.ndmsv 
+караулбазар.ndmsv карачев.ndmsv каргат.ndmsv кардифф.ndmsv каркаралинск.ndmsv карлсборг.ndmsv 
+карлстад.ndmsv карокорум.ndmsv карпатос.ndmsv касан.ndmsv касимов.ndmsv каскелен.ndmsv 
+каттакурган.ndmsv каттегат.ndmsv каунас.ndmsv кафан.ndmsv качканар.ndmsv кашин.ndmsv 
+квебек.ndmsv кевлар.ndmsv кеген.ndmsv кейптаун.ndmsv кекемерен.ndmsv келес.ndmsv 
+кельбаджар.ndmsv кельн.ndmsv кемчуг.ndmsv кенсингтон.ndmsv керман.ndmsv керманшахр.ndmsv 
+керулен.ndmsv кивач.ndmsv киев.ndmsv кизел.ndmsv кизилюрт.ndmsv кильдин.ndmsv 
+кингисепп.ndmsv кингстаун.ndmsv киномир.ndmsv кипр.ndmsv киргизстан.ndmsv киржач.ndmsv 
+кириллов.ndmsv киркук.ndmsv кировград.ndmsv кировоград.ndmsv кирс.ndmsv кирсанов.ndmsv 
+киселевск.ndmsv китаб.ndmsv китнос.ndmsv кишинев.ndmsv кишн.ndmsv кишпинач.ndmsv 
+клагенфурт.ndmsv клайд.ndmsv кланг.ndmsv клецк.ndmsv кливленд.ndmsv княж-погост.ndmsv 
+ковдор.ndmsv когалым.ndmsv кодакан.ndmsv кожимиз.ndmsv козьмодемьянск.ndmsv койбагар.ndmsv 
+коканд.ndmsv кокарал.ndmsv колгуев.ndmsv колл.ndmsv колобжег.ndmsv коломак.ndmsv 
+комрат.ndmsv коннектикут.ndmsv конотоп.ndmsv консепсьон.ndmsv копейск.ndmsv копенгаген.ndmsv 
+копетдаг.ndmsv коринф.ndmsv коркодон.ndmsv коркоран.ndmsv корнат.ndmsv коростышев.ndmsv 
+корткерос.ndmsv кот-д-ивуар.ndmsv котбус.ndmsv котлас.ndmsv котлин.ndmsv кочечум.ndmsv 
+краков.ndmsv красилов.ndmsv краснодар.ndmsv краснозаводск.ndmsv краснотурьинск.ndmsv кременчуг.ndmsv 
+кристиансанн.ndmsv кристианстад.ndmsv крит.ndmsv крк.ndmsv кронштадт.ndmsv крым.ndmsv 
+крюгерсдорп.ndmsv кувандык.ndmsv кудымкар.ndmsv кузбасс.ndmsv кузнецовск.ndmsv куйбышев.ndmsv 
+кукунор.ndmsv кульеган.ndmsv кумак.ndmsv кумкурган.ndmsv кунашак.ndmsv кунашир.ndmsv 
+кунград.ndmsv кунгур.ndmsv кундос.ndmsv купишкис.ndmsv купянск.ndmsv куткашен.ndmsv 
+кушум.ndmsv кызыл.ndmsv кызылкум.ndmsv кыргызстан.ndmsv кыштым.ndmsv кэт.ndmsv 
+кюрдамир.ndmsv кюстендил.ndmsv лабрадор.ndmsv ладушкин.ndmsv ладыжин.ndmsv лакинск.ndmsv 
+лаклан.ndmsv лангепас.ndmsv лачин.ndmsv лаялпур.ndmsv лейден.ndmsv лейпциг.ndmsv 
+лемнос.ndmsv ленгер.ndmsv ленинакан.ndmsv лентварис.ndmsv лептон.ndmsv лесбос.ndmsv 
+лестер.ndmsv лидс.ndmsv лиллехаммер.ndmsv лимасол.ndmsv лимбург.ndmsv линарес.ndmsv 
+линчепинг.ndmsv лисаковск.ndmsv лисичанск.ndmsv лиссабон.ndmsv лихтенштейн.ndmsv ловеч.ndmsv 
+лоддон.ndmsv локчим.ndmsv лонг-айленд.ndmsv лос-аламос.ndmsv лос-анджелес.ndmsv луганчик.ndmsv 
+лукоянов.ndmsv луксор.ndmsv лумпур.ndmsv лух.ndmsv лучегорск.ndmsv львов.ndmsv 
+льгов.ndmsv льюис.ndmsv любек.ndmsv люботин.ndmsv люксембург.ndmsv лямин.ndmsv 
+маадыр.ndmsv маас.ndmsv магадан.ndmsv магдебург.ndmsv мадагаскар.ndmsv мадрас.ndmsv 
+мадрид.ndmsv мажалык.ndmsv майкоп.ndmsv макран.ndmsv маланг.ndmsv мальмбергет.ndmsv 
+мамадышенск.ndmsv мамакан.ndmsv манас.ndmsv манаус.ndmsv мангейм.ndmsv мангит.ndmsv 
+мангышлак.ndmsv манипур.ndmsv манчестер.ndmsv маргилан.ndmsv мардакерт.ndmsv марджанбулак.ndmsv 
+мариестад.ndmsv мархамат.ndmsv маршалл.ndmsv маскат.ndmsv массачусетс.ndmsv матрах.ndmsv 
+машук.ndmsv мглин.ndmsv мегион.ndmsv медан.ndmsv мейнленд.ndmsv мекнес.ndmsv 
+меконг.ndmsv меларен.ndmsv мелвилл.ndmsv мелеуз.ndmsv мельбурн.ndmsv мепл-уайт.ndmsv 
+мерир.ndmsv мерсин.ndmsv мешхед.ndmsv миасс.ndmsv миконос.ndmsv милос.ndmsv 
+мингечаур.ndmsv миньяр.ndmsv миргород.ndmsv миусинск.ndmsv миусс.ndmsv михайловград.ndmsv 
+мичиган.ndmsv млет.ndmsv могилев.ndmsv мозамбик.ndmsv моламьяйн.ndmsv молл.ndmsv 
+молочанск.ndmsv монс.ndmsv монтсерат.ndmsv монтсеррат.ndmsv моркам.ndmsv мосул.ndmsv 
+мубарек.ndmsv муйнак.ndmsv мукур.ndmsv мултан.ndmsv мургаб.ndmsv мурэн.ndmsv 
+мухаррак.ndmsv мьюинджан.ndmsv мэн.ndmsv мэриленд.ndmsv мюнстер.ndmsv мюнхен.ndmsv 
+наблус.ndmsv наварин.ndmsv назарет.ndmsv назым.ndmsv наксос.ndmsv нальчик.ndmsv 
+наманган.ndmsv намюр.ndmsv нанкин.ndmsv нант.ndmsv наньлин.ndmsv нарбутов.ndmsv 
+наргин.ndmsv нариманов.ndmsv нарофоминск.ndmsv нарын.ndmsv нарьян-мар.ndmsv нафталан.ndmsv 
+невис.ndmsv негрос.ndmsv неджеф.ndmsv нежин.ndmsv неккар.ndmsv неман.ndmsv 
+немиров.ndmsv нептун.ndmsv нетешин.ndmsv нигер.ndmsv нижнеянск.ndmsv нил.ndmsv 
+новоазовск.ndmsv нововолынск.ndmsv новодружеск.ndmsv новозыбков.ndmsv новомиргород.ndmsv новомичуринск.ndmsv 
+новопавловск.ndmsv новопетровск.ndmsv новополоцк.ndmsv новоржев.ndmsv новосад.ndmsv новоуральск.ndmsv 
+новохованск.ndmsv нордвик.ndmsv нордкап.ndmsv нордкин.ndmsv норчеппинг.ndmsv ноттингем.ndmsv 
+ноушехр.ndmsv нуакшот.ndmsv нукус.ndmsv нунивак.ndmsv нурабад.ndmsv нурлат.ndmsv 
+нью-йорк.ndmsv ньюфаундленд.ndmsv нюк.ndmsv нюрнберг.ndmsv нярис.ndmsv нячанг.ndmsv 
+оверейселл.ndmsv овстуг.ndmsv окленд.ndmsv оксфорд.ndmsv олимп.ndmsv ольборг.ndmsv 
+ольхон.ndmsv ольштын.ndmsv оман.ndmsv омолон.ndmsv онекотан.ndmsv онемен.ndmsv 
+онон.ndmsv оргеев.ndmsv ордубад.ndmsv оренбург.ndmsv ортолык.ndmsv орхус.ndmsv 
+осмуссар.ndmsv оснабрюкк.ndmsv осташков.ndmsv остер.ndmsv осым.ndmsv очаков.ndmsv 
+павлоград.ndmsv павлодар.ndmsv паг.ndmsv пазарджик.ndmsv пайер.ndmsv пайтуг.ndmsv 
+пакруойис.ndmsv палембанг.ndmsv памир.ndmsv панделис.ndmsv паневежис.ndmsv парамушир.ndmsv 
+парджуман.ndmsv паркент.ndmsv пасвалис.ndmsv пахтаабад.ndmsv пахтакор.ndmsv педжикент.ndmsv 
+пелопоннес.ndmsv пелым.ndmsv перевальск.ndmsv перелюб.ndmsv перник.ndmsv перпиньон.ndmsv 
+перт.ndmsv першотравенск.ndmsv песяков.ndmsv петербург.ndmsv петергоф.ndmsv петриков.ndmsv 
+пешавар.ndmsv пешт.ndmsv пиелинен.ndmsv пинд.ndmsv пирятин.ndmsv питермарицбург.ndmsv 
+питляр.ndmsv питтсбург.ndmsv плевен.ndmsv плимут.ndmsv пловдив.ndmsv плоцк.ndmsv 
+плутон.ndmsv плявиняс.ndmsv поважск.ndmsv подбельск.ndmsv помаран.ndmsv порт-александр.ndmsv 
+порт-оф-пренс.ndmsv порт-оф-спэйн.ndmsv портленд.ndmsv портсмут.ndmsv порхов.ndmsv потомак.ndmsv 
+потсдам.ndmsv поусат.ndmsv почеп.ndmsv праслен.ndmsv прикумск.ndmsv прованс.ndmsv 
+псел.ndmsv пскент.ndmsv псков.ndmsv пунг.ndmsv пунтаренас.ndmsv пусан.ndmsv 
+путалов.ndmsv пхеньян.ndmsv пхукет.ndmsv пыталов.ndmsv пыть-ях.ndmsv пыщуг.ndmsv 
+пьетрос.ndmsv пятигорск.ndmsv пятиморск.ndmsv радвилишкис.ndmsv радехов.ndmsv раджастхан.ndmsv 
+радом.ndmsv разград.ndmsv раздан.ndmsv раздолинск.ndmsv рангун.ndmsv раттен.ndmsv 
+раудатайн.ndmsv регенсбург.ndmsv редант.ndmsv рединг.ndmsv рейкьявик.ndmsv реймс.ndmsv 
+рейн.ndmsv ретавас.ndmsv реут.ndmsv реюньон.ndmsv ржев.ndmsv рим.ndmsv 
+ринггит.ndmsv риштан.ndmsv роанн.ndmsv родос.ndmsv роздол.ndmsv рокишкис.ndmsv 
+рокстон.ndmsv ромитан.ndmsv росток.ndmsv роттердам.ndmsv роудс.ndmsv рохас.ndmsv 
+руан.ndmsv рур.ndmsv рэдан.ndmsv рюген.ndmsv саар.ndmsv сабирабад.ndmsv 
+саган-нур.ndmsv сайвун.ndmsv сайгон.ndmsv сайхут.ndmsv салават.ndmsv салаир.ndmsv 
+салгир.ndmsv салдус.ndmsv салем.ndmsv салехард.ndmsv сальвадор.ndmsv самарканд.ndmsv 
+самбор.ndmsv самос.ndmsv сампур.ndmsv самсун.ndmsv самур.ndmsv сандакан.ndmsv 
+сандвиксен.ndmsv сандерленд.ndmsv санкт-петебрург.ndmsv санкт-петербург.ndmsv сантус.ndmsv сарапул.ndmsv 
+саривон.ndmsv сарканд.ndmsv сарлан.ndmsv саров.ndmsv сартанг.ndmsv сарыагач.ndmsv 
+сарыг-сеп.ndmsv сарыджаз.ndmsv саскатун.ndmsv саскачеван.ndmsv сасык.ndmsv саттахип.ndmsv 
+сатурн.ndmsv саур.ndmsv саутгемптон.ndmsv сахалин.ndmsv свердруп.ndmsv светан.ndmsv 
+светловодск.ndmsv светлоград.ndmsv севан.ndmsv северин.ndmsv северн.ndmsv северо-уральск.ndmsv 
+северобайкальск.ndmsv северодонецк.ndmsv сегед.ndmsv секешфехервар.ndmsv селигдар.ndmsv селигер.ndmsv 
+семаранг.ndmsv семикаракорск.ndmsv семипалатинск.ndmsv семхоз.ndmsv сент-винсент.ndmsv сент-джеймс-стрит.ndmsv 
+сент-китс.ndmsv сентарен.ndmsv серам.ndmsv сергач.ndmsv серет.ndmsv серифос.ndmsv 
+серпухов.ndmsv сескар.ndmsv сестрорецк.ndmsv сетиф.ndmsv сетубал.ndmsv сеул.ndmsv 
+сивас.ndmsv сигуам.ndmsv сикар.ndmsv сикким.ndmsv силхет.ndmsv сильян.ndmsv 
+сим.ndmsv симнас.ndmsv симушир.ndmsv сингапур.ndmsv сирет.ndmsv сирос.ndmsv 
+сисиан.ndmsv сисим.ndmsv сифнос.ndmsv сицзян.ndmsv сиэтл.ndmsv сиялкот.ndmsv 
+скаген.ndmsv скагеррак.ndmsv скадовск.ndmsv скалат.ndmsv скирос.ndmsv скопин.ndmsv 
+скуодас.ndmsv славгород.ndmsv славяногорск.ndmsv сливен.ndmsv слуцк.ndmsv снежинск.ndmsv 
+снятын.ndmsv солигорск.ndmsv сорск.ndmsv спитак.ndmsv сплит.ndmsv спрингс.ndmsv 
+среднекан.ndmsv сринагар.ndmsv старобельск.ndmsv староуткинск.ndmsv староюрьев.ndmsv стаффорд.ndmsv 
+стебник.ndmsv степанаван.ndmsv степанакерт.ndmsv стерлитамак.ndmsv стернхейм.ndmsv стокгольм.ndmsv 
+столин.ndmsv стоход.ndmsv страсбург.ndmsv стремсунд.ndmsv стрижамент.ndmsv стуруван.ndmsv 
+суглан.ndmsv суккур.ndmsv сулак.ndmsv сумгаит.ndmsv сургут.ndmsv сусуман.ndmsv 
+суходольск.ndmsv сухэ-батор.ndmsv сфакс.ndmsv сыктывкар.ndmsv сым.ndmsv сьенфуэгос.ndmsv 
+таврийск.ndmsv таганрог.ndmsv тагил.ndmsv таджикистан.ndmsv таждикистан.ndmsv таймыр.ndmsv 
+тайшет.ndmsv талакан.ndmsv талас.ndmsv талгар.ndmsv талдом.ndmsv талды-курган.ndmsv 
+талдык.ndmsv талимарджан.ndmsv таллин.ndmsv таллинн.ndmsv талнах.ndmsv тамбов.ndmsv 
+тамилнад.ndmsv танджунгприорк.ndmsv танжер.ndmsv тарим.ndmsv тарнув.ndmsv тартус.ndmsv 
+тасос.ndmsv татарстан.ndmsv тауз.ndmsv ташкент.ndmsv таштагол.ndmsv таштып.ndmsv 
+тебриз.ndmsv тегеран.ndmsv теджен.ndmsv тель-авив.ndmsv тельпосиз.ndmsv темир.ndmsv 
+темрюк.ndmsv тенис.ndmsv теплогорск.ndmsv терек.ndmsv терен.ndmsv термаикос.ndmsv 
+термез.ndmsv тертер.ndmsv тетиев.ndmsv тетуан.ndmsv теужеск.ndmsv тилбург.ndmsv 
+тилос.ndmsv тим.ndmsv тимптон.ndmsv тинос.ndmsv тихвин.ndmsv тлумач.ndmsv 
+тогучин.ndmsv токмак.ndmsv толочин.ndmsv томмот.ndmsv тонлесап.ndmsv торренс.ndmsv 
+трабзон.ndmsv треллеборг.ndmsv трент.ndmsv триест.ndmsv тринидад.ndmsv трир.ndmsv 
+троллхетан.ndmsv трубачевск.ndmsv туггурт.ndmsv тукумс.ndmsv тулон.ndmsv тулос.ndmsv 
+тулун.ndmsv тульчин.ndmsv тумэн.ndmsv туракурган.ndmsv туран.ndmsv турин.ndmsv 
+туркечиан.ndmsv туркменистан.ndmsv туртас.ndmsv турухан.ndmsv тхаб.ndmsv тюкян.ndmsv 
+тюнг.ndmsv тясмин.ndmsv тячев.ndmsv убаган.ndmsv угнев.ndmsv уджунгпанданг.ndmsv 
+ужвентис.ndmsv ужгород.ndmsv ужур.ndmsv узбекистан.ndmsv узген.ndmsv улавун.ndmsv 
+улан-батор.ndmsv улуюл.ndmsv ульм.ndmsv ульсан.ndmsv умнак.ndmsv унимак.ndmsv 
+урак.ndmsv ургал.ndmsv ургут.ndmsv уржум.ndmsv урузган.ndmsv уруп.ndmsv 
+урух.ndmsv урюп.ndmsv устилуг.ndmsv усть-абакан.ndmsv усть-катав.ndmsv усть-кут.ndmsv 
+усть-омчуг.ndmsv устюг.ndmsv учарал.ndmsv учкекен.ndmsv учкудук.ndmsv учкурган.ndmsv 
+учур.ndmsv ушишир.ndmsv уэйк.ndmsv уяр.ndmsv файзабад.ndmsv фастов.ndmsv 
+фаял.ndmsv фемарн.ndmsv фишт.ndmsv флорес.ndmsv форарльберг.ndmsv франкфурт.ndmsv 
+фредериксхавн.ndmsv фредрикстад.ndmsv фрейзер.ndmsv фрибур.ndmsv фритаун.ndmsv хаджидер.ndmsv 
+хадыженск.ndmsv хайдарабад.ndmsv хайфон.ndmsv хаккулабад.ndmsv халал.ndmsv халеб.ndmsv 
+халкабад.ndmsv халл.ndmsv хальмстад.ndmsv хамадан.ndmsv хамхын.ndmsv ханабад.ndmsv 
+ханлар.ndmsv харагун.ndmsv харбин.ndmsv харлем.ndmsv харпер.ndmsv харцызск.ndmsv 
+харьков.ndmsv хасавюрт.ndmsv хасан.ndmsv хасселт.ndmsv хачмас.ndmsv хвар.ndmsv 
+хельсингборг.ndmsv хемчик.ndmsv хернестад.ndmsv хиос.ndmsv ходжаабад.ndmsv ходоров.ndmsv 
+холбон.ndmsv холихед.ndmsv хомс.ndmsv хопер.ndmsv хорог.ndmsv хорол.ndmsv 
+хоростков.ndmsv хорремшехр.ndmsv хотин.ndmsv хубсугул.ndmsv худат.ndmsv худжанд.ndmsv 
+хуст.ndmsv хыров.ndmsv хьюстон.ndmsv цахкадзор.ndmsv цесис.ndmsv црес.ndmsv 
+цэцэрлэг.ndmsv цюрих.ndmsv цюрупинск.ndmsv чаган.ndmsv чадан.ndmsv чандпур.ndmsv 
+чаохч.ndmsv чаренцаван.ndmsv чарикар.ndmsv чарск.ndmsv чартак.ndmsv чаткал.ndmsv 
+чатырдаг.ndmsv чаун.ndmsv чахчаран.ndmsv челек.ndmsv челекен.ndmsv челкар.ndmsv 
+чен.ndmsv червоноград.ndmsv чериков.ndmsv чермоз.ndmsv чернигов.ndmsv чечерск.ndmsv 
+чигирин.ndmsv чимкент.ndmsv чиназ.ndmsv чирчик.ndmsv чистоп.ndmsv читтагонг.ndmsv 
+чичкаюл.ndmsv чкалов.ndmsv чойбалсан.ndmsv чондон.ndmsv чоп.ndmsv чорох.ndmsv 
+чортков.ndmsv чугуев.ndmsv чулым.ndmsv чуст.ndmsv чхонджин.ndmsv шагол.ndmsv 
+шагонар.ndmsv шалкар.ndmsv шаргород.ndmsv шарлоттаун.ndmsv шартр.ndmsv шат-эль-араб.ndmsv 
+шахрисабз.ndmsv шахрихан.ndmsv швенченис.ndmsv шверин.ndmsv шеньян.ndmsv шерабад.ndmsv 
+шербур.ndmsv шерхан.ndmsv шеффилд.ndmsv шехркорд.ndmsv шиашкотан.ndmsv шибарган.ndmsv 
+шикотан.ndmsv шимкент.ndmsv шираз.ndmsv ширвинтос.ndmsv шклов.ndmsv шлиссельбург.ndmsv 
+шляйн.ndmsv шопоков.ndmsv шпицберген.ndmsv штральзунд.ndmsv штутгарт.ndmsv шумен.ndmsv 
+шураб.ndmsv щагонар.ndmsv щецин.ndmsv эверест.ndmsv эгер.ndmsv эдинбург.ndmsv 
+эдмонтон.ndmsv эйзенштадт.ndmsv эйлат.ndmsv эйндховен.ndmsv эйр.ndmsv эйшишкес.ndmsv 
+экибастуз.ndmsv эланд.ndmsv элегест.ndmsv электрогорск.ndmsv элефисис.ndmsv элсмир.ndmsv 
+эль-кувейт.ndmsv эль-сальвадор.ndmsv эльбрус.ndmsv эльтон.ndmsv элязыг.ndmsv энергодар.ndmsv 
+энмор-парк.ndmsv эрдек.ndmsv эрджияс.ndmsv эресунн.ndmsv эрзурум.ndmsv эрфурт.ndmsv 
+эсбьерг.ndmsv эстерсунд.ndmsv эчмиадзин.ndmsv юганск.ndmsv южносухокумск.ndmsv юкон.ndmsv 
+юкос.ndmsv юрбаркас.ndmsv юхнов.ndmsv яготин.ndmsv ядрин.ndmsv язгулем.ndmsv 
+яйпан.ndmsv яккабаг.ndmsv ялпуг.ndmsv ямал.ndmsv ямбол.ndmsv янаул.ndmsv 
+янгиабад.ndmsv янгиер.ndmsv янгстаун.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 ковров.= яворов.= :
   LLDWW+ or LLDKF+;
 
 ковров.amss яворов.amss :  <morph-П,мр,ед,кр>;
 
-ковров.ndmsv яворов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ковров.ndmsi яворов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ковров.ndmsv яворов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ковчеж.= :
   LLAXZ+ or LLBYZ+;
@@ -18079,11 +18073,11 @@
 
 кожан.amss :  <morph-П,мр,ед,кр>;
 
-кожан.nlmsi :  <morph-С,мр,од,ед,им>;
+кожан.ndmsi :  <morph-С,мр,но,ед,им>;
 
 кожан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-кожан.ndmsi :  <morph-С,мр,но,ед,им>;
+кожан.nlmsi :  <morph-С,мр,од,ед,им>;
 
 /ru/words/words.103:
   LLDML+;
@@ -18094,9 +18088,9 @@
 коз.= :
   LLAGT+ or LLAUR+ or LLAUV+ or LLBFF+ or LLBUF+ or LLCKR+;
 
-коз.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 коз.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+коз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 козел.= :
   LLAYF+;
@@ -18107,13 +18101,13 @@
 козлищ.= :
   LLARK+ or LLASC+;
 
-козлищ.nlnpg :  <morph-С,ср,од,мн,рд>;
+козлищ.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 козлищ.nlnpv :  <morph-С,ср,од,мн,вн>;
 
-козлищ.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 козлищ.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+козлищ.nlnpg :  <morph-С,ср,од,мн,рд>;
 
 козон.= :
   LLCJW+ or LLDNY+;
@@ -18136,9 +18130,9 @@
 
 график.ndmsv кок.ndmsv пластик.ndmsv рак.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-график.ndmsi кок.ndmsi пластик.ndmsi рак.ndmsi :  <morph-С,мр,но,ед,им>;
-
 график.ndfpg кок.ndfpg пластик.ndfpg рак.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+график.ndmsi кок.ndmsi пластик.ndmsi рак.ndmsi :  <morph-С,мр,но,ед,им>;
 
 коклюш.= :
   LLAAH+ or LLBRI+ or LLBYZ+;
@@ -18150,20 +18144,20 @@
 кокс.= тир.= :
   LLAAQ+ or LLDXR+ or LLCCZ+ or LLCGW+;
 
-кокс.ndmsv тир.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кокс.ndmsi тир.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кокс.ndmsv тир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кол.= :
   LLAAT+ or LLDXR+ or LLFIN+ or LLBRK+ or LLBSW+ or LLCJW+ or LLCLJ+ or LLCLM+ or LLDPF+ or LLFKW+;
 
-кол.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-кол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кол.ndmsi :  <morph-С,мр,но,ед,им>;
 
 кол.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+кол.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+кол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 колдун.= :
   LLACI+ or LLDJV+ or LLDPO+;
@@ -18184,9 +18178,9 @@
 колер.= :
   LLABI+ or LLBYU+ or LLCCZ+ or LLCGW+;
 
-колер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 колер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+колер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 колес.= :
   LLGHE+ or LLBYZ+ or LLCAG+ or LLCCZ+ or LLFWB+ or LLCGW+;
@@ -18216,9 +18210,9 @@
 колон.= :
   LLACI+ or LLDWW+ or LLBRK+ or LLBYZ+ or LLCJW+ or LLCKD+ or LLFWL+;
 
-колон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 колон.nlmsi :  <morph-С,мр,од,ед,им>;
+
+колон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 колон.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -18255,11 +18249,11 @@
 ком.= :
   LLAAZ+ or LLAFX+ or LLAUW+ or LLCJW+;
 
-ком.ndmsv :  <morph-С,мр,но,ед,вн>;
+ком.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 ком.ndmsi :  <morph-С,мр,но,ед,им>;
 
-ком.ndfpg :  <morph-С,жр,но,мн,рд>;
+ком.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 команд.= :
   LLAFX+ or LLBYZ+ or LLCBF+;
@@ -18344,9 +18338,9 @@
 комсомольск.= :
   LLDWW+ or LLFPX+ or LLBEL+;
 
-комсомольск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 комсомольск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+комсомольск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кон.= :
   LLAAS+ or LLAUI+ or LLAUN+ or LLAYB+ or LLBRK+ or LLBYZ+ or LLDMT+;
@@ -18370,11 +18364,11 @@
 кондуктор.= :
   LLAAQ+ or LLACQ+;
 
+кондуктор.ndmsi :  <morph-С,мр,но,ед,им>;
+
 кондуктор.nlmsi :  <morph-С,мр,од,ед,им>;
 
 кондуктор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-кондуктор.ndmsi :  <morph-С,мр,но,ед,им>;
 
 конев.= :
   LLFQF+ or LLDZB+ or LLCJC+;
@@ -18432,11 +18426,11 @@
 константин.= :
   LLGSB+;
 
+константин.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 константин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 константин.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-константин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 конструир.= :
   LLEPJ+ or LLCHH+;
@@ -18444,9 +18438,9 @@
 конструктор.= шибер.= :
   LLAAQ+ or LLACR+;
 
-конструктор.nlmsi шибер.nlmsi :  <morph-С,мр,од,ед,им>;
-
 конструктор.ndmsv шибер.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+конструктор.nlmsi шибер.nlmsi :  <morph-С,мр,од,ед,им>;
 
 конструктор.ndmsi шибер.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -18461,15 +18455,15 @@
 контр.= :
   LLAFH+ or LLELV+ or LLBNY+ or LLDJS+;
 
-контр.nlfpg :  <morph-С,жр,од,мн,рд>;
+контр.npg :  <morph-С,мн,мн,рд>;
 
 контр.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-контр.npg :  <morph-С,мн,мн,рд>;
+контр.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 контр.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-контр.nlfpv :  <morph-С,жр,од,мн,вн>;
+контр.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 контральто.= меццо-сопрано.= сопрано.= :
   LLADG+ or LLADL+;
@@ -18487,9 +18481,9 @@
 конфликт.= :
   LLAAQ+ or LLBYU+ or LLCBF+;
 
-конфликт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 конфликт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+конфликт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 концентрир.= :
   LLCDJ+ or LLCGX+;
@@ -18507,11 +18501,11 @@
 
 коняг.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-коняг.nlmpv :  <morph-С,мр,од,мн,вн>;
+коняг.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 коняг.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-коняг.nlmpg :  <morph-С,мр,од,мн,рд>;
+коняг.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 кооперир.= :
   LLEPG+ or LLCFX+ or LLCGW+ or LLFWD+;
@@ -18557,9 +18551,9 @@
 копыл.= :
   LLAAZ+ or LLEAT+;
 
-копыл.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 копыл.ndmsi :  <morph-С,мр,но,ед,им>;
+
+копыл.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 копыт.= :
   LLAVL+ or LLBYZ+ or LLCAG+ or LLDIC+;
@@ -18581,11 +18575,11 @@
 кордон.= :
   LLAAQ+ or LLFKJ+ or LLFKI+ or LLBYZ+;
 
-кордон.nlmsi :  <morph-С,мр,од,ед,им>;
+кордон.ndmsi :  <morph-С,мр,но,ед,им>;
 
 кордон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-кордон.ndmsi :  <morph-С,мр,но,ед,им>;
+кордон.nlmsi :  <morph-С,мр,од,ед,им>;
 
 коре.= :
   LLAYG+ or LLBPW+ or LLEAY+;
@@ -18604,9 +18598,9 @@
 корм.= :
   LLABI+ or LLAGE+ or LLBII+ or LLBNN+ or LLBYZ+;
 
-корм.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 корм.ndmsi :  <morph-С,мр,но,ед,им>;
+
+корм.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кормил.= :
   LLAYK+ or LLCAG+;
@@ -18655,9 +18649,9 @@
 королев.= :
   LLFJG+ or LLAGT+ or LLFJV+ or LLBUX+;
 
-королев.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 королев.nlmsi :  <morph-С,мр,од,ед,им>;
+
+королев.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 королев.nlfpv :  <morph-С,жр,од,мн,вн>;
 
@@ -18691,9 +18685,9 @@
 корч.= :
   LLAFM+ or LLASV+ or LLATL+ or LLBBY+ or LLBHG+ or LLBMU+ or LLBUL+;
 
-корч.npg :  <morph-С,мн,мн,рд>;
-
 корч.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+корч.npg :  <morph-С,мн,мн,рд>;
 
 корыст.= :
   LLBYU+ or LLFAK+ or LLDNF+;
@@ -18709,13 +18703,13 @@
 кос.= :
   LLDWW+ or LLAFX+ or LLAKZ+ or LLAYJ+ or LLBYU+ or LLCIR+ or LLCIS+ or LLCJW+;
 
-кос.amss :  <morph-П,мр,ед,кр>;
+кос.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-кос.ndmsv :  <morph-С,мр,но,ед,вн>;
+кос.amss :  <morph-П,мр,ед,кр>;
 
 кос.ndmsi :  <morph-С,мр,но,ед,им>;
 
-кос.ndfpg :  <morph-С,жр,но,мн,рд>;
+кос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 косин.= :
   LLAGL+ or LLBRK+ or LLDZR+;
@@ -18747,15 +18741,15 @@
 :
   LLAAQ+ or LLDOO+;
 
-аул.ndmsv ацетил.ndmsv балл.ndmsv вокзал.ndmsv выгул.ndmsv вымпел.ndmsv 
-журнал.ndmsv камзол.ndmsv кинжал.ndmsv костел.ndmsv отгул.ndmsv портал.ndmsv 
-пушбол.ndmsv сантал.ndmsv ствол.ndmsv факел.ndmsv филиал.ndmsv хорал.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
-
 аул.ndmsi ацетил.ndmsi балл.ndmsi вокзал.ndmsi выгул.ndmsi вымпел.ndmsi 
 журнал.ndmsi камзол.ndmsi кинжал.ndmsi костел.ndmsi отгул.ndmsi портал.ndmsi 
 пушбол.ndmsi сантал.ndmsi ствол.ndmsi факел.ndmsi филиал.ndmsi хорал.ndmsi 
 :  <morph-С,мр,но,ед,им>;
+
+аул.ndmsv ацетил.ndmsv балл.ndmsv вокзал.ndmsv выгул.ndmsv вымпел.ndmsv 
+журнал.ndmsv камзол.ndmsv кинжал.ndmsv костел.ndmsv отгул.ndmsv портал.ndmsv 
+пушбол.ndmsv сантал.ndmsv ствол.ndmsv факел.ndmsv филиал.ndmsv хорал.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
 
 костер.= :
   LLBIK+ or LLBNP+ or LLCJW+ or LLDML+ or LLDMT+;
@@ -18795,16 +18789,16 @@
 котор.= :
   LLDWW+ or LLDWM+ or LLDLW+ or LLDLX+ or LLDLY+;
 
-котор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 котор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+котор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кофе.= :
   LLABZ+ or LLADL+ or LLAUC+ or LLBPH+ or LLBQI+ or LLBQS+;
 
-кофе.ndn :  <morph-С,ср,но,0>;
-
 кофе.ndm :  <morph-С,мр,но,0>;
+
+кофе.ndn :  <morph-С,ср,но,0>;
 
 кофи.= :
   LLBPQ+;
@@ -18891,16 +18885,16 @@
 кран.= огород.= сюрприз.= :
   LLAAQ+ or LLAXZ+ or LLBYZ+;
 
-кран.ndmsv огород.ndmsv сюрприз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кран.ndmsi огород.ndmsi сюрприз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кран.ndmsv огород.ndmsv сюрприз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 крап.= :
   LLAAQ+ or LLAHS+;
 
-крап.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 крап.ndmsi :  <morph-С,мр,но,ед,им>;
+
+крап.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 крас.= :
   LLAGE+ or LLBRK+ or LLBYU+ or LLCGW+;
@@ -18921,18 +18915,18 @@
 крат.= :
   LLABW+ or LLBSW+ or LLBYU+;
 
-крат.ndmsv :  <morph-С,мр,но,ед,вн>;
+крат.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 крат.ndmsi :  <morph-С,мр,но,ед,им>;
 
-крат.ndmpg :  <morph-С,мр,но,мн,рд>;
+крат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 крахмал.= :
   LLAAO+ or LLBIA+ or LLBNU+;
 
-крахмал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 крахмал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+крахмал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кре.= :
   LLCSN+ or LLFZC+ or LLCTB+ or LLFZD+;
@@ -18974,18 +18968,18 @@
 крен.= :
   LLAAQ+ or LLBIK+ or LLBNP+;
 
-крен.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 крен.ndmsi :  <morph-С,мр,но,ед,им>;
+
+крен.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 креп.= :
   LLAAQ+ or LLBII+ or LLBNN+ or LLBSP+ or LLBSX+ or LLBWA+ or LLDNF+;
 
-креп.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 креп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 креп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+креп.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 крепост.= :
   LLDHZ+ or LLDNF+;
@@ -18993,9 +18987,9 @@
 крест.= :
   LLAAQ+ or LLAYB+ or LLBCE+ or LLBYZ+;
 
-крест.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 крест.ndmsi :  <morph-С,мр,но,ед,им>;
+
+крест.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 именин.= крестин.= макарон.= :
   LLBYZ+ or LLDJS+;
@@ -19023,9 +19017,9 @@
 критик.= :
   LLACG+ or LLAFU+ or LLCCY+ or LLCGW+;
 
-критик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 критик.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+критик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 крич.= :
   LLAHP+ or LLBYZ+;
@@ -19033,18 +19027,18 @@
 арсеньев.= кричев.= :
   LLDWW+ or LLFQF+ or LLFJN+;
 
-арсеньев.nlmsi кричев.nlmsi :  <morph-С,мр,од,ед,им>;
+арсеньев.ndmsi кричев.ndmsi :  <morph-С,мр,но,ед,им>;
 
 арсеньев.ndmsv кричев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-арсеньев.ndmsi кричев.ndmsi :  <morph-С,мр,но,ед,им>;
+арсеньев.nlmsi кричев.nlmsi :  <morph-С,мр,од,ед,им>;
 
 кров.= :
   LLAAQ+ or LLBUI+ or LLBYU+ or LLDNF+;
 
-кров.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кров.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кров.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кровел.= сабел.= :
   LLDNX+ or LLDOO+;
@@ -19058,10 +19052,6 @@
 пропойц.nlfpg пьяниц.nlfpg самоубийц.nlfpg сестроубийц.nlfpg скромниц.nlfpg сыноубийц.nlfpg 
 убийц.nlfpg умниц.nlfpg цареубийц.nlfpg чадоубийц.nlfpg человекоубийц.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-братоубийц.nlmpv возниц.nlmpv детоубийц.nlmpv кровопийц.nlmpv матереубийц.nlmpv отцеубийц.nlmpv 
-пропойц.nlmpv пьяниц.nlmpv самоубийц.nlmpv сестроубийц.nlmpv скромниц.nlmpv сыноубийц.nlmpv 
-убийц.nlmpv умниц.nlmpv цареубийц.nlmpv чадоубийц.nlmpv человекоубийц.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 братоубийц.nlmpg возниц.nlmpg детоубийц.nlmpg кровопийц.nlmpg матереубийц.nlmpg отцеубийц.nlmpg 
 пропойц.nlmpg пьяниц.nlmpg самоубийц.nlmpg сестроубийц.nlmpg скромниц.nlmpg сыноубийц.nlmpg 
 убийц.nlmpg умниц.nlmpg цареубийц.nlmpg чадоубийц.nlmpg человекоубийц.nlmpg :  <morph-С,мр,од,мн,рд>;
@@ -19069,6 +19059,10 @@
 братоубийц.nlfpv возниц.nlfpv детоубийц.nlfpv кровопийц.nlfpv матереубийц.nlfpv отцеубийц.nlfpv 
 пропойц.nlfpv пьяниц.nlfpv самоубийц.nlfpv сестроубийц.nlfpv скромниц.nlfpv сыноубийц.nlfpv 
 убийц.nlfpv умниц.nlfpv цареубийц.nlfpv чадоубийц.nlfpv человекоубийц.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+братоубийц.nlmpv возниц.nlmpv детоубийц.nlmpv кровопийц.nlmpv матереубийц.nlmpv отцеубийц.nlmpv 
+пропойц.nlmpv пьяниц.nlmpv самоубийц.nlmpv сестроубийц.nlmpv скромниц.nlmpv сыноубийц.nlmpv 
+убийц.nlmpv умниц.nlmpv цареубийц.nlmpv чадоубийц.nlmpv человекоубийц.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 баклан.= бизон.= дельфин.= крокодил.= марал.= налим.= 
 павлин.= пеликан.= сазан.= таракан.= фазан.= :
@@ -19112,15 +19106,15 @@
 бяк.= завирух.= крох.= недотрог.= :
   LLAFG+ or LLAFU+;
 
-бяк.nlfpg завирух.nlfpg крох.nlfpg недотрог.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-бяк.nlmpv завирух.nlmpv крох.nlmpv недотрог.nlmpv :  <morph-С,мр,од,мн,вн>;
+бяк.nlfpv завирух.nlfpv крох.nlfpv недотрог.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 бяк.ndfpg завирух.ndfpg крох.ndfpg недотрог.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-бяк.nlmpg завирух.nlmpg крох.nlmpg недотрог.nlmpg :  <morph-С,мр,од,мн,рд>;
+бяк.nlmpv завирух.nlmpv крох.nlmpv недотрог.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-бяк.nlfpv завирух.nlfpv крох.nlfpv недотрог.nlfpv :  <morph-С,жр,од,мн,вн>;
+бяк.nlfpg завирух.nlfpg крох.nlfpg недотрог.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+бяк.nlmpg завирух.nlmpg крох.nlmpg недотрог.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 крохот.= :
   LLBRH+ or LLBRK+ or LLBYU+;
@@ -19140,9 +19134,9 @@
 артполк.= круг.= норфолк.= полк.= шлях.= :
   LLAAN+;
 
-артполк.ndmsv круг.ndmsv норфолк.ndmsv полк.ndmsv шлях.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 артполк.ndmsi круг.ndmsi норфолк.ndmsi полк.ndmsi шлях.ndmsi :  <morph-С,мр,но,ед,им>;
+
+артполк.ndmsv круг.ndmsv норфолк.ndmsv полк.ndmsv шлях.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бледнолиц.= длиннолиц.= краснолиц.= круглолиц.= плосколиц.= розоволиц.= 
 румянолиц.= светлолиц.= смуглолиц.= толстолиц.= широколиц.= :
@@ -19157,9 +19151,9 @@
 кружев.= :
   LLAHC+ or LLCAG+ or LLDIB+ or LLDIC+ or LLDIE+;
 
-кружев.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 кружев.npg :  <morph-С,мн,мн,рд>;
+
+кружев.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 кружков.= :
   LLAYI+ or LLCJC+;
@@ -19215,9 +19209,9 @@
 крыс.= :
   LLAGT+ or LLAVH+ or LLBFF+;
 
-крыс.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 крыс.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+крыс.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кокет.= конфедерат.= крысолов.= матрос.= мухолов.= чечет.= 
 шахтер.= :
@@ -19245,9 +19239,9 @@
 косов.= кстов.= люблин.= рассказов.= :
   LLDWW+ or LLDZR+;
 
-косов.ndmsv кстов.ndmsv люблин.ndmsv рассказов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 косов.ndmsi кстов.ndmsi люблин.ndmsi рассказов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+косов.ndmsv кстов.ndmsv люблин.ndmsv рассказов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ку.= :
   LLCTB+ or LLCXA+;
@@ -19680,9 +19674,9 @@
 куб.= :
   LLAAQ+ or LLDXR+ or LLCJW+;
 
-куб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 куб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+куб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кубов.= :
   LLAKS+ or LLCJC+ or LLDKJ+;
@@ -19695,15 +19689,15 @@
 таиланд.= тунис.= цейлон.= эквадор.= :
   LLDWW+ or LLAYI+ or LLBRO+;
 
-азербайджан.ndmsv алжир.ndmsv барбадос.ndmsv вьетнам.ndmsv дагестан.ndmsv заир.ndmsv 
-занзибар.ndmsv иран.ndmsv йемен.ndmsv кавказ.ndmsv кашмир.ndmsv кувейт.ndmsv 
-лаос.ndmsv ленинград.ndmsv пакистан.ndmsv свазиленд.ndmsv судан.ndmsv суринам.ndmsv 
-таиланд.ndmsv тунис.ndmsv цейлон.ndmsv эквадор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 азербайджан.ndmsi алжир.ndmsi барбадос.ndmsi вьетнам.ndmsi дагестан.ndmsi заир.ndmsi 
 занзибар.ndmsi иран.ndmsi йемен.ndmsi кавказ.ndmsi кашмир.ndmsi кувейт.ndmsi 
 лаос.ndmsi ленинград.ndmsi пакистан.ndmsi свазиленд.ndmsi судан.ndmsi суринам.ndmsi 
 таиланд.ndmsi тунис.ndmsi цейлон.ndmsi эквадор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+азербайджан.ndmsv алжир.ndmsv барбадос.ndmsv вьетнам.ndmsv дагестан.ndmsv заир.ndmsv 
+занзибар.ndmsv иран.ndmsv йемен.ndmsv кавказ.ndmsv кашмир.ndmsv кувейт.ndmsv 
+лаос.ndmsv ленинград.ndmsv пакистан.ndmsv свазиленд.ndmsv судан.ndmsv суринам.ndmsv 
+таиланд.ndmsv тунис.ndmsv цейлон.ndmsv эквадор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 благоговен.= ерзан.= кровохаркан.= кувыркан.= нежничан.= нюхан.= 
 предвосхищен.= рыган.= соуст.= царапан.= чихан.= щеголян.= 
@@ -19738,11 +19732,11 @@
 кузьмин.= :
   LLFQF+ or LLFJT+ or LLBSP+ or LLDZJ+;
 
-кузьмин.nlfpg :  <morph-С,жр,од,мн,рд>;
+кузьмин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 кузьмин.nlmsi :  <morph-С,мр,од,ед,им>;
 
-кузьмин.nlfpv :  <morph-С,жр,од,мн,вн>;
+кузьмин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кук.= :
   LLFKL+ or LLBTN+ or LLBTO+ or LLCBF+;
@@ -19779,9 +19773,9 @@
 кулич.= :
   LLAAJ+ or LLBSM+ or LLBYU+ or LLCKD+;
 
-кулич.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кулич.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кулич.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 варг.= глинк.= дейнек.= заверюх.= кульбак.= меловатк.= 
 пречистенк.= радк.= шевелух.= :
@@ -19793,18 +19787,18 @@
 культ.= :
   LLAAQ+ or LLDQH+;
 
-культ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 культ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+культ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кум.= :
   LLACL+ or LLAGT+ or LLDXR+ or LLBNN+;
 
+кум.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 кум.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кум.nlmsi :  <morph-С,мр,од,ед,им>;
-
-кум.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 куман.= мужен.= :
   LLAUN+;
@@ -19819,9 +19813,9 @@
 
 кун.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-кун.ndmsi :  <morph-С,мр,но,ед,им>;
-
 кун.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+кун.ndmsi :  <morph-С,мр,но,ед,им>;
 
 куп.= :
   LLAFX+ or LLAYJ+ or LLFWK+ or LLFMU+ or LLBUI+;
@@ -19839,9 +19833,9 @@
 купол.= :
   LLABM+ or LLCJW+ or LLDOO+;
 
-купол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 купол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+купол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 купоро.= :
   LLEOX+ or LLEMF+;
@@ -19849,13 +19843,13 @@
 кур.= :
   LLACI+ or LLAGT+ or LLDXR+ or LLAVH+ or LLBFF+ or LLBHS+ or LLBNP+ or LLBPF+ or LLCJW+ or LLDJS+ or LLDPK+;
 
-кур.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 кур.nlmsi :  <morph-С,мр,од,ед,им>;
 
-кур.npg :  <morph-С,мн,мн,рд>;
+кур.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 кур.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+кур.npg :  <morph-С,мн,мн,рд>;
 
 кураж.= пыж.= :
   LLAAJ+ or LLBMV+;
@@ -19867,20 +19861,20 @@
 курант.= :
   LLAAQ+ or LLAFX+ or LLDJV+;
 
-курант.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 курант.ndmsi :  <morph-С,мр,но,ед,им>;
 
 курант.ndfpg :  <morph-С,жр,но,мн,рд>;
 
+курант.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 курган.= :
   LLAAQ+ or LLAEG+ or LLDWW+ or LLBYZ+;
 
-курган.a :  <morph-П,0>;
+курган.ndmsi :  <morph-С,мр,но,ед,им>;
 
 курган.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-курган.ndmsi :  <morph-С,мр,но,ед,им>;
+курган.a :  <morph-П,0>;
 
 буту.= конфу.= кургу.= муту.= :
   LLBAI+ or LLBBI+;
@@ -19928,9 +19922,9 @@
 курсив.= :
   LLAAQ+ or LLBIU+ or LLBNS+ or LLBYZ+;
 
-курсив.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 курсив.ndmsi :  <morph-С,мр,но,ед,им>;
+
+курсив.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кудряв.= курчав.= кучеряв.= :
   LLBNS+ or LLDKF+;
@@ -19940,11 +19934,11 @@
 балашов.= курчатов.= :
   LLDWW+ or LLFQF+ or LLFOU+;
 
+балашов.ndmsi курчатов.ndmsi :  <morph-С,мр,но,ед,им>;
+
 балашов.nlmsi курчатов.nlmsi :  <morph-С,мр,од,ед,им>;
 
 балашов.ndmsv курчатов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-балашов.ndmsi курчатов.ndmsi :  <morph-С,мр,но,ед,им>;
 
 кус.= :
   LLAAS+ or LLDXR+ or LLCJW+;
@@ -20014,31 +20008,31 @@
 козлов.= лавров.= :
   LLFQF+ or LLFOU+ or LLDKF+;
 
-козлов.amss лавров.amss :  <morph-П,мр,ед,кр>;
-
 козлов.nlmsi лавров.nlmsi :  <morph-С,мр,од,ед,им>;
+
+козлов.amss лавров.amss :  <morph-П,мр,ед,кр>;
 
 лагер.= :
   LLAAY+ or LLBYU+ or LLDMM+;
 
-лагер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лагер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лагер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лад.= :
   LLAAS+ or LLAFH+ or LLFKR+ or LLFKR+ or LLBYZ+ or LLCAC+ or LLCAP+ or LLFHO+ or LLDPK+ or LLFHR+;
 
-лад.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 лад.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-лад.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-лад.ndmsi :  <morph-С,мр,но,ед,им>;
 
 лад.nlmpg :  <morph-С,мр,од,мн,рд>;
 
+лад.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+лад.nlmpv :  <morph-С,мр,од,мн,вн>;
+
 лад.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+лад.ndmsi :  <morph-С,мр,но,ед,им>;
 
 ладан.= разгон.= самогон.= :
   LLAAO+ or LLBRK+ or LLBYZ+;
@@ -20050,11 +20044,11 @@
 ладно.= так-то.= :
   LLAEK+ or LLDTS+ or LLAEL+;
 
-ладно.xn так-то.xn :  <morph-ПРЕДК,нст>;
+ладно.p так-то.p :  <morph-ЧАСТ,0>;
 
 ладно.e так-то.e :  <morph-Н,0>;
 
-ладно.p так-то.p :  <morph-ЧАСТ,0>;
+ладно.xn так-то.xn :  <morph-ПРЕДК,нст>;
 
 ладош.= :
   LLBBY+ or LLBRI+;
@@ -20072,13 +20066,13 @@
 лам.= :
   LLAEY+ or LLAGT+;
 
-лам.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 лам.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 лам.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 лам.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+лам.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 ламинирован.= неакцептован.= :
   LLBDD+ or LLBYN+;
@@ -20093,9 +20087,9 @@
 лан.= :
   LLAAQ+ or LLBRO+ or LLDNL+ or LLEAU+;
 
-лан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лап.= :
   LLAFX+ or LLBRK+ or LLCLG+ or LLCLH+;
@@ -20121,9 +20115,9 @@
 лаур.= :
   LLFOV+;
 
-лаур.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 лаур.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+лаур.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 лач.= :
   LLDXM+ or LLCJU+;
@@ -20144,22 +20138,22 @@
 
 лебедин.amss :  <morph-П,мр,ед,кр>;
 
-лебедин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лебедин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лебедин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лев.= :
   LLAAQ+ or LLFNN+ or LLDJZ+ or LLDKF+;
 
-лев.amss :  <morph-П,мр,ед,кр>;
-
 лев.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+лев.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 лев.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-лев.ndmsi :  <morph-С,мр,но,ед,им>;
+лев.amss :  <morph-П,мр,ед,кр>;
 
-лев.nlmpg :  <morph-С,мр,од,мн,рд>;
+лев.ndmsi :  <morph-С,мр,но,ед,им>;
 
 левобережн.= петродворцов.= :
   LLDLU+ or LLEAP+;
@@ -20208,20 +20202,20 @@
 лезгин.= :
   LLACX+ or LLBRK+ or LLBRO+;
 
-лезгин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 лезгин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 лезгин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
+лезгин.nlmsi :  <morph-С,мр,од,ед,им>;
+
 лейб-гусар.= :
   LLACW+;
+
+лейб-гусар.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 лейб-гусар.nlmsi :  <morph-С,мр,од,ед,им>;
 
 лейб-гусар.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-лейб-гусар.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 леле.= :
   LLDRP+ or LLDSF+;
@@ -20270,18 +20264,18 @@
 лес.= :
   LLABK+ or LLAFX+ or LLAHD+ or LLBRK+ or LLCJW+;
 
-лес.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лес.ndmsi :  <morph-С,мр,но,ед,им>;
 
 лес.ndfpg :  <morph-С,жр,но,мн,рд>;
 
+лес.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 лесин.= :
   LLFJG+ or LLAFX+ or LLFJW+;
 
-лесин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 лесин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+лесин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 лесн.= :
   LLDXR+ or LLCJC+;
@@ -20292,9 +20286,9 @@
 лесозаводск.= :
   LLDWW+ or LLEEK+ or LLGRQ+;
 
-лесозаводск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лесозаводск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лесозаводск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лесоторгов.= :
   LLAYI+ or LLBUI+ or LLDLU+;
@@ -20319,21 +20313,21 @@
 ли.= :
   LLDTM+ or LLFHW+ or LLAZJ+ or LLAZR+ or LLDHW+ or LLFKT+;
 
+ли.p :  <morph-ЧАСТ,0>;
+
 ли.i :  <morph-СОЮЗ,0>;
 
 ли.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-ли.p :  <morph-ЧАСТ,0>;
 
 альпари.= апплике.= барокко.= либерти.= маренго.= неглиже.= 
 плаке.= плиссе.= пралине.= хаки.= эсперанто.= :
   LLADL+ or LLAEG+;
 
-альпари.ndn апплике.ndn барокко.ndn либерти.ndn маренго.ndn неглиже.ndn 
-плаке.ndn плиссе.ndn пралине.ndn хаки.ndn эсперанто.ndn :  <morph-С,ср,но,0>;
-
 альпари.a апплике.a барокко.a либерти.a маренго.a неглиже.a 
 плаке.a плиссе.a пралине.a хаки.a эсперанто.a :  <morph-П,0>;
+
+альпари.ndn апплике.ndn барокко.ndn либерти.ndn маренго.ndn неглиже.ndn 
+плаке.ndn плиссе.ndn пралине.ndn хаки.ndn эсперанто.ndn :  <morph-С,ср,но,0>;
 
 лив.= :
   LLAVL+ or LLDZL+;
@@ -20360,11 +20354,11 @@
 лиз.= :
   LLFLA+ or LLFIN+;
 
-лиз.nlfpg :  <morph-С,жр,од,мн,рд>;
+лиз.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 лиз.nlfsi :  <morph-С,жр,од,ед,им>;
 
-лиз.nlfpv :  <morph-С,жр,од,мн,вн>;
+лиз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 лизир.= муниципализир.= символизир.= :
   LLELI+ or LLCHA+;
@@ -20372,9 +20366,9 @@
 лик.= :
   LLAAM+ or LLCBF+;
 
-лик.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лик.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ликвидир.= :
   LLCDD+ or LLFWB+ or LLCHD+;
@@ -20400,9 +20394,9 @@
 лимонов.= :
   LLFQF+ or LLAYI+ or LLBRK+ or LLDKF+;
 
-лимонов.amss :  <morph-П,мр,ед,кр>;
-
 лимонов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+лимонов.amss :  <morph-П,мр,ед,кр>;
 
 лин.= :
   LLFID+ or LLAUI+ or LLCCZ+ or LLCGW+ or LLDML+ or LLDMT+ or LLDNX+;
@@ -20427,6 +20421,10 @@
 тенгиз.= :
   LLDWW+ or LLFKO+ or LLFIH+;
 
+артем.ndmsi аскольд.ndmsi бахмут.ndmsi бахтемир.ndmsi геральд.ndmsi дакар.ndmsi 
+ермак.ndmsi казбек.ndmsi леон.ndmsi лион.ndmsi певек.ndmsi рудольф.ndmsi 
+тенгиз.ndmsi :  <morph-С,мр,но,ед,им>;
+
 артем.nlmsi аскольд.nlmsi бахмут.nlmsi бахтемир.nlmsi геральд.nlmsi дакар.nlmsi 
 ермак.nlmsi казбек.nlmsi леон.nlmsi лион.nlmsi певек.nlmsi рудольф.nlmsi 
 тенгиз.nlmsi :  <morph-С,мр,од,ед,им>;
@@ -20434,10 +20432,6 @@
 артем.ndmsv аскольд.ndmsv бахмут.ndmsv бахтемир.ndmsv геральд.ndmsv дакар.ndmsv 
 ермак.ndmsv казбек.ndmsv леон.ndmsv лион.ndmsv певек.ndmsv рудольф.ndmsv 
 тенгиз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-артем.ndmsi аскольд.ndmsi бахмут.ndmsi бахтемир.ndmsi геральд.ndmsi дакар.ndmsi 
-ермак.ndmsi казбек.ndmsi леон.ndmsi лион.ndmsi певек.ndmsi рудольф.ndmsi 
-тенгиз.ndmsi :  <morph-С,мр,но,ед,им>;
 
 лип.= :
   LLAFX+ or LLAXZ+ or LLBRK+ or LLBSW+ or LLBVZ+;
@@ -20449,11 +20443,11 @@
 лис.= :
   LLACI+ or LLAGT+ or LLAVH+ or LLBFF+ or LLBGO+ or LLBRO+;
 
-лис.nlfpg :  <morph-С,жр,од,мн,рд>;
+лис.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 лис.nlmsi :  <morph-С,мр,од,ед,им>;
 
-лис.nlfpv :  <morph-С,жр,од,мн,вн>;
+лис.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 галоч.= лисич.= :
   LLBFF+ or LLBRI+ or LLBRM+;
@@ -20468,11 +20462,11 @@
 литер.= :
   LLAAQ+ or LLAFX+ or LLBYU+ or LLCCZ+ or LLFWB+ or LLCGW+;
 
-литер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 литер.ndmsi :  <morph-С,мр,но,ед,им>;
 
 литер.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+литер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.114:
   LLCAG+;
@@ -20561,9 +20555,9 @@
 
 лиц.nlnpg :  <morph-С,ср,од,мн,рд>;
 
-лиц.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 лиц.nlnpv :  <morph-С,ср,од,мн,вн>;
+
+лиц.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 зр.= лицезр.= :
   LLEOQ+ or LLAXP+;
@@ -20603,9 +20597,9 @@
 лов.= :
   LLAAQ+ or LLAYJ+ or LLBII+ or LLBNN+ or LLBSX+ or LLBUI+;
 
-лов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ловуш.= :
   LLBRI+ or LLDZG+;
@@ -20616,9 +20610,9 @@
 берег.= бок.= лог.= отпуск.= франко-берег.= :
   LLABP+;
 
-берег.ndmsv бок.ndmsv лог.ndmsv отпуск.ndmsv франко-берег.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 берег.ndmsi бок.ndmsi лог.ndmsi отпуск.ndmsi франко-берег.ndmsi :  <morph-С,мр,но,ед,им>;
+
+берег.ndmsv бок.ndmsv лог.ndmsv отпуск.ndmsv франко-берег.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 займищ.= капищ.= лежбищ.= логовищ.= пастбищ.= седалищ.= 
 стойбищ.= судбищ.= туловищ.= училищ.= :
@@ -20630,9 +20624,9 @@
 лож.= :
   LLAFM+ or LLARS+ or LLBMS+ or LLBRI+ or LLBYU+ or LLCJW+;
 
-лож.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 лож.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+лож.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 ложкар.= :
   LLBYZ+ or LLDMT+;
@@ -20659,9 +20653,9 @@
 ломбард.= :
   LLAAQ+ or LLAYI+ or LLBYZ+;
 
-ломбард.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ломбард.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ломбард.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лон.= пожнив.= топлив.= :
   LLBYZ+ or LLCAG+;
@@ -20695,11 +20689,11 @@
 лосин.= :
   LLAFX+ or LLBYZ+ or LLDJS+ or LLDKJ+;
 
-лосин.amss :  <morph-П,мр,ед,кр>;
+лосин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 лосин.npg :  <morph-С,мн,мн,рд>;
 
-лосин.ndfpg :  <morph-С,жр,но,мн,рд>;
+лосин.amss :  <morph-П,мр,ед,кр>;
 
 лоскут.= хомут.= :
   LLAAQ+ or LLBYU+ or LLCJW+;
@@ -20748,9 +20742,9 @@
 луг.= :
   LLABP+ or LLDXP+;
 
-луг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 луг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+луг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 абрамович.= иваныч.= луганович.= :
   LLEBD+;
@@ -20770,11 +20764,11 @@
 лук.= :
   LLAAK+ or LLAFU+ or LLBVQ+;
 
-лук.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лук.ndmsi :  <morph-С,мр,но,ед,им>;
 
 лук.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+лук.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лукав.= :
   LLECP+ or LLAYI+ or LLBGQ+ or LLDJZ+ or LLDKF+;
@@ -20804,9 +20798,9 @@
 лус.= :
   LLDWW+ or LLEAF+;
 
-лус.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 лус.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лус.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 луч.= :
   LLAAJ+ or LLBHE+ or LLBMS+ or LLCJU+;
@@ -20827,9 +20821,9 @@
 лыж.= :
   LLAFM+ or LLDXM+ or LLBBY+ or LLBYZ+;
 
-лыж.npg :  <morph-С,мн,мн,рд>;
-
 лыж.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+лыж.npg :  <morph-С,мн,мн,рд>;
 
 лыс.= :
   LLDXT+ or LLBRK+ or LLDJZ+ or LLDKF+;
@@ -20854,9 +20848,9 @@
 
 люб.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-люб.amss :  <morph-П,мр,ед,кр>;
-
 люб.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+люб.amss :  <morph-П,мр,ед,кр>;
 
 любав.= :
   LLFKV+ or LLFIB+;
@@ -20870,11 +20864,11 @@
 любим.= :
   LLDWW+ or LLAKZ+ or LLAYI+ or LLDJZ+ or LLDKF+;
 
-любим.amss :  <morph-П,мр,ед,кр>;
-
 любим.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 любим.ndmsi :  <morph-С,мр,но,ед,им>;
+
+любим.amss :  <morph-П,мр,ед,кр>;
 
 люблинск.= :
   LLFKB+ or LLFKA+ or LLDYV+;
@@ -20909,14 +20903,14 @@
 :
   LLAAQ+ or LLAEG+;
 
+валансьен.ndmsi люкс.ndmsi микст.ndmsi модерн.ndmsi реглан.ndmsi электрон.ndmsi 
+:  <morph-С,мр,но,ед,им>;
+
 валансьен.a люкс.a микст.a модерн.a реглан.a электрон.a 
 :  <morph-П,0>;
 
 валансьен.ndmsv люкс.ndmsv микст.ndmsv модерн.ndmsv реглан.ndmsv электрон.ndmsv 
 :  <morph-С,мр,но,ед,вн>;
-
-валансьен.ndmsi люкс.ndmsi микст.ndmsi модерн.ndmsi реглан.ndmsi электрон.ndmsi 
-:  <morph-С,мр,но,ед,им>;
 
 лют.= :
   LLBZO+ or LLCBF+ or LLDKF+;
@@ -20977,11 +20971,11 @@
 
 мазил.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-мазил.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 мазил.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 мазил.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+мазил.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 мазур.= :
   LLEBJ+ or LLBRK+;
@@ -20997,11 +20991,11 @@
 майн.= :
   LLDWW+ or LLAFX+ or LLDXR+;
 
-майн.ndmsv :  <morph-С,мр,но,ед,вн>;
+майн.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 майн.ndmsi :  <morph-С,мр,но,ед,им>;
 
-майн.ndfpg :  <morph-С,жр,но,мн,рд>;
+майн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 майя.= хауса.= :
   LLABZ+ or LLADB+ or LLAEG+;
@@ -21030,22 +21024,22 @@
 маков.= :
   LLFUO+ or LLBRK+ or LLDKJ+;
 
-маков.amsi :  <morph-П,мр,ед,им>;
+маков.admsv :  <morph-П,мр,ед,вн,но>;
 
 маков.amss :  <morph-П,мр,ед,кр>;
 
-маков.admsv :  <morph-П,мр,ед,вн,но>;
+маков.amsi :  <morph-П,мр,ед,им>;
 
 максим.= :
   LLAAQ+ or LLFKO+ or LLAFX+ or LLFIH+;
 
-максим.nlmsi :  <morph-С,мр,од,ед,им>;
-
-максим.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 максим.ndmsi :  <morph-С,мр,но,ед,им>;
 
 максим.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+максим.nlmsi :  <morph-С,мр,од,ед,им>;
+
+максим.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.116:
   LLBRI+ or LLBYZ+;
@@ -21082,9 +21076,9 @@
 
 малин.ndmsv рам.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-малин.ndmsi рам.ndmsi :  <morph-С,мр,но,ед,им>;
-
 малин.ndfpg рам.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+малин.ndmsi рам.ndmsi :  <morph-С,мр,но,ед,им>;
 
 великоват.= маловат.= :
   LLAEF+ or LLDKP+;
@@ -21140,11 +21134,11 @@
 :
   LLAGT+ or LLBRO+;
 
-баядер.nlfpg кохинхин.nlfpg мам.nlfpg невест.nlfpg ставрид.nlfpg цикад.nlfpg 
-:  <morph-С,жр,од,мн,рд>;
-
 баядер.nlfpv кохинхин.nlfpv мам.nlfpv невест.nlfpv ставрид.nlfpv цикад.nlfpv 
 :  <morph-С,жр,од,мн,вн>;
+
+баядер.nlfpg кохинхин.nlfpg мам.nlfpg невест.nlfpg ставрид.nlfpg цикад.nlfpg 
+:  <morph-С,жр,од,мн,рд>;
 
 мама.= :
   LLFHT+;
@@ -21157,23 +21151,6 @@
 
 /ru/words/words.117:
   LLAGZ+;
-
-агитаторш.nlfpg агрономш.nlfpg адмиральш.nlfpg аптекарш.nlfpg атаманш.nlfpg бабищ.nlfpg 
-банкирш.nlfpg барменш.nlfpg библиотекарш.nlfpg бригадирш.nlfpg бюргерш.nlfpg вахтерш.nlfpg 
-векш.nlfpg великанш.nlfpg визитерш.nlfpg гейш.nlfpg генеральш.nlfpg гримерш.nlfpg 
-дикторш.nlfpg дикуш.nlfpg директорш.nlfpg дирижерш.nlfpg докторш.nlfpg дублерш.nlfpg 
-дурищ.nlfpg жонглерш.nlfpg землемерш.nlfpg имитаторш.nlfpg инженерш.nlfpg казначейш.nlfpg 
-камергерш.nlfpg кассирш.nlfpg кастелянш.nlfpg квакерш.nlfpg квакш.nlfpg кельнерш.nlfpg 
-кликуш.nlfpg клуш.nlfpg кляч.nlfpg кобылищ.nlfpg командирш.nlfpg коровищ.nlfpg 
-корректорш.nlfpg костюмерш.nlfpg кредиторш.nlfpg крякуш.nlfpg кумж.nlfpg курьерш.nlfpg 
-лекарш.nlfpg лекторш.nlfpg лифтерш.nlfpg лошадищ.nlfpg майорш.nlfpg мамаш.nlfpg 
-маникенш.nlfpg маникюрш.nlfpg министерш.nlfpg музыкантш.nlfpg нэпманш.nlfpg опекунш.nlfpg 
-ораторш.nlfpg офицерш.nlfpg паникерш.nlfpg парикмахерш.nlfpg партнерш.nlfpg пасторш.nlfpg 
-патронш.nlfpg педикюрш.nlfpg пикш.nlfpg писарш.nlfpg плакуш.nlfpg помпадурш.nlfpg 
-премьерш.nlfpg призерш.nlfpg ракш.nlfpg регентш.nlfpg регистраторш.nlfpg редакторш.nlfpg 
-репортерш.nlfpg ротмистрш.nlfpg рыбищ.nlfpg секретарш.nlfpg сенаторш.nlfpg собачищ.nlfpg 
-султанш.nlfpg таперш.nlfpg тещ.nlfpg тявкуш.nlfpg учительш.nlfpg фермерш.nlfpg 
-ханш.nlfpg швейцарш.nlfpg юбилярш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 агитаторш.nlfpv агрономш.nlfpv адмиральш.nlfpv аптекарш.nlfpv атаманш.nlfpv бабищ.nlfpv 
 банкирш.nlfpv барменш.nlfpv библиотекарш.nlfpv бригадирш.nlfpv бюргерш.nlfpv вахтерш.nlfpv 
@@ -21191,6 +21168,23 @@
 репортерш.nlfpv ротмистрш.nlfpv рыбищ.nlfpv секретарш.nlfpv сенаторш.nlfpv собачищ.nlfpv 
 султанш.nlfpv таперш.nlfpv тещ.nlfpv тявкуш.nlfpv учительш.nlfpv фермерш.nlfpv 
 ханш.nlfpv швейцарш.nlfpv юбилярш.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+агитаторш.nlfpg агрономш.nlfpg адмиральш.nlfpg аптекарш.nlfpg атаманш.nlfpg бабищ.nlfpg 
+банкирш.nlfpg барменш.nlfpg библиотекарш.nlfpg бригадирш.nlfpg бюргерш.nlfpg вахтерш.nlfpg 
+векш.nlfpg великанш.nlfpg визитерш.nlfpg гейш.nlfpg генеральш.nlfpg гримерш.nlfpg 
+дикторш.nlfpg дикуш.nlfpg директорш.nlfpg дирижерш.nlfpg докторш.nlfpg дублерш.nlfpg 
+дурищ.nlfpg жонглерш.nlfpg землемерш.nlfpg имитаторш.nlfpg инженерш.nlfpg казначейш.nlfpg 
+камергерш.nlfpg кассирш.nlfpg кастелянш.nlfpg квакерш.nlfpg квакш.nlfpg кельнерш.nlfpg 
+кликуш.nlfpg клуш.nlfpg кляч.nlfpg кобылищ.nlfpg командирш.nlfpg коровищ.nlfpg 
+корректорш.nlfpg костюмерш.nlfpg кредиторш.nlfpg крякуш.nlfpg кумж.nlfpg курьерш.nlfpg 
+лекарш.nlfpg лекторш.nlfpg лифтерш.nlfpg лошадищ.nlfpg майорш.nlfpg мамаш.nlfpg 
+маникенш.nlfpg маникюрш.nlfpg министерш.nlfpg музыкантш.nlfpg нэпманш.nlfpg опекунш.nlfpg 
+ораторш.nlfpg офицерш.nlfpg паникерш.nlfpg парикмахерш.nlfpg партнерш.nlfpg пасторш.nlfpg 
+патронш.nlfpg педикюрш.nlfpg пикш.nlfpg писарш.nlfpg плакуш.nlfpg помпадурш.nlfpg 
+премьерш.nlfpg призерш.nlfpg ракш.nlfpg регентш.nlfpg регистраторш.nlfpg редакторш.nlfpg 
+репортерш.nlfpg ротмистрш.nlfpg рыбищ.nlfpg секретарш.nlfpg сенаторш.nlfpg собачищ.nlfpg 
+султанш.nlfpg таперш.nlfpg тещ.nlfpg тявкуш.nlfpg учительш.nlfpg фермерш.nlfpg 
+ханш.nlfpg швейцарш.nlfpg юбилярш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 мамон.= :
   LLAAQ+ or LLAFX+ or LLAGT+ or LLDNY+;
@@ -21219,11 +21213,11 @@
 :
   LLAAQ+ or LLACI+ or LLBRK+;
 
-болван.nlmsi дровокол.nlmsi костолом.nlmsi краскотер.nlmsi мандарин.nlmsi трясун.nlmsi 
-:  <morph-С,мр,од,ед,им>;
-
 болван.ndmsv дровокол.ndmsv костолом.ndmsv краскотер.ndmsv мандарин.ndmsv трясун.ndmsv 
 :  <morph-С,мр,но,ед,вн>;
+
+болван.nlmsi дровокол.nlmsi костолом.nlmsi краскотер.nlmsi мандарин.nlmsi трясун.nlmsi 
+:  <morph-С,мр,од,ед,им>;
 
 болван.ndmsi дровокол.ndmsi костолом.ndmsi краскотер.ndmsi мандарин.ndmsi трясун.ndmsi 
 :  <morph-С,мр,но,ед,им>;
@@ -21239,18 +21233,18 @@
 манеж.= :
   LLAAH+ or LLBHH+ or LLBMV+ or LLBYU+;
 
-манеж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 манеж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+манеж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 манер.= :
   LLAAQ+ or LLAFX+ or LLBNU+ or LLBRK+ or LLBYU+;
 
-манер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 манер.ndmsi :  <morph-С,мр,но,ед,им>;
 
 манер.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+манер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мани.= :
   LLARP+ or LLDQL+;
@@ -21280,25 +21274,25 @@
 хиндустани.= :
   LLABZ+ or LLAEG+;
 
-зулу.a маратхи.a пушту.a суахили.a урду.a хинди.a 
-хиндустани.a :  <morph-П,0>;
-
 зулу.ndm маратхи.ndm пушту.ndm суахили.ndm урду.ndm хинди.ndm 
 хиндустани.ndm :  <morph-С,мр,но,0>;
+
+зулу.a маратхи.a пушту.a суахили.a урду.a хинди.a 
+хиндустани.a :  <morph-П,0>;
 
 куруш.= мараш.= :
   LLDWV+ or LLBRI+;
 
-куруш.ndmsv мараш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 куруш.ndmsi мараш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+куруш.ndmsv мараш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 маргарит.= :
   LLAAY+ or LLFKR+ or LLBRK+ or LLFHR+;
 
-маргарит.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 маргарит.ndmsi :  <morph-С,мр,но,ед,им>;
+
+маргарит.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 маргинал.= :
   LLACI+ or LLDOT+;
@@ -21312,9 +21306,9 @@
 марев.= :
   LLCAG+ or LLDKJ+;
 
-марев.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 марев.amss :  <morph-П,мр,ед,кр>;
+
+марев.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 мари.= :
   LLADB+ or LLFHW+ or LLAYG+ or LLBPY+ or LLFKT+;
@@ -21334,13 +21328,13 @@
 маркиз.= :
   LLACI+ or LLAFX+ or LLAGT+;
 
-маркиз.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-маркиз.nlmsi :  <morph-С,мр,од,ед,им>;
+маркиз.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 маркиз.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-маркиз.ndfpg :  <morph-С,жр,но,мн,рд>;
+маркиз.nlmsi :  <morph-С,мр,од,ед,им>;
+
+маркиз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 марсел.= :
   LLDML+ or LLEAT+ or LLDOO+;
@@ -21358,9 +21352,9 @@
 марш.= :
   LLAAH+ or LLDTP+ or LLBCB+;
 
-марш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 марш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+марш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 маршрутизир.= :
   LLCDD+ or LLCFX+ or LLCGX+;
@@ -21401,9 +21395,9 @@
 
 мастит.amss покат.amss :  <morph-П,мр,ед,кр>;
 
-мастит.ndmsv покат.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мастит.ndmsi покат.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мастит.ndmsv покат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 масштабир.= :
   LLEPO+ or LLCFR+;
@@ -21411,9 +21405,9 @@
 мат.= :
   LLAAQ+ or LLBRK+ or LLBRO+ or LLCCZ+ or LLCGW+ or LLDNN+;
 
-мат.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мат.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 матер.= :
   LLBIK+ or LLBNP+ or LLBRK+ or LLBYU+ or LLCIZ+ or LLDKF+;
@@ -21460,16 +21454,16 @@
 маш.= :
   LLETW+ or LLFJA+;
 
-маш.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 маш.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+маш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 машин.= :
   LLFQF+ or LLAFX+ or LLBRK+ or LLBYU+;
 
-машин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 машин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+машин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 /ru/words/words.121:
   LLAEG+;
@@ -21666,9 +21660,9 @@
 мерси.= :
   LLDTS+ or LLDWZ+ or LLAEL+;
 
-мерси.xn :  <morph-ПРЕДК,нст>;
-
 мерси.p :  <morph-ЧАСТ,0>;
+
+мерси.xn :  <morph-ПРЕДК,нст>;
 
 мертв.= :
   LLBIJ+ or LLBNN+ or LLDJZ+ or LLDKF+;
@@ -21688,16 +21682,16 @@
 кеш.= кэш.= метакэш.= :
   LLABD+;
 
-кеш.ndmsv кэш.ndmsv метакэш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кеш.ndmsi кэш.ndmsi метакэш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кеш.ndmsv кэш.ndmsv метакэш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ионик.= металлопластик.= :
   LLAAM+ or LLAGJ+;
 
-ионик.ndmsv металлопластик.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ионик.ndmsi металлопластик.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ионик.ndmsv металлопластик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бутыл.= метел.= пищал.= сопел.= :
   LLBRK+ or LLDNF+ or LLDOO+;
@@ -21708,9 +21702,9 @@
 варикоз.= метиз.= :
   LLAAY+ or LLBYZ+;
 
-варикоз.ndmsv метиз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 варикоз.ndmsi метиз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+варикоз.ndmsv метиз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 метрогород.= :
   LLEAB+ or LLCJW+;
@@ -21718,9 +21712,9 @@
 мех.= :
   LLABF+ or LLBCC+;
 
-мех.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мех.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мех.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 механизир.= :
   LLCDC+ or LLCGG+;
@@ -21753,10 +21747,6 @@
 милливатт.= милливольт.= электрон-вольт.= :
   LLABW+;
 
-ватт.ndmsv вольт-ампер.ndmsv гектоватт.ndmsv киловатт.ndmsv киловольт.ndmsv киловольт-ампер.ndmsv 
-мегаватт.ndmsv мегаэлектронвольт.ndmsv микроампер.ndmsv микроватт.ndmsv микровольт.ndmsv миллиампер.ndmsv 
-милливатт.ndmsv милливольт.ndmsv электрон-вольт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ватт.ndmsi вольт-ампер.ndmsi гектоватт.ndmsi киловатт.ndmsi киловольт.ndmsi киловольт-ампер.ndmsi 
 мегаватт.ndmsi мегаэлектронвольт.ndmsi микроампер.ndmsi микроватт.ndmsi микровольт.ndmsi миллиампер.ndmsi 
 милливатт.ndmsi милливольт.ndmsi электрон-вольт.ndmsi :  <morph-С,мр,но,ед,им>;
@@ -21764,6 +21754,10 @@
 ватт.ndmpg вольт-ампер.ndmpg гектоватт.ndmpg киловатт.ndmpg киловольт.ndmpg киловольт-ампер.ndmpg 
 мегаватт.ndmpg мегаэлектронвольт.ndmpg микроампер.ndmpg микроватт.ndmpg микровольт.ndmpg миллиампер.ndmpg 
 милливатт.ndmpg милливольт.ndmpg электрон-вольт.ndmpg :  <morph-С,мр,но,мн,рд>;
+
+ватт.ndmsv вольт-ампер.ndmsv гектоватт.ndmsv киловатт.ndmsv киловольт.ndmsv киловольт-ампер.ndmsv 
+мегаватт.ndmsv мегаэлектронвольт.ndmsv микроампер.ndmsv микроватт.ndmsv микровольт.ndmsv миллиампер.ndmsv 
+милливатт.ndmsv милливольт.ndmsv электрон-вольт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 микропор.= :
   LLAFX+ or LLBSP+;
@@ -21784,13 +21778,13 @@
 миллиард.= :
   LLAAQ+ or LLFMM+;
 
-миллиард.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 миллиард.ci :  <morph-ЧИСЛ,им>;
 
-миллиард.cv :  <morph-ЧИСЛ,вн>;
-
 миллиард.ndmsi :  <morph-С,мр,но,ед,им>;
+
+миллиард.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+миллиард.cv :  <morph-ЧИСЛ,вн>;
 
 бенгали.= бри.= гб.= гип.= ея.= интер.= 
 кд.= крамбамбули.= мб.= метиленблау.= милликюри.= млрд.= 
@@ -21811,20 +21805,20 @@
 
 лейб-драгун.ndmsv миллимикрон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-лейб-драгун.ndmsi миллимикрон.ndmsi :  <morph-С,мр,но,ед,им>;
-
 лейб-драгун.ndmpg миллимикрон.ndmpg :  <morph-С,мр,но,мн,рд>;
+
+лейб-драгун.ndmsi миллимикрон.ndmsi :  <morph-С,мр,но,ед,им>;
 
 миллион.= :
   LLAAQ+ or LLFQC+;
 
 миллион.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-миллион.ci :  <morph-ЧИСЛ,им>;
-
 миллион.cv :  <morph-ЧИСЛ,вн>;
 
 миллион.ndmsi :  <morph-С,мр,но,ед,им>;
+
+миллион.ci :  <morph-ЧИСЛ,им>;
 
 мило.= :
   LLAEK+ or LLFJB+;
@@ -21848,13 +21842,13 @@
 вруш.= милаш.= милуш.= :
   LLAFE+ or LLBRG+;
 
-вруш.nlfpg милаш.nlfpg милуш.nlfpg :  <morph-С,жр,од,мн,рд>;
+вруш.nlfpv милаш.nlfpv милуш.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 вруш.nlmpv милаш.nlmpv милуш.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-вруш.nlmpg милаш.nlmpg милуш.nlmpg :  <morph-С,мр,од,мн,рд>;
+вруш.nlfpg милаш.nlfpg милуш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-вруш.nlfpv милаш.nlfpv милуш.nlfpv :  <morph-С,жр,од,мн,вн>;
+вруш.nlmpg милаш.nlmpg милуш.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 /ru/words/words.123:
   LLBYZ+;
@@ -21867,11 +21861,11 @@
 мингрел.= :
   LLACW+ or LLAYK+;
 
-мингрел.nlmsi :  <morph-С,мр,од,ед,им>;
-
 мингрел.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 мингрел.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+мингрел.nlmsi :  <morph-С,мр,од,ед,им>;
 
 мини-молочн.= :
   LLAKT+;
@@ -21879,9 +21873,9 @@
 минивэн.= :
   LLFPB+;
 
-минивэн.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 минивэн.ndmsi :  <morph-С,мр,но,ед,им>;
+
+минивэн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мини-пекар.= минипекар.= хлебопекар.= :
   LLBZP+;
@@ -21892,9 +21886,9 @@
 минор.= :
   LLAAQ+ or LLBRO+ or LLBYU+;
 
-минор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 минор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+минор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 иркутскэнерго.= минприроды.= минсвязи.= минтопэнерго.= минэкономики.= мпс.= 
 мчс.= райпо.= :
@@ -21906,18 +21900,18 @@
 минус.= :
   LLAAQ+ or LLDTD+ or LLBYU+;
 
-минус.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 минус.ndmsi :  <morph-С,мр,но,ед,им>;
+
+минус.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мир.= :
   LLAAQ+ or LLBHT+ or LLBNP+ or LLBYU+ or LLCAG+ or LLCJW+;
 
 мир.ndnpg :  <morph-С,ср,но,мн,рд>;
 
-мир.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мир.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 блатн.= гнед.= запасн.= мастеров.= миров.= цветн.= 
 :
@@ -21937,20 +21931,20 @@
 
 митин.amsi :  <morph-П,мр,ед,им>;
 
-митин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 митин.nlmsi :  <morph-С,мр,од,ед,им>;
 
-митин.admsv :  <morph-П,мр,ед,вн,но>;
+митин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 митин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+митин.admsv :  <morph-П,мр,ед,вн,но>;
 
 митинг.= :
   LLAAM+ or LLCBK+;
 
-митинг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 митинг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+митинг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 михайлов.= :
   LLDWW+ or LLFJG+ or LLFOU+;
@@ -21964,9 +21958,9 @@
 миш.= :
   LLFHZ+ or LLBRD+;
 
-миш.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 миш.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+миш.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 богар.= мерзлот.= мишур.= толстот.= тщет.= :
   LLAGL+ or LLBYU+;
@@ -22047,9 +22041,9 @@
 могоч.= :
   LLDWV+ or LLDXP+;
 
-могоч.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 могоч.ndmsi :  <morph-С,мр,но,ед,им>;
+
+могоч.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 модифицир.= :
   LLCDI+ or LLCFY+;
@@ -22068,9 +22062,9 @@
 мозг.= :
   LLAAL+ or LLBCC+ or LLCBF+;
 
-мозг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мозг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мозг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мозд.= :
   LLEAC+;
@@ -22078,13 +22072,13 @@
 мокасин.= :
   LLABW+ or LLDJS+;
 
-мокасин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-мокасин.ndmsi :  <morph-С,мр,но,ед,им>;
+мокасин.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 мокасин.npg :  <morph-С,мн,мн,рд>;
 
-мокасин.ndmpg :  <morph-С,мр,но,мн,рд>;
+мокасин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мокасин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вевериц.= ветрениц.= голубиц.= грибниц.= гусениц.= гусятниц.= 
 дегтярниц.= жемчужниц.= крапивниц.= медуниц.= мокриц.= молочниц.= 
@@ -22092,20 +22086,20 @@
 шашечниц.= :
   LLAFO+ or LLAGP+;
 
-вевериц.nlfpg ветрениц.nlfpg голубиц.nlfpg грибниц.nlfpg гусениц.nlfpg гусятниц.nlfpg 
-дегтярниц.nlfpg жемчужниц.nlfpg крапивниц.nlfpg медуниц.nlfpg мокриц.nlfpg молочниц.nlfpg 
-пирожниц.nlfpg пятидесятниц.nlfpg табачниц.nlfpg утятниц.nlfpg черниц.nlfpg чесночниц.nlfpg 
-шашечниц.nlfpg :  <morph-С,жр,од,мн,рд>;
+вевериц.ndfpg ветрениц.ndfpg голубиц.ndfpg грибниц.ndfpg гусениц.ndfpg гусятниц.ndfpg 
+дегтярниц.ndfpg жемчужниц.ndfpg крапивниц.ndfpg медуниц.ndfpg мокриц.ndfpg молочниц.ndfpg 
+пирожниц.ndfpg пятидесятниц.ndfpg табачниц.ndfpg утятниц.ndfpg черниц.ndfpg чесночниц.ndfpg 
+шашечниц.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 вевериц.nlfpv ветрениц.nlfpv голубиц.nlfpv грибниц.nlfpv гусениц.nlfpv гусятниц.nlfpv 
 дегтярниц.nlfpv жемчужниц.nlfpv крапивниц.nlfpv медуниц.nlfpv мокриц.nlfpv молочниц.nlfpv 
 пирожниц.nlfpv пятидесятниц.nlfpv табачниц.nlfpv утятниц.nlfpv черниц.nlfpv чесночниц.nlfpv 
 шашечниц.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-вевериц.ndfpg ветрениц.ndfpg голубиц.ndfpg грибниц.ndfpg гусениц.ndfpg гусятниц.ndfpg 
-дегтярниц.ndfpg жемчужниц.ndfpg крапивниц.ndfpg медуниц.ndfpg мокриц.ndfpg молочниц.ndfpg 
-пирожниц.ndfpg пятидесятниц.ndfpg табачниц.ndfpg утятниц.ndfpg черниц.ndfpg чесночниц.ndfpg 
-шашечниц.ndfpg :  <morph-С,жр,но,мн,рд>;
+вевериц.nlfpg ветрениц.nlfpg голубиц.nlfpg грибниц.nlfpg гусениц.nlfpg гусятниц.nlfpg 
+дегтярниц.nlfpg жемчужниц.nlfpg крапивниц.nlfpg медуниц.nlfpg мокриц.nlfpg молочниц.nlfpg 
+пирожниц.nlfpg пятидесятниц.nlfpg табачниц.nlfpg утятниц.nlfpg черниц.nlfpg чесночниц.nlfpg 
+шашечниц.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 мокш.= :
   LLAFM+ or LLDXM+;
@@ -22155,31 +22149,31 @@
 молок.= :
   LLAFU+ or LLBBY+ or LLCAM+;
 
-молок.npg :  <morph-С,мн,мн,рд>;
-
 молок.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+молок.npg :  <morph-С,мн,мн,рд>;
 
 молокан.= :
   LLAAQ+ or LLACX+ or LLBFM+ or LLBRO+;
 
-молокан.nlmsi :  <morph-С,мр,од,ед,им>;
-
-молокан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 молокан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 молокан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+молокан.nlmsi :  <morph-С,мр,од,ед,им>;
+
+молокан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 молокан.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 молот.= :
   LLAAQ+ or LLCJW+ or LLDKJ+;
 
-молот.amss :  <morph-П,мр,ед,кр>;
-
 молот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 молот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+молот.amss :  <morph-П,мр,ед,кр>;
 
 молотил.= мял.= :
   LLBRK+ or LLCAG+ or LLDOZ+;
@@ -22206,9 +22200,9 @@
 монист.= :
   LLACI+ or LLCAG+;
 
-монист.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 монист.nlmsi :  <morph-С,мр,од,ед,им>;
+
+монист.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 деидеологизир.= монополизир.= :
   LLCFX+ or LLELI+ or LLCHA+;
@@ -22219,9 +22213,9 @@
 белозерск.= мончегорск.= :
   LLDWW+ or LLBEP+ or LLDYV+ or LLDZV+;
 
-белозерск.ndmsv мончегорск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 белозерск.ndmsi мончегорск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+белозерск.ndmsv мончегорск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мор.= :
   LLAAQ+ or LLARW+ or LLBHS+ or LLBNP+;
@@ -22256,11 +22250,11 @@
 мороз.= :
   LLAAO+ or LLEBJ+ or LLAXZ+ or LLBYU+;
 
-мороз.nlmsi :  <morph-С,мр,од,ед,им>;
+мороз.ndmsi :  <morph-С,мр,но,ед,им>;
 
 мороз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-мороз.ndmsi :  <morph-С,мр,но,ед,им>;
+мороз.nlmsi :  <morph-С,мр,од,ед,им>;
 
 морок.= :
   LLAAY+ or LLAFU+;
@@ -22312,18 +22306,18 @@
 москвич.= :
   LLAAJ+ or LLACF+ or LLBRM+;
 
-москвич.nlmsi :  <morph-С,мр,од,ед,им>;
+москвич.ndmsi :  <morph-С,мр,но,ед,им>;
 
 москвич.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-москвич.ndmsi :  <morph-С,мр,но,ед,им>;
+москвич.nlmsi :  <morph-С,мр,од,ед,им>;
 
 госарбитраж.= москвичстроймонтаж.= :
   LLEEI+;
 
-госарбитраж.ndmsv москвичстроймонтаж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 госарбитраж.ndmsi москвичстроймонтаж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+госарбитраж.ndmsv москвичстроймонтаж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мостов.= :
   LLAKS+ or LLCJC+ or LLDLU+;
@@ -22334,11 +22328,11 @@
 мот.= :
   LLACI+ or LLFIJ+ or LLBRK+ or LLCJW+ or LLFKY+;
 
-мот.nlmsi :  <morph-С,мр,од,ед,им>;
-
 мот.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 мот.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+мот.nlmsi :  <morph-С,мр,од,ед,им>;
 
 гладил.= коптил.= красил.= мотал.= парил.= умывал.= 
 читал.= :
@@ -22449,9 +22443,9 @@
 мужчин.= :
   LLAEY+ or LLBRF+;
 
-мужчин.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 мужчин.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+мужчин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 винодел.= глиновал.= мукомол.= сыродел.= :
   LLACI+ or LLDOZ+;
@@ -22479,9 +22473,9 @@
 контекст.= мультипроцессор.= :
   LLAAQ+ or LLBYW+;
 
-контекст.ndmsv мультипроцессор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 контекст.ndmsi мультипроцессор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+контекст.ndmsv мультипроцессор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.132:
   LLBPJ+;
@@ -22507,26 +22501,26 @@
 эспад.= :
   LLAEY+;
 
-бонз.nlmpv воротил.nlmpv вышибал.nlmpv громил.nlmpv далай-лам.nlmpv держиморд.nlmpv 
-дурачин.nlmpv заправил.nlmpv здоровил.nlmpv иуд.nlmpv казачин.nlmpv купчин.nlmpv 
-кутил.nlmpv мирз.nlmpv мужичин.nlmpv мулл.nlmpv мурз.nlmpv панчен-лам.nlmpv 
-повес.nlmpv пульчинелл.nlmpv старейшин.nlmpv старичин.nlmpv тамад.nlmpv шудр.nlmpv 
-эспад.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 бонз.nlmpg воротил.nlmpg вышибал.nlmpg громил.nlmpg далай-лам.nlmpg держиморд.nlmpg 
 дурачин.nlmpg заправил.nlmpg здоровил.nlmpg иуд.nlmpg казачин.nlmpg купчин.nlmpg 
 кутил.nlmpg мирз.nlmpg мужичин.nlmpg мулл.nlmpg мурз.nlmpg панчен-лам.nlmpg 
 повес.nlmpg пульчинелл.nlmpg старейшин.nlmpg старичин.nlmpg тамад.nlmpg шудр.nlmpg 
 эспад.nlmpg :  <morph-С,мр,од,мн,рд>;
 
+бонз.nlmpv воротил.nlmpv вышибал.nlmpv громил.nlmpv далай-лам.nlmpv держиморд.nlmpv 
+дурачин.nlmpv заправил.nlmpv здоровил.nlmpv иуд.nlmpv казачин.nlmpv купчин.nlmpv 
+кутил.nlmpv мирз.nlmpv мужичин.nlmpv мулл.nlmpv мурз.nlmpv панчен-лам.nlmpv 
+повес.nlmpv пульчинелл.nlmpv старейшин.nlmpv старичин.nlmpv тамад.nlmpv шудр.nlmpv 
+эспад.nlmpv :  <morph-С,мр,од,мн,вн>;
+
 муром.= :
   LLDWW+ or LLAFX+ or LLAYJ+;
-
-муром.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 муром.ndmsi :  <morph-С,мр,но,ед,им>;
 
 муром.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+муром.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 кучм.= муртаз.= :
   LLECD+;
@@ -22570,11 +22564,11 @@
 мыт.= :
   LLAAQ+ or LLBYU+ or LLDKJ+;
 
+мыт.ndmsi :  <morph-С,мр,но,ед,им>;
+
 мыт.amss :  <morph-П,мр,ед,кр>;
 
 мыт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-мыт.ndmsi :  <morph-С,мр,но,ед,им>;
 
 мытар.= :
   LLBIA+ or LLBNU+ or LLDMT+;
@@ -22594,9 +22588,9 @@
 мякиш.= пунш.= фарш.= :
   LLAAG+;
 
-мякиш.ndmsv пунш.ndmsv фарш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мякиш.ndmsi пунш.ndmsi фарш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мякиш.ndmsv пунш.ndmsv фарш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мямл.= :
   LLBGI+ or LLDPW+;
@@ -22604,19 +22598,19 @@
 мят.= :
   LLAFX+ or LLBDD+ or LLBYU+ or LLDKF+;
 
-мят.amss :  <morph-П,мр,ед,кр>;
-
 мят.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+мят.amss :  <morph-П,мр,ед,кр>;
 
 калач.= кирпич.= мятеж.= падеж.= паралич.= платеж.= 
 поташ.= сургуч.= тираж.= этаж.= :
   LLAAJ+ or LLBYU+;
 
-калач.ndmsv кирпич.ndmsv мятеж.ndmsv падеж.ndmsv паралич.ndmsv платеж.ndmsv 
-поташ.ndmsv сургуч.ndmsv тираж.ndmsv этаж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 калач.ndmsi кирпич.ndmsi мятеж.ndmsi падеж.ndmsi паралич.ndmsi платеж.ndmsi 
 поташ.ndmsi сургуч.ndmsi тираж.ndmsi этаж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+калач.ndmsv кирпич.ndmsv мятеж.ndmsv падеж.ndmsv паралич.ndmsv платеж.ndmsv 
+поташ.ndmsv сургуч.ndmsv тираж.ndmsv этаж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 н.= :
   LLFQH+;
@@ -22627,9 +22621,9 @@
 наб.= :
   LLDWW+ or LLGDA+ or LLGDB+ or LLGDE+ or LLGDF+;
 
-наб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 наб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+наб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вскоч.= выдюж.= доскоч.= заблаж.= забрезж.= заперш.= 
 заскоч.= заспеш.= затуж.= наблаж.= нагреш.= наскоч.= 
@@ -22717,9 +22711,9 @@
 навес.= :
   LLAAQ+ or LLFWS+ or LLBRK+ or LLBYU+;
 
-навес.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 навес.ndmsi :  <morph-С,мр,но,ед,им>;
+
+навес.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 наво.= :
   LLAPG+ or LLAQP+ or LLGDC+ or LLGDD+ or LLFYQ+ or LLEPU+ or LLFXA+ or LLBPJ+;
@@ -22730,13 +22724,13 @@
 наволок.= :
   LLAAM+ or LLAFU+ or LLDYJ+;
 
-наволок.ndmsv :  <morph-С,мр,но,ед,вн>;
+наволок.npg :  <morph-С,мн,мн,рд>;
 
 наволок.ndmsi :  <morph-С,мр,но,ед,им>;
 
-наволок.npg :  <morph-С,мн,мн,рд>;
-
 наволок.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+наволок.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 навор.= :
   LLFWB+ or LLFYC+;
@@ -22826,11 +22820,11 @@
 надолб.= :
   LLAAQ+ or LLAFX+ or LLFWK+ or LLBZO+;
 
-надолб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 надолб.ndmsi :  <morph-С,мр,но,ед,им>;
 
 надолб.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+надолб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выпал.= надпил.= начин.= перекур.= подбел.= похул.= 
 пропил.= распил.= :
@@ -22878,36 +22872,36 @@
 наздратенко.= приходько.= христенко.= :
   LLFLN+ or LLFJX+;
 
-наздратенко.nlmsi приходько.nlmsi христенко.nlmsi :  <morph-С,мр,од,ед,им>;
+наздратенко.nlmpg приходько.nlmpg христенко.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 наздратенко.nlmpi приходько.nlmpi христенко.nlmpi :  <morph-С,мр,од,мн,им>;
 
+наздратенко.nlmpp приходько.nlmpp христенко.nlmpp :  <morph-С,мр,од,мн,пр>;
+
 наздратенко.nlmpt приходько.nlmpt христенко.nlmpt :  <morph-С,мр,од,мн,тв>;
-
-наздратенко.nlmst приходько.nlmst христенко.nlmst :  <morph-С,мр,од,ед,тв>;
-
-наздратенко.nlmpd приходько.nlmpd христенко.nlmpd :  <morph-С,мр,од,мн,дт>;
-
-наздратенко.nlmsp приходько.nlmsp христенко.nlmsp :  <morph-С,мр,од,ед,пр>;
-
-наздратенко.nlmsd приходько.nlmsd христенко.nlmsd :  <morph-С,мр,од,ед,дт>;
 
 наздратенко.nlmsv приходько.nlmsv христенко.nlmsv :  <morph-С,мр,од,ед,вн>;
 
+наздратенко.nlmsd приходько.nlmsd христенко.nlmsd :  <morph-С,мр,од,ед,дт>;
+
+наздратенко.nlmst приходько.nlmst христенко.nlmst :  <morph-С,мр,од,ед,тв>;
+
+наздратенко.nlmsp приходько.nlmsp христенко.nlmsp :  <morph-С,мр,од,ед,пр>;
+
+наздратенко.nlmsi приходько.nlmsi христенко.nlmsi :  <morph-С,мр,од,ед,им>;
+
 наздратенко.nlmsg приходько.nlmsg христенко.nlmsg :  <morph-С,мр,од,ед,рд>;
 
+наздратенко.nlmpd приходько.nlmpd христенко.nlmpd :  <morph-С,мр,од,мн,дт>;
+
 наздратенко.nlmpv приходько.nlmpv христенко.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-наздратенко.nlmpp приходько.nlmpp христенко.nlmpp :  <morph-С,мр,од,мн,пр>;
-
-наздратенко.nlmpg приходько.nlmpg христенко.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 наин.= :
   LLDWW+ or LLFID+;
 
-наин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 наин.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+наин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 наин.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -22936,14 +22930,6 @@
 этикет.= :
   LLAAQ+ or LLBRK+ or LLBYU+;
 
-браслет.ndmsv визит.ndmsv выворот.ndmsv габарит.ndmsv жилет.ndmsv закат.ndmsv 
-захват.ndmsv зачет.ndmsv зенит.ndmsv корсет.ndmsv лимон.ndmsv накат.ndmsv 
-наклад.ndmsv обдир.ndmsv обкат.ndmsv отбор.ndmsv отгон.ndmsv охват.ndmsv 
-перекат.ndmsv перемет.ndmsv планшет.ndmsv поднос.ndmsv понос.ndmsv прилив.ndmsv 
-прокат.ndmsv пролет.ndmsv разнос.ndmsv разряд.ndmsv сброс.ndmsv сгон.ndmsv 
-силуэт.ndmsv сонет.ndmsv упор.ndmsv ухват.ndmsv формат.ndmsv фугас.ndmsv 
-этикет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 браслет.ndmsi визит.ndmsi выворот.ndmsi габарит.ndmsi жилет.ndmsi закат.ndmsi 
 захват.ndmsi зачет.ndmsi зенит.ndmsi корсет.ndmsi лимон.ndmsi накат.ndmsi 
 наклад.ndmsi обдир.ndmsi обкат.ndmsi отбор.ndmsi отгон.ndmsi охват.ndmsi 
@@ -22951,6 +22937,14 @@
 прокат.ndmsi пролет.ndmsi разнос.ndmsi разряд.ndmsi сброс.ndmsi сгон.ndmsi 
 силуэт.ndmsi сонет.ndmsi упор.ndmsi ухват.ndmsi формат.ndmsi фугас.ndmsi 
 этикет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+браслет.ndmsv визит.ndmsv выворот.ndmsv габарит.ndmsv жилет.ndmsv закат.ndmsv 
+захват.ndmsv зачет.ndmsv зенит.ndmsv корсет.ndmsv лимон.ndmsv накат.ndmsv 
+наклад.ndmsv обдир.ndmsv обкат.ndmsv отбор.ndmsv отгон.ndmsv охват.ndmsv 
+перекат.ndmsv перемет.ndmsv планшет.ndmsv поднос.ndmsv понос.ndmsv прилив.ndmsv 
+прокат.ndmsv пролет.ndmsv разнос.ndmsv разряд.ndmsv сброс.ndmsv сгон.ndmsv 
+силуэт.ndmsv сонет.ndmsv упор.ndmsv ухват.ndmsv формат.ndmsv фугас.ndmsv 
+этикет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 накладыва.= :
   LLDBP+ or LLDEY+;
@@ -22961,9 +22955,9 @@
 наклеп.= :
   LLAAQ+ or LLGHC+ or LLBRK+;
 
-наклеп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 наклеп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+наклеп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 захозяйнича.= набезобразнича.= накляузнича.= наябеднича.= пораздума.= :
   LLDCN+ or LLDFF+;
@@ -23019,9 +23013,9 @@
 намол.= :
   LLAAQ+ or LLFWW+;
 
-намол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 намол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+намол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вытаращ.= наморщ.= поморщ.= расплющ.= сморщ.= сплющ.= 
 :
@@ -23058,9 +23052,9 @@
 наплав.= проплав.= :
   LLAAQ+ or LLFYW+ or LLBRK+;
 
-наплав.ndmsv проплав.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 наплав.ndmsi проплав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+наплав.ndmsv проплав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 напле.= :
   LLGFT+ or LLGFU+ or LLFZA+;
@@ -23084,9 +23078,9 @@
 напор.= :
   LLAAQ+ or LLBYU+ or LLGAA+ or LLGAB+ or LLGFC+;
 
-напор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 напор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+напор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 набезобра.= напрока.= :
   LLBAT+;
@@ -23118,9 +23112,9 @@
 нарев.= :
   LLDWW+ or LLGLX+;
 
-нарев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 нарев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+нарев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бекон.= бензин.= боржом.= бром.= бульон.= гуталин.= 
 изюм.= йод.= кефир.= ливер.= назем.= нарзан.= 
@@ -23143,9 +23137,9 @@
 доход.= народ.= :
   LLAAO+ or LLAXZ+ or LLBYU+;
 
-доход.ndmsv народ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 доход.ndmsi народ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+доход.ndmsv народ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 народиш.= :
   LLBTF+;
@@ -23206,9 +23200,9 @@
 насос.= :
   LLAAQ+ or LLFZJ+ or LLFZK+ or LLBYU+;
 
-насос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 насос.ndmsi :  <morph-С,мр,но,ед,им>;
+
+насос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 насплетнича.= поразмахива.= :
   LLDFF+;
@@ -23216,11 +23210,11 @@
 наст.= :
   LLAAQ+ or LLFIR+ or LLGGK+ or LLFKY+;
 
-наст.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 наст.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 наст.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+наст.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 наст.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -23232,9 +23226,9 @@
 настил.= посыл.= продел.= :
   LLAAQ+ or LLBRK+ or LLDOO+;
 
-настил.ndmsv посыл.ndmsv продел.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 настил.ndmsi посыл.ndmsi продел.ndmsi :  <morph-С,мр,но,ед,им>;
+
+настил.ndmsv посыл.ndmsv продел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 насто.= :
   LLBPJ+ or LLBPW+ or LLGLZ+ or LLGHU+ or LLGMA+;
@@ -23293,9 +23287,9 @@
 натур.= :
   LLAFX+ or LLAGT+ or LLBYU+;
 
-натур.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 натур.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+натур.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 натур.ndfpg :  <morph-С,жр,но,мн,рд>;
 
@@ -23312,17 +23306,17 @@
 :
   LLAEG+ or LLAEK+;
 
-альсекко.e альфреско.e амбулаторно.e брутто.e возвратно.e де-факто.e 
-живописно.e культурно.e материально.e морально.e музыкально.e научно.e 
-нервно.e нетто.e объемно.e оперативно.e организационно.e сердечно.e 
-серо.e социально.e территориально.e ударно.e художественно.e ячеисто.e 
-:  <morph-Н,0>;
-
 альсекко.a альфреско.a амбулаторно.a брутто.a возвратно.a де-факто.a 
 живописно.a культурно.a материально.a морально.a музыкально.a научно.a 
 нервно.a нетто.a объемно.a оперативно.a организационно.a сердечно.a 
 серо.a социально.a территориально.a ударно.a художественно.a ячеисто.a 
 :  <morph-П,0>;
+
+альсекко.e альфреско.e амбулаторно.e брутто.e возвратно.e де-факто.e 
+живописно.e культурно.e материально.e морально.e музыкально.e научно.e 
+нервно.e нетто.e объемно.e оперативно.e организационно.e сердечно.e 
+серо.e социально.e территориально.e ударно.e художественно.e ячеисто.e 
+:  <morph-Н,0>;
 
 нахал.= :
   LLACI+ or LLBRO+ or LLDOK+;
@@ -23389,8 +23383,6 @@
 не.= :
   LLDTS+ or LLALI+ or LLBQT+ or LLEAY+;
 
-:  <morph-ЧАСТ,0>;
-
 неб.= :
   LLBYZ+ or LLCAL+;
 
@@ -23406,9 +23398,9 @@
 небось.= :
   LLAEP+ or LLFGK+;
 
-небось.p :  <morph-ЧАСТ,0>;
-
 небось.y :  <morph-ВВОДН,0>;
+
+небось.p :  <morph-ЧАСТ,0>;
 
 небре.= :
   LLDIM+;
@@ -23424,9 +23416,9 @@
 невеж.= :
   LLAFD+;
 
-невеж.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 невеж.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+невеж.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 невзви.= :
   LLGMH+;
@@ -23525,9 +23517,9 @@
 негоже.= подшофе.= :
   LLAEL+ or LLAEK+;
 
-негоже.xn подшофе.xn :  <morph-ПРЕДК,нст>;
-
 негоже.e подшофе.e :  <morph-Н,0>;
+
+негоже.xn подшофе.xn :  <morph-ПРЕДК,нст>;
 
 негу.= :
   LLFVI+;
@@ -23600,9 +23592,9 @@
 недосмотр.= :
   LLAAQ+ or LLFTJ+;
 
-недосмотр.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 недосмотр.ndmsi :  <morph-С,мр,но,ед,им>;
+
+недосмотр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 недосп.= посп.= :
   LLGHR+;
@@ -23616,9 +23608,9 @@
 недосып.= :
   LLAAQ+ or LLGCR+;
 
-недосып.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 недосып.ndmsi :  <morph-С,мр,но,ед,им>;
+
+недосып.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 недоуч.= :
   LLGHA+ or LLBRG+;
@@ -23839,9 +23831,9 @@
 кулуар.= мемуар.= нерв.= :
   LLAAQ+ or LLBYU+ or LLDJV+;
 
-кулуар.ndmsv мемуар.ndmsv нерв.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 кулуар.ndmsi мемуар.ndmsi нерв.ndmsi :  <morph-С,мр,но,ед,им>;
+
+кулуар.ndmsv мемуар.ndmsv нерв.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 неве.= нере.= :
   LLCTB+;
@@ -23849,9 +23841,9 @@
 нередиц.= :
   LLFPU+;
 
-нередиц.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 нередиц.ndfpv :  <morph-С,жр,но,мн,вн>;
+
+нередиц.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 данаид.= нереид.= нимфалид.= эльвир.= :
   LLGSK+;
@@ -23883,14 +23875,14 @@
 :
   LLAEK+ or LLDTU+ or LLAEL+;
 
-безусловно.xn верно.xn вероятно.xn естественно.xn несомненно.xn понятно.xn 
-:  <morph-ПРЕДК,нст>;
-
 безусловно.e верно.e вероятно.e естественно.e несомненно.e понятно.e 
 :  <morph-Н,0>;
 
 безусловно.y верно.y вероятно.y естественно.y несомненно.y понятно.y 
 :  <morph-ВВОДН,0>;
+
+безусловно.xn верно.xn вероятно.xn естественно.xn несомненно.xn понятно.xn 
+:  <morph-ПРЕДК,нст>;
 
 вспомогател.= изначал.= наставител.= некапитал.= нестил.= пирамидал.= 
 смертел.= :
@@ -23929,13 +23921,13 @@
 флорин.= юпитер.= :
   LLAAQ+ or LLDWW+;
 
-аир.ndmsv акрон.ndmsv алексин.ndmsv баргузин.ndmsv боливар.ndmsv кабул.ndmsv 
-катар.ndmsv нефелин.ndmsv орлеан.ndmsv пафос.ndmsv сириус.ndmsv спенсер.ndmsv 
-флорин.ndmsv юпитер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 аир.ndmsi акрон.ndmsi алексин.ndmsi баргузин.ndmsi боливар.ndmsi кабул.ndmsi 
 катар.ndmsi нефелин.ndmsi орлеан.ndmsi пафос.ndmsi сириус.ndmsi спенсер.ndmsi 
 флорин.ndmsi юпитер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+аир.ndmsv акрон.ndmsv алексин.ndmsv баргузин.ndmsv боливар.ndmsv кабул.ndmsv 
+катар.ndmsv нефелин.ndmsv орлеан.ndmsv пафос.ndmsv сириус.ndmsv спенсер.ndmsv 
+флорин.ndmsv юпитер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 неформал.= :
   LLACI+ or LLDOX+;
@@ -24027,9 +24019,9 @@
 ни.= :
   LLDTM+ or LLAZJ+ or LLAZR+ or LLBBM+;
 
-ни.i :  <morph-СОЮЗ,0>;
-
 ни.p :  <morph-ЧАСТ,0>;
+
+ни.i :  <morph-СОЮЗ,0>;
 
 нивх.= :
   LLACG+ or LLBRO+;
@@ -24080,9 +24072,9 @@
 никак.= :
   LLAEK+ or LLAEP+ or LLDVN+;
 
-никак.e :  <morph-Н,0>;
-
 никак.p :  <morph-ЧАСТ,0>;
+
+никак.e :  <morph-Н,0>;
 
 нико.= :
   LLDVD+;
@@ -24090,16 +24082,16 @@
 николаевск.= :
   LLDWW+ or LLBEM+ or LLDYV+;
 
-николаевск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 николаевск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+николаевск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 никольск.= :
   LLDWW+ or LLFKB+ or LLFKA+ or LLDYP+ or LLFJZ+ or LLDYV+;
 
-никольск.nlmsi :  <morph-С,мр,од,ед,им>;
-
 никольск.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+никольск.nlmsi :  <morph-С,мр,од,ед,им>;
 
 никольск.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -24193,16 +24185,16 @@
 ноговиц.= ресниц.= рукавиц.= ягодиц.= :
   LLAFO+ or LLDJS+;
 
-ноговиц.ndfpg ресниц.ndfpg рукавиц.ndfpg ягодиц.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 ноговиц.npg ресниц.npg рукавиц.npg ягодиц.npg :  <morph-С,мн,мн,рд>;
+
+ноговиц.ndfpg ресниц.ndfpg рукавиц.ndfpg ягодиц.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 нож.= :
   LLAAJ+ or LLBRI+ or LLBXK+;
 
-нож.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 нож.ndmsi :  <morph-С,мр,но,ед,им>;
+
+нож.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ножен.= :
   LLBSP+ or LLDNX+;
@@ -24373,9 +24365,9 @@
 обед.= :
   LLAAQ+ or LLBZO+;
 
-обед.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 обед.ndmsi :  <morph-С,мр,но,ед,им>;
+
+обед.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 обезвре.= :
   LLAQK+;
@@ -24470,9 +24462,9 @@
 облез.= :
   LLFYY+ or LLGMS+;
 
-облез.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
-
 облез.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
+
+облез.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 /ru/words/words.144:
   LLDEQ+;
@@ -24513,11 +24505,11 @@
 обмерыш.= персонаж.= поганыш.= светоч.= :
   LLAAH+ or LLACD+;
 
-обмерыш.nlmsi персонаж.nlmsi поганыш.nlmsi светоч.nlmsi :  <morph-С,мр,од,ед,им>;
-
 обмерыш.ndmsv персонаж.ndmsv поганыш.ndmsv светоч.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 обмерыш.ndmsi персонаж.ndmsi поганыш.ndmsi светоч.ndmsi :  <morph-С,мр,но,ед,им>;
+
+обмерыш.nlmsi персонаж.nlmsi поганыш.nlmsi светоч.nlmsi :  <morph-С,мр,од,ед,им>;
 
 обмолв.= :
   LLFXQ+ or LLBRK+;
@@ -24567,9 +24559,9 @@
 колос.= обод.= :
   LLAAZ+ or LLCJW+;
 
-колос.ndmsv обод.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 колос.ndmsi обод.ndmsi :  <morph-С,мр,но,ед,им>;
+
+колос.ndmsv обод.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 обоего.= :
   LLDTB+;
@@ -24663,9 +24655,9 @@
 обруб.= :
   LLAAQ+ or LLFWK+ or LLBRK+ or LLCJW+;
 
-обруб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 обруб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+обруб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 обруч.= :
   LLAAH+ or LLFXI+ or LLFZZ+ or LLBYU+;
@@ -24698,9 +24690,9 @@
 обсев.= :
   LLAAQ+ or LLBSO+ or LLCJW+;
 
-обсев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 обсев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+обсев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выси.= доси.= заси.= наси.= обси.= отси.= 
 :
@@ -24847,14 +24839,6 @@
 шрот-комбикорм.= электродизельпоезд.= электропоезд.= энергопоезд.= :
   LLABM+;
 
-автопоезд.ndmsv автоцех.ndmsv агитпоезд.ndmsv аэропоезд.ndmsv брег.ndmsv бронекатер.ndmsv 
-бронепоезд.ndmsv ваучер.ndmsv гофрокороб.ndmsv деливери-ордер.ndmsv детдом.ndmsv дизель-поезд.ndmsv 
-дизельпоезд.ndmsv загранпаспорт.ndmsv закром.ndmsv кеш-буфер.ndmsv кливер.ndmsv крейсер.ndmsv 
-кэш-буфер.ndmsv леер.ndmsv лемех.ndmsv микроцех.ndmsv мини-трактор.ndmsv мини-цех.ndmsv 
-мотопоезд.ndmsv невод.ndmsv обшлаг.ndmsv огневод.ndmsv полуостров.ndmsv полутом.ndmsv 
-роддом.ndmsv спецкорпус.ndmsv спецсчет.ndmsv триггер.ndmsv хозкорпус.ndmsv шелеп.ndmsv 
-шрот-комбикорм.ndmsv электродизельпоезд.ndmsv электропоезд.ndmsv энергопоезд.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 автопоезд.ndmsi автоцех.ndmsi агитпоезд.ndmsi аэропоезд.ndmsi брег.ndmsi бронекатер.ndmsi 
 бронепоезд.ndmsi ваучер.ndmsi гофрокороб.ndmsi деливери-ордер.ndmsi детдом.ndmsi дизель-поезд.ndmsi 
 дизельпоезд.ndmsi загранпаспорт.ndmsi закром.ndmsi кеш-буфер.ndmsi кливер.ndmsi крейсер.ndmsi 
@@ -24862,6 +24846,14 @@
 мотопоезд.ndmsi невод.ndmsi обшлаг.ndmsi огневод.ndmsi полуостров.ndmsi полутом.ndmsi 
 роддом.ndmsi спецкорпус.ndmsi спецсчет.ndmsi триггер.ndmsi хозкорпус.ndmsi шелеп.ndmsi 
 шрот-комбикорм.ndmsi электродизельпоезд.ndmsi электропоезд.ndmsi энергопоезд.ndmsi :  <morph-С,мр,но,ед,им>;
+
+автопоезд.ndmsv автоцех.ndmsv агитпоезд.ndmsv аэропоезд.ndmsv брег.ndmsv бронекатер.ndmsv 
+бронепоезд.ndmsv ваучер.ndmsv гофрокороб.ndmsv деливери-ордер.ndmsv детдом.ndmsv дизель-поезд.ndmsv 
+дизельпоезд.ndmsv загранпаспорт.ndmsv закром.ndmsv кеш-буфер.ndmsv кливер.ndmsv крейсер.ndmsv 
+кэш-буфер.ndmsv леер.ndmsv лемех.ndmsv микроцех.ndmsv мини-трактор.ndmsv мини-цех.ndmsv 
+мотопоезд.ndmsv невод.ndmsv обшлаг.ndmsv огневод.ndmsv полуостров.ndmsv полутом.ndmsv 
+роддом.ndmsv спецкорпус.ndmsv спецсчет.ndmsv триггер.ndmsv хозкорпус.ndmsv шелеп.ndmsv 
+шрот-комбикорм.ndmsv электродизельпоезд.ndmsv электропоезд.ndmsv энергопоезд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 оговарива.= :
   LLDBY+ or LLDEI+;
@@ -24909,9 +24901,9 @@
 одеколон.= :
   LLAAO+ or LLFTC+ or LLFAN+;
 
-одеколон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 одеколон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+одеколон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 одерж.= попридерж.= придерж.= :
   LLGAT+;
@@ -24953,9 +24945,9 @@
 озер.= :
   LLBYU+ or LLCAG+ or LLDIE+ or LLEAJ+;
 
-озер.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 озер.npg :  <morph-С,мн,мн,рд>;
+
+озер.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 брюшк.= древк.= колесик.= личик.= озерк.= полуочк.= 
 :
@@ -25027,9 +25019,9 @@
 жемчуг.= комбикорм.= окорок.= порох.= :
   LLABI+;
 
-жемчуг.ndmsv комбикорм.ndmsv окорок.ndmsv порох.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 жемчуг.ndmsi комбикорм.ndmsi окорок.ndmsi порох.ndmsi :  <morph-С,мр,но,ед,им>;
+
+жемчуг.ndmsv комбикорм.ndmsv окорок.ndmsv порох.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 окрест.= :
   LLAEK+ or LLDTD+ or LLBYU+;
@@ -25045,13 +25037,13 @@
 округ.= :
   LLABM+ or LLAEK+ or LLAFU+;
 
-округ.e :  <morph-Н,0>;
-
 округ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-округ.ndfpg :  <morph-С,жр,но,мн,рд>;
+округ.e :  <morph-Н,0>;
 
 округ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+округ.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 округл.= :
   LLFWV+ or LLFWW+ or LLDKF+;
@@ -25072,19 +25064,19 @@
 хабаровск.= челябинск.= :
   LLDWW+ or LLBEM+;
 
-амурск.ndmsv архангельск.ndmsv байкальск.ndmsv балтийск.ndmsv благовещенск.ndmsv борисоглебск.ndmsv 
-брянск.ndmsv гвардейск.ndmsv железноводск.ndmsv зеленоградск.ndmsv ижевск.ndmsv иркутск.ndmsv 
-красноярск.ndmsv курск.ndmsv молодогвардейск.ndmsv мурманск.ndmsv мценск.ndmsv новоалтайск.ndmsv 
-новогорск.ndmsv новокузнецк.ndmsv новосибирск.ndmsv ногинск.ndmsv октябрьск.ndmsv омск.ndmsv 
-петрозаводск.ndmsv северск.ndmsv смоленск.ndmsv соликамск.ndmsv сысольск.ndmsv уссурийск.ndmsv 
-хабаровск.ndmsv челябинск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 амурск.ndmsi архангельск.ndmsi байкальск.ndmsi балтийск.ndmsi благовещенск.ndmsi борисоглебск.ndmsi 
 брянск.ndmsi гвардейск.ndmsi железноводск.ndmsi зеленоградск.ndmsi ижевск.ndmsi иркутск.ndmsi 
 красноярск.ndmsi курск.ndmsi молодогвардейск.ndmsi мурманск.ndmsi мценск.ndmsi новоалтайск.ndmsi 
 новогорск.ndmsi новокузнецк.ndmsi новосибирск.ndmsi ногинск.ndmsi октябрьск.ndmsi омск.ndmsi 
 петрозаводск.ndmsi северск.ndmsi смоленск.ndmsi соликамск.ndmsi сысольск.ndmsi уссурийск.ndmsi 
 хабаровск.ndmsi челябинск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+амурск.ndmsv архангельск.ndmsv байкальск.ndmsv балтийск.ndmsv благовещенск.ndmsv борисоглебск.ndmsv 
+брянск.ndmsv гвардейск.ndmsv железноводск.ndmsv зеленоградск.ndmsv ижевск.ndmsv иркутск.ndmsv 
+красноярск.ndmsv курск.ndmsv молодогвардейск.ndmsv мурманск.ndmsv мценск.ndmsv новоалтайск.ndmsv 
+новогорск.ndmsv новокузнецк.ndmsv новосибирск.ndmsv ногинск.ndmsv октябрьск.ndmsv омск.ndmsv 
+петрозаводск.ndmsv северск.ndmsv смоленск.ndmsv соликамск.ndmsv сысольск.ndmsv уссурийск.ndmsv 
+хабаровск.ndmsv челябинск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 окун.= :
   LLAUN+ or LLBRK+ or LLFWI+ or LLFWG+ or LLDMT+;
@@ -25132,13 +25124,13 @@
 омсукчан.= :
   LLDWW+ or LLBFM+;
 
-омсукчан.ndmsv :  <morph-С,мр,но,ед,вн>;
+омсукчан.ndmsi :  <morph-С,мр,но,ед,им>;
 
 омсукчан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-омсукчан.ndmsi :  <morph-С,мр,но,ед,им>;
-
 омсукчан.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+омсукчан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 он.= :
   LLFFW+ or LLDWM+;
@@ -25146,11 +25138,11 @@
 онуч.= :
   LLAAH+ or LLAFM+ or LLBBY+ or LLBRI+;
 
-онуч.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 онуч.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 онуч.ndmsi :  <morph-С,мр,но,ед,им>;
+
+онуч.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 онуч.npg :  <morph-С,мн,мн,рд>;
 
@@ -25163,11 +25155,11 @@
 опал.= :
   LLAAQ+ or LLAFX+ or LLDXR+ or LLFWV+ or LLFWW+ or LLBRK+ or LLDLO+ or LLDOK+;
 
-опал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 опал.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 опал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+опал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 опалуб.= :
   LLGNU+ or LLBRK+;
@@ -25214,9 +25206,9 @@
 ополз.= :
   LLAVL+ or LLGBZ+ or LLGNH+;
 
-ополз.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
-
 ополз.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
+
+ополз.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 ополза.= :
   LLCZE+ or LLDAL+ or LLFWT+ or LLDEM+;
@@ -25226,9 +25218,9 @@
 
 опор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-опор.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 опор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+опор.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 взят.= высад.= мыщел.= надшив.= опояс.= отсад.= 
 павоз.= пазан.= пересад.= подмалев.= привив.= приработ.= 
@@ -25298,27 +25290,27 @@
 орел.= :
   LLDWW+ or LLEAT+;
 
-орел.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 орел.ndmsi :  <morph-С,мр,но,ед,им>;
+
+орел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 орехов.= :
   LLDWW+ or LLBRO+ or LLDKF+;
 
+орехов.ndmsi :  <morph-С,мр,но,ед,им>;
+
 орехов.amss :  <morph-П,мр,ед,кр>;
 
 орехов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-орехов.ndmsi :  <morph-С,мр,но,ед,им>;
 
 оригинал.= :
   LLAAQ+ or LLACI+ or LLBRO+ or LLDOK+;
 
 оригинал.nlmsi :  <morph-С,мр,од,ед,им>;
 
-оригинал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 оригинал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+оригинал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 инструмент.= контрапункт.= оркестр.= орнамент.= презент.= секвестр.= 
 :
@@ -25344,23 +25336,6 @@
 /ru/words/words.154:
   LLDWW+ or LLDYV+;
 
-бердск.ndmsv бийск.ndmsv бирск.ndmsv верх-нейвинск.ndmsv весьегонск.ndmsv всеволжск.ndmsv 
-горно-алтайск.ndmsv ейск.ndmsv елецк.ndmsv жирновск.ndmsv заинск.ndmsv закаменск.ndmsv 
-заозерск.ndmsv зарайск.ndmsv заринск.ndmsv зейск.ndmsv зеленодольск.ndmsv змеиногорск.ndmsv 
-зоринск.ndmsv илецк.ndmsv илимск.ndmsv калачинск.ndmsv канск.ndmsv катав-ивановск.ndmsv 
-катайск.ndmsv кимовск.ndmsv кирово-чепецк.ndmsv климовск.ndmsv козельск.ndmsv кореновск.ndmsv 
-котовск.ndmsv красновишерск.ndmsv краснознаменск.ndmsv краснокаменск.ndmsv краснокамск.ndmsv краснослободск.ndmsv 
-красноуфимск.ndmsv курганинск.ndmsv лениногорск.ndmsv малоархангельск.ndmsv менделеевск.ndmsv мензелинск.ndmsv 
-мещовск.ndmsv моршанск.ndmsv мосальск.ndmsv невельск.ndmsv невьянск.ndmsv новоорск.ndmsv 
-нолинск.ndmsv нязепетровск.ndmsv олекминск.ndmsv омутнинск.ndmsv орск.ndmsv правдинск.ndmsv 
-приозерск.ndmsv прокопьевск.ndmsv пролетарск.ndmsv пуровск.ndmsv райчихинск.ndmsv ряжск.ndmsv 
-северодвинск.ndmsv североморск.ndmsv севск.ndmsv селенгинск.ndmsv сердобск.ndmsv славск.ndmsv 
-снежногорск.ndmsv солнечногорск.ndmsv соль-илецк.ndmsv сорочинск.ndmsv сосновоборск.ndmsv спас-деменск.ndmsv 
-спаск.ndmsv среднеколымск.ndmsv сурск.ndmsv тимашевск.ndmsv туринск.ndmsv туруханск.ndmsv 
-тюкалинск.ndmsv углегорск.ndmsv урюпинск.ndmsv усть-илимск.ndmsv ханты-мансийск.ndmsv харовск.ndmsv 
-цивильск.ndmsv чапаевск.ndmsv чепецк.ndmsv черняховск.ndmsv чкаловск.ndmsv шадринск.ndmsv 
-шацк.ndmsv шенкурск.ndmsv яранск.ndmsv ясногорск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бердск.ndmsi бийск.ndmsi бирск.ndmsi верх-нейвинск.ndmsi весьегонск.ndmsi всеволжск.ndmsi 
 горно-алтайск.ndmsi ейск.ndmsi елецк.ndmsi жирновск.ndmsi заинск.ndmsi закаменск.ndmsi 
 заозерск.ndmsi зарайск.ndmsi заринск.ndmsi зейск.ndmsi зеленодольск.ndmsi змеиногорск.ndmsi 
@@ -25377,6 +25352,23 @@
 тюкалинск.ndmsi углегорск.ndmsi урюпинск.ndmsi усть-илимск.ndmsi ханты-мансийск.ndmsi харовск.ndmsi 
 цивильск.ndmsi чапаевск.ndmsi чепецк.ndmsi черняховск.ndmsi чкаловск.ndmsi шадринск.ndmsi 
 шацк.ndmsi шенкурск.ndmsi яранск.ndmsi ясногорск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бердск.ndmsv бийск.ndmsv бирск.ndmsv верх-нейвинск.ndmsv весьегонск.ndmsv всеволжск.ndmsv 
+горно-алтайск.ndmsv ейск.ndmsv елецк.ndmsv жирновск.ndmsv заинск.ndmsv закаменск.ndmsv 
+заозерск.ndmsv зарайск.ndmsv заринск.ndmsv зейск.ndmsv зеленодольск.ndmsv змеиногорск.ndmsv 
+зоринск.ndmsv илецк.ndmsv илимск.ndmsv калачинск.ndmsv канск.ndmsv катав-ивановск.ndmsv 
+катайск.ndmsv кимовск.ndmsv кирово-чепецк.ndmsv климовск.ndmsv козельск.ndmsv кореновск.ndmsv 
+котовск.ndmsv красновишерск.ndmsv краснознаменск.ndmsv краснокаменск.ndmsv краснокамск.ndmsv краснослободск.ndmsv 
+красноуфимск.ndmsv курганинск.ndmsv лениногорск.ndmsv малоархангельск.ndmsv менделеевск.ndmsv мензелинск.ndmsv 
+мещовск.ndmsv моршанск.ndmsv мосальск.ndmsv невельск.ndmsv невьянск.ndmsv новоорск.ndmsv 
+нолинск.ndmsv нязепетровск.ndmsv олекминск.ndmsv омутнинск.ndmsv орск.ndmsv правдинск.ndmsv 
+приозерск.ndmsv прокопьевск.ndmsv пролетарск.ndmsv пуровск.ndmsv райчихинск.ndmsv ряжск.ndmsv 
+северодвинск.ndmsv североморск.ndmsv севск.ndmsv селенгинск.ndmsv сердобск.ndmsv славск.ndmsv 
+снежногорск.ndmsv солнечногорск.ndmsv соль-илецк.ndmsv сорочинск.ndmsv сосновоборск.ndmsv спас-деменск.ndmsv 
+спаск.ndmsv среднеколымск.ndmsv сурск.ndmsv тимашевск.ndmsv туринск.ndmsv туруханск.ndmsv 
+тюкалинск.ndmsv углегорск.ndmsv урюпинск.ndmsv усть-илимск.ndmsv ханты-мансийск.ndmsv харовск.ndmsv 
+цивильск.ndmsv чапаевск.ndmsv чепецк.ndmsv черняховск.ndmsv чкаловск.ndmsv шадринск.ndmsv 
+шацк.ndmsv шенкурск.ndmsv яранск.ndmsv ясногорск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 оруд.= :
   LLBYZ+ or LLCBF+;
@@ -25438,11 +25430,11 @@
 оскар.= :
   LLFKO+ or LLAAQ+ or LLFIH+;
 
-оскар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 оскар.nlmsi :  <morph-С,мр,од,ед,им>;
 
 оскар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+оскар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 оскол.= :
   LLDWW+ or LLCJW+;
@@ -25480,16 +25472,16 @@
 осмотр.= :
   LLAAQ+ or LLGGI+ or LLGAQ+;
 
-осмотр.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 осмотр.ndmsi :  <morph-С,мр,но,ед,им>;
+
+осмотр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 особ.= :
   LLAGT+ or LLBNS+ or LLDLC+ or LLDNL+;
 
-особ.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 особ.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+особ.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 взъерепен.= встопыр.= заскипидар.= изморщин.= наодеколон.= обасурман.= 
 оскандал.= осовремен.= перессор.= подкрахмал.= подрумян.= проканител.= 
@@ -25500,9 +25492,9 @@
 ост.= :
   LLAAQ+ or LLCMY+ or LLDNF+;
 
-ост.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ост.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ост.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 оста.= расста.= :
   LLAMG+ or LLFXV+;
@@ -25536,9 +25528,9 @@
 остов.= :
   LLAAQ+ or LLDKJ+;
 
-остов.amss :  <morph-П,мр,ед,кр>;
-
 остов.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+остов.amss :  <morph-П,мр,ед,кр>;
 
 остов.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -25551,9 +25543,9 @@
 остров.= :
   LLABM+ or LLEDS+ or LLCJW+;
 
-остров.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 остров.ndmsi :  <morph-С,мр,но,ед,им>;
+
+остров.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 островск.= :
   LLFJZ+ or LLDYV+ or LLCJF+;
@@ -25563,9 +25555,9 @@
 
 острог.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-острог.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 острог.ndmsi :  <morph-С,мр,но,ед,им>;
+
+острог.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 остроглаз.= :
   LLDKO+ or LLDNT+;
@@ -25612,9 +25604,9 @@
 отбел.= :
   LLAAQ+ or LLFWV+ or LLBRK+ or LLDOK+;
 
-отбел.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отбел.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отбел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отбл.= побл.= пробл.= :
   LLGHZ+;
@@ -25641,9 +25633,9 @@
 отвар.= :
   LLAAO+ or LLFWV+ or LLFWW+ or LLBRK+;
 
-отвар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отвар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отвар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отве.= :
   LLFWR+ or LLFXE+ or LLGOG+ or LLFYL+ or LLFYM+;
@@ -25688,9 +25680,9 @@
 отговор.= :
   LLAAQ+ or LLFWV+ or LLFWW+ or LLBRK+ or LLDJV+;
 
-отговор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отговор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отговор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отгор.= :
   LLGIN+ or LLFXX+;
@@ -25730,9 +25722,9 @@
 надел.= отзол.= :
   LLAAQ+ or LLFWV+ or LLBRK+ or LLDOO+;
 
-надел.ndmsv отзол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 надел.ndmsi отзол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+надел.ndmsv отзол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отка.= :
   LLGOI+ or LLFXK+ or LLFXL+ or LLFXF+ or LLFXG+;
@@ -25809,9 +25801,9 @@
 откуп.= :
   LLABM+ or LLFWK+ or LLFXQ+;
 
-откуп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 откуп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+откуп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отла.= :
   LLGHL+ or LLGIR+ or LLFYL+ or LLFYM+;
@@ -25824,13 +25816,13 @@
 :
   LLAAQ+ or LLFWK+;
 
-вылов.ndmsv излом.ndmsv обкорм.ndmsv облов.ndmsv озноб.ndmsv окорм.ndmsv 
-отлов.ndmsv оцеп.ndmsv перелов.ndmsv разгром.ndmsv раскорм.ndmsv скорм.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
-
 вылов.ndmsi излом.ndmsi обкорм.ndmsi облов.ndmsi озноб.ndmsi окорм.ndmsi 
 отлов.ndmsi оцеп.ndmsi перелов.ndmsi разгром.ndmsi раскорм.ndmsi скорм.ndmsi 
 :  <morph-С,мр,но,ед,им>;
+
+вылов.ndmsv излом.ndmsv обкорм.ndmsv облов.ndmsv озноб.ndmsv окорм.ndmsv 
+отлов.ndmsv оцеп.ndmsv перелов.ndmsv разгром.ndmsv раскорм.ndmsv скорм.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
 
 отлом.= :
   LLFWK+ or LLFXQ+ or LLCJW+;
@@ -25919,9 +25911,9 @@
 отруб.= :
   LLABN+ or LLBCE+ or LLFWK+ or LLBYZ+;
 
-отруб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отруб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отруб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отсе.= усе.= :
   LLFXJ+ or LLFYL+ or LLFYM+;
@@ -25929,9 +25921,9 @@
 отсев.= :
   LLAAQ+ or LLBSO+;
 
-отсев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отсев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отсев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 обска.= отска.= проска.= :
   LLGGE+;
@@ -25954,9 +25946,9 @@
 отсос.= :
   LLAAQ+ or LLFZJ+ or LLBYU+;
 
-отсос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отсос.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отсос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отсто.= :
   LLBPJ+ or LLBQI+ or LLDRL+ or LLGHU+ or LLGGL+;
@@ -26003,15 +25995,6 @@
 /ru/words/words.159:
   LLFUO+;
 
-авгиев.amsi аннибалов.amsi ахиллесов.amsi базедов.amsi бертолетов.amsi бикфордов.amsi 
-буриданов.amsi валаамов.amsi валтасаров.amsi виттов.amsi гайморов.amsi глауберов.amsi 
-гордиев.amsi государев.amsi дамоклов.amsi деверев.amsi дедов.amsi демосфенов.amsi 
-дьяволов.amsi евстахиев.amsi женихов.amsi зятев.amsi каинов.amsi кесарев.amsi 
-кощеев.amsi кумов.amsi лукуллов.amsi мамаев.amsi мафусаилов.amsi ноев.amsi 
-олегов.amsi отцов.amsi пирров.amsi пифагоров.amsi прадедов.amsi прокрустов.amsi 
-святославов.amsi сизифов.amsi сынов.amsi тестев.amsi успеньев.amsi фаллопиев.amsi 
-хамов.amsi христов.amsi шуринов.amsi шутов.amsi :  <morph-П,мр,ед,им>;
-
 авгиев.admsv аннибалов.admsv ахиллесов.admsv базедов.admsv бертолетов.admsv бикфордов.admsv 
 буриданов.admsv валаамов.admsv валтасаров.admsv виттов.admsv гайморов.admsv глауберов.admsv 
 гордиев.admsv государев.admsv дамоклов.admsv деверев.admsv дедов.admsv демосфенов.admsv 
@@ -26020,6 +26003,15 @@
 олегов.admsv отцов.admsv пирров.admsv пифагоров.admsv прадедов.admsv прокрустов.admsv 
 святославов.admsv сизифов.admsv сынов.admsv тестев.admsv успеньев.admsv фаллопиев.admsv 
 хамов.admsv христов.admsv шуринов.admsv шутов.admsv :  <morph-П,мр,ед,вн,но>;
+
+авгиев.amsi аннибалов.amsi ахиллесов.amsi базедов.amsi бертолетов.amsi бикфордов.amsi 
+буриданов.amsi валаамов.amsi валтасаров.amsi виттов.amsi гайморов.amsi глауберов.amsi 
+гордиев.amsi государев.amsi дамоклов.amsi деверев.amsi дедов.amsi демосфенов.amsi 
+дьяволов.amsi евстахиев.amsi женихов.amsi зятев.amsi каинов.amsi кесарев.amsi 
+кощеев.amsi кумов.amsi лукуллов.amsi мамаев.amsi мафусаилов.amsi ноев.amsi 
+олегов.amsi отцов.amsi пирров.amsi пифагоров.amsi прадедов.amsi прокрустов.amsi 
+святославов.amsi сизифов.amsi сынов.amsi тестев.amsi успеньев.amsi фаллопиев.amsi 
+хамов.amsi христов.amsi шуринов.amsi шутов.amsi :  <morph-П,мр,ед,им>;
 
 отчленя.= :
   LLDAG+;
@@ -26099,9 +26091,9 @@
 малмыж.= ош.= :
   LLDWV+ or LLDXM+;
 
-малмыж.ndmsv ош.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 малмыж.ndmsi ош.ndmsi :  <morph-С,мр,но,ед,им>;
+
+малмыж.ndmsv ош.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 оше.= переше.= :
   LLAUD+;
@@ -26123,16 +26115,16 @@
 пав.= :
   LLAGT+ or LLFMI+ or LLBFF+;
 
-пав.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 пав.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+пав.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 павлово.= :
   LLAEG+ or LLDXD+;
 
-павлово.ndn :  <morph-С,ср,но,0>;
-
 павлово.a :  <morph-П,0>;
+
+павлово.ndn :  <morph-С,ср,но,0>;
 
 павловск.= :
   LLDWW+ or LLFJZ+ or LLBEM+ or LLDYV+;
@@ -26172,9 +26164,9 @@
 пал.= :
   LLAAS+ or LLAYE+ or LLBGI+ or LLBHS+ or LLBNP+ or LLBRK+ or LLDLO+ or LLDNF+;
 
-пал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.161:
   LLBEP+ or LLDYV+;
@@ -26182,9 +26174,9 @@
 пали.= :
   LLABZ+ or LLAEG+ or LLDQV+;
 
-пали.a :  <morph-П,0>;
-
 пали.ndm :  <morph-С,мр,но,0>;
+
+пали.a :  <morph-П,0>;
 
 /ru/words/words.162:
   LLADA+;
@@ -26231,19 +26223,19 @@
 шергин.= :
   LLDWW+ or LLFQF+;
 
-ананьев.nlmsi бикин.nlmsi богодухов.nlmsi борщев.nlmsi гагарин.nlmsi гайсин.nlmsi 
-гафуров.nlmsi глазов.nlmsi глухов.nlmsi горбатов.nlmsi данков.nlmsi демидов.nlmsi 
-ефремов.nlmsi кадников.nlmsi кобрин.nlmsi макарьев.nlmsi нестеров.nlmsi николаев.nlmsi 
-обухов.nlmsi панфилов.nlmsi почаев.nlmsi пугачев.nlmsi рогачев.nlmsi серов.nlmsi 
-темников.nlmsi тутаев.nlmsi фурманов.nlmsi халтурин.nlmsi чехов.nlmsi шелехов.nlmsi 
-шергин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 ананьев.ndmsv бикин.ndmsv богодухов.ndmsv борщев.ndmsv гагарин.ndmsv гайсин.ndmsv 
 гафуров.ndmsv глазов.ndmsv глухов.ndmsv горбатов.ndmsv данков.ndmsv демидов.ndmsv 
 ефремов.ndmsv кадников.ndmsv кобрин.ndmsv макарьев.ndmsv нестеров.ndmsv николаев.ndmsv 
 обухов.ndmsv панфилов.ndmsv почаев.ndmsv пугачев.ndmsv рогачев.ndmsv серов.ndmsv 
 темников.ndmsv тутаев.ndmsv фурманов.ndmsv халтурин.ndmsv чехов.ndmsv шелехов.ndmsv 
 шергин.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+ананьев.nlmsi бикин.nlmsi богодухов.nlmsi борщев.nlmsi гагарин.nlmsi гайсин.nlmsi 
+гафуров.nlmsi глазов.nlmsi глухов.nlmsi горбатов.nlmsi данков.nlmsi демидов.nlmsi 
+ефремов.nlmsi кадников.nlmsi кобрин.nlmsi макарьев.nlmsi нестеров.nlmsi николаев.nlmsi 
+обухов.nlmsi панфилов.nlmsi почаев.nlmsi пугачев.nlmsi рогачев.nlmsi серов.nlmsi 
+темников.nlmsi тутаев.nlmsi фурманов.nlmsi халтурин.nlmsi чехов.nlmsi шелехов.nlmsi 
+шергин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 ананьев.ndmsi бикин.ndmsi богодухов.ndmsi борщев.ndmsi гагарин.ndmsi гайсин.ndmsi 
 гафуров.ndmsi глазов.ndmsi глухов.ndmsi горбатов.ndmsi данков.ndmsi демидов.ndmsi 
@@ -26255,9 +26247,9 @@
 пап.= :
   LLAEY+ or LLBRK+;
 
-пап.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 пап.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+пап.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 папай.= параной.= секвой.= :
   LLDPZ+;
@@ -26285,11 +26277,11 @@
 пар.= :
   LLAAP+ or LLAFX+ or LLDXR+ or LLAVM+ or LLBGI+ or LLBIA+ or LLBNU+ or LLBRK+ or LLBRO+ or LLBSW+ or LLBZF+ or LLCCZ+ or LLCGW+ or LLCJU+ or LLDJV+ or LLDPS+;
 
-пар.ndmsv :  <morph-С,мр,но,ед,вн>;
+пар.ndmsi :  <morph-С,мр,но,ед,им>;
 
 пар.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-пар.ndmsi :  <morph-С,мр,но,ед,им>;
+пар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 алта.= парагва.= уругва.= :
   LLAYG+ or LLDZD+ or LLBPY+;
@@ -26297,11 +26289,11 @@
 парадиз.= :
   LLAAQ+ or LLEBJ+ or LLBRK+;
 
+парадиз.ndmsi :  <morph-С,мр,но,ед,им>;
+
 парадиз.nlmsi :  <morph-С,мр,од,ед,им>;
 
 парадиз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-парадиз.ndmsi :  <morph-С,мр,но,ед,им>;
 
 вычитаем.= главн.= должн.= зажит.= кафе-морожен.= кратн.= 
 множим.= нажит.= наружн.= парадн.= поличн.= потогонн.= 
@@ -26313,9 +26305,9 @@
 
 водонос.nlmsi паразит.nlmsi тихоход.nlmsi :  <morph-С,мр,од,ед,им>;
 
-водонос.ndmsv паразит.ndmsv тихоход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 водонос.ndmsi паразит.ndmsi тихоход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+водонос.ndmsv паразит.ndmsv тихоход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 параллел.= :
   LLDNF+ or LLDOV+;
@@ -26357,11 +26349,11 @@
 килопарсек.= мегапарсек.= мегаэрг.= парсек.= эрг.= :
   LLABS+;
 
+килопарсек.ndmsi мегапарсек.ndmsi мегаэрг.ndmsi парсек.ndmsi эрг.ndmsi :  <morph-С,мр,но,ед,им>;
+
 килопарсек.ndmsv мегапарсек.ndmsv мегаэрг.ndmsv парсек.ndmsv эрг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 килопарсек.ndmpg мегапарсек.ndmpg мегаэрг.ndmpg парсек.ndmpg эрг.ndmpg :  <morph-С,мр,но,мн,рд>;
-
-килопарсек.ndmsi мегапарсек.ndmsi мегаэрг.ndmsi парсек.ndmsi эрг.ndmsi :  <morph-С,мр,но,ед,им>;
 
 парти.= студи.= :
   LLAYG+ or LLBPW+ or LLBPY+ or LLBQK+ or LLDQL+;
@@ -26369,18 +26361,18 @@
 партизан.= :
   LLACX+ or LLBGW+ or LLBRO+;
 
-партизан.nlmsi :  <morph-С,мр,од,ед,им>;
+партизан.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 партизан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-партизан.nlmpg :  <morph-С,мр,од,мн,рд>;
+партизан.nlmsi :  <morph-С,мр,од,ед,им>;
 
 парус.= :
   LLABM+ or LLBGF+ or LLBYU+ or LLCJW+;
 
-парус.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 парус.ndmsi :  <morph-С,мр,но,ед,им>;
+
+парус.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 паршив.= :
   LLAYI+ or LLBIU+ or LLBNS+ or LLBRO+ or LLDKF+;
@@ -26390,11 +26382,11 @@
 пас.= :
   LLAAQ+ or LLAEL+ or LLDTP+ or LLCBF+ or LLCCZ+ or LLCGW+ or LLEMD+ or LLCWW+;
 
-пас.xn :  <morph-ПРЕДК,нст>;
-
 пас.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пас.vnpdpms :  <morph-Г,нс,пе,дст,прш,мр,ед>;
+
+пас.xn :  <morph-ПРЕДК,нст>;
 
 пас.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -26410,16 +26402,16 @@
 патент.= :
   LLAAQ+ or LLBYU+ or LLFRF+ or LLEUU+;
 
-патент.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 патент.ndmsi :  <morph-С,мр,но,ед,им>;
+
+патент.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 патрон.= :
   LLAAQ+ or LLACI+ or LLBRK+ or LLBYZ+;
 
-патрон.nlmsi :  <morph-С,мр,од,ед,им>;
-
 патрон.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+патрон.nlmsi :  <morph-С,мр,од,ед,им>;
 
 патрон.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -26440,11 +26432,11 @@
 пах.= :
   LLABA+ or LLBVZ+;
 
-пах.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 пах.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пах.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пах.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 крошен.= латан.= пахан.= таскан.= цежен.= штукатурен.= 
 :
@@ -26459,11 +26451,11 @@
 пейзан.= :
   LLACX+ or LLBFM+ or LLBRO+;
 
-пейзан.nlmsi :  <morph-С,мр,од,ед,им>;
+пейзан.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 пейзан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-пейзан.nlmpg :  <morph-С,мр,од,мн,рд>;
+пейзан.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пекар.= токар.= :
   LLBYZ+ or LLBZO+ or LLDMU+;
@@ -26485,9 +26477,9 @@
 пеленг.= :
   LLABG+ or LLFRE+;
 
-пеленг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пеленг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пеленг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пельмен.= :
   LLBCE+ or LLDML+;
@@ -26534,9 +26526,9 @@
 первач.= :
   LLAAJ+ or LLCJU+;
 
-первач.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 первач.ndmsi :  <morph-С,мр,но,ед,им>;
+
+первач.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 буденн.= головат.= довгопят.= заболотн.= загребельн.= колодяжн.= 
 паперн.= первозванн.= пидкасист.= поддубн.= пошелюжн.= семичастн.= 
@@ -26595,9 +26587,9 @@
 перевал.= :
   LLAAQ+ or LLAYE+ or LLFWV+ or LLFWW+ or LLBRK+;
 
-перевал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перевал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перевал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 заве.= переве.= :
   LLFWM+ or LLFWN+ or LLFXE+ or LLFYK+ or LLFYL+;
@@ -26684,9 +26676,9 @@
 перед.= :
   LLABP+ or LLDTD+ or LLCJW+ or LLGDE+ or LLGDF+;
 
-перед.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перед.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перед.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 переда.= :
   LLALV+ or LLGLN+ or LLAMG+ or LLGAR+ or LLFXR+;
@@ -26732,9 +26724,9 @@
 перезаклад.= перезаряд.= :
   LLAAQ+ or LLBRL+;
 
-перезаклад.ndmsv перезаряд.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перезаклад.ndmsi перезаряд.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перезаклад.ndmsv перезаряд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 перезаключ.= :
   LLEQQ+ or LLBKE+;
@@ -26790,9 +26782,9 @@
 перекоп.= :
   LLAAQ+ or LLBRK+ or LLFST+ or LLFDN+;
 
-перекоп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перекоп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перекоп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 перекорм.= перетрав.= :
   LLAAQ+ or LLFSV+;
@@ -26899,9 +26891,9 @@
 перенос.= :
   LLAAQ+ or LLBRK+ or LLBYZ+ or LLCKD+;
 
-перенос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перенос.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перенос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 перенумеровыва.= :
   LLDBP+ or LLDEL+;
@@ -26953,9 +26945,9 @@
 переплав.= :
   LLAAQ+ or LLFTD+ or LLFDF+ or LLBRK+;
 
-переплав.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 переплав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+переплав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 переплы.= проплы.= :
   LLGNZ+;
@@ -27035,9 +27027,9 @@
 перерасход.= :
   LLAAQ+ or LLCGE+;
 
-перерасход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перерасход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перерасход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 перерегистрир.= :
   LLGHH+ or LLCHP+ or LLCGQ+;
@@ -27235,9 +27227,9 @@
 отшиб.= перешиб.= :
   LLAAQ+ or LLGCX+;
 
-отшиб.vspdpms перешиб.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
-
 отшиб.ndmsv перешиб.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+отшиб.vspdpms перешиб.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 отшиб.ndmsi перешиб.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -27265,9 +27257,9 @@
 перст.= :
   LLAAQ+ or LLAVL+ or LLDNF+;
 
-перст.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перст.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перст.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 васил.= камел.= клубен.= комел.= перстен.= поршен.= 
 стержен.= тебен.= :
@@ -27311,18 +27303,18 @@
 петров.= :
   LLFQF+ or LLADW+ or LLFOU+ or LLBSP+;
 
-петров.amsi :  <morph-П,мр,ед,им>;
+петров.admsv :  <morph-П,мр,ед,вн,но>;
 
 петров.nlmsi :  <morph-С,мр,од,ед,им>;
 
-петров.admsv :  <morph-П,мр,ед,вн,но>;
+петров.amsi :  <morph-П,мр,ед,им>;
 
 петровск.= :
   LLDWW+ or LLFJZ+ or LLBEL+ or LLDZV+;
 
-петровск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 петровск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+петровск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 зубкевич.= онищук.= петрук.= :
   LLFJY+;
@@ -27352,9 +27344,9 @@
 печорск.= :
   LLDWW+ or LLBEM+ or LLDYX+;
 
-печорск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 печорск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+печорск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пеш.= :
   LLDXM+ or LLBDN+ or LLBRI+ or LLBRM+;
@@ -27385,22 +27377,22 @@
 пик.= :
   LLAAM+ or LLAEG+ or LLAFU+ or LLBBY+;
 
-пик.ndmsv :  <morph-С,мр,но,ед,вн>;
+пик.ndmsi :  <morph-С,мр,но,ед,им>;
 
 пик.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 пик.a :  <morph-П,0>;
 
-пик.ndmsi :  <morph-С,мр,но,ед,им>;
-
 пик.npg :  <morph-С,мн,мн,рд>;
+
+пик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пике.= :
   LLADL+ or LLAEG+ or LLBQK+;
 
-пике.ndn :  <morph-С,ср,но,0>;
-
 пике.a :  <morph-П,0>;
+
+пике.ndn :  <morph-С,ср,но,0>;
 
 пикир.= :
   LLCBF+ or LLGAZ+ or LLCCZ+ or LLFWB+ or LLCGW+;
@@ -27474,9 +27466,9 @@
 
 пинанг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-пинанг.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 пинанг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пинанг.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 баламут.= виртуоз.= маловер.= пионер.= санитар.= эстет.= 
 :
@@ -27498,9 +27490,9 @@
 пирай.= :
   LLDQO+;
 
-пирай.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 пирай.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+пирай.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 гимала.= пирене.= поныр.= фангаре.= :
   LLDYN+;
@@ -27555,11 +27547,11 @@
 плавун.= :
   LLAAQ+ or LLACI+ or LLAYJ+;
 
-плавун.nlmsi :  <morph-С,мр,од,ед,им>;
-
 плавун.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 плавун.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плавун.nlmsi :  <morph-С,мр,од,ед,им>;
 
 бесстыж.= блестящ.= везуч.= всемогущ.= гремуч.= дремуч.= 
 дюж.= жгуч.= завидущ.= загребущ.= зловещ.= зыбуч.= 
@@ -27613,9 +27605,9 @@
 пласт.= :
   LLAAQ+ or LLCCZ+ or LLCGW+ or LLDNF+;
 
-пласт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пласт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пласт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пластифицир.= цементир.= :
   LLCES+ or LLEPR+;
@@ -27643,9 +27635,9 @@
 плац.= :
   LLAAE+;
 
-плац.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 плац.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плац.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 плачев.= :
   LLBYU+ or LLCJC+;
@@ -27656,18 +27648,18 @@
 плев.= :
   LLAFX+ or LLCJW+ or LLDKJ+;
 
-плев.amss :  <morph-П,мр,ед,кр>;
-
 плев.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+плев.amss :  <morph-П,мр,ед,кр>;
 
 плен.= :
   LLAAS+ or LLAFX+ or LLFWV+ or LLFWW+ or LLBRK+ or LLBYZ+;
 
-плен.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 плен.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 плен.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плен.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 плескан.= сказан.= щелкан.= :
   LLFWL+ or LLDNT+;
@@ -27688,11 +27680,11 @@
 плиссировщик.= :
   LLAAM+ or LLACI+;
 
-плиссировщик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 плиссировщик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 плиссировщик.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плиссировщик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пло.= :
   LLAPG+ or LLAQP+ or LLBHS+ or LLBNP+ or LLBPW+ or LLCPQ+ or LLCXI+ or LLCYK+;
@@ -27713,9 +27705,9 @@
 пломбир.= :
   LLAAO+ or LLBYU+ or LLCEM+ or LLCGU+;
 
-пломбир.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пломбир.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пломбир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.170:
   LLDKO+;
@@ -27832,9 +27824,9 @@
 плот.= :
   LLAAS+ or LLBYU+ or LLDNF+;
 
-плот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 плот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 желн.= камс.= плотв.= хамс.= :
   LLAGX+;
@@ -27849,13 +27841,13 @@
 :
   LLARK+;
 
-бычищ.nlmpv великанищ.nlmpv волчищ.nlmpv дружищ.nlmpv дурачищ.nlmpv комарищ.nlmpv 
-котищ.nlmpv мужичищ.nlmpv парнищ.nlmpv плутищ.nlmpv уродищ.nlmpv человечищ.nlmpv 
-:  <morph-С,мр,од,мн,вн>;
-
 бычищ.nlmpg великанищ.nlmpg волчищ.nlmpg дружищ.nlmpg дурачищ.nlmpg комарищ.nlmpg 
 котищ.nlmpg мужичищ.nlmpg парнищ.nlmpg плутищ.nlmpg уродищ.nlmpg человечищ.nlmpg 
 :  <morph-С,мр,од,мн,рд>;
+
+бычищ.nlmpv великанищ.nlmpv волчищ.nlmpv дружищ.nlmpv дурачищ.nlmpv комарищ.nlmpv 
+котищ.nlmpv мужичищ.nlmpv парнищ.nlmpv плутищ.nlmpv уродищ.nlmpv человечищ.nlmpv 
+:  <morph-С,мр,од,мн,вн>;
 
 плы.= слы.= :
   LLCZD+;
@@ -27871,11 +27863,11 @@
 плюс.= :
   LLAAQ+ or LLDTF+ or LLBRK+ or LLBUV+ or LLCCZ+ or LLCGW+;
 
-плюс.i :  <morph-СОЮЗ,0>;
-
 плюс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 плюс.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плюс.i :  <morph-СОЮЗ,0>;
 
 плюх.= :
   LLAEL+ or LLDTP+ or LLAFU+;
@@ -27887,9 +27879,9 @@
 плющ.= :
   LLAAJ+ or LLFAU+ or LLEQX+;
 
-плющ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 плющ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+плющ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пля.= :
   LLCNE+ or LLCNJ+;
@@ -27973,9 +27965,9 @@
 повал.= :
   LLAAQ+ or LLFYV+ or LLFWV+ or LLFWW+ or LLDOK+;
 
-повал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 повал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+повал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 повапленн.= :
   LLDLV+;
@@ -27991,9 +27983,9 @@
 повез.= :
   LLFLY+ or LLGBZ+ or LLFWX+;
 
-повез.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
-
 повез.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
+
+повез.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 повер.= :
   LLGHS+ or LLFXB+ or LLBRK+ or LLFXD+ or LLGHK+ or LLDNT+;
@@ -28010,9 +28002,9 @@
 повод.= прут.= :
   LLAAR+ or LLCJW+;
 
-повод.ndmsv прут.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 повод.ndmsi прут.ndmsi :  <morph-С,мр,но,ед,им>;
+
+повод.ndmsv прут.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 поводыр.= :
   LLDMT+ or LLEDY+;
@@ -28076,9 +28068,9 @@
 
 погиб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-погиб.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
-
 погиб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+погиб.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
 
 поглатыва.= :
   LLFRZ+ or LLEUW+;
@@ -28100,13 +28092,13 @@
 погон.= :
   LLABW+ or LLBYZ+ or LLDJS+ or LLDQC+;
 
-погон.ndmsv :  <morph-С,мр,но,ед,вн>;
+погон.npg :  <morph-С,мн,мн,рд>;
 
 погон.ndmpg :  <morph-С,мр,но,мн,рд>;
 
-погон.ndmsi :  <morph-С,мр,но,ед,им>;
+погон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-погон.npg :  <morph-С,мн,мн,рд>;
+погон.ndmsi :  <morph-С,мр,но,ед,им>;
 
 погор.= :
   LLFXO+ or LLGIN+ or LLFXX+;
@@ -28114,9 +28106,9 @@
 погост.= :
   LLAAQ+ or LLASY+ or LLBYZ+;
 
-погост.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 погост.ndmsi :  <morph-С,мр,но,ед,им>;
+
+погост.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 погре.= :
   LLGIR+ or LLGFG+ or LLGGG+ or LLFXW+ or LLFWU+;
@@ -28124,9 +28116,9 @@
 погреб.= :
   LLABM+ or LLAYB+ or LLCJW+;
 
-погреб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 погреб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+погреб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 погрем.= :
   LLFYT+ or LLCJW+;
@@ -28200,9 +28192,9 @@
 подвиг.= :
   LLAAM+ or LLGAS+ or LLGPD+;
 
-подвиг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подвиг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подвиг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 подвин.= :
   LLFXF+ or LLFXS+ or LLFXT+;
@@ -28297,11 +28289,11 @@
 припыл.= промысл.= укор.= урон.= :
   LLAAQ+ or LLFWV+;
 
-недосол.ndmsv отстрел.ndmsv пересол.ndmsv подкур.ndmsv подпал.ndmsv посол.ndmsv 
-припыл.ndmsv промысл.ndmsv укор.ndmsv урон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 недосол.ndmsi отстрел.ndmsi пересол.ndmsi подкур.ndmsi подпал.ndmsi посол.ndmsi 
 припыл.ndmsi промысл.ndmsi укор.ndmsi урон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+недосол.ndmsv отстрел.ndmsv пересол.ndmsv подкур.ndmsv подпал.ndmsv посол.ndmsv 
+припыл.ndmsv промысл.ndmsv укор.ndmsv урон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 подл.= :
   LLGAY+ or LLDKJ+;
@@ -28318,11 +28310,11 @@
 
 подлаз.nlmsi сомнамбул.nlmsi :  <morph-С,мр,од,ед,им>;
 
-подлаз.nlfpv сомнамбул.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 подлаз.nlmpv сомнамбул.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 подлаз.nlmpg сомнамбул.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+подлаз.nlfpv сомнамбул.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 подле.= :
   LLDTD+ or LLAEK+ or LLFZD+ or LLFYZ+ or LLCZE+;
@@ -28379,11 +28371,11 @@
 подмен.= :
   LLAAQ+ or LLAFX+ or LLFWV+ or LLBYZ+;
 
-подмен.ndmsv :  <morph-С,мр,но,ед,вн>;
+подмен.ndmsi :  <morph-С,мр,но,ед,им>;
 
 подмен.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-подмен.ndmsi :  <morph-С,мр,но,ед,им>;
+подмен.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 подмигива.= :
   LLCZI+ or LLCZM+;
@@ -28455,18 +28447,18 @@
 подпол.= :
   LLAAQ+ or LLDNS+ or LLDOK+;
 
-подпол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подпол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подпол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 подпор.= :
   LLAAQ+ or LLAFX+ or LLBRK+ or LLBYZ+ or LLGAA+ or LLGAB+ or LLGFC+;
 
 подпор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-подпор.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 подпор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подпор.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 подпря.= :
   LLGJP+ or LLGCB+ or LLGCC+;
@@ -28533,11 +28525,11 @@
 подряд.= :
   LLAAQ+ or LLAEK+ or LLBYZ+;
 
-подряд.e :  <morph-Н,0>;
+подряд.ndmsi :  <morph-С,мр,но,ед,им>;
 
 подряд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-подряд.ndmsi :  <morph-С,мр,но,ед,им>;
+подряд.e :  <morph-Н,0>;
 
 подс.= :
   LLALF+ or LLFEI+ or LLAMP+ or LLFEP+ or LLGBM+ or LLFBX+ or LLFEK+ or LLFUE+ or LLFCH+ or LLFER+ or LLFBZ+ or LLFEL+ or LLFWB+ or LLFSB+ or LLFSC+;
@@ -28545,9 +28537,9 @@
 отвод.= подзем.= подсад.= :
   LLAAQ+ or LLBRK+ or LLBYZ+ or LLCJW+;
 
-отвод.ndmsv подзем.ndmsv подсад.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отвод.ndmsi подзем.ndmsi подсад.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отвод.ndmsv подзем.ndmsv подсад.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 подсви.= :
   LLCQV+;
@@ -28596,16 +28588,16 @@
 подсос.= :
   LLAAQ+ or LLFZJ+ or LLFZK+ or LLBYU+ or LLCKD+;
 
-подсос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подсос.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подсос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 отмок.= подсох.= :
   LLAFU+ or LLFYG+;
 
-отмок.vsndpms подсох.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
-
 отмок.ndfpg подсох.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+отмок.vsndpms подсох.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
 
 подковырн.= подстрекн.= хлобыстн.= :
   LLDGI+;
@@ -28632,9 +28624,9 @@
 подтоп.= :
   LLAAQ+ or LLFWK+ or LLBRK+ or LLCJW+ or LLFZB+;
 
-подтоп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подтоп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подтоп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 поду.= :
   LLGIJ+ or LLFZC+ or LLFYB+;
@@ -28664,9 +28656,9 @@
 обмер.= подчал.= :
   LLAAQ+ or LLFXB+ or LLFXC+ or LLBRK+ or LLCJW+;
 
-обмер.ndmsv подчал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 обмер.ndmsi подчал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+обмер.ndmsv подчал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 всклеп.= вытреп.= отреп.= подщип.= притреп.= :
   LLGCJ+;
@@ -28686,9 +28678,9 @@
 поезд.= :
   LLABM+ or LLBRK+;
 
-поезд.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 поезд.ndmsi :  <morph-С,мр,но,ед,им>;
+
+поезд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 заело.= поело.= спрока.= :
   LLGIR+;
@@ -28764,9 +28756,9 @@
 позор.= :
   LLAAQ+ or LLBIA+ or LLBNU+ or LLBYU+;
 
-позор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 позор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+позор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пои.= :
   LLFZS+ or LLFCN+ or LLFEW+ or LLGLF+;
@@ -28796,11 +28788,11 @@
 пока.= :
   LLAEK+ or LLDTM+ or LLGIK+ or LLFXK+ or LLFXL+ or LLFXF+ or LLFXG+ or LLFYM+;
 
-пока.i :  <morph-СОЮЗ,0>;
-
 пока.e :  <morph-Н,0>;
 
 пока.p :  <morph-ЧАСТ,0>;
+
+пока.i :  <morph-СОЮЗ,0>;
 
 питател.= показател.= раздражител.= :
   LLDML+ or LLDOL+;
@@ -28851,9 +28843,9 @@
 покровск.= :
   LLDWW+ or LLFJZ+ or LLBEP+ or LLDYV+ or LLDZV+;
 
-покровск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 покровск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+покровск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вознамер.= заерепен.= захорохор.= обыностран.= опростофил.= поканител.= 
 покручин.= поцеремон.= пригорюн.= принахмур.= притуман.= прифасон.= 
@@ -28887,13 +28879,13 @@
 пол.= :
   LLAAS+ or LLAFX+ or LLGPL+ or LLAOA+ or LLARW+ or LLASO+ or LLGAY+ or LLGDA+ or LLGDB+ or LLBRK+ or LLBVW+ or LLBZL+ or LLCJW+ or LLCLJ+ or LLCLM+ or LLDWH+ or LLDWI+ or LLDIF+ or LLDKJ+ or LLEGE+ or LLDNT+ or LLDNX+ or LLDNY+ or LLFKY+;
 
-пол.amss :  <morph-П,мр,ед,кр>;
-
-пол.ndmsv :  <morph-С,мр,но,ед,вн>;
+пол.ndmsi :  <morph-С,мр,но,ед,им>;
 
 пол.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-пол.ndmsi :  <morph-С,мр,но,ед,им>;
+пол.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+пол.amss :  <morph-П,мр,ед,кр>;
 
 пола.= :
   LLGHL+ or LLGIR+ or LLGHV+ or LLFYM+;
@@ -28923,9 +28915,9 @@
 ползун.= :
   LLAAQ+ or LLACI+ or LLCJW+ or LLCKD+ or LLDPO+;
 
-ползун.nlmsi :  <morph-С,мр,од,ед,им>;
-
 ползун.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+ползун.nlmsi :  <morph-С,мр,од,ед,им>;
 
 ползун.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -28946,14 +28938,6 @@
 :
   LLAGQ+;
 
-аппаратчиц.nlfpg арматурщиц.nlfpg асфальтобетонщиц.nlfpg ворсовальщиц.nlfpg вышивальщиц.nlfpg гардеробщиц.nlfpg 
-дозировщиц.nlfpg лакировщиц.nlfpg обжигальщиц.nlfpg отделочниц.nlfpg паяльщиц.nlfpg переплетчиц.nlfpg 
-поливальщиц.nlfpg полировщиц.nlfpg правопреемниц.nlfpg прессовщиц.nlfpg приемосдатчиц.nlfpg прядильщиц.nlfpg 
-раскладчиц.nlfpg раскройщиц.nlfpg регулировщиц.nlfpg резьбонарезчиц.nlfpg сверловщиц.nlfpg современниц.nlfpg 
-сортировщиц.nlfpg стерженщиц.nlfpg тепличниц.nlfpg термоизолировщиц.nlfpg термоотделочниц.nlfpg транспортерщиц.nlfpg 
-транспортировщиц.nlfpg узловязальщиц.nlfpg усыновительниц.nlfpg шпаклевщиц.nlfpg штамповщиц.nlfpg электрообмотчиц.nlfpg 
-:  <morph-С,жр,од,мн,рд>;
-
 аппаратчиц.nlfpv арматурщиц.nlfpv асфальтобетонщиц.nlfpv ворсовальщиц.nlfpv вышивальщиц.nlfpv гардеробщиц.nlfpv 
 дозировщиц.nlfpv лакировщиц.nlfpv обжигальщиц.nlfpv отделочниц.nlfpv паяльщиц.nlfpv переплетчиц.nlfpv 
 поливальщиц.nlfpv полировщиц.nlfpv правопреемниц.nlfpv прессовщиц.nlfpv приемосдатчиц.nlfpv прядильщиц.nlfpv 
@@ -28961,6 +28945,14 @@
 сортировщиц.nlfpv стерженщиц.nlfpv тепличниц.nlfpv термоизолировщиц.nlfpv термоотделочниц.nlfpv транспортерщиц.nlfpv 
 транспортировщиц.nlfpv узловязальщиц.nlfpv усыновительниц.nlfpv шпаклевщиц.nlfpv штамповщиц.nlfpv электрообмотчиц.nlfpv 
 :  <morph-С,жр,од,мн,вн>;
+
+аппаратчиц.nlfpg арматурщиц.nlfpg асфальтобетонщиц.nlfpg ворсовальщиц.nlfpg вышивальщиц.nlfpg гардеробщиц.nlfpg 
+дозировщиц.nlfpg лакировщиц.nlfpg обжигальщиц.nlfpg отделочниц.nlfpg паяльщиц.nlfpg переплетчиц.nlfpg 
+поливальщиц.nlfpg полировщиц.nlfpg правопреемниц.nlfpg прессовщиц.nlfpg приемосдатчиц.nlfpg прядильщиц.nlfpg 
+раскладчиц.nlfpg раскройщиц.nlfpg регулировщиц.nlfpg резьбонарезчиц.nlfpg сверловщиц.nlfpg современниц.nlfpg 
+сортировщиц.nlfpg стерженщиц.nlfpg тепличниц.nlfpg термоизолировщиц.nlfpg термоотделочниц.nlfpg транспортерщиц.nlfpg 
+транспортировщиц.nlfpg узловязальщиц.nlfpg усыновительниц.nlfpg шпаклевщиц.nlfpg штамповщиц.nlfpg электрообмотчиц.nlfpg 
+:  <morph-С,жр,од,мн,рд>;
 
 политизир.= :
   LLCER+ or LLERB+;
@@ -28975,9 +28967,9 @@
 поллыев.= :
   LLFJG+ or LLFKF+ or LLFKG+;
 
-поллыев.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 поллыев.nlmsi :  <morph-С,мр,од,ед,им>;
+
+поллыев.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 злосчаст.= полновод.= :
   LLBYT+ or LLDNT+;
@@ -29000,11 +28992,11 @@
 половин.= :
   LLAFX+ or LLAGT+ or LLBRK+ or LLBYZ+;
 
+половин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 половин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 половин.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-половин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 облуч.= полож.= :
   LLFXI+ or LLFZZ+ or LLCJW+;
@@ -29017,9 +29009,9 @@
 полоз.= :
   LLAAZ+ or LLACI+ or LLCJW+;
 
-полоз.nlmsi :  <morph-С,мр,од,ед,им>;
-
 полоз.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+полоз.nlmsi :  <morph-С,мр,од,ед,им>;
 
 полоз.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -29029,9 +29021,9 @@
 полон.= :
   LLAAQ+ or LLBHS+ or LLFWV+ or LLBNP+;
 
-полон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 полон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+полон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ассириян.= афинян.= галилеян.= киевлян.= латинян.= персиян.= 
 полонян.= поселян.= римлян.= россиян.= сабинян.= финикиян.= 
@@ -29062,13 +29054,13 @@
 синегорск.= сольвычегодск.= сосновоозерск.= сосногорск.= :
   LLDWW+ or LLDYX+;
 
-полоцк.ndmsv предивинск.ndmsv приокск.ndmsv реченск.ndmsv рудногорск.ndmsv светлогорск.ndmsv 
-светогорск.ndmsv святогорск.ndmsv североуральск.ndmsv серноводск.ndmsv сийск.ndmsv симбирск.ndmsv 
-синегорск.ndmsv сольвычегодск.ndmsv сосновоозерск.ndmsv сосногорск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 полоцк.ndmsi предивинск.ndmsi приокск.ndmsi реченск.ndmsi рудногорск.ndmsi светлогорск.ndmsi 
 светогорск.ndmsi святогорск.ndmsi североуральск.ndmsi серноводск.ndmsi сийск.ndmsi симбирск.ndmsi 
 синегорск.ndmsi сольвычегодск.ndmsi сосновоозерск.ndmsi сосногорск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+полоцк.ndmsv предивинск.ndmsv приокск.ndmsv реченск.ndmsv рудногорск.ndmsv светлогорск.ndmsv 
+светогорск.ndmsv святогорск.ndmsv североуральск.ndmsv серноводск.ndmsv сийск.ndmsv симбирск.ndmsv 
+синегорск.ndmsv сольвычегодск.ndmsv сосновоозерск.ndmsv сосногорск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 полу.= :
   LLGCH+ or LLDZD+;
@@ -29082,9 +29074,9 @@
 ад.= полубред.= :
   LLABA+;
 
-ад.ndmsv полубред.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ад.ndmsi полубред.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ад.ndmsv полубред.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 полугод.= :
   LLAAY+ or LLCKD+;
@@ -29127,11 +29119,11 @@
 полусапог.= :
   LLABT+;
 
+полусапог.ndmsi :  <morph-С,мр,но,ед,им>;
+
 полусапог.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 полусапог.ndmpg :  <morph-С,мр,но,мн,рд>;
-
-полусапог.ndmsi :  <morph-С,мр,но,ед,им>;
 
 полуси.= :
   LLAOC+;
@@ -29164,9 +29156,9 @@
 полян.= :
   LLAFX+ or LLBFS+ or LLBRK+;
 
-полян.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 полян.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+полян.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 полян.nlmpg :  <morph-С,мр,од,мн,рд>;
 
@@ -29241,17 +29233,17 @@
 :
   LLBFM+;
 
-агарян.nlmpv бояр.nlmpv волгожан.nlmpv дунган.nlmpv иркутян.nlmpv калужан.nlmpv 
-клинчан.nlmpv курян.nlmpv минчан.nlmpv мокшан.nlmpv назарян.nlmpv несториан.nlmpv 
-никониан.nlmpv огнищан.nlmpv палешан.nlmpv полчан.nlmpv помочан.nlmpv пражан.nlmpv 
-рижан.nlmpv соборян.nlmpv угличан.nlmpv уличан.nlmpv устюжан.nlmpv чужан.nlmpv 
-:  <morph-С,мр,од,мн,вн>;
-
 агарян.nlmpg бояр.nlmpg волгожан.nlmpg дунган.nlmpg иркутян.nlmpg калужан.nlmpg 
 клинчан.nlmpg курян.nlmpg минчан.nlmpg мокшан.nlmpg назарян.nlmpg несториан.nlmpg 
 никониан.nlmpg огнищан.nlmpg палешан.nlmpg полчан.nlmpg помочан.nlmpg пражан.nlmpg 
 рижан.nlmpg соборян.nlmpg угличан.nlmpg уличан.nlmpg устюжан.nlmpg чужан.nlmpg 
 :  <morph-С,мр,од,мн,рд>;
+
+агарян.nlmpv бояр.nlmpv волгожан.nlmpv дунган.nlmpv иркутян.nlmpv калужан.nlmpv 
+клинчан.nlmpv курян.nlmpv минчан.nlmpv мокшан.nlmpv назарян.nlmpv несториан.nlmpv 
+никониан.nlmpv огнищан.nlmpv палешан.nlmpv полчан.nlmpv помочан.nlmpv пражан.nlmpv 
+рижан.nlmpv соборян.nlmpv угличан.nlmpv уличан.nlmpv устюжан.nlmpv чужан.nlmpv 
+:  <morph-С,мр,од,мн,вн>;
 
 понабре.= :
   LLFSE+;
@@ -29340,11 +29332,11 @@
 попов.= :
   LLFQF+ or LLFUO+ or LLBUX+;
 
+попов.admsv :  <morph-П,мр,ед,вн,но>;
+
 попов.amsi :  <morph-П,мр,ед,им>;
 
 попов.nlmsi :  <morph-С,мр,од,ед,им>;
-
-попов.admsv :  <morph-П,мр,ед,вн,но>;
 
 пополз.= :
   LLAVM+ or LLGBZ+;
@@ -29421,9 +29413,9 @@
 порося.= :
   LLADN+;
 
-порося.nlnsi :  <morph-С,ср,од,ед,им>;
-
 порося.nlnsv :  <morph-С,ср,од,ед,вн>;
+
+порося.nlnsi :  <morph-С,ср,од,ед,им>;
 
 /ru/words/words.181:
   LLCIZ+;
@@ -29439,9 +29431,9 @@
 порт.= :
   LLAAS+ or LLBSO+ or LLDJV+;
 
-порт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 порт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+порт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 портач.= :
   LLACF+ or LLBFZ+;
@@ -29460,9 +29452,9 @@
 портрет.= сюжет.= характер.= :
   LLAAQ+ or LLAXZ+ or LLBYU+;
 
-портрет.ndmsv сюжет.ndmsv характер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 портрет.ndmsi сюжет.ndmsi характер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+портрет.ndmsv сюжет.ndmsv характер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бенгал.= латгал.= народовол.= португал.= сидел.= :
   LLAYK+ or LLBRO+;
@@ -29480,14 +29472,14 @@
 :
   LLAAQ+ or LLAFX+ or LLBYU+;
 
-банкнот.ndmsv вариант.ndmsv гранат.ndmsv карьер.ndmsv порфир.ndmsv пурпур.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
-
 банкнот.ndfpg вариант.ndfpg гранат.ndfpg карьер.ndfpg порфир.ndfpg пурпур.ndfpg 
 :  <morph-С,жр,но,мн,рд>;
 
 банкнот.ndmsi вариант.ndmsi гранат.ndmsi карьер.ndmsi порфир.ndmsi пурпур.ndmsi 
 :  <morph-С,мр,но,ед,им>;
+
+банкнот.ndmsv вариант.ndmsv гранат.ndmsv карьер.ndmsv порфир.ndmsv пурпур.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
 
 викун.= дуэн.= пиран.= порхун.= резвун.= :
   LLDPO+;
@@ -29527,9 +29519,9 @@
 бридж.= овощ.= поскребыш.= :
   LLAAH+ or LLBCB+;
 
-бридж.ndmsv овощ.ndmsv поскребыш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бридж.ndmsi овощ.ndmsi поскребыш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бридж.ndmsv овощ.ndmsv поскребыш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выезжа.= досыпа.= заправля.= засыпа.= изменя.= наезжа.= 
 недоеда.= недосыпа.= облеза.= отзыва.= послабля.= промока.= 
@@ -29566,11 +29558,11 @@
 навык.= посох.= :
   LLAAM+ or LLFYG+;
 
-навык.ndmsv посох.ndmsv :  <morph-С,мр,но,ед,вн>;
+навык.ndmsi посох.ndmsi :  <morph-С,мр,но,ед,им>;
 
 навык.vsndpms посох.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
 
-навык.ndmsi посох.ndmsi :  <morph-С,мр,но,ед,им>;
+навык.ndmsv посох.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ниспа.= поспа.= совпа.= упа.= :
   LLGBQ+;
@@ -29581,25 +29573,25 @@
 пост.= :
   LLAAS+ or LLGGK+ or LLGJZ+ or LLBYU+;
 
-пост.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пост.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пост.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 постав.= :
   LLABM+ or LLAYB+ or LLFYW+ or LLBRK+ or LLBYZ+ or LLEAJ+;
+
+постав.npg :  <morph-С,мн,мн,рд>;
 
 постав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 постав.ndmsi :  <morph-С,мр,но,ед,им>;
 
-постав.npg :  <morph-С,мн,мн,рд>;
-
 постанов.= :
   LLAAQ+ or LLBJG+ or LLGBN+ or LLBRK+;
 
-постанов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 постанов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+постанов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 постановля.= :
   LLERD+ or LLDEP+;
@@ -29652,9 +29644,9 @@
 пот.= :
   LLAAP+ or LLGFQ+ or LLGGT+ or LLBYU+;
 
-пот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 поте.= :
   LLGBT+ or LLCZE+ or LLGCU+;
@@ -29702,11 +29694,11 @@
 :
   LLAFU+ or LLBBY+;
 
-вериг.ndfpg кеньг.ndfpg колик.ndfpg краг.ndfpg потуг.ndfpg рюх.ndfpg 
-:  <morph-С,жр,но,мн,рд>;
-
 вериг.npg кеньг.npg колик.npg краг.npg потуг.npg рюх.npg 
 :  <morph-С,мн,мн,рд>;
+
+вериг.ndfpg кеньг.ndfpg колик.ndfpg краг.ndfpg потуг.ndfpg рюх.ndfpg 
+:  <morph-С,жр,но,мн,рд>;
 
 потуп.= :
   LLFYR+ or LLFYX+;
@@ -29790,9 +29782,9 @@
 почин.= :
   LLAAQ+ or LLFWV+ or LLFWW+ or LLBRK+ or LLBYZ+ or LLEDT+ or LLCJW+;
 
-почин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 почин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+почин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бесн.= кучк.= почк.= соревн.= :
   LLCGW+;
@@ -29831,11 +29823,11 @@
 правда.= равно.= :
   LLAEK+ or LLAEL+ or LLDTI+;
 
-правда.i равно.i :  <morph-СОЮЗ,0>;
+правда.e равно.e :  <morph-Н,0>;
 
 правда.xn равно.xn :  <morph-ПРЕДК,нст>;
 
-правда.e равно.e :  <morph-Н,0>;
+правда.i равно.i :  <morph-СОЮЗ,0>;
 
 правдолюб.= :
   LLACI+ or LLAYI+ or LLBDD+;
@@ -29872,9 +29864,9 @@
 практик.= :
   LLACG+ or LLAFU+ or LLEQA+ or LLCGW+;
 
-практик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 практик.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+практик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пращ.= :
   LLAAJ+ or LLAGA+;
@@ -30053,13 +30045,13 @@
 предтеч.= :
   LLAFE+ or LLBRI+;
 
-предтеч.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 предтеч.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+предтеч.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 предтеч.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-предтеч.nlmpg :  <morph-С,мр,од,мн,рд>;
+предтеч.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 предубежден.= :
   LLBDC+ or LLFVE+;
@@ -30144,9 +30136,9 @@
 англикан.= пресвитериан.= :
   LLAYI+ or LLBFT+ or LLBRO+;
 
-англикан.nlmpv пресвитериан.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 англикан.nlmpg пресвитериан.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+англикан.nlmpv пресвитериан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 пресвя.= :
   LLCYY+;
@@ -30257,9 +30249,9 @@
 приговор.= :
   LLAAQ+ or LLBKX+ or LLBRK+;
 
-приговор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 приговор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+приговор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пригор.= :
   LLFXX+ or LLCJW+;
@@ -30273,13 +30265,13 @@
 придир.= улыб.= :
   LLAFH+ or LLBRK+;
 
-придир.nlfpg улыб.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 придир.nlfpv улыб.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+придир.nlmpg улыб.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 придир.nlmpv улыб.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-придир.nlmpg улыб.nlmpg :  <morph-С,мр,од,мн,рд>;
+придир.nlfpg улыб.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 придур.= :
   LLCKD+ or LLDNF+;
@@ -30304,22 +30296,22 @@
 приживал.= :
   LLACI+ or LLAFH+ or LLBRO+;
 
+приживал.nlmpv :  <morph-С,мр,од,мн,вн>;
+
 приживал.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 приживал.nlmsi :  <morph-С,мр,од,ед,им>;
 
 приживал.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-приживал.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 приживал.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 приз.= :
   LLAAQ+ or LLGAX+;
 
-приз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 приз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+приз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 закален.= насторожен.= обязан.= помешан.= призван.= утолщен.= 
 ухожен.= :
@@ -30359,22 +30351,22 @@
 прилипал.= :
   LLAFH+ or LLCAA+;
 
-прилипал.nlfpg :  <morph-С,жр,од,мн,рд>;
+прилипал.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 прилипал.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-прилипал.nlmpv :  <morph-С,мр,од,мн,вн>;
+прилипал.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-прилипал.nlmpg :  <morph-С,мр,од,мн,рд>;
+прилипал.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 прим.= :
   LLAFX+ or LLAGT+ or LLGJH+ or LLGFE+ or LLFZD+ or LLGFK+ or LLGQF+;
 
+прим.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 прим.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 прим.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-прим.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 обма.= перере.= подма.= прима.= сре.= :
   LLFZN+ or LLGCF+;
@@ -30388,9 +30380,9 @@
 пример.= :
   LLAAQ+ or LLFXB+ or LLFXC+ or LLBRK+ or LLBYU+;
 
-пример.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пример.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пример.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вочеловеч.= закочевряж.= затревож.= искособоч.= осередняч.= поднатуж.= 
 покочевряж.= примерещ.= раздурач.= разнедуж.= раскураж.= :
@@ -30406,11 +30398,11 @@
 :
   LLABN+ or LLBYZ+;
 
-корпус.ndmsv примус.ndmsv рупор.ndmsv сектор.ndmsv туер.ndmsv штуцер.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
-
 корпус.ndmsi примус.ndmsi рупор.ndmsi сектор.ndmsi туер.ndmsi штуцер.ndmsi 
 :  <morph-С,мр,но,ед,им>;
+
+корпус.ndmsv примус.ndmsv рупор.ndmsv сектор.ndmsv туер.ndmsv штуцер.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
 
 недопо.= переза.= приза.= прина.= :
   LLGHO+;
@@ -30444,9 +30436,9 @@
 приостанов.= :
   LLAAQ+ or LLFWK+ or LLBON+ or LLBRL+;
 
-приостанов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 приостанов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+приостанов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 насты.= опосты.= осты.= подсты.= поосты.= приосты.= 
 просты.= :
@@ -30466,18 +30458,18 @@
 
 припас.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
-припас.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 припас.ndmsi :  <morph-С,мр,но,ед,им>;
+
+припас.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 припек.= :
   LLAAK+ or LLAFU+;
 
 припек.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-припек.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 припек.ndmsi :  <morph-С,мр,но,ед,им>;
+
+припек.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 приплющ.= :
   LLGFX+;
@@ -30495,9 +30487,9 @@
 обрез.= прирез.= :
   LLAAQ+ or LLBRK+ or LLCJW+ or LLDNF+;
 
-обрез.ndmsv прирез.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 обрез.ndmsi прирез.ndmsi :  <morph-С,мр,но,ед,им>;
+
+обрез.ndmsv прирез.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 выровн.= заровн.= обровн.= подравн.= подровн.= поравн.= 
 поровн.= приравн.= прировн.= разровн.= сровн.= уравн.= 
@@ -30518,14 +30510,14 @@
 яг.= :
   LLAFU+ or LLAGR+;
 
-бодяг.nlfpg прислуг.nlfpg присух.nlfpg фаланг.nlfpg черепах.nlfpg шутих.nlfpg 
-яг.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 бодяг.nlfpv прислуг.nlfpv присух.nlfpv фаланг.nlfpv черепах.nlfpv шутих.nlfpv 
 яг.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 бодяг.ndfpg прислуг.ndfpg присух.ndfpg фаланг.ndfpg черепах.ndfpg шутих.ndfpg 
 яг.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+бодяг.nlfpg прислуг.nlfpg присух.nlfpg фаланг.nlfpg черепах.nlfpg шутих.nlfpg 
+яг.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 прислуж.= :
   LLFSW+ or LLFZZ+;
@@ -30560,11 +30552,11 @@
 пристав.= :
   LLAAQ+ or LLACQ+ or LLFYW+ or LLBRK+;
 
-пристав.nlmsi :  <morph-С,мр,од,ед,им>;
-
 пристав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пристав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пристав.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пристальн.= удостоверительн.= фолиев.= :
   LLDLI+;
@@ -30591,9 +30583,9 @@
 приступ.= :
   LLAAQ+ or LLGBC+ or LLFXQ+ or LLBRK+ or LLCJW+;
 
-приступ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 приступ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+приступ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 присты.= :
   LLGCH+ or LLGKB+ or LLFVY+;
@@ -30610,15 +30602,15 @@
 притвор.= :
   LLAAQ+ or LLAFH+ or LLFWV+ or LLFWW+ or LLBYU+;
 
-притвор.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-притвор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-притвор.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 притвор.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 притвор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+притвор.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+притвор.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+притвор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 притвор.nlmpg :  <morph-С,мр,од,мн,рд>;
 
@@ -30630,9 +30622,9 @@
 притоп.= :
   LLAAQ+ or LLFZB+ or LLGJI+;
 
-притоп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 притоп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+притоп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 подгру.= притормо.= :
   LLFYQ+;
@@ -30666,9 +30658,9 @@
 приход.= :
   LLAAQ+ or LLBYZ+ or LLCDC+;
 
-приход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 приход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+приход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 приходиться.= :
   LLFLU+;
@@ -30708,11 +30700,11 @@
 пришиб.= :
   LLDWW+ or LLGCX+;
 
+пришиб.ndmsi :  <morph-С,мр,но,ед,им>;
+
 пришиб.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 пришиб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-пришиб.ndmsi :  <morph-С,мр,но,ед,им>;
 
 прищи.= :
   LLCME+;
@@ -30744,9 +30736,9 @@
 пробел.= :
   LLABN+ or LLFWV+ or LLFWW+ or LLBRK+ or LLDNF+ or LLDOO+;
 
-пробел.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пробел.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пробел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пробир.= :
   LLBRK+ or LLBYU+ or LLFRF+ or LLEUU+;
@@ -30766,13 +30758,13 @@
 провар.= раскур.= увар.= :
   LLAAQ+ or LLFWV+ or LLFWW+ or LLBRK+;
 
-вывал.ndmsv выдел.ndmsv досол.ndmsv закал.ndmsv заслон.ndmsv навал.ndmsv 
-накал.ndmsv оговор.ndmsv перевар.ndmsv передел.ndmsv перекал.ndmsv подсол.ndmsv 
-провар.ndmsv раскур.ndmsv увар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 вывал.ndmsi выдел.ndmsi досол.ndmsi закал.ndmsi заслон.ndmsi навал.ndmsi 
 накал.ndmsi оговор.ndmsi перевар.ndmsi передел.ndmsi перекал.ndmsi подсол.ndmsi 
 провар.ndmsi раскур.ndmsi увар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+вывал.ndmsv выдел.ndmsv досол.ndmsv закал.ndmsv заслон.ndmsv навал.ndmsv 
+накал.ndmsv оговор.ndmsv перевар.ndmsv передел.ndmsv перекал.ndmsv подсол.ndmsv 
+провар.ndmsv раскур.ndmsv увар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 прове.= :
   LLFWM+ or LLFWN+ or LLFXE+ or LLFYL+ or LLFYM+;
@@ -30797,9 +30789,9 @@
 провод.= :
   LLABM+ or LLBRK+ or LLCJW+ or LLDJV+;
 
-провод.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 провод.ndmsi :  <morph-С,мр,но,ед,им>;
+
+провод.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 проводников.= :
   LLDLT+;
@@ -30813,13 +30805,13 @@
 провор.= :
   LLAFH+ or LLBIA+ or LLBNU+ or LLBYU+ or LLFDA+;
 
-провор.nlfpg :  <morph-С,жр,од,мн,рд>;
+провор.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 провор.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-провор.nlmpv :  <morph-С,мр,од,мн,вн>;
+провор.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-провор.nlmpg :  <morph-С,мр,од,мн,рд>;
+провор.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 пог.= прог.= :
   LLGAP+ or LLGPB+;
@@ -30857,9 +30849,9 @@
 придел.= прогул.= футбол.= :
   LLAAQ+ or LLBRK+ or LLDOK+;
 
-придел.ndmsv прогул.ndmsv футбол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 придел.ndmsi прогул.ndmsi футбол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+придел.ndmsv прогул.ndmsv футбол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 прогундо.= :
   LLERK+;
@@ -30933,9 +30925,9 @@
 прок.= :
   LLAAK+ or LLFWB+;
 
-прок.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 прок.ndmsi :  <morph-С,мр,но,ед,им>;
+
+прок.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 прока.= :
   LLBAD+ or LLFYQ+ or LLFXF+ or LLFXG+;
@@ -30966,11 +30958,11 @@
 прокоп.= :
   LLAAQ+ or LLFKJ+ or LLFKI+ or LLBRK+ or LLFYZ+ or LLFXF+ or LLFXG+;
 
+прокоп.ndmsi :  <morph-С,мр,но,ед,им>;
+
 прокоп.nlmsi :  <morph-С,мр,од,ед,им>;
 
 прокоп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-прокоп.ndmsi :  <morph-С,мр,но,ед,им>;
 
 амвроси.= антипи.= аполлинари.= арсени.= артеми.= аурели.= 
 афанаси.= варсанофи.= викенти.= дари.= димитри.= диониси.= 
@@ -31014,19 +31006,19 @@
 пролаз.= :
   LLAAQ+ or LLACI+ or LLAFH+;
 
-пролаз.nlfpg :  <morph-С,жр,од,мн,рд>;
+пролаз.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-пролаз.nlmsi :  <morph-С,мр,од,ед,им>;
+пролаз.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 пролаз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-пролаз.nlfpv :  <morph-С,жр,од,мн,вн>;
+пролаз.ndmsi :  <morph-С,мр,но,ед,им>;
 
 пролаз.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-пролаз.ndmsi :  <morph-С,мр,но,ед,им>;
+пролаз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-пролаз.nlmpg :  <morph-С,мр,од,мн,рд>;
+пролаз.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пролеж.= :
   LLGAT+ or LLAVL+ or LLBRI+;
@@ -31037,30 +31029,30 @@
 пролив.= :
   LLAAQ+ or LLAVL+ or LLBYZ+;
 
-пролив.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пролив.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пролив.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пролин.= :
   LLAAY+ or LLFRG+;
 
-пролин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пролин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пролин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ворох.= кожух.= пролог.= :
   LLABG+;
 
-ворох.ndmsv кожух.ndmsv пролог.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ворох.ndmsi кожух.ndmsi пролог.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ворох.ndmsv кожух.ndmsv пролог.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пролом.= :
   LLAAQ+ or LLFWK+ or LLFXQ+ or LLBYZ+;
 
-пролом.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пролом.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пролом.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 забормо.= набормо.= побормо.= пробормо.= пролепе.= пролопо.= 
 :
@@ -31113,9 +31105,9 @@
 прообраз.= :
   LLAAQ+ or LLFRG+;
 
-прообраз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 прообраз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+прообраз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 прооперир.= :
   LLGQK+;
@@ -31198,9 +31190,9 @@
 проруб.= :
   LLAAQ+ or LLFWK+ or LLFXQ+ or LLBRK+ or LLDNF+;
 
-проруб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 проруб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+проруб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 поры.= проры.= :
   LLGPT+;
@@ -31301,11 +31293,11 @@
 просто.= :
   LLAEK+ or LLAEL+ or LLDTS+ or LLBPJ+ or LLBQK+ or LLGHU+;
 
-просто.xn :  <morph-ПРЕДК,нст>;
-
 просто.e :  <morph-Н,0>;
 
 просто.p :  <morph-ЧАСТ,0>;
+
+просто.xn :  <morph-ПРЕДК,нст>;
 
 безразлич.= бесчест.= простодуш.= :
   LLBDD+ or LLBYU+ or LLDNT+;
@@ -31321,9 +31313,9 @@
 прострел.= :
   LLAAQ+ or LLFSU+;
 
-прострел.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 прострел.ndmsi :  <morph-С,мр,но,ед,им>;
+
+прострел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 проступ.= :
   LLGBC+ or LLCJW+ or LLDNF+;
@@ -31419,9 +31411,9 @@
 прототип.= :
   LLAAQ+ or LLACI+ or LLBZI+;
 
-прототип.nlmsi :  <morph-С,мр,од,ед,им>;
-
 прототип.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+прототип.nlmsi :  <morph-С,мр,од,ед,им>;
 
 прототип.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -31444,15 +31436,6 @@
 /ru/words/words.191:
   LLAGO+;
 
-администраторш.nlfpg аккомпаниаторш.nlfpg арендаторш.nlfpg бандерш.nlfpg билетерш.nlfpg бухгалтерш.nlfpg 
-гастролерш.nlfpg гипнотизерш.nlfpg губернаторш.nlfpg декламаторш.nlfpg инициаторш.nlfpg инспекторш.nlfpg 
-инструкторш.nlfpg капельдинерш.nlfpg киоскерш.nlfpg комендантш.nlfpg композиторш.nlfpg кондитерш.nlfpg 
-кондукторш.nlfpg контролерш.nlfpg кухмистерш.nlfpg литераторш.nlfpg миллиардерш.nlfpg миллионерш.nlfpg 
-модельерш.nlfpg надзирательш.nlfpg олуш.nlfpg организаторш.nlfpg пекарш.nlfpg политиканш.nlfpg 
-почтальонш.nlfpg почтмейстерш.nlfpg предводительш.nlfpg провизорш.nlfpg провокаторш.nlfpg профессорш.nlfpg 
-репетиторш.nlfpg скульпторш.nlfpg смотрительш.nlfpg стриптизерш.nlfpg узурпаторш.nlfpg унтер-офицерш.nlfpg 
-управительш.nlfpg фабрикантш.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 администраторш.nlfpv аккомпаниаторш.nlfpv арендаторш.nlfpv бандерш.nlfpv билетерш.nlfpv бухгалтерш.nlfpv 
 гастролерш.nlfpv гипнотизерш.nlfpv губернаторш.nlfpv декламаторш.nlfpv инициаторш.nlfpv инспекторш.nlfpv 
 инструкторш.nlfpv капельдинерш.nlfpv киоскерш.nlfpv комендантш.nlfpv композиторш.nlfpv кондитерш.nlfpv 
@@ -31461,6 +31444,15 @@
 почтальонш.nlfpv почтмейстерш.nlfpv предводительш.nlfpv провизорш.nlfpv провокаторш.nlfpv профессорш.nlfpv 
 репетиторш.nlfpv скульпторш.nlfpv смотрительш.nlfpv стриптизерш.nlfpv узурпаторш.nlfpv унтер-офицерш.nlfpv 
 управительш.nlfpv фабрикантш.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+администраторш.nlfpg аккомпаниаторш.nlfpg арендаторш.nlfpg бандерш.nlfpg билетерш.nlfpg бухгалтерш.nlfpg 
+гастролерш.nlfpg гипнотизерш.nlfpg губернаторш.nlfpg декламаторш.nlfpg инициаторш.nlfpg инспекторш.nlfpg 
+инструкторш.nlfpg капельдинерш.nlfpg киоскерш.nlfpg комендантш.nlfpg композиторш.nlfpg кондитерш.nlfpg 
+кондукторш.nlfpg контролерш.nlfpg кухмистерш.nlfpg литераторш.nlfpg миллиардерш.nlfpg миллионерш.nlfpg 
+модельерш.nlfpg надзирательш.nlfpg олуш.nlfpg организаторш.nlfpg пекарш.nlfpg политиканш.nlfpg 
+почтальонш.nlfpg почтмейстерш.nlfpg предводительш.nlfpg провизорш.nlfpg провокаторш.nlfpg профессорш.nlfpg 
+репетиторш.nlfpg скульпторш.nlfpg смотрительш.nlfpg стриптизерш.nlfpg узурпаторш.nlfpg унтер-офицерш.nlfpg 
+управительш.nlfpg фабрикантш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 бемол.= зажигател.= кабел.= ковыл.= миндал.= профил.= 
 утил.= хрустал.= цокол.= :
@@ -31536,9 +31528,9 @@
 мост.= мыс.= паз.= пруд.= :
   LLAAS+ or LLCJW+;
 
-мост.ndmsv мыс.ndmsv паз.ndmsv пруд.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 мост.ndmsi мыс.ndmsi паз.ndmsi пруд.ndmsi :  <morph-С,мр,но,ед,им>;
+
+мост.ndmsv мыс.ndmsv паз.ndmsv пруд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пружин.= :
   LLAFX+ or LLBGU+ or LLBIA+ or LLBNU+ or LLBRK+ or LLBYU+;
@@ -31571,9 +31563,9 @@
 пряслиц.= :
   LLAFO+ or LLARS+;
 
-пряслиц.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 пряслиц.ndnpg :  <morph-С,ср,но,мн,рд>;
+
+пряслиц.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 псал.= :
   LLCKQ+;
@@ -31587,24 +31579,24 @@
 псевдоадрес.= :
   LLABO+;
 
-псевдоадрес.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 псевдоадрес.ndmsi :  <morph-С,мр,но,ед,им>;
+
+псевдоадрес.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 псин.= :
   LLAEY+ or LLAFX+ or LLAGT+ or LLDKJ+;
 
-псин.amss :  <morph-П,мр,ед,кр>;
+псин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-псин.nlfpg :  <morph-С,жр,од,мн,рд>;
+псин.amss :  <morph-П,мр,ед,кр>;
 
 псин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-псин.ndfpg :  <morph-С,жр,но,мн,рд>;
+псин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 псин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-псин.nlmpg :  <morph-С,мр,од,мн,рд>;
+псин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 казак.= комик.= псих.= чумак.= :
   LLACG+ or LLCBF+;
@@ -31615,11 +31607,11 @@
 политкаторжан.= псковитян.= самаритян.= сограждан.= филистимлян.= :
   LLBFT+ or LLBRO+;
 
-вавилонян.nlmpv израильтян.nlmpv карфагенян.nlmpv магометан.nlmpv малороссиян.nlmpv островитян.nlmpv 
-политкаторжан.nlmpv псковитян.nlmpv самаритян.nlmpv сограждан.nlmpv филистимлян.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 вавилонян.nlmpg израильтян.nlmpg карфагенян.nlmpg магометан.nlmpg малороссиян.nlmpg островитян.nlmpg 
 политкаторжан.nlmpg псковитян.nlmpg самаритян.nlmpg сограждан.nlmpg филистимлян.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+вавилонян.nlmpv израильтян.nlmpv карфагенян.nlmpv магометан.nlmpv малороссиян.nlmpv островитян.nlmpv 
+политкаторжан.nlmpv псковитян.nlmpv самаритян.nlmpv сограждан.nlmpv филистимлян.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 птицефабрик.= :
   LLAFV+ or LLEEW+;
@@ -31634,19 +31626,19 @@
 якушкин.= :
   LLFJK+;
 
-бацын.nlmsi безмельницын.nlmsi бессолицын.nlmsi бесхмельницын.nlmsi брицын.nlmsi брусницын.nlmsi 
-бурдавицын.nlmsi вавицын.nlmsi вязаницын.nlmsi гоголицын.nlmsi голицын.nlmsi грызунов.nlmsi 
-демин.nlmsi доильницын.nlmsi дощицын.nlmsi драницын.nlmsi ельцин.nlmsi кислицын.nlmsi 
-косицын.nlmsi крицын.nlmsi лисицын.nlmsi наговицын.nlmsi перепелицын.nlmsi потылицын.nlmsi 
-птицын.nlmsi пшеницын.nlmsi синицын.nlmsi спицын.nlmsi хачукаев.nlmsi черномырдин.nlmsi 
-якушкин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 бацын.nlmsv безмельницын.nlmsv бессолицын.nlmsv бесхмельницын.nlmsv брицын.nlmsv брусницын.nlmsv 
 бурдавицын.nlmsv вавицын.nlmsv вязаницын.nlmsv гоголицын.nlmsv голицын.nlmsv грызунов.nlmsv 
 демин.nlmsv доильницын.nlmsv дощицын.nlmsv драницын.nlmsv ельцин.nlmsv кислицын.nlmsv 
 косицын.nlmsv крицын.nlmsv лисицын.nlmsv наговицын.nlmsv перепелицын.nlmsv потылицын.nlmsv 
 птицын.nlmsv пшеницын.nlmsv синицын.nlmsv спицын.nlmsv хачукаев.nlmsv черномырдин.nlmsv 
 якушкин.nlmsv :  <morph-С,мр,од,ед,вн>;
+
+бацын.nlmsi безмельницын.nlmsi бессолицын.nlmsi бесхмельницын.nlmsi брицын.nlmsi брусницын.nlmsi 
+бурдавицын.nlmsi вавицын.nlmsi вязаницын.nlmsi гоголицын.nlmsi голицын.nlmsi грызунов.nlmsi 
+демин.nlmsi доильницын.nlmsi дощицын.nlmsi драницын.nlmsi ельцин.nlmsi кислицын.nlmsi 
+косицын.nlmsi крицын.nlmsi лисицын.nlmsi наговицын.nlmsi перепелицын.nlmsi потылицын.nlmsi 
+птицын.nlmsi пшеницын.nlmsi синицын.nlmsi спицын.nlmsi хачукаев.nlmsi черномырдин.nlmsi 
+якушкин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 птич.= :
   LLBFF+ or LLBRI+ or LLBRM+ or LLEAU+;
@@ -31659,9 +31651,9 @@
 божеств.= пугал.= :
   LLCAG+ or LLCAQ+;
 
-божеств.nlnpg пугал.nlnpg :  <morph-С,ср,од,мн,рд>;
-
 божеств.ndnpg пугал.ndnpg :  <morph-С,ср,но,мн,рд>;
+
+божеств.nlnpg пугал.nlnpg :  <morph-С,ср,од,мн,рд>;
 
 божеств.nlnpv пугал.nlnpv :  <morph-С,ср,од,мн,вн>;
 
@@ -31717,11 +31709,11 @@
 
 пустельг.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-пустельг.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 пустельг.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 пустельг.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+пустельг.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 безголосиц.= безработиц.= мокропогодиц.= надкостниц.= надхрящниц.= пепелиц.= 
 пересортиц.= печеночниц.= пицц.= пустоколосиц.= узкополосиц.= череззерниц.= 
@@ -31752,6 +31744,32 @@
 
 /ru/words/words.192:
   LLAAM+ or LLACG+;
+
+бактериофаг.ndmsi балясник.ndmsi баранчик.ndmsi благовестник.ndmsi блинник.ndmsi боевик.ndmsi 
+болванчик.ndmsi болотник.ndmsi большак.ndmsi букашник.ndmsi булавочник.ndmsi бумажник.ndmsi 
+вестник.ndmsi воздушник.ndmsi воловик.ndmsi волосатик.ndmsi голубятник.ndmsi гонококк.ndmsi 
+гречишник.ndmsi гусятник.ndmsi двойник.ndmsi дворник.ndmsi диплококк.ndmsi дровяник.ndmsi 
+ершик.ndmsi живчик.ndmsi зайчик.ndmsi законник.ndmsi запасник.ndmsi зеленчук.ndmsi 
+иголочник.ndmsi каботажник.ndmsi камышник.ndmsi канонник.ndmsi капустник.ndmsi каретник.ndmsi 
+кодировщик.ndmsi кокк.ndmsi коник.ndmsi котик.ndmsi крапивник.ndmsi крольчатник.ndmsi 
+кулак.ndmsi курятник.ndmsi лосятник.ndmsi лох.ndmsi малинник.ndmsi маточник.ndmsi 
+матрасник.ndmsi медвежатник.ndmsi мертвяк.ndmsi месячник.ndmsi метчик.ndmsi микрококк.ndmsi 
+молочник.ndmsi муравейник.ndmsi навозник.ndmsi нагрузчик.ndmsi неводник.ndmsi ночник.ndmsi 
+огуречник.ndmsi орлик.ndmsi орляк.ndmsi отладчик.ndmsi отметчик.ndmsi отпрыск.ndmsi 
+палочник.ndmsi парусник.ndmsi передатчик.ndmsi пересыльщик.ndmsi перехватчик.ndmsi песенник.ndmsi 
+пикник.ndmsi плужник.ndmsi пневмококк.ndmsi погрузчик.ndmsi подборщик.ndmsi подорожник.ndmsi 
+подручник.ndmsi половник.ndmsi постельник.ndmsi посудник.ndmsi призрак.ndmsi пробник.ndmsi 
+пробочник.ndmsi проводник.ndmsi прокладчик.ndmsi птичник.ndmsi пуговичник.ndmsi пузанчик.ndmsi 
+путеукладчик.ndmsi пухляк.ndmsi пыжик.ndmsi радужник.ndmsi раешник.ndmsi разгрузчик.ndmsi 
+разрядник.ndmsi резак.ndmsi резчик.ndmsi решетник.ndmsi розанчик.ndmsi ручник.ndmsi 
+рыбник.ndmsi рыжик.ndmsi рыхляк.ndmsi рябинник.ndmsi рябчик.ndmsi связник.ndmsi 
+сердечник.ndmsi сеточник.ndmsi солнечник.ndmsi спальник.ndmsi споровик.ndmsi спутник.ndmsi 
+стафилококк.ndmsi субботник.ndmsi счетчик.ndmsi телятник.ndmsi тенетник.ndmsi терпуг.ndmsi 
+торфяник.ndmsi третьяк.ndmsi трубоукладчик.ndmsi тумак.ndmsi тупик.ndmsi тюфяк.ndmsi 
+угольник.ndmsi угольщик.ndmsi ударник.ndmsi уник.ndmsi франк.ndmsi цыплятник.ndmsi 
+частик.ndmsi червяк.ndmsi чижик.ndmsi чистик.ndmsi шпорник.ndmsi штурмовик.ndmsi 
+эксцентрик.ndmsi энтерококк.ndmsi эхинококк.ndmsi яблочник.ndmsi ягнятник.ndmsi ягодник.ndmsi 
+язык.ndmsi :  <morph-С,мр,но,ед,им>;
 
 бактериофаг.nlmsi балясник.nlmsi баранчик.nlmsi благовестник.nlmsi блинник.nlmsi боевик.nlmsi 
 болванчик.nlmsi болотник.nlmsi большак.nlmsi букашник.nlmsi булавочник.nlmsi бумажник.nlmsi 
@@ -31805,50 +31823,24 @@
 эксцентрик.ndmsv энтерококк.ndmsv эхинококк.ndmsv яблочник.ndmsv ягнятник.ndmsv ягодник.ndmsv 
 язык.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-бактериофаг.ndmsi балясник.ndmsi баранчик.ndmsi благовестник.ndmsi блинник.ndmsi боевик.ndmsi 
-болванчик.ndmsi болотник.ndmsi большак.ndmsi букашник.ndmsi булавочник.ndmsi бумажник.ndmsi 
-вестник.ndmsi воздушник.ndmsi воловик.ndmsi волосатик.ndmsi голубятник.ndmsi гонококк.ndmsi 
-гречишник.ndmsi гусятник.ndmsi двойник.ndmsi дворник.ndmsi диплококк.ndmsi дровяник.ndmsi 
-ершик.ndmsi живчик.ndmsi зайчик.ndmsi законник.ndmsi запасник.ndmsi зеленчук.ndmsi 
-иголочник.ndmsi каботажник.ndmsi камышник.ndmsi канонник.ndmsi капустник.ndmsi каретник.ndmsi 
-кодировщик.ndmsi кокк.ndmsi коник.ndmsi котик.ndmsi крапивник.ndmsi крольчатник.ndmsi 
-кулак.ndmsi курятник.ndmsi лосятник.ndmsi лох.ndmsi малинник.ndmsi маточник.ndmsi 
-матрасник.ndmsi медвежатник.ndmsi мертвяк.ndmsi месячник.ndmsi метчик.ndmsi микрококк.ndmsi 
-молочник.ndmsi муравейник.ndmsi навозник.ndmsi нагрузчик.ndmsi неводник.ndmsi ночник.ndmsi 
-огуречник.ndmsi орлик.ndmsi орляк.ndmsi отладчик.ndmsi отметчик.ndmsi отпрыск.ndmsi 
-палочник.ndmsi парусник.ndmsi передатчик.ndmsi пересыльщик.ndmsi перехватчик.ndmsi песенник.ndmsi 
-пикник.ndmsi плужник.ndmsi пневмококк.ndmsi погрузчик.ndmsi подборщик.ndmsi подорожник.ndmsi 
-подручник.ndmsi половник.ndmsi постельник.ndmsi посудник.ndmsi призрак.ndmsi пробник.ndmsi 
-пробочник.ndmsi проводник.ndmsi прокладчик.ndmsi птичник.ndmsi пуговичник.ndmsi пузанчик.ndmsi 
-путеукладчик.ndmsi пухляк.ndmsi пыжик.ndmsi радужник.ndmsi раешник.ndmsi разгрузчик.ndmsi 
-разрядник.ndmsi резак.ndmsi резчик.ndmsi решетник.ndmsi розанчик.ndmsi ручник.ndmsi 
-рыбник.ndmsi рыжик.ndmsi рыхляк.ndmsi рябинник.ndmsi рябчик.ndmsi связник.ndmsi 
-сердечник.ndmsi сеточник.ndmsi солнечник.ndmsi спальник.ndmsi споровик.ndmsi спутник.ndmsi 
-стафилококк.ndmsi субботник.ndmsi счетчик.ndmsi телятник.ndmsi тенетник.ndmsi терпуг.ndmsi 
-торфяник.ndmsi третьяк.ndmsi трубоукладчик.ndmsi тумак.ndmsi тупик.ndmsi тюфяк.ndmsi 
-угольник.ndmsi угольщик.ndmsi ударник.ndmsi уник.ndmsi франк.ndmsi цыплятник.ndmsi 
-частик.ndmsi червяк.ndmsi чижик.ndmsi чистик.ndmsi шпорник.ndmsi штурмовик.ndmsi 
-эксцентрик.ndmsi энтерококк.ndmsi эхинококк.ndmsi яблочник.ndmsi ягнятник.ndmsi ягодник.ndmsi 
-язык.ndmsi :  <morph-С,мр,но,ед,им>;
-
 путиловск.= :
   LLBEM+ or LLDYS+;
 
 путин.= :
   LLFJG+ or LLAFX+ or LLBYZ+;
 
-путин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 путин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+путин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пух.= :
   LLAAX+ or LLBVZ+;
 
-пух.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 пух.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пух.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пух.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 дрюч.= клоч.= пуч.= стож.= :
   LLBHH+ or LLBMV+ or LLCJW+;
@@ -31859,15 +31851,15 @@
 губкин.= ляпин.= пушкин.= :
   LLDWW+ or LLFQF+ or LLFJT+;
 
+губкин.nlmsi ляпин.nlmsi пушкин.nlmsi :  <morph-С,мр,од,ед,им>;
+
 губкин.nlfpg ляпин.nlfpg пушкин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-губкин.nlmsi ляпин.nlmsi пушкин.nlmsi :  <morph-С,мр,од,ед,им>;
+губкин.ndmsi ляпин.ndmsi пушкин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 губкин.ndmsv ляпин.ndmsv пушкин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 губкин.nlfpv ляпин.nlfpv пушкин.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-губкин.ndmsi ляпин.ndmsi пушкин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 пушкиниан.= :
   LLAFX+ or LLAYI+;
@@ -31892,9 +31884,9 @@
 пчел.= :
   LLAGT+ or LLBRO+ or LLDOO+;
 
-пчел.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 пчел.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+пчел.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 /ru/words/words.193:
   LLFQF+ or LLFOU+;
@@ -31932,9 +31924,9 @@
 пшик.= :
   LLAAM+ or LLDTP+;
 
-пшик.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пшик.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пшик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пы.= :
   LLDHB+;
@@ -31952,9 +31944,9 @@
 пылесос.= :
   LLAAQ+ or LLERQ+ or LLERR+;
 
-пылесос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 пылесос.ndmsi :  <morph-С,мр,но,ед,им>;
+
+пылесос.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пых.= :
   LLAEL+ or LLDTP+ or LLCVR+;
@@ -32071,13 +32063,13 @@
 спецсемлесхоз.= станкозавод.= станкоремзавод.= стеклозавод.= :
   LLEEH+;
 
-поссовет.ndmsv потребсоюз.ndmsv прудхоз.ndmsv птицесовхоз.ndmsv радиотехникум.ndmsv райкомзем.ndmsv 
-райотдел.ndmsv райпотребсоюз.ndmsv респотребсоюз.ndmsv роспотребсоюз.ndmsv рыбзавод.ndmsv рыбколхоз.ndmsv 
-спецсемлесхоз.ndmsv станкозавод.ndmsv станкоремзавод.ndmsv стеклозавод.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 поссовет.ndmsi потребсоюз.ndmsi прудхоз.ndmsi птицесовхоз.ndmsi радиотехникум.ndmsi райкомзем.ndmsi 
 райотдел.ndmsi райпотребсоюз.ndmsi респотребсоюз.ndmsi роспотребсоюз.ndmsi рыбзавод.ndmsi рыбколхоз.ndmsi 
 спецсемлесхоз.ndmsi станкозавод.ndmsi станкоремзавод.ndmsi стеклозавод.ndmsi :  <morph-С,мр,но,ед,им>;
+
+поссовет.ndmsv потребсоюз.ndmsv прудхоз.ndmsv птицесовхоз.ndmsv радиотехникум.ndmsv райкомзем.ndmsv 
+райотдел.ndmsv райпотребсоюз.ndmsv респотребсоюз.ndmsv роспотребсоюз.ndmsv рыбзавод.ndmsv рыбколхоз.ndmsv 
+спецсемлесхоз.ndmsv станкозавод.ndmsv станкоремзавод.ndmsv стеклозавод.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.195:
   LLBYU+ or LLDNF+;
@@ -32085,24 +32077,24 @@
 раж.= :
   LLAAH+ or LLBDQ+;
 
-раж.amss :  <morph-П,мр,ед,кр>;
+раж.ndmsi :  <morph-С,мр,но,ед,им>;
 
 раж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-раж.ndmsi :  <morph-С,мр,но,ед,им>;
+раж.amss :  <morph-П,мр,ед,кр>;
 
 раз.= :
   LLABW+ or LLAEK+ or LLDTI+ or LLFWP+ or LLFYE+ or LLFXH+ or LLFYN+ or LLFXY+ or LLFXZ+ or LLGKS+ or LLGKT+ or LLGAD+ or LLGAE+ or LLGAG+ or LLGAH+ or LLBYZ+ or LLGAJ+ or LLFZF+ or LLGAL+ or LLGQV+ or LLFZG+ or LLFZH+ or LLCJW+;
 
+раз.ndmsi :  <morph-С,мр,но,ед,им>;
+
 раз.i :  <morph-СОЮЗ,0>;
+
+раз.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 раз.e :  <morph-Н,0>;
 
 раз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-раз.ndmpg :  <morph-С,мр,но,мн,рд>;
-
-раз.ndmsi :  <morph-С,мр,но,ед,им>;
 
 разбе.= :
   LLGQI+ or LLFYD+;
@@ -32125,9 +32117,9 @@
 разбурав.= :
   LLAAQ+ or LLFTD+;
 
-разбурав.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 разбурав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+разбурав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 разв.= :
   LLGCG+;
@@ -32142,18 +32134,18 @@
 развалин.= :
   LLAGT+ or LLDJS+;
 
-развалин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 развалин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 развалин.npg :  <morph-С,мн,мн,рд>;
 
+развалин.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 разве.= :
   LLDTM+ or LLFWM+ or LLFWN+ or LLFXE+ or LLFYK+ or LLFYL+ or LLFYM+;
 
-разве.i :  <morph-СОЮЗ,0>;
-
 разве.p :  <morph-ЧАСТ,0>;
+
+разве.i :  <morph-СОЮЗ,0>;
 
 обвер.= развер.= :
   LLFXD+ or LLGHK+;
@@ -32206,9 +32198,9 @@
 подговор.= разговор.= :
   LLAAQ+ or LLFSU+ or LLFDD+;
 
-подговор.ndmsv разговор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подговор.ndmsi разговор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подговор.ndmsv разговор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 всмотр.= засмотр.= разгор.= :
   LLGAQ+;
@@ -32251,9 +32243,9 @@
 отдел.= раздел.= :
   LLAAQ+ or LLFWV+ or LLFWW+ or LLBRK+ or LLDOK+;
 
-отдел.ndmsv раздел.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 отдел.ndmsi раздел.ndmsi :  <morph-С,мр,но,ед,им>;
+
+отдел.ndmsv раздел.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 раздин.= :
   LLFJT+ or LLFHJ+;
@@ -32291,11 +32283,11 @@
 раззяв.= :
   LLAFH+ or LLFYW+;
 
+раззяв.nlmpv :  <morph-С,мр,од,мн,вн>;
+
 раззяв.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 раззяв.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-раззяв.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 раззяв.nlmpg :  <morph-С,мр,од,мн,рд>;
 
@@ -32334,9 +32326,9 @@
 размер.= :
   LLAAQ+ or LLFXB+ or LLBYU+;
 
-размер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 размер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+размер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 размин.= :
   LLBRK+ or LLFWG+;
@@ -32396,9 +32388,9 @@
 разноцвет.= :
   LLAAQ+ or LLBYU+ or LLDNT+;
 
-разноцвет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 разноцвет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+разноцвет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 разношерст.= тонкошерст.= :
   LLBYT+ or LLDLO+;
@@ -32493,22 +32485,22 @@
 :
   LLAAQ+ or LLEEK+;
 
-автоагрегат.ndmsv биокомбинат.ndmsv биофизприбор.ndmsv втуз.ndmsv газаппарат.ndmsv гидротехотряд.ndmsv 
-гипротрубопровод.ndmsv госплан.ndmsv госстандарт.ndmsv камаз.ndmsv муниципалитет.ndmsv облпотребсоюз.ndmsv 
-пединститут.ndmsv пентагон.ndmsv радиоприбор.ndmsv райвоенкомат.ndmsv спорткомитет.ndmsv экофонд.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
-
 автоагрегат.ndmsi биокомбинат.ndmsi биофизприбор.ndmsi втуз.ndmsi газаппарат.ndmsi гидротехотряд.ndmsi 
 гипротрубопровод.ndmsi госплан.ndmsi госстандарт.ndmsi камаз.ndmsi муниципалитет.ndmsi облпотребсоюз.ndmsi 
 пединститут.ndmsi пентагон.ndmsi радиоприбор.ndmsi райвоенкомат.ndmsi спорткомитет.ndmsi экофонд.ndmsi 
 :  <morph-С,мр,но,ед,им>;
 
+автоагрегат.ndmsv биокомбинат.ndmsv биофизприбор.ndmsv втуз.ndmsv газаппарат.ndmsv гидротехотряд.ndmsv 
+гипротрубопровод.ndmsv госплан.ndmsv госстандарт.ndmsv камаз.ndmsv муниципалитет.ndmsv облпотребсоюз.ndmsv 
+пединститут.ndmsv пентагон.ndmsv радиоприбор.ndmsv райвоенкомат.ndmsv спорткомитет.ndmsv экофонд.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
+
 райисполком.= :
   LLAAQ+ or LLEEH+;
 
-райисполком.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 райисполком.ndmsi :  <morph-С,мр,но,ед,им>;
+
+райисполком.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 жуляби.= ракали.= :
   LLDPY+;
@@ -32516,11 +32508,11 @@
 рамазан.= :
   LLAAQ+ or LLFKO+ or LLFIH+;
 
-рамазан.nlmsi :  <morph-С,мр,од,ед,им>;
-
 рамазан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рамазан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+рамазан.nlmsi :  <morph-С,мр,од,ед,им>;
 
 рамалл.= :
   LLFPN+;
@@ -32545,9 +32537,9 @@
 нивелир.= ранжир.= :
   LLAAQ+ or LLCDC+;
 
-нивелир.ndmsv ранжир.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 нивелир.ndmsi ранжир.ndmsi :  <morph-С,мр,но,ед,им>;
+
+нивелир.ndmsv ранжир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рапорт.= :
   LLABN+ or LLCCZ+ or LLCFR+ or LLCGW+;
@@ -32585,11 +32577,11 @@
 раскос.= :
   LLAAQ+ or LLBRK+ or LLDKF+;
 
+раскос.ndmsi :  <morph-С,мр,но,ед,им>;
+
 раскос.amss :  <morph-П,мр,ед,кр>;
 
 раскос.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-раскос.ndmsi :  <morph-С,мр,но,ед,им>;
 
 взбаламу.= взлохма.= засекре.= излохма.= намагни.= обюрокра.= 
 подмагни.= разлохма.= размагни.= раскосма.= :
@@ -32622,9 +32614,9 @@
 распар.= счал.= :
   LLAAQ+ or LLFXB+ or LLFXC+ or LLBRK+;
 
-распар.ndmsv счал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 распар.ndmsi счал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+распар.ndmsv счал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 распелена.= :
   LLFCU+ or LLFDG+;
@@ -32670,9 +32662,9 @@
 закол.= откол.= раскол.= распор.= :
   LLAAQ+ or LLBRK+ or LLGAA+ or LLGAB+;
 
-закол.ndmsv откол.ndmsv раскол.ndmsv распор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 закол.ndmsi откол.ndmsi раскол.ndmsi распор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+закол.ndmsv откол.ndmsv раскол.ndmsv распор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 распоря.= :
   LLAQS+;
@@ -32763,16 +32755,16 @@
 рассол.= :
   LLAAO+ or LLDOO+;
 
-рассол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 рассол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+рассол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рассомах.= :
   LLAGS+;
 
-рассомах.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 рассомах.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+рассомах.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 рассор.= :
   LLGKM+ or LLGEO+;
@@ -32840,20 +32832,20 @@
 растреп.= :
   LLAFH+ or LLGCJ+ or LLGCL+ or LLBRH+;
 
+растреп.nlmpv :  <morph-С,мр,од,мн,вн>;
+
 растреп.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 растреп.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-растреп.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 растреп.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 раструб.= :
   LLAAQ+ or LLFWK+ or LLBYZ+;
 
-раструб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 раструб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+раструб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 расформир.= :
   LLCFX+ or LLCHP+;
@@ -32974,17 +32966,17 @@
 рев.= :
   LLAAQ+ or LLAFH+ or LLAWP+;
 
-рев.nlfpg :  <morph-С,жр,од,мн,рд>;
+рев.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 рев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рев.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-рев.nlmpv :  <morph-С,мр,од,мн,вн>;
+рев.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 рев.ndmsi :  <morph-С,мр,но,ед,им>;
 
-рев.nlmpg :  <morph-С,мр,од,мн,рд>;
+рев.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 дебютир.= дегенерир.= коалир.= парашютир.= реваншир.= рикошетир.= 
 финишир.= :
@@ -33030,9 +33022,9 @@
 рез.= :
   LLAAQ+ or LLAYB+ or LLBRK+ or LLBSW+ or LLDNF+;
 
-рез.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 рез.ndmsi :  <morph-С,мр,но,ед,им>;
+
+рез.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 резан.= :
   LLAFX+ or LLFWL+ or LLDLO+;
@@ -33083,9 +33075,9 @@
 рем.= :
   LLFKQ+ or LLFHQ+ or LLAFX+ or LLAVL+;
 
-рем.nlmsi :  <morph-С,мр,од,ед,им>;
-
 рем.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+рем.nlmsi :  <morph-С,мр,од,ед,им>;
 
 реми.= :
   LLBAP+ or LLBBI+;
@@ -33101,9 +33093,9 @@
 
 ренат.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-ренат.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 ренат.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+ренат.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 реорганиз.= :
   LLEQA+ or LLFWB+ or LLCHL+ or LLCHV+;
@@ -33154,9 +33146,9 @@
 
 борисов.nlmsi ольгин.nlmsi реутов.nlmsi :  <morph-С,мр,од,ед,им>;
 
-борисов.ndmsv ольгин.ndmsv реутов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 борисов.ndmsi ольгин.ndmsi реутов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+борисов.ndmsv ольгин.ndmsv реутов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рециркулир.= :
   LLESB+ or LLENL+;
@@ -33267,16 +33259,16 @@
 риск.= шик.= :
   LLAAK+ or LLCBF+;
 
-риск.ndmsv шик.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 риск.ndmsi шик.ndmsi :  <morph-С,мр,но,ед,им>;
+
+риск.ndmsv шик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ангор.= ришт.= :
   LLAGL+ or LLAGT+;
 
-ангор.nlfpg ришт.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 ангор.nlfpv ришт.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+ангор.nlfpg ришт.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 ркрп.= :
   LLFVV+;
@@ -33295,22 +33287,22 @@
 ровно.= :
   LLAEK+ or LLDTM+ or LLDXD+;
 
-ровно.i :  <morph-СОЮЗ,0>;
+ровно.ndn :  <morph-С,ср,но,0>;
 
 ровно.e :  <morph-Н,0>;
 
-ровно.ndn :  <morph-С,ср,но,0>;
-
 ровно.p :  <morph-ЧАСТ,0>;
+
+ровно.i :  <morph-СОЮЗ,0>;
 
 рогатин.= :
   LLDWW+ or LLAFX+ or LLBRK+;
 
-рогатин.ndmsv :  <morph-С,мр,но,ед,вн>;
+рогатин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 рогатин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-рогатин.ndmsi :  <morph-С,мр,но,ед,им>;
+рогатин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 путов.= рогов.= :
   LLFOU+ or LLCJC+;
@@ -33323,9 +33315,9 @@
 род.= :
   LLABQ+ or LLDJV+;
 
-род.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 род.ndmsi :  <morph-С,мр,но,ед,им>;
+
+род.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 родим.= :
   LLAXZ+ or LLDKF+;
@@ -33363,11 +33355,11 @@
 роз.= :
   LLAFX+ or LLFIQ+ or LLAMY+ or LLFHX+ or LLBYU+;
 
-роз.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 роз.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 роз.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+роз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 заговен.= розговен.= :
   LLDJS+ or LLDNT+;
@@ -33387,18 +33379,18 @@
 рококо.= :
   LLABZ+ or LLADL+ or LLAEG+;
 
-рококо.ndn :  <morph-С,ср,но,0>;
-
 рококо.a :  <morph-П,0>;
 
 рококо.ndm :  <morph-С,мр,но,0>;
 
+рококо.ndn :  <morph-С,ср,но,0>;
+
 рол.= :
   LLAAQ+ or LLDNF+ or LLDNX+ or LLDOO+ or LLDOZ+ or LLDQC+;
 
-рол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 рол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+рол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ром.= :
   LLAAO+ or LLDZL+;
@@ -33410,15 +33402,15 @@
 роман.= :
   LLAAQ+ or LLFJM+ or LLFJL+ or LLAYI+ or LLBYZ+;
 
-роман.nlmsi :  <morph-С,мр,од,ед,им>;
-
 роман.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+роман.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+роман.nlmsi :  <morph-С,мр,од,ед,им>;
 
 роман.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 роман.ndmsi :  <morph-С,мр,но,ед,им>;
-
-роман.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 абсолютизир.= гипнотизир.= демуниципализир.= драматизир.= идеализир.= рецензир.= 
 романтизир.= :
@@ -33629,9 +33621,9 @@
 ронж.= :
   LLAFM+ or LLAGO+;
 
-ронж.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 ронж.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+ронж.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 ронж.ndfpg :  <morph-С,жр,но,мн,рд>;
 
@@ -33682,9 +33674,9 @@
 ростов.= :
   LLDWW+ or LLDXJ+ or LLFOU+ or LLCJC+ or LLDLO+;
 
-ростов.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ростов.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ростов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 арктикуг.= башкируг.= беловоуг.= вахрушевразрезуг.= вахрушевуг.= воркутауг.= 
 востсибуг.= гуковуг.= дальвостокуг.= зарубежуг.= интауг.= киселевскуг.= 
@@ -33746,13 +33738,13 @@
 руин.= :
   LLAFX+ or LLAGT+ or LLBYU+ or LLDJS+;
 
-руин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-руин.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 руин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
+руин.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 руин.npg :  <morph-С,мн,мн,рд>;
+
+руин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 руково.= :
   LLAOZ+ or LLAPE+ or LLAQP+;
@@ -33849,9 +33841,9 @@
 рыбин.= :
   LLAFX+ or LLAGT+ or LLBRO+;
 
-рыбин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 рыбин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+рыбин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 рыбин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
@@ -33890,9 +33882,9 @@
 рюш.= :
   LLAAH+ or LLBRI+ or LLBYU+;
 
-рюш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 рюш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+рюш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ряб.= :
   LLBII+ or LLBNN+ or LLCIS+ or LLCKD+ or LLDNF+;
@@ -33929,9 +33921,9 @@
 бутов.= сабуров.= :
   LLFQF+ or LLDZR+ or LLDKJ+;
 
-бутов.amss сабуров.amss :  <morph-П,мр,ед,кр>;
-
 бутов.nlmsi сабуров.nlmsi :  <morph-С,мр,од,ед,им>;
+
+бутов.amss сабуров.amss :  <morph-П,мр,ед,кр>;
 
 саврас.= :
   LLACI+ or LLBRH+ or LLDKF+;
@@ -33969,11 +33961,11 @@
 сак.= :
   LLAAM+ or LLDYJ+;
 
+сак.npg :  <morph-С,мн,мн,рд>;
+
 сак.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сак.ndmsi :  <morph-С,мр,но,ед,им>;
-
-сак.npg :  <morph-С,мн,мн,рд>;
 
 сал.= :
   LLBIA+ or LLBNU+ or LLBRH+ or LLBSP+ or LLCAG+ or LLDOK+ or LLDPD+;
@@ -33985,13 +33977,13 @@
 чертяг.= чертяк.= юнг.= ярыг.= :
   LLAEX+;
 
-аг.nlmpv владык.nlmpv вояк.nlmpv забулдыг.nlmpv кожемяк.nlmpv парнюг.nlmpv 
-парняг.nlmpv расстриг.nlmpv рубак.nlmpv салаг.nlmpv слуг.nlmpv служак.nlmpv 
-чертяг.nlmpv чертяк.nlmpv юнг.nlmpv ярыг.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 аг.nlmpg владык.nlmpg вояк.nlmpg забулдыг.nlmpg кожемяк.nlmpg парнюг.nlmpg 
 парняг.nlmpg расстриг.nlmpg рубак.nlmpg салаг.nlmpg слуг.nlmpg служак.nlmpg 
 чертяг.nlmpg чертяк.nlmpg юнг.nlmpg ярыг.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+аг.nlmpv владык.nlmpv вояк.nlmpv забулдыг.nlmpv кожемяк.nlmpv парнюг.nlmpv 
+парняг.nlmpv расстриг.nlmpv рубак.nlmpv салаг.nlmpv слуг.nlmpv служак.nlmpv 
+чертяг.nlmpv чертяк.nlmpv юнг.nlmpv ярыг.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 автогон.= взаимопостав.= деньжон.= догонял.= дожин.= задвор.= 
 закор.= зен.= карпет.= колгот.= микит.= напад.= 
@@ -34077,9 +34069,9 @@
 сан.= :
   LLAAQ+ or LLDXR+ or LLBCE+ or LLBSP+ or LLBYZ+ or LLFKX+;
 
-сан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 сан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 пярну.= сан-марино.= сан-пауло.= сантьяго-де-куба.= :
   LLDWT+;
@@ -34110,40 +34102,40 @@
 рушайло.= сапиро.= :
   LLEBR+ or LLEBZ+;
 
-рушайло.nlmsi сапиро.nlmsi :  <morph-С,мр,од,ед,им>;
-
-рушайло.nlmpi сапиро.nlmpi :  <morph-С,мр,од,мн,им>;
+рушайло.nlmpp сапиро.nlmpp :  <morph-С,мр,од,мн,пр>;
 
 рушайло.nlmpt сапиро.nlmpt :  <morph-С,мр,од,мн,тв>;
 
-рушайло.nlmst сапиро.nlmst :  <morph-С,мр,од,ед,тв>;
+рушайло.nlmpg сапиро.nlmpg :  <morph-С,мр,од,мн,рд>;
 
-рушайло.nlmpd сапиро.nlmpd :  <morph-С,мр,од,мн,дт>;
-
-рушайло.nlmsp сапиро.nlmsp :  <morph-С,мр,од,ед,пр>;
+рушайло.nlmpi сапиро.nlmpi :  <morph-С,мр,од,мн,им>;
 
 рушайло.nlmsv сапиро.nlmsv :  <morph-С,мр,од,ед,вн>;
 
 рушайло.nlmsd сапиро.nlmsd :  <morph-С,мр,од,ед,дт>;
 
+рушайло.nlmsi сапиро.nlmsi :  <morph-С,мр,од,ед,им>;
+
 рушайло.nlmsg сапиро.nlmsg :  <morph-С,мр,од,ед,рд>;
 
+рушайло.nlmsp сапиро.nlmsp :  <morph-С,мр,од,ед,пр>;
+
+рушайло.nlmst сапиро.nlmst :  <morph-С,мр,од,ед,тв>;
+
+рушайло.nlmpd сапиро.nlmpd :  <morph-С,мр,од,мн,дт>;
+
 рушайло.nlmpv сапиро.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-рушайло.nlmpp сапиро.nlmpp :  <morph-С,мр,од,мн,пр>;
-
-рушайло.nlmpg сапиро.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 сапог.= :
   LLABT+ or LLBBY+;
 
 сапог.ndmsv :  <morph-С,мр,но,ед,вн>;
 
+сапог.npg :  <morph-С,мн,мн,рд>;
+
 сапог.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 сапог.ndmsi :  <morph-С,мр,но,ед,им>;
-
-сапог.npg :  <morph-С,мн,мн,рд>;
 
 сапож.= :
   LLBSN+ or LLBYZ+ or LLCJT+;
@@ -34177,11 +34169,11 @@
 сардин.= :
   LLAGT+ or LLAYI+ or LLBRO+ or LLDJS+;
 
-сардин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 сардин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 сардин.npg :  <morph-С,мн,мн,рд>;
+
+сардин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 парасол.= перкал.= сарсапарел.= сассапарел.= :
   LLDML+ or LLDNF+;
@@ -34200,11 +34192,11 @@
 
 сатан.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-сатан.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 сатан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 сатан.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+сатан.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 карамзин.= сафин.= :
   LLFOQ+;
@@ -34229,9 +34221,9 @@
 саш.= :
   LLFLD+;
 
-саш.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 саш.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+саш.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 перезаб.= позаб.= сб.= :
   LLGHJ+ or LLGIF+;
@@ -34277,9 +34269,9 @@
 свал.= :
   LLAAQ+ or LLFYV+ or LLFWV+ or LLFWW+ or LLBRK+ or LLDOK+;
 
-свал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 свал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+свал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сванидзе.= :
   LLFLP+ or LLFJY+;
@@ -34306,9 +34298,9 @@
 свекров.= :
   LLFUO+ or LLDNL+;
 
-свекров.amsi :  <morph-П,мр,ед,им>;
-
 свекров.admsv :  <morph-П,мр,ед,вн,но>;
+
+свекров.amsi :  <morph-П,мр,ед,им>;
 
 свер.= :
   LLGIH+ or LLFXA+ or LLFXB+ or LLFXC+ or LLBRK+ or LLFXD+;
@@ -34321,9 +34313,9 @@
 сверлил.= :
   LLCAA+;
 
-сверлил.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 сверлил.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+сверлил.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 равновелик.= сверхвысок.= сверхглубок.= :
   LLBDX+;
@@ -34348,9 +34340,9 @@
 свет.= :
   LLAAX+ or LLAYB+ or LLBUG+;
 
-свет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 свет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+свет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 светил.= :
   LLCAG+ or LLCAQ+ or LLDOO+ or LLDOZ+;
@@ -34364,11 +34356,11 @@
 светло.= темно.= :
   LLAEG+ or LLAEK+ or LLAEL+;
 
+светло.a темно.a :  <morph-П,0>;
+
 светло.xn темно.xn :  <morph-ПРЕДК,нст>;
 
 светло.e темно.e :  <morph-Н,0>;
-
-светло.a темно.a :  <morph-П,0>;
 
 деж.= свеч.= :
   LLAGC+ or LLBRI+;
@@ -34390,9 +34382,9 @@
 свинин.= :
   LLFQF+ or LLAFX+ or LLBRK+;
 
-свинин.nlmsi :  <morph-С,мр,од,ед,им>;
-
 свинин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+свинин.nlmsi :  <morph-С,мр,од,ед,им>;
 
 свинобо.= :
   LLAYG+ or LLBPS+;
@@ -34470,9 +34462,9 @@
 
 навис.ndmsv провис.ndmsv сгиб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-навис.vsndpms провис.vsndpms сгиб.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
-
 навис.ndmsi провис.ndmsi сгиб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+навис.vsndpms провис.vsndpms сгиб.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
 
 сгла.= :
   LLGHL+ or LLGIL+ or LLGKU+;
@@ -34513,9 +34505,9 @@
 сев.= :
   LLAAQ+ or LLAYJ+ or LLCJW+;
 
-сев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 сев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 израил.= севастопол.= :
   LLAYK+ or LLEAT+;
@@ -34538,9 +34530,9 @@
 седан.= :
   LLDWW+ or LLAAQ+;
 
-седан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 седан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+седан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 седел.= :
   LLBRK+ or LLDOO+ or LLDPD+;
@@ -34555,14 +34547,14 @@
 секач.= толкач.= :
   LLAAJ+ or LLACF+;
 
-гладыш.nlmsi горбач.nlmsi копач.nlmsi кряж.nlmsi пугач.nlmsi рогач.nlmsi 
-секач.nlmsi толкач.nlmsi :  <morph-С,мр,од,ед,им>;
-
 гладыш.ndmsv горбач.ndmsv копач.ndmsv кряж.ndmsv пугач.ndmsv рогач.ndmsv 
 секач.ndmsv толкач.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 гладыш.ndmsi горбач.ndmsi копач.ndmsi кряж.ndmsi пугач.ndmsi рогач.ndmsi 
 секач.ndmsi толкач.ndmsi :  <morph-С,мр,но,ед,им>;
+
+гладыш.nlmsi горбач.nlmsi копач.nlmsi кряж.nlmsi пугач.nlmsi рогач.nlmsi 
+секач.nlmsi толкач.nlmsi :  <morph-С,мр,од,ед,им>;
 
 секрет.= :
   LLAAQ+ or LLAXZ+ or LLBRK+ or LLBYU+;
@@ -34598,9 +34590,9 @@
 белух.= журавлих.= калуг.= селенг.= :
   LLAGR+ or LLDXP+;
 
-белух.nlfpg журавлих.nlfpg калуг.nlfpg селенг.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 белух.nlfpv журавлих.nlfpv калуг.nlfpv селенг.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+белух.nlfpg журавлих.nlfpg калуг.nlfpg селенг.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 болог.= кубенск.= куровск.= маковск.= новояворовск.= паланск.= 
 ретюнск.= ровкульск.= сарезск.= селецк.= синдорск.= тростенск.= 
@@ -34634,14 +34626,6 @@
 хуторян.= эрзян.= южан.= :
   LLBFM+ or LLBRO+;
 
-англичан.nlmpv аравитян.nlmpv армян.nlmpv волжан.nlmpv гаитян.nlmpv галичан.nlmpv 
-горожан.nlmpv датчан.nlmpv дворян.nlmpv дехкан.nlmpv египтян.nlmpv зырян.nlmpv 
-каторжан.nlmpv клирошан.nlmpv крестьян.nlmpv критян.nlmpv лаотян.nlmpv лужичан.nlmpv 
-лютеран.nlmpv марсиан.nlmpv мещан.nlmpv мирян.nlmpv могикан.nlmpv молдаван.nlmpv 
-мусульман.nlmpv однополчан.nlmpv односельчан.nlmpv парижан.nlmpv поезжан.nlmpv поморян.nlmpv 
-прихожан.nlmpv пуритан.nlmpv северян.nlmpv сельчан.nlmpv слобожан.nlmpv христиан.nlmpv 
-хуторян.nlmpv эрзян.nlmpv южан.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 англичан.nlmpg аравитян.nlmpg армян.nlmpg волжан.nlmpg гаитян.nlmpg галичан.nlmpg 
 горожан.nlmpg датчан.nlmpg дворян.nlmpg дехкан.nlmpg египтян.nlmpg зырян.nlmpg 
 каторжан.nlmpg клирошан.nlmpg крестьян.nlmpg критян.nlmpg лаотян.nlmpg лужичан.nlmpg 
@@ -34649,6 +34633,14 @@
 мусульман.nlmpg однополчан.nlmpg односельчан.nlmpg парижан.nlmpg поезжан.nlmpg поморян.nlmpg 
 прихожан.nlmpg пуритан.nlmpg северян.nlmpg сельчан.nlmpg слобожан.nlmpg христиан.nlmpg 
 хуторян.nlmpg эрзян.nlmpg южан.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+англичан.nlmpv аравитян.nlmpv армян.nlmpv волжан.nlmpv гаитян.nlmpv галичан.nlmpv 
+горожан.nlmpv датчан.nlmpv дворян.nlmpv дехкан.nlmpv египтян.nlmpv зырян.nlmpv 
+каторжан.nlmpv клирошан.nlmpv крестьян.nlmpv критян.nlmpv лаотян.nlmpv лужичан.nlmpv 
+лютеран.nlmpv марсиан.nlmpv мещан.nlmpv мирян.nlmpv могикан.nlmpv молдаван.nlmpv 
+мусульман.nlmpv однополчан.nlmpv односельчан.nlmpv парижан.nlmpv поезжан.nlmpv поморян.nlmpv 
+прихожан.nlmpv пуритан.nlmpv северян.nlmpv сельчан.nlmpv слобожан.nlmpv христиан.nlmpv 
+хуторян.nlmpv эрзян.nlmpv южан.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 сем.= :
   LLDTS+ or LLAFX+ or LLDWO+ or LLDWQ+ or LLDWR+ or LLDPK+ or LLDQZ+;
@@ -34660,9 +34652,9 @@
 барабан.= майдан.= семафор.= штопор.= :
   LLAAQ+ or LLBGR+ or LLBYZ+;
 
-барабан.ndmsv майдан.ndmsv семафор.ndmsv штопор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 барабан.ndmsi майдан.ndmsi семафор.ndmsi штопор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+барабан.ndmsv майдан.ndmsv семафор.ndmsv штопор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 семе.= :
   LLBPW+ or LLBQI+;
@@ -34700,9 +34692,9 @@
 сеностав.= :
   LLAAQ+ or LLAYI+ or LLBRO+;
 
-сеностав.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 сеностав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сеностав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сенсибилизир.= :
   LLCGD+ or LLEQV+ or LLEPR+;
@@ -34720,18 +34712,18 @@
 серафимович.= :
   LLDWV+ or LLEBG+;
 
-серафимович.nlmsi :  <morph-С,мр,од,ед,им>;
-
 серафимович.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 серафимович.ndmsi :  <morph-С,мр,но,ед,им>;
 
+серафимович.nlmsi :  <morph-С,мр,од,ед,им>;
+
 варшавян.= селян.= сербиян.= славян.= :
   LLBFS+ or LLBRK+ or LLBRO+;
 
-варшавян.nlmpv селян.nlmpv сербиян.nlmpv славян.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 варшавян.nlmpg селян.nlmpg сербиян.nlmpg славян.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+варшавян.nlmpv селян.nlmpv сербиян.nlmpv славян.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 бюстгальт.= серв.= чаб.= :
   LLAVQ+;
@@ -34780,9 +34772,9 @@
 сет.= :
   LLAAQ+ or LLDWW+ or LLBRK+ or LLBYZ+ or LLCBF+ or LLDNF+;
 
-сет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 сет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сеян.= :
   LLAXZ+ or LLBRK+ or LLDLO+;
@@ -34820,16 +34812,16 @@
 остронос.= сиволап.= хвостист.= :
   LLACI+ or LLDKF+;
 
-остронос.amss сиволап.amss хвостист.amss :  <morph-П,мр,ед,кр>;
-
 остронос.nlmsi сиволап.nlmsi хвостист.nlmsi :  <morph-С,мр,од,ед,им>;
+
+остронос.amss сиволап.amss хвостист.amss :  <morph-П,мр,ед,кр>;
 
 лат.= папирос.= сигарет.= :
   LLAFX+ or LLBRK+ or LLBYU+ or LLDJS+;
 
-лат.ndfpg папирос.ndfpg сигарет.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 лат.npg папирос.npg сигарет.npg :  <morph-С,мн,мн,рд>;
+
+лат.ndfpg папирос.ndfpg сигарет.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 сигнал.= трал.= :
   LLAAQ+ or LLBIA+ or LLBNU+ or LLDOO+;
@@ -34869,9 +34861,9 @@
 символ.= :
   LLAAQ+ or LLDOQ+;
 
-символ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 символ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+символ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 симпс.= :
   LLFNR+;
@@ -34893,22 +34885,22 @@
 сип.= :
   LLAAQ+ or LLACI+ or LLAWQ+ or LLBWA+;
 
-сип.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
-сип.nlmsi :  <morph-С,мр,од,ед,им>;
-
 сип.ndmsv :  <morph-С,мр,но,ед,вн>;
 
+сип.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
+
 сип.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сип.nlmsi :  <morph-С,мр,од,ед,им>;
 
 сирен.= :
   LLAFX+ or LLAGT+ or LLBYZ+ or LLDNF+ or LLDNX+;
 
+сирен.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 сирен.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 сирен.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-сирен.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 сиро.= :
   LLAEK+ or LLELT+ or LLCYK+;
@@ -34918,13 +34910,13 @@
 сирот.= сиротин.= :
   LLAFH+ or LLBRH+;
 
-сирот.nlfpg сиротин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 сирот.nlfpv сиротин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+сирот.nlmpg сиротин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 сирот.nlmpv сиротин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-сирот.nlmpg сиротин.nlmpg :  <morph-С,мр,од,мн,рд>;
+сирот.nlfpg сиротин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 систематизир.= :
   LLCFX+ or LLELD+ or LLCGX+;
@@ -34954,9 +34946,9 @@
 
 скал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-скал.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 скал.ndnpg :  <morph-С,ср,но,мн,рд>;
+
+скал.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 скал.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -34970,9 +34962,9 @@
 скандал.= :
   LLAAO+ or LLBGR+ or LLBNU+ or LLDOO+;
 
-скандал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 скандал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+скандал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сканир.= :
   LLCDD+ or LLFWA+;
@@ -34985,24 +34977,24 @@
 скаред.= :
   LLACI+ or LLAFH+ or LLBYU+;
 
-скаред.nlfpg :  <morph-С,жр,од,мн,рд>;
+скаред.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 скаред.nlmsi :  <morph-С,мр,од,ед,им>;
 
-скаред.nlfpv :  <morph-С,жр,од,мн,вн>;
+скаред.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-скаред.nlmpv :  <morph-С,мр,од,мн,вн>;
+скаред.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 скаред.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 аноним.= скат.= :
   LLAAQ+ or LLACI+ or LLBRK+ or LLBYU+;
 
-аноним.nlmsi скат.nlmsi :  <morph-С,мр,од,ед,им>;
-
 аноним.ndmsv скат.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 аноним.ndmsi скат.ndmsi :  <morph-С,мр,но,ед,им>;
+
+аноним.nlmsi скат.nlmsi :  <morph-С,мр,од,ед,им>;
 
 скач.= :
   LLBRI+ or LLBSM+ or LLCJW+;
@@ -35041,11 +35033,11 @@
 пресс.= скирд.= черед.= :
   LLAAQ+ or LLAFX+ or LLCCZ+ or LLCGW+;
 
-пресс.ndmsv скирд.ndmsv черед.ndmsv :  <morph-С,мр,но,ед,вн>;
+пресс.ndmsi скирд.ndmsi черед.ndmsi :  <morph-С,мр,но,ед,им>;
 
 пресс.ndfpg скирд.ndfpg черед.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-пресс.ndmsi скирд.ndmsi черед.ndmsi :  <morph-С,мр,но,ед,им>;
+пресс.ndmsv скирд.ndmsv черед.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 назяб.= намерз.= обвык.= скис.= смерз.= :
   LLFYG+ or LLGEC+;
@@ -35055,18 +35047,18 @@
 ветрогон.= истукан.= скиф.= султан.= :
   LLAAQ+ or LLACI+ or LLBRO+;
 
-ветрогон.nlmsi истукан.nlmsi скиф.nlmsi султан.nlmsi :  <morph-С,мр,од,ед,им>;
-
 ветрогон.ndmsv истукан.ndmsv скиф.ndmsv султан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ветрогон.ndmsi истукан.ndmsi скиф.ndmsi султан.ndmsi :  <morph-С,мр,но,ед,им>;
 
+ветрогон.nlmsi истукан.nlmsi скиф.nlmsi султан.nlmsi :  <morph-С,мр,од,ед,им>;
+
 склад.= :
   LLAAS+ or LLAVL+ or LLBRK+ or LLBYU+;
 
-склад.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 склад.ndmsi :  <morph-С,мр,но,ед,им>;
+
+склад.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 склеротич.= :
   LLBRM+ or LLBZE+;
@@ -35100,9 +35092,9 @@
 выпор.= скол.= :
   LLAAQ+ or LLBRK+ or LLCJW+ or LLGAA+ or LLGAB+;
 
-выпор.ndmsv скол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 выпор.ndmsi скол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+выпор.ndmsv скол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сколь.= :
   LLAEK+ or LLBAC+;
@@ -35121,13 +35113,13 @@
 скоп.= :
   LLAAQ+ or LLAGT+ or LLAYJ+ or LLBII+ or LLFWK+ or LLFXQ+ or LLDNT+;
 
-скоп.nlfpg :  <morph-С,жр,од,мн,рд>;
+скоп.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 скоп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-скоп.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 скоп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+скоп.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 скор.= :
   LLAGL+ or LLDKF+;
@@ -35168,24 +35160,24 @@
 скот.= :
   LLAAQ+ or LLACI+ or LLBFF+ or LLBYU+;
 
-скот.nlmsi :  <morph-С,мр,од,ед,им>;
-
 скот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 скот.ndmsi :  <morph-С,мр,но,ед,им>;
 
+скот.nlmsi :  <morph-С,мр,од,ед,им>;
+
 скотин.= :
   LLAFH+ or LLAFX+ or LLAGT+ or LLBRK+ or LLBRO+;
+
+скотин.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+скотин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 скотин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 скотин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-скотин.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 скотин.nlmpv :  <morph-С,мр,од,мн,вн>;
-
-скотин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 скотобо.= :
   LLAYG+ or LLBQS+;
@@ -35202,20 +35194,20 @@
 зацеп.= скреп.= :
   LLAAQ+ or LLAFX+ or LLFWK+ or LLFXQ+ or LLBRK+;
 
-зацеп.ndmsv скреп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 зацеп.ndfpg скреп.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 зацеп.ndmsi скреп.ndmsi :  <morph-С,мр,но,ед,им>;
 
+зацеп.ndmsv скреп.ndmsv :  <morph-С,мр,но,ед,вн>;
+
 скрип.= :
   LLAAO+ or LLAEL+ or LLDTP+ or LLAWQ+ or LLBRK+;
+
+скрип.ndmsi :  <morph-С,мр,но,ед,им>;
 
 скрип.xn :  <morph-ПРЕДК,нст>;
 
 скрип.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-скрип.ndmsi :  <morph-С,мр,но,ед,им>;
 
 богач.= дурныш.= ингуш.= латыш.= ловкач.= силач.= 
 скрипач.= талыш.= трепач.= хохмач.= циркач.= :
@@ -35265,11 +35257,11 @@
 скуп.= :
   LLAAQ+ or LLAYJ+ or LLFWK+ or LLBNN+ or LLBRK+ or LLCIS+;
 
-скуп.amss :  <morph-П,мр,ед,кр>;
+скуп.ndmsi :  <morph-С,мр,но,ед,им>;
 
 скуп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-скуп.ndmsi :  <morph-С,мр,но,ед,им>;
+скуп.amss :  <morph-П,мр,ед,кр>;
 
 /ru/words/words.209:
   LLAFM+;
@@ -35343,11 +35335,11 @@
 след.= :
   LLAAS+ or LLAEL+ or LLFMK+ or LLCBF+ or LLCJW+;
 
+след.ndmsi :  <morph-С,мр,но,ед,им>;
+
 след.xn :  <morph-ПРЕДК,нст>;
 
 след.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-след.ndmsi :  <morph-С,мр,но,ед,им>;
 
 следовательно.= :
   LLDTI+ or LLFGK+;
@@ -35394,9 +35386,9 @@
 подрост.= слет.= :
   LLAAQ+ or LLCKD+;
 
-подрост.ndmsv слет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подрост.ndmsi слет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подрост.ndmsv слет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сбега.= слета.= :
   LLCZE+ or LLFYB+ or LLDEM+ or LLFWU+;
@@ -35406,9 +35398,9 @@
 
 слив.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-слив.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 слив.ndmsi :  <morph-С,мр,но,ед,им>;
+
+слив.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 сливоч.= :
   LLBSM+ or LLBYU+;
@@ -35500,9 +35492,9 @@
 
 бесспорно.xn возможно.xn очевидно.xn слышно.xn :  <morph-ПРЕДК,нст>;
 
-бесспорно.e возможно.e очевидно.e слышно.e :  <morph-Н,0>;
-
 бесспорно.y возможно.y очевидно.y слышно.y :  <morph-ВВОДН,0>;
+
+бесспорно.e возможно.e очевидно.e слышно.e :  <morph-Н,0>;
 
 слэш.= :
   LLABC+;
@@ -35570,15 +35562,15 @@
 смирен.= :
   LLAFH+ or LLBYA+;
 
+смирен.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 смирен.amss :  <morph-П,мр,ед,кр>;
 
-смирен.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-смирен.nlfpv :  <morph-С,жр,од,мн,вн>;
+смирен.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 смирен.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-смирен.nlmpg :  <morph-С,мр,од,мн,рд>;
+смирен.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 смол.= :
   LLAFX+ or LLBHS+ or LLBNP+ or LLBRK+ or LLDNF+ or LLDOK+;
@@ -35588,13 +35580,13 @@
 смолян.= :
   LLDWW+ or LLBFS+ or LLBRK+ or LLCIZ+;
 
-смолян.ndmsv :  <morph-С,мр,но,ед,вн>;
+смолян.ndmsi :  <morph-С,мр,но,ед,им>;
 
 смолян.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-смолян.ndmsi :  <morph-С,мр,но,ед,им>;
-
 смолян.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+смолян.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 забрак.= забронир.= завуалир.= интерполир.= клонир.= коррегир.= 
 корреспондир.= опротест.= откорректир.= отрегулир.= отредактир.= отреставрир.= 
@@ -35694,205 +35686,15 @@
 соб.= :
   LLDWW+ or LLGDE+ or LLGDF+ or LLEAU+;
 
-соб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 соб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+соб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 собач.= :
   LLBFF+ or LLBHH+ or LLBMV+ or LLBRI+ or LLBRM+ or LLCKS+;
 
 /ru/words/words.214:
   LLAGP+;
-
-автоматчиц.nlfpg агниц.nlfpg алиментщиц.nlfpg ампульщиц.nlfpg анонимщиц.nlfpg аппретурщиц.nlfpg 
-артельщиц.nlfpg бабочниц.nlfpg багетчиц.nlfpg балаганщиц.nlfpg балалаечниц.nlfpg баловниц.nlfpg 
-банкаброшниц.nlfpg банщиц.nlfpg барабанщиц.nlfpg барахольщиц.nlfpg басонщиц.nlfpg бахромщиц.nlfpg 
-башмачниц.nlfpg безбилетниц.nlfpg безбожниц.nlfpg бездельниц.nlfpg беззаконниц.nlfpg безобразниц.nlfpg 
-бекасниц.nlfpg белильщиц.nlfpg белиц.nlfpg белорыбиц.nlfpg бельевщиц.nlfpg бесприданниц.nlfpg 
-беспризорниц.nlfpg беспутниц.nlfpg бессребрениц.nlfpg бесстыдниц.nlfpg бетонщиц.nlfpg благодетельниц.nlfpg 
-благожелательниц.nlfpg благотворительниц.nlfpg блудниц.nlfpg блюстительниц.nlfpg богоотступниц.nlfpg богородиц.nlfpg 
-богохульниц.nlfpg болельщиц.nlfpg боронильщиц.nlfpg бороновальщиц.nlfpg бортпроводниц.nlfpg боярышниц.nlfpg 
-браковщиц.nlfpg брезгливиц.nlfpg брошюровщиц.nlfpg брюквенниц.nlfpg буйволиц.nlfpg булочниц.nlfpg 
-бунтовщиц.nlfpg бурильщиц.nlfpg буфетчиц.nlfpg вагонетчиц.nlfpg вакуумщиц.nlfpg вальцовщиц.nlfpg 
-валютчиц.nlfpg валяльщиц.nlfpg ваннщиц.nlfpg ватерщиц.nlfpg вафельщиц.nlfpg вдовиц.nlfpg 
-вдохновительниц.nlfpg веерниц.nlfpg великомучениц.nlfpg велогонщиц.nlfpg верблюдиц.nlfpg вербовщиц.nlfpg 
-веретениц.nlfpg вероотступниц.nlfpg верстальщиц.nlfpg вертолетчиц.nlfpg весовщиц.nlfpg вестниц.nlfpg 
-вестовщиц.nlfpg ветошниц.nlfpg вечерниц.nlfpg вещательниц.nlfpg веяльщиц.nlfpg вздорщиц.nlfpg 
-вздыхательниц.nlfpg взяточниц.nlfpg виновниц.nlfpg вкладчиц.nlfpg владелиц.nlfpg владетельниц.nlfpg 
-владычиц.nlfpg властительниц.nlfpg внешкольниц.nlfpg воднолыжниц.nlfpg возбудительниц.nlfpg воздухоплавательниц.nlfpg 
-воздыхательниц.nlfpg возмутительниц.nlfpg воительниц.nlfpg волокитчиц.nlfpg волчиц.nlfpg волшебниц.nlfpg 
-вольноотпущенниц.nlfpg вольнослушательниц.nlfpg воплениц.nlfpg вопленниц.nlfpg вопрошательниц.nlfpg ворсильщиц.nlfpg 
-воспитанниц.nlfpg воспитательниц.nlfpg восприемниц.nlfpg восьмиклассниц.nlfpg вредительниц.nlfpg всадниц.nlfpg 
-вскормленниц.nlfpg второгодниц.nlfpg второклассниц.nlfpg второкурсниц.nlfpg выбивальщиц.nlfpg выборщиц.nlfpg 
-выверщиц.nlfpg выдувальщиц.nlfpg выдумщиц.nlfpg выжлиц.nlfpg выкупщиц.nlfpg вымогательниц.nlfpg 
-выпарщиц.nlfpg выпускниц.nlfpg выразительниц.nlfpg выучениц.nlfpg вязальщиц.nlfpg гадальщиц.nlfpg 
-гадательниц.nlfpg газетчиц.nlfpg газировщиц.nlfpg галлиц.nlfpg гладильщиц.nlfpg говельщиц.nlfpg 
-гонительниц.nlfpg гонщиц.nlfpg горлиц.nlfpg горнолыжниц.nlfpg городошниц.nlfpg грабительниц.nlfpg 
-гравировщиц.nlfpg гранильщиц.nlfpg гранулировщиц.nlfpg греховодниц.nlfpg грешниц.nlfpg гримасниц.nlfpg 
-грузчиц.nlfpg губительниц.nlfpg дарительниц.nlfpg дачевладелиц.nlfpg дачниц.nlfpg двоемужниц.nlfpg 
-двоечниц.nlfpg двумужниц.nlfpg двурушниц.nlfpg девиц.nlfpg девственниц.nlfpg девятиклассниц.nlfpg 
-декатировщиц.nlfpg делопроизводительниц.nlfpg деревообделочниц.nlfpg держательниц.nlfpg десятиклассниц.nlfpg деятельниц.nlfpg 
-дипломниц.nlfpg доброжелательниц.nlfpg добытчиц.nlfpg доверительниц.nlfpg доильщиц.nlfpg доказчиц.nlfpg 
-докладчиц.nlfpg долгожительниц.nlfpg должниц.nlfpg дольщиц.nlfpg домовладелиц.nlfpg домоправительниц.nlfpg 
-домработниц.nlfpg доносительниц.nlfpg доносчиц.nlfpg дорожниц.nlfpg досмотрщиц.nlfpg доставщиц.nlfpg 
-дошкольниц.nlfpg дражировщиц.nlfpg драпировщиц.nlfpg древесниц.nlfpg дрессировщиц.nlfpg дружинниц.nlfpg 
-духанщиц.nlfpg духовидиц.nlfpg душеприказчиц.nlfpg дьяволиц.nlfpg дьякониц.nlfpg единоличниц.nlfpg 
-единомышленниц.nlfpg единоплеменниц.nlfpg естественниц.nlfpg естествоиспытательниц.nlfpg ехидниц.nlfpg жалобщиц.nlfpg 
-жар-птиц.nlfpg железнодорожниц.nlfpg жеманниц.nlfpg жертвовательниц.nlfpg жилиц.nlfpg жительниц.nlfpg 
-жниц.nlfpg жриц.nlfpg жужелиц.nlfpg забавниц.nlfpg забастовщиц.nlfpg заварщиц.nlfpg 
-завещательниц.nlfpg завистниц.nlfpg заводчиц.nlfpg завоевательниц.nlfpg загадчиц.nlfpg заговорщиц.nlfpg 
-заготовщиц.nlfpg задавальщиц.nlfpg задолжниц.nlfpg зажимщиц.nlfpg заказчиц.nlfpg закладчиц.nlfpg 
-заклинательниц.nlfpg законниц.nlfpg законодательниц.nlfpg закоперщиц.nlfpg закрепщиц.nlfpg закройщиц.nlfpg 
-закупорщиц.nlfpg закупщиц.nlfpg заложниц.nlfpg заместительниц.nlfpg заочниц.nlfpg запайщиц.nlfpg 
-заправщиц.nlfpg засольщиц.nlfpg застрельщиц.nlfpg застройщиц.nlfpg заступниц.nlfpg засыпщиц.nlfpg 
-затворниц.nlfpg затейниц.nlfpg затейщиц.nlfpg захватчиц.nlfpg захребетниц.nlfpg зачинательниц.nlfpg 
-зачинщиц.nlfpg защитниц.nlfpg заявительниц.nlfpg заявщиц.nlfpg зеленщиц.nlfpg землевладелиц.nlfpg 
-зенитчиц.nlfpg зимовщиц.nlfpg злопыхательниц.nlfpg злоумышленниц.nlfpg злоязычниц.nlfpg змееящериц.nlfpg 
-зрительниц.nlfpg идолопоклонниц.nlfpg избавительниц.nlfpg избирательниц.nlfpg избранниц.nlfpg изгнанниц.nlfpg 
-издательниц.nlfpg изменниц.nlfpg изменщиц.nlfpg изобличительниц.nlfpg изобретательниц.nlfpg изолировщиц.nlfpg 
-ильниц.nlfpg именинниц.nlfpg императриц.nlfpg иноплеменниц.nlfpg инструментальщиц.nlfpg искательниц.nlfpg 
-искусительниц.nlfpg искусниц.nlfpg искусственниц.nlfpg исповедниц.nlfpg исполнительниц.nlfpg испольщиц.nlfpg 
-исправниц.nlfpg испытательниц.nlfpg исследовательниц.nlfpg истиц.nlfpg истолковательниц.nlfpg истопниц.nlfpg 
-истязательниц.nlfpg исцелительниц.nlfpg кабатчиц.nlfpg каверзниц.nlfpg калибровщиц.nlfpg калильщиц.nlfpg 
-каменщиц.nlfpg камышниц.nlfpg канатчиц.nlfpg канительщиц.nlfpg капризниц.nlfpg капустниц.nlfpg 
-каракатиц.nlfpg караульщиц.nlfpg кардовщиц.nlfpg карлиц.nlfpg картежниц.nlfpg картонажниц.nlfpg 
-картонщиц.nlfpg картотетчиц.nlfpg кассетчиц.nlfpg катальщиц.nlfpg каторжниц.nlfpg кафельщиц.nlfpg 
-квартиросъемщиц.nlfpg келейниц.nlfpg керосинщиц.nlfpg кисловщиц.nlfpg кладовщиц.nlfpg клеветниц.nlfpg 
-клеильщиц.nlfpg клеймовщиц.nlfpg клейщиц.nlfpg клепальщиц.nlfpg клушиц.nlfpg ключниц.nlfpg 
-клятвопреступниц.nlfpg кляузниц.nlfpg книжниц.nlfpg кобылиц.nlfpg коверщиц.nlfpg ковровщиц.nlfpg 
-кокильщиц.nlfpg колбасниц.nlfpg колодниц.nlfpg колпиц.nlfpg колхозниц.nlfpg комплектовщиц.nlfpg 
-конвейерщиц.nlfpg конторщиц.nlfpg конфетчиц.nlfpg конъюнктурщиц.nlfpg копировальщиц.nlfpg копировщиц.nlfpg 
-коптильщиц.nlfpg копьеметательниц.nlfpg корзинщиц.nlfpg кормилиц.nlfpg коробейниц.nlfpg коробочниц.nlfpg 
-коровниц.nlfpg корообдирщиц.nlfpg корректировщиц.nlfpg корсажниц.nlfpg корсетниц.nlfpg корчемниц.nlfpg 
-костюмщиц.nlfpg кочевниц.nlfpg кошатниц.nlfpg крановщиц.nlfpg красавиц.nlfpg красильщиц.nlfpg 
-крахмальщиц.nlfpg крепостниц.nlfpg крестниц.nlfpg крошильщиц.nlfpg кружевниц.nlfpg крутильщиц.nlfpg 
-кудесниц.nlfpg кукольниц.nlfpg куниц.nlfpg купальщиц.nlfpg курильщиц.nlfpg курортниц.nlfpg 
-курятниц.nlfpg кутейниц.nlfpg лабазниц.nlfpg лавочниц.nlfpg лагерниц.nlfpg лазутчиц.nlfpg 
-ламповщиц.nlfpg лапотниц.nlfpg ларечниц.nlfpg лекальщиц.nlfpg ленивиц.nlfpg ленточниц.nlfpg 
-лепщиц.nlfpg летчиц.nlfpg лжесвидетельниц.nlfpg лимонниц.nlfpg линовщиц.nlfpg лисиц.nlfpg 
-лицовщиц.nlfpg лишайниц.nlfpg лодочниц.nlfpg лоскутниц.nlfpg лоточниц.nlfpg лотошниц.nlfpg 
-лохмотниц.nlfpg лошадниц.nlfpg лукавиц.nlfpg лыжниц.nlfpg львиц.nlfpg любимиц.nlfpg 
-любительниц.nlfpg любовниц.nlfpg мазальщиц.nlfpg макетчиц.nlfpg манекенщиц.nlfpg мастериц.nlfpg 
-медяниц.nlfpg месильщиц.nlfpg метательниц.nlfpg метельщиц.nlfpg меховщиц.nlfpg мечтательниц.nlfpg 
-мешальщиц.nlfpg мешочниц.nlfpg миллионщиц.nlfpg мироносиц.nlfpg миротвориц.nlfpg мирохранительниц.nlfpg 
-многостаночниц.nlfpg многоцветниц.nlfpg модельщиц.nlfpg модниц.nlfpg мойщиц.nlfpg молельщиц.nlfpg 
-молитвенниц.nlfpg молодиц.nlfpg молотильщиц.nlfpg молчальниц.nlfpg монтажниц.nlfpg мороженщиц.nlfpg 
-мотальщиц.nlfpg мотовильщиц.nlfpg мотогонщиц.nlfpg мошенниц.nlfpg мстительниц.nlfpg мужененавистниц.nlfpg 
-мужеубийц.nlfpg мусорщиц.nlfpg мучениц.nlfpg мучительниц.nlfpg мятежниц.nlfpg набивальщиц.nlfpg 
-наблюдательниц.nlfpg набойщиц.nlfpg наборщиц.nlfpg наветчиц.nlfpg навивальщиц.nlfpg наводчиц.nlfpg 
-нагребальщиц.nlfpg надвязчиц.nlfpg надзирательниц.nlfpg надомниц.nlfpg надсмотрщиц.nlfpg наездниц.nlfpg 
-наемниц.nlfpg наемщиц.nlfpg наклейщиц.nlfpg накопительниц.nlfpg наладчиц.nlfpg налетчиц.nlfpg 
-налогоплательщиц.nlfpg наложниц.nlfpg наместниц.nlfpg намотчиц.nlfpg нанимательниц.nlfpg напарниц.nlfpg 
-наперсниц.nlfpg направщиц.nlfpg народниц.nlfpg нарушительниц.nlfpg нарядчиц.nlfpg насекальщиц.nlfpg 
-наследниц.nlfpg наследодательниц.nlfpg насмешниц.nlfpg наставниц.nlfpg настоятельниц.nlfpg настройщиц.nlfpg 
-насыпальщиц.nlfpg насыпщиц.nlfpg натурщиц.nlfpg наушниц.nlfpg нахлебниц.nlfpg начальниц.nlfpg 
-начетниц.nlfpg начетчиц.nlfpg начинательниц.nlfpg невольниц.nlfpg негодниц.nlfpg недоброжелательниц.nlfpg 
-нектарниц.nlfpg ненавистниц.nlfpg неплательщиц.nlfpg неприятельниц.nlfpg несчастливиц.nlfpg неудачниц.nlfpg 
-нечестивиц.nlfpg нивелировщиц.nlfpg никелировщиц.nlfpg ниточниц.nlfpg нормировщиц.nlfpg носительниц.nlfpg 
-ночлежниц.nlfpg ночниц.nlfpg нумеровщиц.nlfpg ныряльщиц.nlfpg нюхальщиц.nlfpg обвинительниц.nlfpg 
-обворожительниц.nlfpg обжарщиц.nlfpg обидчиц.nlfpg обитательниц.nlfpg обладательниц.nlfpg облицовщиц.nlfpg 
-обличительниц.nlfpg обманщиц.nlfpg обмеловщиц.nlfpg обмотчиц.nlfpg обожательниц.nlfpg обозревательниц.nlfpg 
-обольстительниц.nlfpg обработчиц.nlfpg обтяжчиц.nlfpg обувщиц.nlfpg обшивальщиц.nlfpg обшивщиц.nlfpg 
-общественниц.nlfpg обывательниц.nlfpg огнепоклонниц.nlfpg огородниц.nlfpg одноклассниц.nlfpg одноклубниц.nlfpg 
-однокурсниц.nlfpg однофамилиц.nlfpg озорниц.nlfpg орлиц.nlfpg осведомительниц.nlfpg освободительниц.nlfpg 
-оскорбительниц.nlfpg ослиц.nlfpg ослушниц.nlfpg основательниц.nlfpg остриц.nlfpg острожниц.nlfpg 
-отбельщиц.nlfpg отборщиц.nlfpg отвальщиц.nlfpg ответчиц.nlfpg отгадчиц.nlfpg отдельщиц.nlfpg 
-отжимщиц.nlfpg отказчиц.nlfpg откатчиц.nlfpg отличниц.nlfpg отправительниц.nlfpg отпускниц.nlfpg 
-отпущенниц.nlfpg отравительниц.nlfpg отроковиц.nlfpg отступниц.nlfpg отшельниц.nlfpg оформительниц.nlfpg 
-охальниц.nlfpg охотниц.nlfpg охранительниц.nlfpg охранниц.nlfpg оценщиц.nlfpg очаровательниц.nlfpg 
-очевидиц.nlfpg очковтирательниц.nlfpg падчериц.nlfpg пайщиц.nlfpg пакетчиц.nlfpg пакостниц.nlfpg 
-паломниц.nlfpg паскудниц.nlfpg пахтальщиц.nlfpg певиц.nlfpg пенниц.nlfpg первоклассниц.nlfpg 
-первокурсниц.nlfpg первооткрывательниц.nlfpg перворазрядниц.nlfpg перебежчиц.nlfpg переборщиц.nlfpg переводчиц.nlfpg 
-перевозчиц.nlfpg передатчиц.nlfpg перекупщиц.nlfpg перематывальщиц.nlfpg переносчиц.nlfpg перепелиц.nlfpg 
-переписчиц.nlfpg пересказчиц.nlfpg пересмешниц.nlfpg перестраховщиц.nlfpg пересудчиц.nlfpg перловиц.nlfpg 
-перчаточниц.nlfpg песенниц.nlfpg печальниц.nlfpg пигалиц.nlfpg пикетчиц.nlfpg пильщиц.nlfpg 
-писательниц.nlfpg питомиц.nlfpg пиявиц.nlfpg плакальщиц.nlfpg плательщиц.nlfpg платьевщиц.nlfpg 
-племянниц.nlfpg пленниц.nlfpg плетельщиц.nlfpg плотвиц.nlfpg плотиц.nlfpg плотниц.nlfpg 
-площиц.nlfpg победительниц.nlfpg поборниц.nlfpg повелительниц.nlfpg погонщиц.nlfpg подавальщиц.nlfpg 
-подательниц.nlfpg подборщиц.nlfpg подвижниц.nlfpg подговорщиц.nlfpg поденщиц.nlfpg поджигательниц.nlfpg 
-подкулачниц.nlfpg подметальщиц.nlfpg подносчиц.nlfpg подписчиц.nlfpg подполковниц.nlfpg подпольщиц.nlfpg 
-подражательниц.nlfpg подсказчиц.nlfpg подсобниц.nlfpg подстрекательниц.nlfpg подушечниц.nlfpg поздравительниц.nlfpg 
-позорниц.nlfpg поилиц.nlfpg поклепщиц.nlfpg поклонниц.nlfpg покойниц.nlfpg покорительниц.nlfpg 
-покровительниц.nlfpg покупательниц.nlfpg покупщиц.nlfpg полковниц.nlfpg полольщиц.nlfpg поломойщиц.nlfpg 
-полуночниц.nlfpg получательниц.nlfpg полюбовниц.nlfpg полярниц.nlfpg помазанниц.nlfpg помещиц.nlfpg 
-помощниц.nlfpg пономариц.nlfpg попечительниц.nlfpg попустительниц.nlfpg попутчиц.nlfpg поработительниц.nlfpg 
-поручительниц.nlfpg посадниц.nlfpg посетительниц.nlfpg посланниц.nlfpg последовательниц.nlfpg послушниц.nlfpg 
-пособниц.nlfpg посредниц.nlfpg поставщиц.nlfpg постельниц.nlfpg постниц.nlfpg постоялиц.nlfpg 
-пострижениц.nlfpg посудниц.nlfpg потатчиц.nlfpg потворщиц.nlfpg похабниц.nlfpg похитительниц.nlfpg 
-почитательниц.nlfpg пошивщиц.nlfpg праведниц.nlfpg правительниц.nlfpg правонарушительниц.nlfpg правщиц.nlfpg 
-прародительниц.nlfpg предательниц.nlfpg предвестниц.nlfpg предводительниц.nlfpg предвозвестниц.nlfpg предпринимательниц.nlfpg 
-председательниц.nlfpg предсказательниц.nlfpg представительниц.nlfpg предстательниц.nlfpg предшественниц.nlfpg предъявительниц.nlfpg 
-преемниц.nlfpg прелестниц.nlfpg преобразовательниц.nlfpg препаратчиц.nlfpg преподавательниц.nlfpg преследовательниц.nlfpg 
-преступниц.nlfpg привередниц.nlfpg привратниц.nlfpg приданниц.nlfpg придирщиц.nlfpg придумщиц.nlfpg 
-приемщиц.nlfpg приживальщиц.nlfpg приказчиц.nlfpg примирительниц.nlfpg прислужниц.nlfpg приспешниц.nlfpg 
-притворщиц.nlfpg притеснительниц.nlfpg прихлебательниц.nlfpg прицепщиц.nlfpg причастниц.nlfpg причитальщиц.nlfpg 
-причудниц.nlfpg пришелиц.nlfpg приятельниц.nlfpg проверщиц.nlfpg провидиц.nlfpg проводниц.nlfpg 
-провозвестниц.nlfpg прогульщиц.nlfpg продавщиц.nlfpg продолжательниц.nlfpg проектировщиц.nlfpg прожигательниц.nlfpg 
-прозорливиц.nlfpg производительниц.nlfpg производственниц.nlfpg проказниц.nlfpg пропитчиц.nlfpg проповедниц.nlfpg 
-прорицательниц.nlfpg пророчиц.nlfpg просветительниц.nlfpg просительниц.nlfpg противниц.nlfpg протирщиц.nlfpg 
-протопопиц.nlfpg протяжчиц.nlfpg профилировщиц.nlfpg проходчиц.nlfpg процентщиц.nlfpg пружинщиц.nlfpg 
-псиц.nlfpg птиц.nlfpg птичниц.nlfpg пулеметчиц.nlfpg пустынниц.nlfpg путеобходчиц.nlfpg 
-путешественниц.nlfpg путниц.nlfpg пядениц.nlfpg пятерочниц.nlfpg пятиклассниц.nlfpg рабовладелиц.nlfpg 
-работниц.nlfpg радетельниц.nlfpg радиослушательниц.nlfpg радужниц.nlfpg разбойниц.nlfpg разборщиц.nlfpg 
-разведчиц.nlfpg развесчиц.nlfpg развозчиц.nlfpg развратительниц.nlfpg развратниц.nlfpg разгадчиц.nlfpg 
-раздатчиц.nlfpg раздевальщиц.nlfpg разлучниц.nlfpg разметчиц.nlfpg размотчиц.nlfpg разносчиц.nlfpg 
-разоблачительниц.nlfpg разорительниц.nlfpg разрезальщиц.nlfpg разрисовщиц.nlfpg разрушительниц.nlfpg разрядниц.nlfpg 
-разумниц.nlfpg ракетчиц.nlfpg расклейщиц.nlfpg раскольниц.nlfpg раскрасавиц.nlfpg распорядительниц.nlfpg 
-распространительниц.nlfpg распутниц.nlfpg рассказчиц.nlfpg рассыпальщиц.nlfpg рассыпщиц.nlfpg растирщиц.nlfpg 
-растлительниц.nlfpg расточительниц.nlfpg растратчиц.nlfpg растрясальщиц.nlfpg расфасовщиц.nlfpg расхитительниц.nlfpg 
-расчетчиц.nlfpg рачительниц.nlfpg ревнивиц.nlfpg ревнительниц.nlfpg револьверщиц.nlfpg резальщиц.nlfpg 
-резинщиц.nlfpg резчиц.nlfpg резьбовщиц.nlfpg ремесленниц.nlfpg репейниц.nlfpg репниц.nlfpg 
-рисовальщиц.nlfpg ровесниц.nlfpg ровничниц.nlfpg родильниц.nlfpg родительниц.nlfpg родоначальниц.nlfpg 
-родственниц.nlfpg рожениц.nlfpg рольщиц.nlfpg ростовщиц.nlfpg рубщиц.nlfpg ругательниц.nlfpg 
-руководительниц.nlfpg рукодельниц.nlfpg ручниц.nlfpg рыбиц.nlfpg рыдальщиц.nlfpg саботажниц.nlfpg 
-садовниц.nlfpg салопниц.nlfpg самогонщиц.nlfpg самодержиц.nlfpg сановниц.nlfpg сахарозаводчиц.nlfpg 
-сбитенщиц.nlfpg сборщиц.nlfpg сварливиц.nlfpg сварщиц.nlfpg свежевальщиц.nlfpg сверстниц.nlfpg 
-сверщиц.nlfpg свидетельниц.nlfpg сводниц.nlfpg своевольниц.nlfpg свойственниц.nlfpg своячениц.nlfpg 
-сдатчиц.nlfpg сдельщиц.nlfpg сезонниц.nlfpg семиклассниц.nlfpg сердечниц.nlfpg сестриц.nlfpg 
-сеяльщиц.nlfpg сигнатурщиц.nlfpg синиц.nlfpg сказительниц.nlfpg сказочниц.nlfpg скаредниц.nlfpg 
-сквалыжниц.nlfpg скиталиц.nlfpg скитниц.nlfpg склочниц.nlfpg скотниц.nlfpg скупщиц.nlfpg 
-сладострастниц.nlfpg словесниц.nlfpg служительниц.nlfpg слушательниц.nlfpg слюняниц.nlfpg смазчиц.nlfpg 
-сменщиц.nlfpg смерщиц.nlfpg смиренниц.nlfpg смотрительниц.nlfpg смотчиц.nlfpg сновальщиц.nlfpg 
-сновидиц.nlfpg собачниц.nlfpg собеседниц.nlfpg собирательниц.nlfpg соблазнительниц.nlfpg собственниц.nlfpg 
-советниц.nlfpg советчиц.nlfpg совладелиц.nlfpg совместительниц.nlfpg совратительниц.nlfpg содержательниц.nlfpg 
-сожительниц.nlfpg создательниц.nlfpg созерцательниц.nlfpg созидательниц.nlfpg соименниц.nlfpg соискательниц.nlfpg 
-сокурсниц.nlfpg сонаследниц.nlfpg сонливиц.nlfpg сообщниц.nlfpg соотечественниц.nlfpg соперниц.nlfpg 
-соплеменниц.nlfpg сопливиц.nlfpg сопроводительниц.nlfpg соратниц.nlfpg сослуживиц.nlfpg составительниц.nlfpg 
-сотрудниц.nlfpg соумышленниц.nlfpg соучастниц.nlfpg соучениц.nlfpg сочинительниц.nlfpg союзниц.nlfpg 
-спасительниц.nlfpg спесивиц.nlfpg сплетниц.nlfpg сподвижниц.nlfpg сподручниц.nlfpg спорщиц.nlfpg 
-спутниц.nlfpg срамниц.nlfpg сродниц.nlfpg сродственниц.nlfpg ссучивальщиц.nlfpg ссыпщиц.nlfpg 
-ставленниц.nlfpg станочниц.nlfpg старательниц.nlfpg старшеклассниц.nlfpg старшекурсниц.nlfpg старьевщиц.nlfpg 
-стачечниц.nlfpg стегальщиц.nlfpg стеклянниц.nlfpg стервятниц.nlfpg сторонниц.nlfpg страдалиц.nlfpg 
-странниц.nlfpg страстотерпиц.nlfpg стрелочниц.nlfpg стригальщиц.nlfpg строительниц.nlfpg строптивиц.nlfpg 
-стыдливиц.nlfpg стяжательниц.nlfpg сумеречниц.nlfpg супротивниц.nlfpg супружниц.nlfpg сутяжниц.nlfpg 
-сучильщиц.nlfpg сушильщиц.nlfpg схимниц.nlfpg сцепщиц.nlfpg счастливиц.nlfpg счетчиц.nlfpg 
-считчиц.nlfpg сшивальщиц.nlfpg съемщиц.nlfpg сыщиц.nlfpg табельщиц.nlfpg таежниц.nlfpg 
-танцовщиц.nlfpg тачальщиц.nlfpg текстильщиц.nlfpg телиц.nlfpg телятниц.nlfpg теребильщиц.nlfpg 
-тигриц.nlfpg толковательниц.nlfpg топильщиц.nlfpg тортовщиц.nlfpg торфяниц.nlfpg точильщиц.nlfpg 
-трактирщиц.nlfpg трамвайщиц.nlfpg транзитниц.nlfpg транспортниц.nlfpg траурниц.nlfpg трезвенниц.nlfpg 
-трепальщиц.nlfpg третьеклассниц.nlfpg третьекурсниц.nlfpg трикотажниц.nlfpg троечниц.nlfpg тростильщиц.nlfpg 
-тружениц.nlfpg тряпичниц.nlfpg туберкулезниц.nlfpg тунеядиц.nlfpg тюремщиц.nlfpg тяжебщиц.nlfpg 
-уборщиц.nlfpg угадчиц.nlfpg угнетательниц.nlfpg угодниц.nlfpg уголовниц.nlfpg угольщиц.nlfpg 
-удавленниц.nlfpg ударниц.nlfpg удачниц.nlfpg удильщиц.nlfpg узниц.nlfpg указчиц.nlfpg 
-укладчиц.nlfpg укротительниц.nlfpg укрывательниц.nlfpg укупорщиц.nlfpg умелиц.nlfpg упаковщиц.nlfpg 
-управительниц.nlfpg упрямиц.nlfpg уставщиц.nlfpg устроительниц.nlfpg утешительниц.nlfpg утильщиц.nlfpg 
-утиц.nlfpg утопленниц.nlfpg утюжильщиц.nlfpg участниц.nlfpg учениц.nlfpg учетчиц.nlfpg 
-учительниц.nlfpg учредительниц.nlfpg ушкуйниц.nlfpg факельщиц.nlfpg фальцовщиц.nlfpg фальшивомонетчиц.nlfpg 
-фарцовщиц.nlfpg фасовщиц.nlfpg фасонщиц.nlfpg фельдшериц.nlfpg фехтовальщиц.nlfpg физкультурниц.nlfpg 
-флерниц.nlfpg фокусниц.nlfpg фонарниц.nlfpg фонарщиц.nlfpg формовщиц.nlfpg форсунщиц.nlfpg 
-фрезеровщиц.nlfpg фуражечниц.nlfpg футлярщиц.nlfpg халтурщиц.nlfpg харчевниц.nlfpg хищниц.nlfpg 
-хлопальщиц.nlfpg хороводниц.nlfpg хранительниц.nlfpg христарадниц.nlfpg хрустальщиц.nlfpg художниц.nlfpg 
-хулительниц.nlfpg цариц.nlfpg царь-девиц.nlfpg цветочниц.nlfpg целинниц.nlfpg целительниц.nlfpg 
-ценительниц.nlfpg церемонниц.nlfpg церковниц.nlfpg цыплятниц.nlfpg чаевниц.nlfpg чаровниц.nlfpg 
-частниц.nlfpg частушечниц.nlfpg челобитчиц.nlfpg человеконенавистниц.nlfpg черпальщиц.nlfpg чертежниц.nlfpg 
-чесальщиц.nlfpg четвероклассниц.nlfpg четверочниц.nlfpg чешуйниц.nlfpg чиновниц.nlfpg чистильщиц.nlfpg 
-читательниц.nlfpg чревовещательниц.nlfpg чревоугодниц.nlfpg чтиц.nlfpg чудесниц.nlfpg чулочниц.nlfpg 
-шапочниц.nlfpg шарманщиц.nlfpg швейниц.nlfpg шелкомотальщиц.nlfpg шестидесятниц.nlfpg шестиклассниц.nlfpg 
-шифровальщиц.nlfpg шкодниц.nlfpg школьниц.nlfpg шлифовальщиц.nlfpg шлифовщиц.nlfpg шляпниц.nlfpg 
-шоколадниц.nlfpg шпульниц.nlfpg штапелировщиц.nlfpg штопальщиц.nlfpg штриховщиц.nlfpg штучниц.nlfpg 
-шутниц.nlfpg щевриц.nlfpg щетинщиц.nlfpg эстрадниц.nlfpg этикетчиц.nlfpg юбочниц.nlfpg 
-юниц.nlfpg ябедниц.nlfpg ягодниц.nlfpg язычниц.nlfpg яловиц.nlfpg ясновидиц.nlfpg 
-ящериц.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 автоматчиц.nlfpv агниц.nlfpv алиментщиц.nlfpv ампульщиц.nlfpv анонимщиц.nlfpv аппретурщиц.nlfpv 
 артельщиц.nlfpv бабочниц.nlfpv багетчиц.nlfpv балаганщиц.nlfpv балалаечниц.nlfpv баловниц.nlfpv 
@@ -36084,15 +35886,205 @@
 юниц.nlfpv ябедниц.nlfpv ягодниц.nlfpv язычниц.nlfpv яловиц.nlfpv ясновидиц.nlfpv 
 ящериц.nlfpv :  <morph-С,жр,од,мн,вн>;
 
+автоматчиц.nlfpg агниц.nlfpg алиментщиц.nlfpg ампульщиц.nlfpg анонимщиц.nlfpg аппретурщиц.nlfpg 
+артельщиц.nlfpg бабочниц.nlfpg багетчиц.nlfpg балаганщиц.nlfpg балалаечниц.nlfpg баловниц.nlfpg 
+банкаброшниц.nlfpg банщиц.nlfpg барабанщиц.nlfpg барахольщиц.nlfpg басонщиц.nlfpg бахромщиц.nlfpg 
+башмачниц.nlfpg безбилетниц.nlfpg безбожниц.nlfpg бездельниц.nlfpg беззаконниц.nlfpg безобразниц.nlfpg 
+бекасниц.nlfpg белильщиц.nlfpg белиц.nlfpg белорыбиц.nlfpg бельевщиц.nlfpg бесприданниц.nlfpg 
+беспризорниц.nlfpg беспутниц.nlfpg бессребрениц.nlfpg бесстыдниц.nlfpg бетонщиц.nlfpg благодетельниц.nlfpg 
+благожелательниц.nlfpg благотворительниц.nlfpg блудниц.nlfpg блюстительниц.nlfpg богоотступниц.nlfpg богородиц.nlfpg 
+богохульниц.nlfpg болельщиц.nlfpg боронильщиц.nlfpg бороновальщиц.nlfpg бортпроводниц.nlfpg боярышниц.nlfpg 
+браковщиц.nlfpg брезгливиц.nlfpg брошюровщиц.nlfpg брюквенниц.nlfpg буйволиц.nlfpg булочниц.nlfpg 
+бунтовщиц.nlfpg бурильщиц.nlfpg буфетчиц.nlfpg вагонетчиц.nlfpg вакуумщиц.nlfpg вальцовщиц.nlfpg 
+валютчиц.nlfpg валяльщиц.nlfpg ваннщиц.nlfpg ватерщиц.nlfpg вафельщиц.nlfpg вдовиц.nlfpg 
+вдохновительниц.nlfpg веерниц.nlfpg великомучениц.nlfpg велогонщиц.nlfpg верблюдиц.nlfpg вербовщиц.nlfpg 
+веретениц.nlfpg вероотступниц.nlfpg верстальщиц.nlfpg вертолетчиц.nlfpg весовщиц.nlfpg вестниц.nlfpg 
+вестовщиц.nlfpg ветошниц.nlfpg вечерниц.nlfpg вещательниц.nlfpg веяльщиц.nlfpg вздорщиц.nlfpg 
+вздыхательниц.nlfpg взяточниц.nlfpg виновниц.nlfpg вкладчиц.nlfpg владелиц.nlfpg владетельниц.nlfpg 
+владычиц.nlfpg властительниц.nlfpg внешкольниц.nlfpg воднолыжниц.nlfpg возбудительниц.nlfpg воздухоплавательниц.nlfpg 
+воздыхательниц.nlfpg возмутительниц.nlfpg воительниц.nlfpg волокитчиц.nlfpg волчиц.nlfpg волшебниц.nlfpg 
+вольноотпущенниц.nlfpg вольнослушательниц.nlfpg воплениц.nlfpg вопленниц.nlfpg вопрошательниц.nlfpg ворсильщиц.nlfpg 
+воспитанниц.nlfpg воспитательниц.nlfpg восприемниц.nlfpg восьмиклассниц.nlfpg вредительниц.nlfpg всадниц.nlfpg 
+вскормленниц.nlfpg второгодниц.nlfpg второклассниц.nlfpg второкурсниц.nlfpg выбивальщиц.nlfpg выборщиц.nlfpg 
+выверщиц.nlfpg выдувальщиц.nlfpg выдумщиц.nlfpg выжлиц.nlfpg выкупщиц.nlfpg вымогательниц.nlfpg 
+выпарщиц.nlfpg выпускниц.nlfpg выразительниц.nlfpg выучениц.nlfpg вязальщиц.nlfpg гадальщиц.nlfpg 
+гадательниц.nlfpg газетчиц.nlfpg газировщиц.nlfpg галлиц.nlfpg гладильщиц.nlfpg говельщиц.nlfpg 
+гонительниц.nlfpg гонщиц.nlfpg горлиц.nlfpg горнолыжниц.nlfpg городошниц.nlfpg грабительниц.nlfpg 
+гравировщиц.nlfpg гранильщиц.nlfpg гранулировщиц.nlfpg греховодниц.nlfpg грешниц.nlfpg гримасниц.nlfpg 
+грузчиц.nlfpg губительниц.nlfpg дарительниц.nlfpg дачевладелиц.nlfpg дачниц.nlfpg двоемужниц.nlfpg 
+двоечниц.nlfpg двумужниц.nlfpg двурушниц.nlfpg девиц.nlfpg девственниц.nlfpg девятиклассниц.nlfpg 
+декатировщиц.nlfpg делопроизводительниц.nlfpg деревообделочниц.nlfpg держательниц.nlfpg десятиклассниц.nlfpg деятельниц.nlfpg 
+дипломниц.nlfpg доброжелательниц.nlfpg добытчиц.nlfpg доверительниц.nlfpg доильщиц.nlfpg доказчиц.nlfpg 
+докладчиц.nlfpg долгожительниц.nlfpg должниц.nlfpg дольщиц.nlfpg домовладелиц.nlfpg домоправительниц.nlfpg 
+домработниц.nlfpg доносительниц.nlfpg доносчиц.nlfpg дорожниц.nlfpg досмотрщиц.nlfpg доставщиц.nlfpg 
+дошкольниц.nlfpg дражировщиц.nlfpg драпировщиц.nlfpg древесниц.nlfpg дрессировщиц.nlfpg дружинниц.nlfpg 
+духанщиц.nlfpg духовидиц.nlfpg душеприказчиц.nlfpg дьяволиц.nlfpg дьякониц.nlfpg единоличниц.nlfpg 
+единомышленниц.nlfpg единоплеменниц.nlfpg естественниц.nlfpg естествоиспытательниц.nlfpg ехидниц.nlfpg жалобщиц.nlfpg 
+жар-птиц.nlfpg железнодорожниц.nlfpg жеманниц.nlfpg жертвовательниц.nlfpg жилиц.nlfpg жительниц.nlfpg 
+жниц.nlfpg жриц.nlfpg жужелиц.nlfpg забавниц.nlfpg забастовщиц.nlfpg заварщиц.nlfpg 
+завещательниц.nlfpg завистниц.nlfpg заводчиц.nlfpg завоевательниц.nlfpg загадчиц.nlfpg заговорщиц.nlfpg 
+заготовщиц.nlfpg задавальщиц.nlfpg задолжниц.nlfpg зажимщиц.nlfpg заказчиц.nlfpg закладчиц.nlfpg 
+заклинательниц.nlfpg законниц.nlfpg законодательниц.nlfpg закоперщиц.nlfpg закрепщиц.nlfpg закройщиц.nlfpg 
+закупорщиц.nlfpg закупщиц.nlfpg заложниц.nlfpg заместительниц.nlfpg заочниц.nlfpg запайщиц.nlfpg 
+заправщиц.nlfpg засольщиц.nlfpg застрельщиц.nlfpg застройщиц.nlfpg заступниц.nlfpg засыпщиц.nlfpg 
+затворниц.nlfpg затейниц.nlfpg затейщиц.nlfpg захватчиц.nlfpg захребетниц.nlfpg зачинательниц.nlfpg 
+зачинщиц.nlfpg защитниц.nlfpg заявительниц.nlfpg заявщиц.nlfpg зеленщиц.nlfpg землевладелиц.nlfpg 
+зенитчиц.nlfpg зимовщиц.nlfpg злопыхательниц.nlfpg злоумышленниц.nlfpg злоязычниц.nlfpg змееящериц.nlfpg 
+зрительниц.nlfpg идолопоклонниц.nlfpg избавительниц.nlfpg избирательниц.nlfpg избранниц.nlfpg изгнанниц.nlfpg 
+издательниц.nlfpg изменниц.nlfpg изменщиц.nlfpg изобличительниц.nlfpg изобретательниц.nlfpg изолировщиц.nlfpg 
+ильниц.nlfpg именинниц.nlfpg императриц.nlfpg иноплеменниц.nlfpg инструментальщиц.nlfpg искательниц.nlfpg 
+искусительниц.nlfpg искусниц.nlfpg искусственниц.nlfpg исповедниц.nlfpg исполнительниц.nlfpg испольщиц.nlfpg 
+исправниц.nlfpg испытательниц.nlfpg исследовательниц.nlfpg истиц.nlfpg истолковательниц.nlfpg истопниц.nlfpg 
+истязательниц.nlfpg исцелительниц.nlfpg кабатчиц.nlfpg каверзниц.nlfpg калибровщиц.nlfpg калильщиц.nlfpg 
+каменщиц.nlfpg камышниц.nlfpg канатчиц.nlfpg канительщиц.nlfpg капризниц.nlfpg капустниц.nlfpg 
+каракатиц.nlfpg караульщиц.nlfpg кардовщиц.nlfpg карлиц.nlfpg картежниц.nlfpg картонажниц.nlfpg 
+картонщиц.nlfpg картотетчиц.nlfpg кассетчиц.nlfpg катальщиц.nlfpg каторжниц.nlfpg кафельщиц.nlfpg 
+квартиросъемщиц.nlfpg келейниц.nlfpg керосинщиц.nlfpg кисловщиц.nlfpg кладовщиц.nlfpg клеветниц.nlfpg 
+клеильщиц.nlfpg клеймовщиц.nlfpg клейщиц.nlfpg клепальщиц.nlfpg клушиц.nlfpg ключниц.nlfpg 
+клятвопреступниц.nlfpg кляузниц.nlfpg книжниц.nlfpg кобылиц.nlfpg коверщиц.nlfpg ковровщиц.nlfpg 
+кокильщиц.nlfpg колбасниц.nlfpg колодниц.nlfpg колпиц.nlfpg колхозниц.nlfpg комплектовщиц.nlfpg 
+конвейерщиц.nlfpg конторщиц.nlfpg конфетчиц.nlfpg конъюнктурщиц.nlfpg копировальщиц.nlfpg копировщиц.nlfpg 
+коптильщиц.nlfpg копьеметательниц.nlfpg корзинщиц.nlfpg кормилиц.nlfpg коробейниц.nlfpg коробочниц.nlfpg 
+коровниц.nlfpg корообдирщиц.nlfpg корректировщиц.nlfpg корсажниц.nlfpg корсетниц.nlfpg корчемниц.nlfpg 
+костюмщиц.nlfpg кочевниц.nlfpg кошатниц.nlfpg крановщиц.nlfpg красавиц.nlfpg красильщиц.nlfpg 
+крахмальщиц.nlfpg крепостниц.nlfpg крестниц.nlfpg крошильщиц.nlfpg кружевниц.nlfpg крутильщиц.nlfpg 
+кудесниц.nlfpg кукольниц.nlfpg куниц.nlfpg купальщиц.nlfpg курильщиц.nlfpg курортниц.nlfpg 
+курятниц.nlfpg кутейниц.nlfpg лабазниц.nlfpg лавочниц.nlfpg лагерниц.nlfpg лазутчиц.nlfpg 
+ламповщиц.nlfpg лапотниц.nlfpg ларечниц.nlfpg лекальщиц.nlfpg ленивиц.nlfpg ленточниц.nlfpg 
+лепщиц.nlfpg летчиц.nlfpg лжесвидетельниц.nlfpg лимонниц.nlfpg линовщиц.nlfpg лисиц.nlfpg 
+лицовщиц.nlfpg лишайниц.nlfpg лодочниц.nlfpg лоскутниц.nlfpg лоточниц.nlfpg лотошниц.nlfpg 
+лохмотниц.nlfpg лошадниц.nlfpg лукавиц.nlfpg лыжниц.nlfpg львиц.nlfpg любимиц.nlfpg 
+любительниц.nlfpg любовниц.nlfpg мазальщиц.nlfpg макетчиц.nlfpg манекенщиц.nlfpg мастериц.nlfpg 
+медяниц.nlfpg месильщиц.nlfpg метательниц.nlfpg метельщиц.nlfpg меховщиц.nlfpg мечтательниц.nlfpg 
+мешальщиц.nlfpg мешочниц.nlfpg миллионщиц.nlfpg мироносиц.nlfpg миротвориц.nlfpg мирохранительниц.nlfpg 
+многостаночниц.nlfpg многоцветниц.nlfpg модельщиц.nlfpg модниц.nlfpg мойщиц.nlfpg молельщиц.nlfpg 
+молитвенниц.nlfpg молодиц.nlfpg молотильщиц.nlfpg молчальниц.nlfpg монтажниц.nlfpg мороженщиц.nlfpg 
+мотальщиц.nlfpg мотовильщиц.nlfpg мотогонщиц.nlfpg мошенниц.nlfpg мстительниц.nlfpg мужененавистниц.nlfpg 
+мужеубийц.nlfpg мусорщиц.nlfpg мучениц.nlfpg мучительниц.nlfpg мятежниц.nlfpg набивальщиц.nlfpg 
+наблюдательниц.nlfpg набойщиц.nlfpg наборщиц.nlfpg наветчиц.nlfpg навивальщиц.nlfpg наводчиц.nlfpg 
+нагребальщиц.nlfpg надвязчиц.nlfpg надзирательниц.nlfpg надомниц.nlfpg надсмотрщиц.nlfpg наездниц.nlfpg 
+наемниц.nlfpg наемщиц.nlfpg наклейщиц.nlfpg накопительниц.nlfpg наладчиц.nlfpg налетчиц.nlfpg 
+налогоплательщиц.nlfpg наложниц.nlfpg наместниц.nlfpg намотчиц.nlfpg нанимательниц.nlfpg напарниц.nlfpg 
+наперсниц.nlfpg направщиц.nlfpg народниц.nlfpg нарушительниц.nlfpg нарядчиц.nlfpg насекальщиц.nlfpg 
+наследниц.nlfpg наследодательниц.nlfpg насмешниц.nlfpg наставниц.nlfpg настоятельниц.nlfpg настройщиц.nlfpg 
+насыпальщиц.nlfpg насыпщиц.nlfpg натурщиц.nlfpg наушниц.nlfpg нахлебниц.nlfpg начальниц.nlfpg 
+начетниц.nlfpg начетчиц.nlfpg начинательниц.nlfpg невольниц.nlfpg негодниц.nlfpg недоброжелательниц.nlfpg 
+нектарниц.nlfpg ненавистниц.nlfpg неплательщиц.nlfpg неприятельниц.nlfpg несчастливиц.nlfpg неудачниц.nlfpg 
+нечестивиц.nlfpg нивелировщиц.nlfpg никелировщиц.nlfpg ниточниц.nlfpg нормировщиц.nlfpg носительниц.nlfpg 
+ночлежниц.nlfpg ночниц.nlfpg нумеровщиц.nlfpg ныряльщиц.nlfpg нюхальщиц.nlfpg обвинительниц.nlfpg 
+обворожительниц.nlfpg обжарщиц.nlfpg обидчиц.nlfpg обитательниц.nlfpg обладательниц.nlfpg облицовщиц.nlfpg 
+обличительниц.nlfpg обманщиц.nlfpg обмеловщиц.nlfpg обмотчиц.nlfpg обожательниц.nlfpg обозревательниц.nlfpg 
+обольстительниц.nlfpg обработчиц.nlfpg обтяжчиц.nlfpg обувщиц.nlfpg обшивальщиц.nlfpg обшивщиц.nlfpg 
+общественниц.nlfpg обывательниц.nlfpg огнепоклонниц.nlfpg огородниц.nlfpg одноклассниц.nlfpg одноклубниц.nlfpg 
+однокурсниц.nlfpg однофамилиц.nlfpg озорниц.nlfpg орлиц.nlfpg осведомительниц.nlfpg освободительниц.nlfpg 
+оскорбительниц.nlfpg ослиц.nlfpg ослушниц.nlfpg основательниц.nlfpg остриц.nlfpg острожниц.nlfpg 
+отбельщиц.nlfpg отборщиц.nlfpg отвальщиц.nlfpg ответчиц.nlfpg отгадчиц.nlfpg отдельщиц.nlfpg 
+отжимщиц.nlfpg отказчиц.nlfpg откатчиц.nlfpg отличниц.nlfpg отправительниц.nlfpg отпускниц.nlfpg 
+отпущенниц.nlfpg отравительниц.nlfpg отроковиц.nlfpg отступниц.nlfpg отшельниц.nlfpg оформительниц.nlfpg 
+охальниц.nlfpg охотниц.nlfpg охранительниц.nlfpg охранниц.nlfpg оценщиц.nlfpg очаровательниц.nlfpg 
+очевидиц.nlfpg очковтирательниц.nlfpg падчериц.nlfpg пайщиц.nlfpg пакетчиц.nlfpg пакостниц.nlfpg 
+паломниц.nlfpg паскудниц.nlfpg пахтальщиц.nlfpg певиц.nlfpg пенниц.nlfpg первоклассниц.nlfpg 
+первокурсниц.nlfpg первооткрывательниц.nlfpg перворазрядниц.nlfpg перебежчиц.nlfpg переборщиц.nlfpg переводчиц.nlfpg 
+перевозчиц.nlfpg передатчиц.nlfpg перекупщиц.nlfpg перематывальщиц.nlfpg переносчиц.nlfpg перепелиц.nlfpg 
+переписчиц.nlfpg пересказчиц.nlfpg пересмешниц.nlfpg перестраховщиц.nlfpg пересудчиц.nlfpg перловиц.nlfpg 
+перчаточниц.nlfpg песенниц.nlfpg печальниц.nlfpg пигалиц.nlfpg пикетчиц.nlfpg пильщиц.nlfpg 
+писательниц.nlfpg питомиц.nlfpg пиявиц.nlfpg плакальщиц.nlfpg плательщиц.nlfpg платьевщиц.nlfpg 
+племянниц.nlfpg пленниц.nlfpg плетельщиц.nlfpg плотвиц.nlfpg плотиц.nlfpg плотниц.nlfpg 
+площиц.nlfpg победительниц.nlfpg поборниц.nlfpg повелительниц.nlfpg погонщиц.nlfpg подавальщиц.nlfpg 
+подательниц.nlfpg подборщиц.nlfpg подвижниц.nlfpg подговорщиц.nlfpg поденщиц.nlfpg поджигательниц.nlfpg 
+подкулачниц.nlfpg подметальщиц.nlfpg подносчиц.nlfpg подписчиц.nlfpg подполковниц.nlfpg подпольщиц.nlfpg 
+подражательниц.nlfpg подсказчиц.nlfpg подсобниц.nlfpg подстрекательниц.nlfpg подушечниц.nlfpg поздравительниц.nlfpg 
+позорниц.nlfpg поилиц.nlfpg поклепщиц.nlfpg поклонниц.nlfpg покойниц.nlfpg покорительниц.nlfpg 
+покровительниц.nlfpg покупательниц.nlfpg покупщиц.nlfpg полковниц.nlfpg полольщиц.nlfpg поломойщиц.nlfpg 
+полуночниц.nlfpg получательниц.nlfpg полюбовниц.nlfpg полярниц.nlfpg помазанниц.nlfpg помещиц.nlfpg 
+помощниц.nlfpg пономариц.nlfpg попечительниц.nlfpg попустительниц.nlfpg попутчиц.nlfpg поработительниц.nlfpg 
+поручительниц.nlfpg посадниц.nlfpg посетительниц.nlfpg посланниц.nlfpg последовательниц.nlfpg послушниц.nlfpg 
+пособниц.nlfpg посредниц.nlfpg поставщиц.nlfpg постельниц.nlfpg постниц.nlfpg постоялиц.nlfpg 
+пострижениц.nlfpg посудниц.nlfpg потатчиц.nlfpg потворщиц.nlfpg похабниц.nlfpg похитительниц.nlfpg 
+почитательниц.nlfpg пошивщиц.nlfpg праведниц.nlfpg правительниц.nlfpg правонарушительниц.nlfpg правщиц.nlfpg 
+прародительниц.nlfpg предательниц.nlfpg предвестниц.nlfpg предводительниц.nlfpg предвозвестниц.nlfpg предпринимательниц.nlfpg 
+председательниц.nlfpg предсказательниц.nlfpg представительниц.nlfpg предстательниц.nlfpg предшественниц.nlfpg предъявительниц.nlfpg 
+преемниц.nlfpg прелестниц.nlfpg преобразовательниц.nlfpg препаратчиц.nlfpg преподавательниц.nlfpg преследовательниц.nlfpg 
+преступниц.nlfpg привередниц.nlfpg привратниц.nlfpg приданниц.nlfpg придирщиц.nlfpg придумщиц.nlfpg 
+приемщиц.nlfpg приживальщиц.nlfpg приказчиц.nlfpg примирительниц.nlfpg прислужниц.nlfpg приспешниц.nlfpg 
+притворщиц.nlfpg притеснительниц.nlfpg прихлебательниц.nlfpg прицепщиц.nlfpg причастниц.nlfpg причитальщиц.nlfpg 
+причудниц.nlfpg пришелиц.nlfpg приятельниц.nlfpg проверщиц.nlfpg провидиц.nlfpg проводниц.nlfpg 
+провозвестниц.nlfpg прогульщиц.nlfpg продавщиц.nlfpg продолжательниц.nlfpg проектировщиц.nlfpg прожигательниц.nlfpg 
+прозорливиц.nlfpg производительниц.nlfpg производственниц.nlfpg проказниц.nlfpg пропитчиц.nlfpg проповедниц.nlfpg 
+прорицательниц.nlfpg пророчиц.nlfpg просветительниц.nlfpg просительниц.nlfpg противниц.nlfpg протирщиц.nlfpg 
+протопопиц.nlfpg протяжчиц.nlfpg профилировщиц.nlfpg проходчиц.nlfpg процентщиц.nlfpg пружинщиц.nlfpg 
+псиц.nlfpg птиц.nlfpg птичниц.nlfpg пулеметчиц.nlfpg пустынниц.nlfpg путеобходчиц.nlfpg 
+путешественниц.nlfpg путниц.nlfpg пядениц.nlfpg пятерочниц.nlfpg пятиклассниц.nlfpg рабовладелиц.nlfpg 
+работниц.nlfpg радетельниц.nlfpg радиослушательниц.nlfpg радужниц.nlfpg разбойниц.nlfpg разборщиц.nlfpg 
+разведчиц.nlfpg развесчиц.nlfpg развозчиц.nlfpg развратительниц.nlfpg развратниц.nlfpg разгадчиц.nlfpg 
+раздатчиц.nlfpg раздевальщиц.nlfpg разлучниц.nlfpg разметчиц.nlfpg размотчиц.nlfpg разносчиц.nlfpg 
+разоблачительниц.nlfpg разорительниц.nlfpg разрезальщиц.nlfpg разрисовщиц.nlfpg разрушительниц.nlfpg разрядниц.nlfpg 
+разумниц.nlfpg ракетчиц.nlfpg расклейщиц.nlfpg раскольниц.nlfpg раскрасавиц.nlfpg распорядительниц.nlfpg 
+распространительниц.nlfpg распутниц.nlfpg рассказчиц.nlfpg рассыпальщиц.nlfpg рассыпщиц.nlfpg растирщиц.nlfpg 
+растлительниц.nlfpg расточительниц.nlfpg растратчиц.nlfpg растрясальщиц.nlfpg расфасовщиц.nlfpg расхитительниц.nlfpg 
+расчетчиц.nlfpg рачительниц.nlfpg ревнивиц.nlfpg ревнительниц.nlfpg револьверщиц.nlfpg резальщиц.nlfpg 
+резинщиц.nlfpg резчиц.nlfpg резьбовщиц.nlfpg ремесленниц.nlfpg репейниц.nlfpg репниц.nlfpg 
+рисовальщиц.nlfpg ровесниц.nlfpg ровничниц.nlfpg родильниц.nlfpg родительниц.nlfpg родоначальниц.nlfpg 
+родственниц.nlfpg рожениц.nlfpg рольщиц.nlfpg ростовщиц.nlfpg рубщиц.nlfpg ругательниц.nlfpg 
+руководительниц.nlfpg рукодельниц.nlfpg ручниц.nlfpg рыбиц.nlfpg рыдальщиц.nlfpg саботажниц.nlfpg 
+садовниц.nlfpg салопниц.nlfpg самогонщиц.nlfpg самодержиц.nlfpg сановниц.nlfpg сахарозаводчиц.nlfpg 
+сбитенщиц.nlfpg сборщиц.nlfpg сварливиц.nlfpg сварщиц.nlfpg свежевальщиц.nlfpg сверстниц.nlfpg 
+сверщиц.nlfpg свидетельниц.nlfpg сводниц.nlfpg своевольниц.nlfpg свойственниц.nlfpg своячениц.nlfpg 
+сдатчиц.nlfpg сдельщиц.nlfpg сезонниц.nlfpg семиклассниц.nlfpg сердечниц.nlfpg сестриц.nlfpg 
+сеяльщиц.nlfpg сигнатурщиц.nlfpg синиц.nlfpg сказительниц.nlfpg сказочниц.nlfpg скаредниц.nlfpg 
+сквалыжниц.nlfpg скиталиц.nlfpg скитниц.nlfpg склочниц.nlfpg скотниц.nlfpg скупщиц.nlfpg 
+сладострастниц.nlfpg словесниц.nlfpg служительниц.nlfpg слушательниц.nlfpg слюняниц.nlfpg смазчиц.nlfpg 
+сменщиц.nlfpg смерщиц.nlfpg смиренниц.nlfpg смотрительниц.nlfpg смотчиц.nlfpg сновальщиц.nlfpg 
+сновидиц.nlfpg собачниц.nlfpg собеседниц.nlfpg собирательниц.nlfpg соблазнительниц.nlfpg собственниц.nlfpg 
+советниц.nlfpg советчиц.nlfpg совладелиц.nlfpg совместительниц.nlfpg совратительниц.nlfpg содержательниц.nlfpg 
+сожительниц.nlfpg создательниц.nlfpg созерцательниц.nlfpg созидательниц.nlfpg соименниц.nlfpg соискательниц.nlfpg 
+сокурсниц.nlfpg сонаследниц.nlfpg сонливиц.nlfpg сообщниц.nlfpg соотечественниц.nlfpg соперниц.nlfpg 
+соплеменниц.nlfpg сопливиц.nlfpg сопроводительниц.nlfpg соратниц.nlfpg сослуживиц.nlfpg составительниц.nlfpg 
+сотрудниц.nlfpg соумышленниц.nlfpg соучастниц.nlfpg соучениц.nlfpg сочинительниц.nlfpg союзниц.nlfpg 
+спасительниц.nlfpg спесивиц.nlfpg сплетниц.nlfpg сподвижниц.nlfpg сподручниц.nlfpg спорщиц.nlfpg 
+спутниц.nlfpg срамниц.nlfpg сродниц.nlfpg сродственниц.nlfpg ссучивальщиц.nlfpg ссыпщиц.nlfpg 
+ставленниц.nlfpg станочниц.nlfpg старательниц.nlfpg старшеклассниц.nlfpg старшекурсниц.nlfpg старьевщиц.nlfpg 
+стачечниц.nlfpg стегальщиц.nlfpg стеклянниц.nlfpg стервятниц.nlfpg сторонниц.nlfpg страдалиц.nlfpg 
+странниц.nlfpg страстотерпиц.nlfpg стрелочниц.nlfpg стригальщиц.nlfpg строительниц.nlfpg строптивиц.nlfpg 
+стыдливиц.nlfpg стяжательниц.nlfpg сумеречниц.nlfpg супротивниц.nlfpg супружниц.nlfpg сутяжниц.nlfpg 
+сучильщиц.nlfpg сушильщиц.nlfpg схимниц.nlfpg сцепщиц.nlfpg счастливиц.nlfpg счетчиц.nlfpg 
+считчиц.nlfpg сшивальщиц.nlfpg съемщиц.nlfpg сыщиц.nlfpg табельщиц.nlfpg таежниц.nlfpg 
+танцовщиц.nlfpg тачальщиц.nlfpg текстильщиц.nlfpg телиц.nlfpg телятниц.nlfpg теребильщиц.nlfpg 
+тигриц.nlfpg толковательниц.nlfpg топильщиц.nlfpg тортовщиц.nlfpg торфяниц.nlfpg точильщиц.nlfpg 
+трактирщиц.nlfpg трамвайщиц.nlfpg транзитниц.nlfpg транспортниц.nlfpg траурниц.nlfpg трезвенниц.nlfpg 
+трепальщиц.nlfpg третьеклассниц.nlfpg третьекурсниц.nlfpg трикотажниц.nlfpg троечниц.nlfpg тростильщиц.nlfpg 
+тружениц.nlfpg тряпичниц.nlfpg туберкулезниц.nlfpg тунеядиц.nlfpg тюремщиц.nlfpg тяжебщиц.nlfpg 
+уборщиц.nlfpg угадчиц.nlfpg угнетательниц.nlfpg угодниц.nlfpg уголовниц.nlfpg угольщиц.nlfpg 
+удавленниц.nlfpg ударниц.nlfpg удачниц.nlfpg удильщиц.nlfpg узниц.nlfpg указчиц.nlfpg 
+укладчиц.nlfpg укротительниц.nlfpg укрывательниц.nlfpg укупорщиц.nlfpg умелиц.nlfpg упаковщиц.nlfpg 
+управительниц.nlfpg упрямиц.nlfpg уставщиц.nlfpg устроительниц.nlfpg утешительниц.nlfpg утильщиц.nlfpg 
+утиц.nlfpg утопленниц.nlfpg утюжильщиц.nlfpg участниц.nlfpg учениц.nlfpg учетчиц.nlfpg 
+учительниц.nlfpg учредительниц.nlfpg ушкуйниц.nlfpg факельщиц.nlfpg фальцовщиц.nlfpg фальшивомонетчиц.nlfpg 
+фарцовщиц.nlfpg фасовщиц.nlfpg фасонщиц.nlfpg фельдшериц.nlfpg фехтовальщиц.nlfpg физкультурниц.nlfpg 
+флерниц.nlfpg фокусниц.nlfpg фонарниц.nlfpg фонарщиц.nlfpg формовщиц.nlfpg форсунщиц.nlfpg 
+фрезеровщиц.nlfpg фуражечниц.nlfpg футлярщиц.nlfpg халтурщиц.nlfpg харчевниц.nlfpg хищниц.nlfpg 
+хлопальщиц.nlfpg хороводниц.nlfpg хранительниц.nlfpg христарадниц.nlfpg хрустальщиц.nlfpg художниц.nlfpg 
+хулительниц.nlfpg цариц.nlfpg царь-девиц.nlfpg цветочниц.nlfpg целинниц.nlfpg целительниц.nlfpg 
+ценительниц.nlfpg церемонниц.nlfpg церковниц.nlfpg цыплятниц.nlfpg чаевниц.nlfpg чаровниц.nlfpg 
+частниц.nlfpg частушечниц.nlfpg челобитчиц.nlfpg человеконенавистниц.nlfpg черпальщиц.nlfpg чертежниц.nlfpg 
+чесальщиц.nlfpg четвероклассниц.nlfpg четверочниц.nlfpg чешуйниц.nlfpg чиновниц.nlfpg чистильщиц.nlfpg 
+читательниц.nlfpg чревовещательниц.nlfpg чревоугодниц.nlfpg чтиц.nlfpg чудесниц.nlfpg чулочниц.nlfpg 
+шапочниц.nlfpg шарманщиц.nlfpg швейниц.nlfpg шелкомотальщиц.nlfpg шестидесятниц.nlfpg шестиклассниц.nlfpg 
+шифровальщиц.nlfpg шкодниц.nlfpg школьниц.nlfpg шлифовальщиц.nlfpg шлифовщиц.nlfpg шляпниц.nlfpg 
+шоколадниц.nlfpg шпульниц.nlfpg штапелировщиц.nlfpg штопальщиц.nlfpg штриховщиц.nlfpg штучниц.nlfpg 
+шутниц.nlfpg щевриц.nlfpg щетинщиц.nlfpg эстрадниц.nlfpg этикетчиц.nlfpg юбочниц.nlfpg 
+юниц.nlfpg ябедниц.nlfpg ягодниц.nlfpg язычниц.nlfpg яловиц.nlfpg ясновидиц.nlfpg 
+ящериц.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 собол.= :
   LLAVH+ or LLBFF+ or LLDMN+ or LLDMU+;
 
 собор.= :
   LLAAQ+ or LLBYU+ or LLCCZ+ or LLFWB+ or LLCGW+ or LLFWD+;
 
-собор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 собор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+собор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.215:
   LLARS+;
@@ -36140,9 +36132,9 @@
 сов.= :
   LLAGT+ or LLAVH+ or LLBFF+ or LLBRO+ or LLBSW+ or LLCJW+;
 
-сов.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 сов.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+сов.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 сове.= :
   LLCSO+ or LLCTB+ or LLCZE+;
@@ -36331,9 +36323,9 @@
 содом.= :
   LLAAQ+ or LLBGQ+;
 
-содом.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 содом.ndmsi :  <morph-С,мр,но,ед,им>;
+
+содом.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 всполь.= жнивь.= обручь.= одонь.= окось.= перенось.= 
 плать.= подстоль.= предусть.= созвучь.= :
@@ -36365,9 +36357,9 @@
 
 сокол.nlmsi :  <morph-С,мр,од,ед,им>;
 
-сокол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 сокол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сокол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сол.= :
   LLGPL+ or LLAVJ+ or LLBHS+ or LLBNP+ or LLBRK+ or LLDNF+ or LLDOO+;
@@ -36376,11 +36368,11 @@
 :
   LLACX+ or LLBRO+;
 
-башкир.nlmsi грузин.nlmsi мадьяр.nlmsi осетин.nlmsi румын.nlmsi солдат.nlmsi 
-:  <morph-С,мр,од,ед,им>;
-
 башкир.nlmpv грузин.nlmpv мадьяр.nlmpv осетин.nlmpv румын.nlmpv солдат.nlmpv 
 :  <morph-С,мр,од,мн,вн>;
+
+башкир.nlmsi грузин.nlmsi мадьяр.nlmsi осетин.nlmsi румын.nlmsi солдат.nlmsi 
+:  <morph-С,мр,од,ед,им>;
 
 башкир.nlmpg грузин.nlmpg мадьяр.nlmpg осетин.nlmpg румын.nlmpg солдат.nlmpg 
 :  <morph-С,мр,од,мн,рд>;
@@ -36392,18 +36384,18 @@
 солнечно.= :
   LLAEK+ or LLDXI+;
 
-солнечно.e :  <morph-Н,0>;
-
 солнечно.a :  <morph-П,0>;
+
+солнечно.e :  <morph-Н,0>;
 
 соло.= :
   LLADL+ or LLAEG+ or LLAEK+ or LLAPG+ or LLAQP+;
 
+соло.a :  <morph-П,0>;
+
 соло.e :  <morph-Н,0>;
 
 соло.ndn :  <morph-С,ср,но,0>;
-
-соло.a :  <morph-П,0>;
 
 солов.= :
   LLATY+ or LLBRO+ or LLDKF+;
@@ -36419,9 +36411,9 @@
 керосин.= мармелад.= сахарин.= солод.= щекот.= :
   LLAAO+ or LLBRK+;
 
-керосин.ndmsv мармелад.ndmsv сахарин.ndmsv солод.ndmsv щекот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 керосин.ndmsi мармелад.ndmsi сахарин.ndmsi солод.ndmsi щекот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+керосин.ndmsv мармелад.ndmsv сахарин.ndmsv солод.ndmsv щекот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 солодов.= :
   LLBZO+ or LLDKJ+;
@@ -36431,9 +36423,9 @@
 соломонов.= :
   LLFVN+;
 
-соломонов.amsi :  <morph-П,мр,ед,им>;
-
 соломонов.admsv :  <morph-П,мр,ед,вн,но>;
+
+соломонов.amsi :  <morph-П,мр,ед,им>;
 
 солон.= :
   LLAYB+ or LLBRK+;
@@ -36444,18 +36436,18 @@
 сом.= :
   LLACI+ or LLAFX+ or LLAVH+;
 
-сом.nlmsi :  <morph-С,мр,од,ед,им>;
-
 сом.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+сом.nlmsi :  <morph-С,мр,од,ед,им>;
 
 сомали.= :
   LLABZ+ or LLAEG+ or LLDXD+ or LLAYG+ or LLBPY+;
 
 сомали.ndn :  <morph-С,ср,но,0>;
 
-сомали.a :  <morph-П,0>;
-
 сомали.ndm :  <morph-С,мр,но,0>;
+
+сомали.a :  <morph-П,0>;
 
 кротов.= сомов.= :
   LLBFF+ or LLDKJ+;
@@ -36511,9 +36503,9 @@
 сор.= :
   LLAAO+ or LLBGI+ or LLBYU+;
 
-сор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 сор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 соразмер.= :
   LLFSS+ or LLBYX+;
@@ -36521,15 +36513,15 @@
 сорок.= :
   LLDSZ+ or LLAFU+ or LLAGR+;
 
-сорок.nlfpg :  <morph-С,жр,од,мн,рд>;
+сорок.cv :  <morph-ЧИСЛ,вн>;
 
 сорок.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+сорок.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 сорок.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 сорок.ci :  <morph-ЧИСЛ,им>;
-
-сорок.cv :  <morph-ЧИСЛ,вн>;
 
 сороков.= :
   LLBRK+ or LLDVP+;
@@ -36582,9 +36574,9 @@
 сосков.= :
   LLFKJ+ or LLFKI+ or LLDKJ+;
 
-сосков.amss :  <morph-П,мр,ед,кр>;
-
 сосков.nlmsi :  <morph-С,мр,од,ед,им>;
+
+сосков.amss :  <morph-П,мр,ед,кр>;
 
 сосредоточ.= :
   LLBDD+ or LLFYH+ or LLBOC+;
@@ -36592,9 +36584,9 @@
 состав.= :
   LLAAQ+ or LLFYW+ or LLFYX+;
 
-состав.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 состав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+состав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 состо.= :
   LLDRL+ or LLGGL+;
@@ -36677,13 +36669,13 @@
 спас.= :
   LLAAQ+ or LLACI+ or LLGAZ+ or LLGFN+ or LLGJM+;
 
-спас.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
-
 спас.nlmsi :  <morph-С,мр,од,ед,им>;
 
-спас.ndmsv :  <morph-С,мр,но,ед,вн>;
+спас.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
 спас.ndmsi :  <morph-С,мр,но,ед,им>;
+
+спас.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 спас-верховь.= :
   LLDXW+;
@@ -36693,9 +36685,9 @@
 спасибо.= :
   LLADL+ or LLAEL+;
 
-спасибо.xn :  <morph-ПРЕДК,нст>;
-
 спасибо.ndn :  <morph-С,ср,но,0>;
+
+спасибо.xn :  <morph-ПРЕДК,нст>;
 
 спасоналивковск.= :
   LLDYU+;
@@ -36703,9 +36695,9 @@
 спасск.= :
   LLDWW+ or LLFJZ+ or LLDYV+ or LLDZV+;
 
-спасск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 спасск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+спасск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 спе.= :
   LLCZE+ or LLFXJ+ or LLGAK+;
@@ -36752,35 +36744,6 @@
 /ru/words/words.220:
   LLAGT+;
 
-аббатис.nlfpg аббатисс.nlfpg акарид.nlfpg актиномицет.nlfpg актрис.nlfpg ам.nlfpg 
-амблистом.nlfpg анаконд.nlfpg анкилостом.nlfpg анодонт.nlfpg антилоп.nlfpg аонид.nlfpg 
-аскарид.nlfpg балерин.nlfpg баронесс.nlfpg барракуд.nlfpg бой-баб.nlfpg бонн.nlfpg 
-брамапутр.nlfpg ванесс.nlfpg ведьм.nlfpg виверр.nlfpg виконтесс.nlfpg випер.nlfpg 
-гадин.nlfpg гамадриад.nlfpg генетт.nlfpg гетер.nlfpg гидр.nlfpg гидромедуз.nlfpg 
-гиен.nlfpg горилл.nlfpg гюрз.nlfpg диаконис.nlfpg дивчин.nlfpg дискомедуз.nlfpg 
-догаресс.nlfpg донн.nlfpg дриад.nlfpg дрозофил.nlfpg дроф.nlfpg ехидн.nlfpg 
-женщин.nlfpg зебр.nlfpg игуан.nlfpg инспектрис.nlfpg кайр.nlfpg камбал.nlfpg 
-камер-фрейлин.nlfpg канн.nlfpg канонисс.nlfpg кантарид.nlfpg капибар.nlfpg карамор.nlfpg 
-квакв.nlfpg кикимор.nlfpg киноактрис.nlfpg кинозвезд.nlfpg коал.nlfpg коломбин.nlfpg 
-корифен.nlfpg креатур.nlfpg кронпринцесс.nlfpg крякв.nlfpg кузин.nlfpg курв.nlfpg 
-лакедр.nlfpg лектрис.nlfpg лиманд.nlfpg литорин.nlfpg лярв.nlfpg мадонн.nlfpg 
-макайр.nlfpg матрон.nlfpg мегер.nlfpg медуз.nlfpg менад.nlfpg мессалин.nlfpg 
-метресс.nlfpg меч-рыб.nlfpg миксин.nlfpg миксомицет.nlfpg мойв.nlfpg мойр.nlfpg 
-молот-рыб.nlfpg мольв.nlfpg муз.nlfpg мультипар.nlfpg мурен.nlfpg мымр.nlfpg 
-наяд.nlfpg нельм.nlfpg нематод.nlfpg нерп.nlfpg нимфалин.nlfpg океанид.nlfpg 
-ореад.nlfpg панд.nlfpg панн.nlfpg пантер.nlfpg патронесс.nlfpg пеламид.nlfpg 
-перкарин.nlfpg персон.nlfpg питт.nlfpg полихет.nlfpg полудев.nlfpg полукобыл.nlfpg 
-полукоров.nlfpg полуобезьян.nlfpg полурыб.nlfpg поэтесс.nlfpg прима-балерин.nlfpg примадонн.nlfpg 
-принцесс.nlfpg приоресс.nlfpg пум.nlfpg редактрис.nlfpg ремень-рыб.nlfpg ремор.nlfpg 
-рок-звезд.nlfpg рулен.nlfpg сагитт.nlfpg сайр.nlfpg саккулин.nlfpg саламандр.nlfpg 
-сандрильон.nlfpg секс-бомб.nlfpg сеньорит.nlfpg серн.nlfpg сивилл.nlfpg сильфид.nlfpg 
-синьорин.nlfpg скифомедуз.nlfpg сколопендр.nlfpg скорпен.nlfpg смарид.nlfpg спизелл.nlfpg 
-статс-дам.nlfpg стерв.nlfpg стюардесс.nlfpg суперзвезд.nlfpg сфецид.nlfpg сциен.nlfpg 
-сцифомедуз.nlfpg танагр.nlfpg тахин.nlfpg телезвезд.nlfpg терморф.nlfpg трематод.nlfpg 
-тригл.nlfpg тридакн.nlfpg трихин.nlfpg трихинелл.nlfpg туатар.nlfpg ундин.nlfpg 
-фавел.nlfpg фефел.nlfpg филлоксер.nlfpg фиф.nlfpg фолад.nlfpg фрейлин.nlfpg 
-харит.nlfpg циветт.nlfpg цистод.nlfpg эвменид.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 аббатис.nlfpv аббатисс.nlfpv акарид.nlfpv актиномицет.nlfpv актрис.nlfpv ам.nlfpv 
 амблистом.nlfpv анаконд.nlfpv анкилостом.nlfpv анодонт.nlfpv антилоп.nlfpv аонид.nlfpv 
 аскарид.nlfpv балерин.nlfpv баронесс.nlfpv барракуд.nlfpv бой-баб.nlfpv бонн.nlfpv 
@@ -36810,12 +36773,41 @@
 фавел.nlfpv фефел.nlfpv филлоксер.nlfpv фиф.nlfpv фолад.nlfpv фрейлин.nlfpv 
 харит.nlfpv циветт.nlfpv цистод.nlfpv эвменид.nlfpv :  <morph-С,жр,од,мн,вн>;
 
+аббатис.nlfpg аббатисс.nlfpg акарид.nlfpg актиномицет.nlfpg актрис.nlfpg ам.nlfpg 
+амблистом.nlfpg анаконд.nlfpg анкилостом.nlfpg анодонт.nlfpg антилоп.nlfpg аонид.nlfpg 
+аскарид.nlfpg балерин.nlfpg баронесс.nlfpg барракуд.nlfpg бой-баб.nlfpg бонн.nlfpg 
+брамапутр.nlfpg ванесс.nlfpg ведьм.nlfpg виверр.nlfpg виконтесс.nlfpg випер.nlfpg 
+гадин.nlfpg гамадриад.nlfpg генетт.nlfpg гетер.nlfpg гидр.nlfpg гидромедуз.nlfpg 
+гиен.nlfpg горилл.nlfpg гюрз.nlfpg диаконис.nlfpg дивчин.nlfpg дискомедуз.nlfpg 
+догаресс.nlfpg донн.nlfpg дриад.nlfpg дрозофил.nlfpg дроф.nlfpg ехидн.nlfpg 
+женщин.nlfpg зебр.nlfpg игуан.nlfpg инспектрис.nlfpg кайр.nlfpg камбал.nlfpg 
+камер-фрейлин.nlfpg канн.nlfpg канонисс.nlfpg кантарид.nlfpg капибар.nlfpg карамор.nlfpg 
+квакв.nlfpg кикимор.nlfpg киноактрис.nlfpg кинозвезд.nlfpg коал.nlfpg коломбин.nlfpg 
+корифен.nlfpg креатур.nlfpg кронпринцесс.nlfpg крякв.nlfpg кузин.nlfpg курв.nlfpg 
+лакедр.nlfpg лектрис.nlfpg лиманд.nlfpg литорин.nlfpg лярв.nlfpg мадонн.nlfpg 
+макайр.nlfpg матрон.nlfpg мегер.nlfpg медуз.nlfpg менад.nlfpg мессалин.nlfpg 
+метресс.nlfpg меч-рыб.nlfpg миксин.nlfpg миксомицет.nlfpg мойв.nlfpg мойр.nlfpg 
+молот-рыб.nlfpg мольв.nlfpg муз.nlfpg мультипар.nlfpg мурен.nlfpg мымр.nlfpg 
+наяд.nlfpg нельм.nlfpg нематод.nlfpg нерп.nlfpg нимфалин.nlfpg океанид.nlfpg 
+ореад.nlfpg панд.nlfpg панн.nlfpg пантер.nlfpg патронесс.nlfpg пеламид.nlfpg 
+перкарин.nlfpg персон.nlfpg питт.nlfpg полихет.nlfpg полудев.nlfpg полукобыл.nlfpg 
+полукоров.nlfpg полуобезьян.nlfpg полурыб.nlfpg поэтесс.nlfpg прима-балерин.nlfpg примадонн.nlfpg 
+принцесс.nlfpg приоресс.nlfpg пум.nlfpg редактрис.nlfpg ремень-рыб.nlfpg ремор.nlfpg 
+рок-звезд.nlfpg рулен.nlfpg сагитт.nlfpg сайр.nlfpg саккулин.nlfpg саламандр.nlfpg 
+сандрильон.nlfpg секс-бомб.nlfpg сеньорит.nlfpg серн.nlfpg сивилл.nlfpg сильфид.nlfpg 
+синьорин.nlfpg скифомедуз.nlfpg сколопендр.nlfpg скорпен.nlfpg смарид.nlfpg спизелл.nlfpg 
+статс-дам.nlfpg стерв.nlfpg стюардесс.nlfpg суперзвезд.nlfpg сфецид.nlfpg сциен.nlfpg 
+сцифомедуз.nlfpg танагр.nlfpg тахин.nlfpg телезвезд.nlfpg терморф.nlfpg трематод.nlfpg 
+тригл.nlfpg тридакн.nlfpg трихин.nlfpg трихинелл.nlfpg туатар.nlfpg ундин.nlfpg 
+фавел.nlfpg фефел.nlfpg филлоксер.nlfpg фиф.nlfpg фолад.nlfpg фрейлин.nlfpg 
+харит.nlfpg циветт.nlfpg цистод.nlfpg эвменид.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 подпил.= спил.= :
   LLAAQ+ or LLFWV+ or LLBRK+ or LLCJW+;
 
-подпил.ndmsv спил.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 подпил.ndmsi спил.ndmsi :  <morph-С,мр,но,ед,им>;
+
+подпил.ndmsv спил.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 спиртн.= :
   LLCIK+ or LLCIZ+;
@@ -36863,9 +36855,9 @@
 
 спор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-спор.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 спор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+спор.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 спортив.= :
   LLBSP+ or LLBYU+;
@@ -36994,11 +36986,11 @@
 аредов.= демьянов.= стариков.= :
   LLFQF+ or LLFUO+;
 
-аредов.amsi демьянов.amsi стариков.amsi :  <morph-П,мр,ед,им>;
+аредов.admsv демьянов.admsv стариков.admsv :  <morph-П,мр,ед,вн,но>;
 
 аредов.nlmsi демьянов.nlmsi стариков.nlmsi :  <morph-С,мр,од,ед,им>;
 
-аредов.admsv демьянов.admsv стариков.admsv :  <morph-П,мр,ед,вн,но>;
+аредов.amsi демьянов.amsi стариков.amsi :  <morph-П,мр,ед,им>;
 
 старин.= :
   LLAFB+ or LLAFX+ or LLBRK+ or LLBYU+;
@@ -37008,11 +37000,11 @@
 стариц.= :
   LLAFO+ or LLAGP+ or LLDXN+;
 
-стариц.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 стариц.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 стариц.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+стариц.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 старо-голутвин.= :
   LLDZO+;
@@ -37023,9 +37015,9 @@
 стародуб.= :
   LLDWW+ or LLEBJ+ or LLBRK+;
 
-стародуб.nlmsi :  <morph-С,мр,од,ед,им>;
-
 стародуб.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+стародуб.nlmsi :  <morph-С,мр,од,ед,им>;
 
 стародуб.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -37037,11 +37029,11 @@
 
 старост.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-старост.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 старост.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 старост.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+старост.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 старт.= :
   LLAAQ+ or LLCBF+ or LLGAZ+;
@@ -37056,11 +37048,11 @@
 рынд.= старшин.= человечин.= :
   LLAEY+ or LLAFX+;
 
-рынд.ndfpg старшин.ndfpg человечин.ndfpg :  <morph-С,жр,но,мн,рд>;
+рынд.nlmpg старшин.nlmpg человечин.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 рынд.nlmpv старшин.nlmpv человечин.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-рынд.nlmpg старшин.nlmpg человечин.nlmpg :  <morph-С,мр,од,мн,рд>;
+рынд.ndfpg старшин.ndfpg человечин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 стат.= :
   LLBYU+ or LLDNF+ or LLDPK+;
@@ -37097,11 +37089,11 @@
 стек.= :
   LLAAM+ or LLAFU+ or LLBUC+;
 
-стек.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 стек.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 стек.ndmsi :  <morph-С,мр,но,ед,им>;
+
+стек.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 саванн.= стекловат.= :
   LLAFX+ or LLDLO+;
@@ -37130,16 +37122,16 @@
 стервоз.= :
   LLAGT+ or LLBYU+;
 
-стервоз.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 стервоз.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+стервоз.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 стереотип.= темперамент.= :
   LLAAQ+ or LLBYT+;
 
-стереотип.ndmsv темперамент.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 стереотип.ndmsi темперамент.ndmsi :  <morph-С,мр,но,ед,им>;
+
+стереотип.ndmsv темперамент.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 стерляд.= :
   LLBRO+ or LLDNL+;
@@ -37164,11 +37156,11 @@
 стих.= :
   LLAAM+ or LLBCC+ or LLFXM+;
 
-стих.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 стих.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
 
 стих.ndmsi :  <morph-С,мр,но,ед,им>;
+
+стих.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 стихов.= :
   LLBUV+ or LLCJC+;
@@ -37215,14 +37207,14 @@
 столечко.= эстолько.= :
   LLAEK+ or LLDSY+;
 
+немало.cv немножечко.cv немножко.cv нисколечко.cv нисколько.cv сколечко.cv 
+столечко.cv эстолько.cv :  <morph-ЧИСЛ,вн>;
+
 немало.e немножечко.e немножко.e нисколечко.e нисколько.e сколечко.e 
 столечко.e эстолько.e :  <morph-Н,0>;
 
 немало.ci немножечко.ci немножко.ci нисколечко.ci нисколько.ci сколечко.ci 
 столечко.ci эстолько.ci :  <morph-ЧИСЛ,им>;
-
-немало.cv немножечко.cv немножко.cv нисколечко.cv нисколько.cv сколечко.cv 
-столечко.cv эстолько.cv :  <morph-ЧИСЛ,вн>;
 
 маслен.= столов.= :
   LLAKS+ or LLBRK+ or LLDLO+;
@@ -37232,9 +37224,9 @@
 
 столп.nlmsi :  <morph-С,мр,од,ед,им>;
 
-столп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 столп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+столп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 стольк.= :
   LLDVG+;
@@ -37255,16 +37247,16 @@
 стон.= :
   LLAAQ+ or LLAHW+;
 
-стон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 стон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+стон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 стоп.= :
   LLAEG+ or LLDTP+ or LLAFX+ or LLFWK+ or LLFXQ+ or LLBRK+ or LLBYZ+ or LLFZB+ or LLGJI+;
 
-стоп.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 стоп.a :  <morph-П,0>;
+
+стоп.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 стопов.= :
   LLCJC+ or LLDLS+;
@@ -37279,13 +37271,13 @@
 сторож.= :
   LLAAH+ or LLACO+ or LLAFM+ or LLBHE+ or LLBMS+ or LLBRI+ or LLBSR+ or LLCJW+;
 
-сторож.nlmsi :  <morph-С,мр,од,ед,им>;
-
 сторож.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+сторож.ndmsi :  <morph-С,мр,но,ед,им>;
 
 сторож.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-сторож.ndmsi :  <morph-С,мр,но,ед,им>;
+сторож.nlmsi :  <morph-С,мр,од,ед,им>;
 
 сторон.= :
   LLAFX+ or LLBNP+ or LLBRK+;
@@ -37309,9 +37301,9 @@
 страж.= :
   LLACD+ or LLAFM+;
 
-страж.nlmsi :  <morph-С,мр,од,ед,им>;
-
 страж.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+страж.nlmsi :  <morph-С,мр,од,ед,им>;
 
 стражд.= :
   LLAHV+;
@@ -37319,11 +37311,11 @@
 страх.= :
   LLAAK+ or LLAEK+ or LLCCZ+ or LLCGW+;
 
+страх.ndmsi :  <morph-С,мр,но,ед,им>;
+
 страх.e :  <morph-Н,0>;
 
 страх.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-страх.ndmsi :  <morph-С,мр,но,ед,им>;
 
 страхов.= :
   LLFQF+ or LLBRK+ or LLCJC+;
@@ -37333,24 +37325,24 @@
 страшил.= :
   LLAFH+ or LLCAQ+;
 
-страшил.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-страшил.nlfpv :  <morph-С,жр,од,мн,вн>;
+страшил.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 страшил.nlnpg :  <morph-С,ср,од,мн,рд>;
 
-страшил.nlnpv :  <morph-С,ср,од,мн,вн>;
+страшил.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+страшил.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 страшил.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-страшил.nlmpg :  <morph-С,мр,од,мн,рд>;
+страшил.nlnpv :  <morph-С,ср,од,мн,вн>;
 
 идолищ.= страшилищ.= чудищ.= :
   LLASC+;
 
-идолищ.nlnpg страшилищ.nlnpg чудищ.nlnpg :  <morph-С,ср,од,мн,рд>;
-
 идолищ.nlnpv страшилищ.nlnpv чудищ.nlnpv :  <morph-С,ср,од,мн,вн>;
+
+идолищ.nlnpg страшилищ.nlnpg чудищ.nlnpg :  <morph-С,ср,од,мн,рд>;
 
 стрежев.= :
   LLDZY+ or LLEAA+;
@@ -37378,9 +37370,9 @@
 двадцатипятилетник.= менингококк.= стрептококк.= топливозаправщик.= :
   LLACU+;
 
-двадцатипятилетник.nlmsi менингококк.nlmsi стрептококк.nlmsi топливозаправщик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 двадцатипятилетник.nlmsv менингококк.nlmsv стрептококк.nlmsv топливозаправщик.nlmsv :  <morph-С,мр,од,ед,вн>;
+
+двадцатипятилетник.nlmsi менингококк.nlmsi стрептококк.nlmsi топливозаправщик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 стере.= стри.= :
   LLDIO+ or LLDJD+;
@@ -37388,13 +37380,13 @@
 стригал.= :
   LLAFH+ or LLDOZ+;
 
-стригал.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 стригал.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+стригал.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 стригал.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-стригал.nlmpg :  <morph-С,мр,од,мн,рд>;
+стригал.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 стригун.= :
   LLACI+ or LLAYJ+ or LLCKD+;
@@ -37454,9 +37446,9 @@
 струп.= :
   LLAAZ+ or LLBYZ+;
 
-струп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 струп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+струп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 стручков.= :
   LLFOU+ or LLDKF+;
@@ -37469,18 +37461,18 @@
 стук.= :
   LLAAK+ or LLAEL+;
 
-стук.xn :  <morph-ПРЕДК,нст>;
-
 стук.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 стук.ndmsi :  <morph-С,мр,но,ед,им>;
 
+стук.xn :  <morph-ПРЕДК,нст>;
+
 стул.= :
   LLAAR+;
 
-стул.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 стул.ndmsi :  <morph-С,мр,но,ед,им>;
+
+стул.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ступ.= :
   LLAFX+ or LLGBC+ or LLBRK+;
@@ -37521,16 +37513,16 @@
 лбин.= сугробин.= :
   LLAEU+ or LLAFY+;
 
-лбин.ndmpg сугробин.ndmpg :  <morph-С,мр,но,мн,рд>;
-
 лбин.ndfpg сугробин.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+лбин.ndmpg сугробин.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 суд.= :
   LLAAQ+ or LLBVN+ or LLBYZ+ or LLCJW+ or LLDNO+ or LLDPH+;
 
-суд.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 суд.ndmsi :  <morph-С,мр,но,ед,им>;
+
+суд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бобыл.= богатыр.= бунтар.= дикар.= корчмар.= лекар.= 
 судар.= цесар.= :
@@ -37568,9 +37560,9 @@
 сук.= :
   LLAGR+ or LLBVQ+;
 
-сук.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 сук.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+сук.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 сукновал.= :
   LLACI+ or LLBRK+ or LLDOZ+;
@@ -37590,11 +37582,11 @@
 сулейман.= :
   LLDWW+ or LLFHI+ or LLFHJ+;
 
-сулейман.nlmsi :  <morph-С,мр,од,ед,им>;
-
 сулейман.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сулейман.ndmsi :  <morph-С,мр,но,ед,им>;
+
+сулейман.nlmsi :  <morph-С,мр,од,ед,им>;
 
 сум.= :
   LLAGE+ or LLBRK+ or LLBYU+ or LLEAJ+;
@@ -37662,13 +37654,13 @@
 супруг.= :
   LLACG+ or LLAGR+ or LLBCA+;
 
-супруг.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-супруг.nlmsi :  <morph-С,мр,од,ед,им>;
+супруг.npg :  <morph-С,мн,мн,рд>;
 
 супруг.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-супруг.npg :  <morph-С,мн,мн,рд>;
+супруг.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+супруг.nlmsi :  <morph-С,мр,од,ед,им>;
 
 сур.= :
   LLAFX+ or LLDXR+ or LLCKD+;
@@ -37782,9 +37774,9 @@
 счет.= :
   LLABM+ or LLAXZ+ or LLBYU+ or LLDJV+;
 
-счет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 счет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+счет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 начи.= обчи.= отчи.= очи.= подчи.= расчи.= 
 счи.= :
@@ -37877,9 +37869,9 @@
 сяк.= :
   LLAEK+ or LLBWA+ or LLDVN+;
 
-сяк.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 сяк.e :  <morph-Н,0>;
+
+сяк.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 т.= :
   LLAVV+ or LLAWA+ or LLDVU+ or LLCLE+ or LLDWJ+ or LLDOD+;
@@ -37908,9 +37900,9 @@
 таган.= :
   LLAAQ+ or LLAYB+ or LLBYZ+ or LLCJW+;
 
-таган.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 таган.ndmsi :  <morph-С,мр,но,ед,им>;
+
+таган.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 петербургск.= североамериканск.= таганрогск.= тюменск.= :
   LLBEM+ or LLDYX+;
@@ -37931,9 +37923,9 @@
 таитян.= :
   LLAYI+ or LLBFM+ or LLBRO+;
 
-таитян.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 таитян.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+таитян.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 тайван.= :
   LLAYI+ or LLEAT+;
@@ -37968,25 +37960,25 @@
 тал.= :
   LLAAQ+ or LLBCE+ or LLDKF+ or LLDNF+ or LLDNX+ or LLDPL+;
 
-тал.amss :  <morph-П,мр,ед,кр>;
+тал.ndmsi :  <morph-С,мр,но,ед,им>;
 
 тал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-тал.ndmsi :  <morph-С,мр,но,ед,им>;
+тал.amss :  <morph-П,мр,ед,кр>;
 
 талан.= :
   LLAAQ+ or LLBGR+ or LLBNU+;
 
-талан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 талан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+талан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 джазмен.= дисковод.= талиб.= :
   LLACT+;
 
-джазмен.nlmsi дисковод.nlmsi талиб.nlmsi :  <morph-С,мр,од,ед,им>;
-
 джазмен.nlmsv дисковод.nlmsv талиб.nlmsv :  <morph-С,мр,од,ед,вн>;
+
+джазмен.nlmsi дисковод.nlmsi талиб.nlmsi :  <morph-С,мр,од,ед,им>;
 
 тамбовчан.= :
   LLBFM+ or LLBRP+;
@@ -38003,9 +37995,9 @@
 танталов.= :
   LLFUO+ or LLDLU+;
 
-танталов.amsi :  <morph-П,мр,ед,им>;
-
 танталов.admsv :  <morph-П,мр,ед,вн,но>;
+
+танталов.amsi :  <morph-П,мр,ед,им>;
 
 тап.= :
   LLAFX+ or LLDXR+ or LLBRK+ or LLBSP+;
@@ -38015,20 +38007,20 @@
 таран.= :
   LLAAQ+ or LLBFF+ or LLBIA+ or LLFXB+ or LLBNU+ or LLBYZ+ or LLCXB+ or LLDNL+;
 
-таран.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 таран.ndmsi :  <morph-С,мр,но,ед,им>;
+
+таран.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 таратор.= :
   LLAFH+ or LLBIA+ or LLBNU+ or LLBRH+;
 
-таратор.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 таратор.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+таратор.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 таратор.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-таратор.nlmpg :  <morph-С,мр,од,мн,рд>;
+таратор.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 крях.= тарах.= :
   LLCVR+;
@@ -38054,11 +38046,11 @@
 анаэроб.nlmsi аэроб.nlmsi баритон.nlmsi капер.nlmsi микроб.nlmsi полотер.nlmsi 
 рясофор.nlmsi тархан.nlmsi шипорез.nlmsi :  <morph-С,мр,од,ед,им>;
 
-анаэроб.ndmsv аэроб.ndmsv баритон.ndmsv капер.ndmsv микроб.ndmsv полотер.ndmsv 
-рясофор.ndmsv тархан.ndmsv шипорез.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 анаэроб.ndmsi аэроб.ndmsi баритон.ndmsi капер.ndmsi микроб.ndmsi полотер.ndmsi 
 рясофор.ndmsi тархан.ndmsi шипорез.ndmsi :  <morph-С,мр,но,ед,им>;
+
+анаэроб.ndmsv аэроб.ndmsv баритон.ndmsv капер.ndmsv микроб.ndmsv полотер.ndmsv 
+рясофор.ndmsv тархан.ndmsv шипорез.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тас.= :
   LLBRK+ or LLCCZ+ or LLCGW+;
@@ -38066,18 +38058,18 @@
 тат.= :
   LLACI+ or LLAEY+ or LLBRO+ or LLDMT+;
 
+тат.nlmpg :  <morph-С,мр,од,мн,рд>;
+
 тат.nlmsi :  <morph-С,мр,од,ед,им>;
 
 тат.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-тат.nlmpg :  <morph-С,мр,од,мн,рд>;
-
 татар.= :
   LLBFO+ or LLBRK+ or LLBRO+;
 
-татар.nlmpv :  <morph-С,мр,од,мн,вн>;
-
 татар.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+татар.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 татр.= :
   LLAFX+ or LLEAJ+;
@@ -38137,9 +38129,9 @@
 теля.= :
   LLADP+;
 
-теля.nlnsi :  <morph-С,ср,од,ед,им>;
-
 теля.nlnsv :  <morph-С,ср,од,ед,вн>;
+
+теля.nlnsi :  <morph-С,ср,од,ед,им>;
 
 тем.= :
   LLDTI+ or LLAFX+ or LLBYU+ or LLDNF+ or LLDRA+;
@@ -38153,9 +38145,9 @@
 
 бык.nlmsi дубровник.nlmsi темник.nlmsi :  <morph-С,мр,од,ед,им>;
 
-бык.ndmsv дубровник.ndmsv темник.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бык.ndmsi дубровник.ndmsi темник.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бык.ndmsv дубровник.ndmsv темник.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 температур.= :
   LLAFX+ or LLBGR+;
@@ -38170,22 +38162,22 @@
 тенор.= :
   LLABM+ or LLACQ+ or LLCJW+;
 
-тенор.nlmsi :  <morph-С,мр,од,ед,им>;
-
 тенор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тенор.ndmsi :  <morph-С,мр,но,ед,им>;
 
+тенор.nlmsi :  <morph-С,мр,од,ед,им>;
+
 теп.= :
   LLAFH+ or LLBUG+;
 
-теп.nlfpg :  <morph-С,жр,од,мн,рд>;
+теп.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 теп.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-теп.nlmpv :  <morph-С,мр,од,мн,вн>;
+теп.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-теп.nlmpg :  <morph-С,мр,од,мн,рд>;
+теп.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 серебр.= тепл.= :
   LLBHS+ or LLBNP+ or LLCAM+;
@@ -38727,9 +38719,9 @@
 институт.= первотел.= терцерон.= :
   LLAAQ+ or LLBRO+;
 
-институт.ndmsv первотел.ndmsv терцерон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 институт.ndmsi первотел.ndmsi терцерон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+институт.ndmsv первотел.ndmsv терцерон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тес.= :
   LLAAO+ or LLBRK+ or LLBUA+ or LLBYU+;
@@ -38741,9 +38733,9 @@
 тест.= :
   LLAAQ+ or LLCAG+ or LLDMT+;
 
-тест.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тест.ndnpg :  <morph-С,ср,но,мн,рд>;
+
+тест.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тест.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -38781,9 +38773,9 @@
 техас.= :
   LLAAY+ or LLAYI+;
 
-техас.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 техас.ndmsi :  <morph-С,мр,но,ед,им>;
+
+техас.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 теч.= :
   LLDXL+ or LLBRI+ or LLDNC+;
@@ -38799,9 +38791,9 @@
 венециан.= тибет.= :
   LLAAY+ or LLAYI+ or LLBRO+;
 
-венециан.ndmsv тибет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 венециан.ndmsi тибет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+венециан.ndmsv тибет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тибр.= :
   LLDWW+ or LLBHS+ or LLBNP+;
@@ -38822,26 +38814,14 @@
 тип.= :
   LLAAQ+ or LLACI+ or LLAYB+;
 
-тип.nlmsi :  <morph-С,мр,од,ед,им>;
-
 тип.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+тип.nlmsi :  <morph-С,мр,од,ед,им>;
 
 тип.ndmsi :  <morph-С,мр,но,ед,им>;
 
 /ru/words/words.226:
   LLAAJ+;
-
-автогараж.ndmsv бердыш.ndmsv буж.ndmsv витраж.ndmsv вольтаж.ndmsv галдеж.ndmsv 
-гамма-луч.ndmsv грабеж.ndmsv гуж.ndmsv зернофураж.ndmsv камыш.ndmsv карандаш.ndmsv 
-кедрач.ndmsv киномонтаж.ndmsv ключ.ndmsv ковш.ndmsv корж.ndmsv круглыш.ndmsv 
-крыж.ndmsv крылач.ndmsv кулеш.ndmsv кунтуш.ndmsv купаж.ndmsv кутеж.ndmsv 
-листаж.ndmsv литмонтаж.ndmsv литраж.ndmsv магарыч.ndmsv метраж.ndmsv меч.ndmsv 
-мосарбитраж.ndmsv мяч.ndmsv неплатеж.ndmsv нетерпеж.ndmsv палаш.ndmsv пернач.ndmsv 
-пихтач.ndmsv плащ.ndmsv подэтаж.ndmsv прыщ.ndmsv ряж.ndmsv свербеж.ndmsv 
-свищ.ndmsv сенаж.ndmsv сенофураж.ndmsv скулеж.ndmsv сныч.ndmsv спорыш.ndmsv 
-спотыкач.ndmsv стрекач.ndmsv сутаж.ndmsv терпеж.ndmsv типаж.ndmsv тирлич.ndmsv 
-тупыш.ndmsv тягач.ndmsv фотомонтаж.ndmsv хвощ.ndmsv хлебофураж.ndmsv хрящ.ndmsv 
-целкач.ndmsv шалаш.ndmsv электронож.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 автогараж.ndmsi бердыш.ndmsi буж.ndmsi витраж.ndmsi вольтаж.ndmsi галдеж.ndmsi 
 гамма-луч.ndmsi грабеж.ndmsi гуж.ndmsi зернофураж.ndmsi камыш.ndmsi карандаш.ndmsi 
@@ -38854,6 +38834,18 @@
 спотыкач.ndmsi стрекач.ndmsi сутаж.ndmsi терпеж.ndmsi типаж.ndmsi тирлич.ndmsi 
 тупыш.ndmsi тягач.ndmsi фотомонтаж.ndmsi хвощ.ndmsi хлебофураж.ndmsi хрящ.ndmsi 
 целкач.ndmsi шалаш.ndmsi электронож.ndmsi :  <morph-С,мр,но,ед,им>;
+
+автогараж.ndmsv бердыш.ndmsv буж.ndmsv витраж.ndmsv вольтаж.ndmsv галдеж.ndmsv 
+гамма-луч.ndmsv грабеж.ndmsv гуж.ndmsv зернофураж.ndmsv камыш.ndmsv карандаш.ndmsv 
+кедрач.ndmsv киномонтаж.ndmsv ключ.ndmsv ковш.ndmsv корж.ndmsv круглыш.ndmsv 
+крыж.ndmsv крылач.ndmsv кулеш.ndmsv кунтуш.ndmsv купаж.ndmsv кутеж.ndmsv 
+листаж.ndmsv литмонтаж.ndmsv литраж.ndmsv магарыч.ndmsv метраж.ndmsv меч.ndmsv 
+мосарбитраж.ndmsv мяч.ndmsv неплатеж.ndmsv нетерпеж.ndmsv палаш.ndmsv пернач.ndmsv 
+пихтач.ndmsv плащ.ndmsv подэтаж.ndmsv прыщ.ndmsv ряж.ndmsv свербеж.ndmsv 
+свищ.ndmsv сенаж.ndmsv сенофураж.ndmsv скулеж.ndmsv сныч.ndmsv спорыш.ndmsv 
+спотыкач.ndmsv стрекач.ndmsv сутаж.ndmsv терпеж.ndmsv типаж.ndmsv тирлич.ndmsv 
+тупыш.ndmsv тягач.ndmsv фотомонтаж.ndmsv хвощ.ndmsv хлебофураж.ndmsv хрящ.ndmsv 
+целкач.ndmsv шалаш.ndmsv электронож.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 типизир.= :
   LLCER+ or LLCGD+ or LLENL+;
@@ -38872,9 +38864,9 @@
 тит.= :
   LLAAQ+ or LLDNX+;
 
-тит.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тит.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тит.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 титов.= :
   LLFJG+ or LLFOU+ or LLBRK+;
@@ -38884,9 +38876,9 @@
 титул.= :
   LLAAQ+ or LLCCZ+ or LLFWB+ or LLCGW+ or LLDOK+;
 
-титул.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 титул.ndmsi :  <morph-С,мр,но,ед,им>;
+
+титул.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тихон.= :
   LLFKO+ or LLFIH+ or LLDPW+;
@@ -38934,16 +38926,16 @@
 тобол.= урал.= :
   LLDWW+ or LLAYK+;
 
-тобол.ndmsv урал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тобол.ndmsi урал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тобол.ndmsv урал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 товар.= :
   LLAAO+ or LLBRO+ or LLBYU+;
 
-товар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 товар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+товар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 товаропот.= :
   LLCJX+;
@@ -38963,9 +38955,9 @@
 ток.= :
   LLABF+ or LLCBF+;
 
-ток.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ток.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ток.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тока.= :
   LLDZC+ or LLBPH+;
@@ -38973,18 +38965,18 @@
 тол.= :
   LLAAQ+ or LLDXR+ or LLCLQ+ or LLCLS+ or LLCSN+ or LLCTB+ or LLCTH+ or LLDML+ or LLFIE+;
 
-тол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 толк.= :
   LLAAK+ or LLAEL+ or LLDTP+ or LLBCC+ or LLCCZ+ or LLCGW+;
 
-толк.xn :  <morph-ПРЕДК,нст>;
-
 толк.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 толк.ndmsi :  <morph-С,мр,но,ед,им>;
+
+толк.xn :  <morph-ПРЕДК,нст>;
 
 толкуч.= :
   LLBDE+ or LLBDQ+ or LLBRI+;
@@ -39032,11 +39024,11 @@
 том.= :
   LLABM+ or LLFIX+ or LLBII+ or LLBNN+ or LLBYU+ or LLEAU+;
 
+том.ndmsi :  <morph-С,мр,но,ед,им>;
+
 том.nlmsi :  <morph-С,мр,од,ед,им>;
 
 том.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-том.ndmsi :  <morph-С,мр,но,ед,им>;
 
 амбарищ.= арбузищ.= басищ.= валищ.= ветрищ.= гвоздищ.= 
 голосищ.= дождищ.= домищ.= заборищ.= заводищ.= котлищ.= 
@@ -39057,22 +39049,22 @@
 тон.= :
   LLABN+ or LLFIR+ or LLBSZ+ or LLBYZ+ or LLDFW+ or LLDQC+ or LLFKY+;
 
-тон.nlfpg :  <morph-С,жр,од,мн,рд>;
+тон.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 тон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-тон.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 тон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тон.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 топ.= :
   LLAAQ+ or LLAEL+ or LLBII+ or LLBNN+ or LLBRK+ or LLDZJ+ or LLBSW+ or LLCUQ+ or LLCVF+ or LLDNF+;
 
-топ.xn :  <morph-ПРЕДК,нст>;
-
 топ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 топ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+топ.xn :  <morph-ПРЕДК,нст>;
 
 дворищ.= кострищ.= огнищ.= пожарищ.= топорищ.= :
   LLARI+ or LLARS+;
@@ -39087,11 +39079,11 @@
 тор.= :
   LLAAQ+ or LLAFX+ or LLAYB+ or LLBHS+ or LLBNP+ or LLBYU+;
 
-тор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тор.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 тор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рог.= торбаз.= торбас.= :
   LLABM+ or LLAHD+;
@@ -39103,9 +39095,9 @@
 торг.= :
   LLAAN+ or LLBCC+ or LLCCZ+ or LLCGW+;
 
-торг.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 торг.ndmsi :  <morph-С,мр,но,ед,им>;
+
+торг.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 торгов.= :
   LLAYI+ or LLBRO+ or LLBUI+ or LLDLO+;
@@ -39134,9 +39126,9 @@
 клейстер.= торф.= :
   LLAAW+;
 
-клейстер.ndmsv торф.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 клейстер.ndmsi торф.ndmsi :  <morph-С,мр,но,ед,им>;
+
+клейстер.ndmsv торф.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 глянц.= кольц.= лупц.= свинц.= танц.= торц.= 
 :
@@ -39166,9 +39158,9 @@
 трав.= :
   LLAFX+ or LLBII+ or LLBNN+ or LLBRK+ or LLBUI+ or LLBYZ+ or LLDJS+;
 
-трав.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 трав.npg :  <morph-С,мн,мн,рд>;
+
+трав.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 травмир.= :
   LLCDC+ or LLCGD+ or LLCHP+ or LLCHF+;
@@ -39179,9 +39171,9 @@
 буер.= рукав.= трактор.= :
   LLABM+ or LLBYZ+;
 
-буер.ndmsv рукав.ndmsv трактор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 буер.ndmsi рукав.ndmsi трактор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+буер.ndmsv рукав.ndmsv трактор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.227:
   LLFRE+ or LLFWA+;
@@ -39189,15 +39181,15 @@
 транжир.= :
   LLACI+ or LLAFH+ or LLBIA+ or LLBNU+ or LLBRO+;
 
-транжир.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-транжир.nlmsi :  <morph-С,мр,од,ед,им>;
+транжир.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 транжир.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-транжир.nlmpv :  <morph-С,мр,од,мн,вн>;
+транжир.nlmsi :  <morph-С,мр,од,ед,им>;
 
-транжир.nlmpg :  <morph-С,мр,од,мн,рд>;
+транжир.nlfpg :  <morph-С,жр,од,мн,рд>;
+
+транжир.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 трансагентств.= :
   LLCAG+ or LLEFN+;
@@ -39210,9 +39202,9 @@
 транспортир.= :
   LLAAQ+ or LLCER+ or LLCGD+ or LLEPR+;
 
-транспортир.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 транспортир.ndmsi :  <morph-С,мр,но,ед,им>;
+
+транспортир.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 рублевск.= таймырск.= ташкентск.= транссибирск.= :
   LLBEP+ or LLDYX+;
@@ -39274,9 +39266,9 @@
 треног.= :
   LLAFU+ or LLBDW+;
 
-треног.amss :  <morph-П,мр,ед,кр>;
-
 треног.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+треног.amss :  <morph-П,мр,ед,кр>;
 
 треп.= :
   LLAAO+ or LLAIL+ or LLAKB+ or LLAYJ+ or LLBRK+;
@@ -39288,9 +39280,9 @@
 трепан.= :
   LLAAQ+ or LLFWL+ or LLDLO+;
 
-трепан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 трепан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+трепан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 трепе.= :
   LLCUM+ or LLCVH+;
@@ -39301,9 +39293,9 @@
 треск.= :
   LLAAK+ or LLAGW+;
 
-треск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 треск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+треск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 сверн.= тресн.= :
   LLFWF+ or LLFWI+ or LLFWG+;
@@ -39319,11 +39311,11 @@
 
 бон.ndmsv треф.ndmsv эполет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-бон.ndfpg треф.ndfpg эполет.ndfpg :  <morph-С,жр,но,мн,рд>;
+бон.npg треф.npg эполет.npg :  <morph-С,мн,мн,рд>;
 
 бон.ndmsi треф.ndmsi эполет.ndmsi :  <morph-С,мр,но,ед,им>;
 
-бон.npg треф.npg эполет.npg :  <morph-С,мн,мн,рд>;
+бон.ndfpg треф.ndfpg эполет.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 трехперст.= :
   LLBDC+ or LLBRO+;
@@ -39345,11 +39337,11 @@
 триллион.= :
   LLAAQ+ or LLELB+;
 
+триллион.cv :  <morph-ЧИСЛ,вн>;
+
 триллион.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 триллион.ci :  <morph-ЧИСЛ,им>;
-
-триллион.cv :  <morph-ЧИСЛ,вн>;
 
 триллион.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -39409,17 +39401,17 @@
 захаренко.= кириленко.= трофименко.= :
   LLFLM+;
 
-захаренко.nlmsi кириленко.nlmsi трофименко.nlmsi :  <morph-С,мр,од,ед,им>;
-
-захаренко.nlmst кириленко.nlmst трофименко.nlmst :  <morph-С,мр,од,ед,тв>;
-
-захаренко.nlmsp кириленко.nlmsp трофименко.nlmsp :  <morph-С,мр,од,ед,пр>;
+захаренко.nlmsv кириленко.nlmsv трофименко.nlmsv :  <morph-С,мр,од,ед,вн>;
 
 захаренко.nlmsd кириленко.nlmsd трофименко.nlmsd :  <morph-С,мр,од,ед,дт>;
 
-захаренко.nlmsv кириленко.nlmsv трофименко.nlmsv :  <morph-С,мр,од,ед,вн>;
-
 захаренко.nlmsg кириленко.nlmsg трофименко.nlmsg :  <morph-С,мр,од,ед,рд>;
+
+захаренко.nlmsi кириленко.nlmsi трофименко.nlmsi :  <morph-С,мр,од,ед,им>;
+
+захаренко.nlmsp кириленко.nlmsp трофименко.nlmsp :  <morph-С,мр,од,ед,пр>;
+
+захаренко.nlmst кириленко.nlmst трофименко.nlmst :  <morph-С,мр,од,ед,тв>;
 
 бирюков.= болдин.= боресков.= бушмин.= вологдин.= еремин.= 
 истомин.= сергиев.= смышляев.= сутягин.= тимурзиев.= толстошеин.= 
@@ -39435,9 +39427,9 @@
 столик.= тонконог.= трояк.= :
   LLAAM+ or LLBDW+;
 
-столик.amss тонконог.amss трояк.amss :  <morph-П,мр,ед,кр>;
-
 столик.ndmsv тонконог.ndmsv трояк.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+столик.amss тонконог.amss трояк.amss :  <morph-П,мр,ед,кр>;
 
 столик.ndmsi тонконог.ndmsi трояк.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -39458,11 +39450,11 @@
 трус.= :
   LLAAQ+ or LLACI+ or LLDJV+;
 
+трус.ndmsi :  <morph-С,мр,но,ед,им>;
+
 трус.nlmsi :  <morph-С,мр,од,ед,им>;
 
 трус.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-трус.ndmsi :  <morph-С,мр,но,ед,им>;
 
 трусц.= :
   LLAGN+;
@@ -39470,9 +39462,9 @@
 трут.= :
   LLAAQ+ or LLAVM+;
 
-трут.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 трут.ndmsi :  <morph-С,мр,но,ед,им>;
+
+трут.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 трух.= :
   LLAGJ+ or LLCVR+;
@@ -39505,11 +39497,11 @@
 :
   LLABM+ or LLCJW+;
 
-колоб.ndmsv кузов.ndmsv пояс.ndmsv терем.ndmsv туес.ndmsv череп.ndmsv 
-:  <morph-С,мр,но,ед,вн>;
-
 колоб.ndmsi кузов.ndmsi пояс.ndmsi терем.ndmsi туес.ndmsi череп.ndmsi 
 :  <morph-С,мр,но,ед,им>;
+
+колоб.ndmsv кузов.ndmsv пояс.ndmsv терем.ndmsv туес.ndmsv череп.ndmsv 
+:  <morph-С,мр,но,ед,вн>;
 
 туж.= :
   LLBFY+ or LLBMV+;
@@ -39549,9 +39541,9 @@
 дурман.= туман.= :
   LLAAO+ or LLBIA+ or LLBNU+ or LLBYU+;
 
-дурман.ndmsv туман.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 дурман.ndmsi туман.ndmsi :  <morph-С,мр,но,ед,им>;
+
+дурман.ndmsv туман.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 тун.= :
   LLACI+ or LLAYJ+;
@@ -39575,13 +39567,13 @@
 тур.= :
   LLAAQ+ or LLACI+ or LLAFX+ or LLDXR+ or LLBFF+ or LLBHS+ or LLBNP+ or LLCKG+;
 
-тур.nlmsi :  <morph-С,мр,од,ед,им>;
-
 тур.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-тур.ndfpg :  <morph-С,жр,но,мн,рд>;
+тур.nlmsi :  <morph-С,мр,од,ед,им>;
 
 тур.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тур.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 курлы.= мурлы.= турлы.= :
   LLBRR+;
@@ -39594,20 +39586,20 @@
 тут.= :
   LLAAQ+ or LLAEK+ or LLAFX+;
 
-тут.e :  <morph-Н,0>;
-
 тут.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-тут.ndfpg :  <morph-С,жр,но,мн,рд>;
+тут.e :  <morph-Н,0>;
 
 тут.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тут.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 туф.= :
   LLAAQ+ or LLBTV+ or LLBUI+;
 
-туф.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 туф.ndmsi :  <morph-С,мр,но,ед,им>;
+
+туф.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 туфел.= :
   LLDNX+ or LLDNY+ or LLDNZ+ or LLDOO+;
@@ -39650,9 +39642,9 @@
 тыл.= :
   LLAAS+ or LLDOK+;
 
-тыл.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тыл.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тыл.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 арыс.= тым.= :
   LLDWW+ or LLEAU+;
@@ -39664,9 +39656,9 @@
 анкер.= блин.= поддон.= тын.= :
   LLAAQ+ or LLBYZ+ or LLCJW+;
 
-анкер.ndmsv блин.ndmsv поддон.ndmsv тын.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 анкер.ndmsi блин.ndmsi поддон.ndmsi тын.ndmsi :  <morph-С,мр,но,ед,им>;
+
+анкер.ndmsv блин.ndmsv поддон.ndmsv тын.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 долдон.= мусол.= сусол.= топыр.= тыр.= шпар.= 
 щер.= :
@@ -39688,9 +39680,9 @@
 тюк.= :
   LLAAM+ or LLAEL+ or LLDTP+ or LLCCZ+ or LLCGW+;
 
-тюк.xn :  <morph-ПРЕДК,нст>;
-
 тюк.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+тюк.xn :  <morph-ПРЕДК,нст>;
 
 тюк.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -39746,9 +39738,9 @@
 тяж.= :
   LLAAJ+ or LLBSR+;
 
-тяж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 тяж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+тяж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 толстен.= тяжелен.= :
   LLAUO+ or LLBYU+;
@@ -39905,11 +39897,11 @@
 
 уд.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-уд.ndfpg :  <morph-С,жр,но,мн,рд>;
+уд.npg :  <morph-С,мн,мн,рд>;
 
 уд.ndmsi :  <morph-С,мр,но,ед,им>;
 
-уд.npg :  <morph-С,мн,мн,рд>;
+уд.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 удав.= :
   LLACI+ or LLFWK+ or LLFXQ+ or LLBRK+;
@@ -39947,9 +39939,9 @@
 удерж.= :
   LLAAH+ or LLGAT+ or LLGAU+;
 
-удерж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 удерж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+удерж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 воспитан.= жалован.= изумлен.= отдален.= отчаян.= поруган.= 
 презрен.= смятен.= удивлен.= уединен.= умилен.= унижен.= 
@@ -39980,18 +39972,18 @@
 уж.= :
   LLACF+ or LLAEK+ or LLDTS+ or LLGEE+ or LLGEF+ or LLCKS+;
 
-уж.e :  <morph-Н,0>;
-
 уж.nlmsi :  <morph-С,мр,од,ед,им>;
+
+уж.e :  <morph-Н,0>;
 
 уж.p :  <morph-ЧАСТ,0>;
 
 уже.= :
   LLDTS+ or LLAEK+;
 
-уже.e :  <morph-Н,0>;
-
 уже.p :  <morph-ЧАСТ,0>;
+
+уже.e :  <morph-Н,0>;
 
 вжи.= пообжи.= расплы.= ужи.= :
   LLFYA+;
@@ -40013,9 +40005,9 @@
 узин.= :
   LLDWW+ or LLAGL+;
 
-узин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 узин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+узин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 созна.= узна.= :
   LLALV+ or LLAMG+ or LLFWT+ or LLFWU+;
@@ -40044,9 +40036,9 @@
 надкол.= отпор.= укол.= :
   LLAAQ+ or LLGAA+ or LLGAB+;
 
-надкол.ndmsv отпор.ndmsv укол.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 надкол.ndmsi отпор.ndmsi укол.ndmsi :  <morph-С,мр,но,ед,им>;
+
+надкол.ndmsv отпор.ndmsv укол.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 взаимосоглас.= выгравир.= доукомплект.= заблокир.= завизир.= закодир.= 
 законсервир.= запрограммир.= засвидетельств.= истолк.= освидетельств.= откомандир.= 
@@ -40065,9 +40057,9 @@
 украинск.= :
   LLDWW+ or LLBEL+ or LLDYX+;
 
-украинск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 украинск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+украинск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 укупор.= :
   LLGDN+ or LLBRK+;
@@ -40098,9 +40090,9 @@
 саянск.= судженск.= ульяновск.= :
   LLDWW+ or LLBEP+ or LLDYX+;
 
-саянск.ndmsv судженск.ndmsv ульяновск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 саянск.ndmsi судженск.ndmsi ульяновск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+саянск.ndmsv судженск.ndmsv ульяновск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ум.= :
   LLAAQ+ or LLGJH+ or LLBYU+ or LLFZO+ or LLGCG+ or LLGFK+ or LLGJK+;
@@ -40133,11 +40125,11 @@
 умолк.= :
   LLAAM+ or LLFXM+;
 
-умолк.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 умолк.vsndpms :  <morph-Г,св,нп,дст,прш,мр,ед>;
 
 умолк.ndmsi :  <morph-С,мр,но,ед,им>;
+
+умолк.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 воодушевля.= замета.= оплодотворя.= перезаряжа.= переоформля.= переполня.= 
 перепроверя.= подправля.= подстрека.= предостерега.= приподнима.= промета.= 
@@ -40178,11 +40170,11 @@
 универсал.= :
   LLAAQ+ or LLACI+ or LLDOK+;
 
-универсал.nlmsi :  <morph-С,мр,од,ед,им>;
-
 универсал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 универсал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+универсал.nlmsi :  <morph-С,мр,од,ед,им>;
 
 уп.= :
   LLDXR+ or LLGFQ+ or LLGGT+ or LLGDB+;
@@ -40190,9 +40182,9 @@
 упак.= :
   LLAAM+ or LLFWB+ or LLFWD+;
 
-упак.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 упак.ndmsi :  <morph-С,мр,но,ед,им>;
+
+упак.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вду.= взгре.= выду.= заду.= запелена.= отду.= 
 переду.= поднаду.= разду.= сду.= спелена.= упелена.= 
@@ -40296,9 +40288,9 @@
 усищ.= :
   LLARI+ or LLBBY+;
 
-усищ.ndmpg :  <morph-С,мр,но,мн,рд>;
-
 усищ.npg :  <morph-С,мн,мн,рд>;
+
+усищ.ndmpg :  <morph-С,мр,но,мн,рд>;
 
 повска.= поска.= приска.= уска.= :
   LLGCI+;
@@ -40327,9 +40319,9 @@
 устав.= :
   LLAAQ+ or LLFYW+ or LLFYX+ or LLBRK+ or LLBYZ+;
 
-устав.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 устав.ndmsi :  <morph-С,мр,но,ед,им>;
+
+устав.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 вбухива.= вылежива.= долежива.= сплыва.= уматыва.= устаива.= 
 :
@@ -40341,18 +40333,18 @@
 устриц.= :
   LLAFQ+ or LLAGP+;
 
+устриц.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 устриц.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 устриц.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-устриц.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 уступ.= :
   LLAAQ+ or LLFWK+ or LLBRK+ or LLBYU+;
 
-уступ.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 уступ.ndmsi :  <morph-С,мр,но,ед,им>;
+
+уступ.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 усть.= :
   LLAEG+ or LLARV+;
@@ -40452,16 +40444,16 @@
 
 ушиб.vspdpms :  <morph-Г,св,пе,дст,прш,мр,ед>;
 
-ушиб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ушиб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ушиб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 перелом.= ущерб.= :
   LLAAQ+ or LLFWK+ or LLFXQ+ or LLBYU+;
 
-перелом.ndmsv ущерб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 перелом.ndmsi ущерб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+перелом.ndmsv ущерб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 фа.= :
   LLADL+ or LLBPJ+;
@@ -40476,18 +40468,18 @@
 фактически.= :
   LLAEK+ or LLAEP+ or LLFGK+;
 
+фактически.y :  <morph-ВВОДН,0>;
+
 фактически.e :  <morph-Н,0>;
 
 фактически.p :  <morph-ЧАСТ,0>;
 
-фактически.y :  <morph-ВВОДН,0>;
-
 фал.= :
   LLAAQ+ or LLAYE+;
 
-фал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 фал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+фал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 фальшив.= :
   LLBGQ+ or LLBRK+ or LLDKF+;
@@ -40517,9 +40509,9 @@
 вольтов.= драконов.= крокодилов.= фараонов.= :
   LLFUO+ or LLDLO+;
 
-вольтов.amsi драконов.amsi крокодилов.amsi фараонов.amsi :  <morph-П,мр,ед,им>;
-
 вольтов.admsv драконов.admsv крокодилов.admsv фараонов.admsv :  <morph-П,мр,ед,вн,но>;
+
+вольтов.amsi драконов.amsi крокодилов.amsi фараонов.amsi :  <morph-П,мр,ед,им>;
 
 фармзащит.= :
   LLAGM+ or LLEFA+;
@@ -40527,9 +40519,9 @@
 фарт.= :
   LLAAQ+ or LLBGP+;
 
-фарт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 фарт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+фарт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 фат.= :
   LLACI+ or LLAGE+;
@@ -40568,9 +40560,9 @@
 посад.= фес.= :
   LLAAQ+ or LLDWW+ or LLBRK+;
 
-посад.ndmsv фес.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 посад.ndmsi фес.ndmsi :  <morph-С,мр,но,ед,им>;
+
+посад.ndmsv фес.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.232:
   LLAFX+;
@@ -40964,9 +40956,9 @@
 филигран.= :
   LLAAQ+ or LLBZE+ or LLDNF+;
 
-филигран.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 филигран.ndmsi :  <morph-С,мр,но,ед,им>;
+
+филигран.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 филиппин.= :
   LLAYI+ or LLBRO+ or LLEAJ+;
@@ -40981,9 +40973,9 @@
 фильтр.= :
   LLAAQ+ or LLEQA+ or LLCGW+;
 
-фильтр.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 фильтр.ndmsi :  <morph-С,мр,но,ед,им>;
+
+фильтр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 фин.= :
   LLBRK+ or LLBRO+ or LLCXA+;
@@ -40991,9 +40983,9 @@
 гном.= премьер.= сатир.= трибун.= финн.= :
   LLACI+ or LLAFX+;
 
-гном.nlmsi премьер.nlmsi сатир.nlmsi трибун.nlmsi финн.nlmsi :  <morph-С,мр,од,ед,им>;
-
 гном.ndfpg премьер.ndfpg сатир.ndfpg трибун.ndfpg финн.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+гном.nlmsi премьер.nlmsi сатир.nlmsi трибун.nlmsi финн.nlmsi :  <morph-С,мр,од,ед,им>;
 
 финьшампань.= :
   LLABY+;
@@ -41042,18 +41034,18 @@
 флюгер.= :
   LLABM+ or LLACI+ or LLBYZ+;
 
-флюгер.nlmsi :  <morph-С,мр,од,ед,им>;
-
 флюгер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 флюгер.ndmsi :  <morph-С,мр,но,ед,им>;
 
+флюгер.nlmsi :  <morph-С,мр,од,ед,им>;
+
 флюс.= :
   LLAAS+ or LLBYU+ or LLCCZ+ or LLCGW+;
 
-флюс.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 флюс.ndmsi :  <morph-С,мр,но,ед,им>;
+
+флюс.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 фок-ре.= хоре.= :
   LLBPJ+ or LLDQB+;
@@ -41066,13 +41058,13 @@
 
 фомин.amsi :  <morph-П,мр,ед,им>;
 
-фомин.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 фомин.nlmsi :  <morph-С,мр,од,ед,им>;
 
-фомин.nlfpv :  <morph-С,жр,од,мн,вн>;
+фомин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 фомин.admsv :  <morph-П,мр,ед,вн,но>;
+
+фомин.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 агробирж.= микрофиш.= перепродаж.= подзадач.= радиотелепередач.= телепередач.= 
 телерадиопередач.= фондоотдач.= электропередач.= :
@@ -41867,13 +41859,13 @@
 флец.= форзац.= хромэрзац.= шлиц.= эрзац.= :
   LLAAD+;
 
-абзац.ndmsv бикварц.ndmsv блиц.ndmsv зельц.ndmsv кварц.ndmsv матрац.ndmsv 
-мерседес-бенц.ndmsv месяц.ndmsv палац.ndmsv полумесяц.ndmsv пьезокварц.ndmsv терц.ndmsv 
-флец.ndmsv форзац.ndmsv хромэрзац.ndmsv шлиц.ndmsv эрзац.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 абзац.ndmsi бикварц.ndmsi блиц.ndmsi зельц.ndmsi кварц.ndmsi матрац.ndmsi 
 мерседес-бенц.ndmsi месяц.ndmsi палац.ndmsi полумесяц.ndmsi пьезокварц.ndmsi терц.ndmsi 
 флец.ndmsi форзац.ndmsi хромэрзац.ndmsi шлиц.ndmsi эрзац.ndmsi :  <morph-С,мр,но,ед,им>;
+
+абзац.ndmsv бикварц.ndmsv блиц.ndmsv зельц.ndmsv кварц.ndmsv матрац.ndmsv 
+мерседес-бенц.ndmsv месяц.ndmsv палац.ndmsv полумесяц.ndmsv пьезокварц.ndmsv терц.ndmsv 
+флец.ndmsv форзац.ndmsv хромэрзац.ndmsv шлиц.ndmsv эрзац.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 баррикадир.= гримир.= мультиплексир.= подтестир.= продуцир.= растрир.= 
 форматир.= фотографир.= хэшир.= черенк.= электриз.= :
@@ -41903,20 +41895,20 @@
 форт.= :
   LLAAS+ or LLBRK+;
 
-форт.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 форт.ndmsi :  <morph-С,мр,но,ед,им>;
+
+форт.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 /ru/words/words.236:
   LLADL+ or LLAEG+ or LLAEK+;
 
-адажио.e алегретто.e аллегро.e анданте.e андантино.e аппассионато.e 
-арпеджио.e арпеджо.e вибрато.e виваче.e глиссандо.e граве.e 
-декрешендо.e декрещендо.e диминуэндо.e дольче.e ин-кварто.e ин-октаво.e 
-кантабиле.e крешендо.e крещендо.e ларгетто.e ларго.e легато.e 
-ленто.e маэстозо.e модерато.e пианиссимо.e пиано.e пиццикато.e 
-престиссимо.e престо.e ритенуто.e стаккато.e стретто.e сфорцандо.e 
-сфорцато.e тремоландо.e факсимиле.e форте.e фортиссимо.e :  <morph-Н,0>;
+адажио.a алегретто.a аллегро.a анданте.a андантино.a аппассионато.a 
+арпеджио.a арпеджо.a вибрато.a виваче.a глиссандо.a граве.a 
+декрешендо.a декрещендо.a диминуэндо.a дольче.a ин-кварто.a ин-октаво.a 
+кантабиле.a крешендо.a крещендо.a ларгетто.a ларго.a легато.a 
+ленто.a маэстозо.a модерато.a пианиссимо.a пиано.a пиццикато.a 
+престиссимо.a престо.a ритенуто.a стаккато.a стретто.a сфорцандо.a 
+сфорцато.a тремоландо.a факсимиле.a форте.a фортиссимо.a :  <morph-П,0>;
 
 адажио.ndn алегретто.ndn аллегро.ndn анданте.ndn андантино.ndn аппассионато.ndn 
 арпеджио.ndn арпеджо.ndn вибрато.ndn виваче.ndn глиссандо.ndn граве.ndn 
@@ -41926,13 +41918,13 @@
 престиссимо.ndn престо.ndn ритенуто.ndn стаккато.ndn стретто.ndn сфорцандо.ndn 
 сфорцато.ndn тремоландо.ndn факсимиле.ndn форте.ndn фортиссимо.ndn :  <morph-С,ср,но,0>;
 
-адажио.a алегретто.a аллегро.a анданте.a андантино.a аппассионато.a 
-арпеджио.a арпеджо.a вибрато.a виваче.a глиссандо.a граве.a 
-декрешендо.a декрещендо.a диминуэндо.a дольче.a ин-кварто.a ин-октаво.a 
-кантабиле.a крешендо.a крещендо.a ларгетто.a ларго.a легато.a 
-ленто.a маэстозо.a модерато.a пианиссимо.a пиано.a пиццикато.a 
-престиссимо.a престо.a ритенуто.a стаккато.a стретто.a сфорцандо.a 
-сфорцато.a тремоландо.a факсимиле.a форте.a фортиссимо.a :  <morph-П,0>;
+адажио.e алегретто.e аллегро.e анданте.e андантино.e аппассионато.e 
+арпеджио.e арпеджо.e вибрато.e виваче.e глиссандо.e граве.e 
+декрешендо.e декрещендо.e диминуэндо.e дольче.e ин-кварто.e ин-октаво.e 
+кантабиле.e крешендо.e крещендо.e ларгетто.e ларго.e легато.e 
+ленто.e маэстозо.e модерато.e пианиссимо.e пиано.e пиццикато.e 
+престиссимо.e престо.e ритенуто.e стаккато.e стретто.e сфорцандо.e 
+сфорцато.e тремоландо.e факсимиле.e форте.e фортиссимо.e :  <morph-Н,0>;
 
 фортун.= :
   LLAFX+ or LLBGR+ or LLBRK+;
@@ -41990,9 +41982,9 @@
 функционал.= :
   LLAAQ+ or LLDOP+;
 
-функционал.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 функционал.ndmsi :  <morph-С,мр,но,ед,им>;
+
+функционал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 фуражир.= :
   LLACI+ or LLBYU+ or LLCBK+;
@@ -42004,11 +41996,11 @@
 
 фуфыр.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-фуфыр.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 фуфыр.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 фуфыр.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+фуфыр.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 ха.= :
   LLDTP+ or LLDRP+ or LLDSF+;
@@ -42016,9 +42008,9 @@
 трест.= хабар.= чум.= :
   LLAAQ+ or LLAGL+;
 
-трест.ndmsv хабар.ndmsv чум.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 трест.ndmsi хабар.ndmsi чум.ndmsi :  <morph-С,мр,но,ед,им>;
+
+трест.ndmsv хабар.ndmsv чум.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 хаврон.= :
   LLFNL+;
@@ -42026,9 +42018,9 @@
 хазар.= :
   LLACX+ or LLBFO+;
 
-хазар.nlmsi :  <morph-С,мр,од,ед,им>;
-
 хазар.nlmpv :  <morph-С,мр,од,мн,вн>;
+
+хазар.nlmsi :  <morph-С,мр,од,ед,им>;
 
 хазар.nlmpg :  <morph-С,мр,од,мн,рд>;
 
@@ -42047,14 +42039,14 @@
 халд.= :
   LLACI+ or LLAGT+;
 
+жираф.nlfpv инфант.nlfpv лангуст.nlfpv мангуст.nlfpv сеньор.nlfpv синьор.nlfpv 
+халд.nlfpv :  <morph-С,жр,од,мн,вн>;
+
 жираф.nlfpg инфант.nlfpg лангуст.nlfpg мангуст.nlfpg сеньор.nlfpg синьор.nlfpg 
 халд.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 жираф.nlmsi инфант.nlmsi лангуст.nlmsi мангуст.nlmsi сеньор.nlmsi синьор.nlmsi 
 халд.nlmsi :  <morph-С,мр,од,ед,им>;
-
-жираф.nlfpv инфант.nlfpv лангуст.nlfpv мангуст.nlfpv сеньор.nlfpv синьор.nlfpv 
-халд.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 халтур.= :
   LLAFX+ or LLBGR+ or LLBRK+ or LLBYU+;
@@ -42144,9 +42136,9 @@
 хвост.= :
   LLAAQ+ or LLAYB+;
 
-хвост.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хвост.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хвост.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 хиж.= :
   LLFLF+ or LLFHV+;
@@ -42162,11 +42154,11 @@
 химер.= :
   LLAFX+ or LLAGT+ or LLBZE+;
 
+химер.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 химер.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 химер.nlfpv :  <morph-С,жр,од,мн,вн>;
-
-химер.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 химич.= :
   LLBGC+ or LLBRM+;
@@ -42182,9 +42174,9 @@
 хит.= :
   LLAAQ+ or LLCMZ+;
 
-хит.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хит.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хит.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 благовол.= медл.= петл.= трун.= хитр.= :
   LLBGI+;
@@ -42197,9 +42189,9 @@
 хихон.= :
   LLDWW+ or LLDNZ+;
 
-хихон.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хихон.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хихон.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 мясохладобо.= хладобо.= :
   LLBQS+;
@@ -42207,9 +42199,9 @@
 хламидомонад.= :
   LLAGU+;
 
-хламидомонад.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 хламидомонад.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+хламидомонад.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 хлеб.= :
   LLABN+ or LLAXZ+ or LLBYU+ or LLCJW+;
@@ -42232,18 +42224,18 @@
 хлев.= :
   LLABP+ or LLBYU+ or LLCJW+;
 
-хлев.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хлев.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хлев.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 хлест.= :
   LLAAQ+ or LLACI+ or LLBSW+;
 
+хлест.ndmsi :  <morph-С,мр,но,ед,им>;
+
 хлест.nlmsi :  <morph-С,мр,од,ед,им>;
 
 хлест.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-хлест.ndmsi :  <morph-С,мр,но,ед,им>;
 
 хле.= хлобы.= хлы.= :
   LLCQG+ or LLCQK+;
@@ -42251,13 +42243,13 @@
 хлоп.= :
   LLAAQ+ or LLACI+ or LLAEL+ or LLDTP+ or LLAYI+ or LLCJW+;
 
+хлоп.ndmsi :  <morph-С,мр,но,ед,им>;
+
 хлоп.xn :  <morph-ПРЕДК,нст>;
 
 хлоп.nlmsi :  <morph-С,мр,од,ед,им>;
 
 хлоп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-хлоп.ndmsi :  <morph-С,мр,но,ед,им>;
 
 хлопот.= шахмат.= :
   LLBYU+ or LLDJS+;
@@ -42267,9 +42259,9 @@
 хлыстов.= :
   LLFQF+ or LLFOU+ or LLBRO+ or LLDKJ+;
 
-хлыстов.amss :  <morph-П,мр,ед,кр>;
-
 хлыстов.nlmsi :  <morph-С,мр,од,ед,им>;
+
+хлыстов.amss :  <morph-П,мр,ед,кр>;
 
 хм.= :
   LLDTP+ or LLEDB+;
@@ -42294,16 +42286,16 @@
 хобот.= :
   LLABN+ or LLBYU+ or LLCJW+;
 
-хобот.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хобот.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хобот.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ход.= :
   LLABL+ or LLAVL+ or LLBRK+ or LLBSW+ or LLCJW+;
 
-ход.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ход.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ход.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ходж.= :
   LLAFA+;
@@ -42322,22 +42314,22 @@
 холер.= :
   LLAFH+ or LLAFX+ or LLBYU+;
 
-холер.nlfpg :  <morph-С,жр,од,мн,рд>;
+холер.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 холер.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-холер.nlfpv :  <morph-С,жр,од,мн,вн>;
+холер.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-холер.nlmpv :  <morph-С,мр,од,мн,вн>;
+холер.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 холер.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 холм.= :
   LLAAQ+ or LLBII+ or LLBNN+ or LLCJW+;
 
-холм.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 холм.ndmsi :  <morph-С,мр,но,ед,им>;
+
+холм.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 холо.= :
   LLAPG+ or LLAQP+ or LLCSN+ or LLCTB+;
@@ -42345,9 +42337,9 @@
 холод.= :
   LLABI+ or LLAYA+ or LLBYU+ or LLCJU+;
 
-холод.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 холод.ndmsi :  <morph-С,мр,но,ед,им>;
+
+холод.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 холодов.= :
   LLFJJ+ or LLDLO+;
@@ -42365,9 +42357,9 @@
 хор.= :
   LLAAQ+ or LLAUN+ or LLDJT+ or LLDMT+;
 
-хор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 хор.npg :  <morph-С,мн,мн,рд>;
 
@@ -42395,9 +42387,9 @@
 ведь.= хоть.= хотя.= :
   LLDTI+ or LLAEP+;
 
-ведь.i хоть.i хотя.i :  <morph-СОЮЗ,0>;
-
 ведь.p хоть.p хотя.p :  <morph-ЧАСТ,0>;
+
+ведь.i хоть.i хотя.i :  <morph-СОЮЗ,0>;
 
 хох.= :
   LLCKJ+ or LLCKL+;
@@ -42414,9 +42406,9 @@
 хошимин.= :
   LLDWW+ or LLFHJ+;
 
-хошимин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 хошимин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+хошимин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 студен.= храбр.= :
   LLBNP+ or LLDKF+;
@@ -42441,16 +42433,16 @@
 квас.= хрен.= :
   LLAAO+ or LLCJU+;
 
-квас.ndmsv хрен.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 квас.ndmsi хрен.ndmsi :  <morph-С,мр,но,ед,им>;
+
+квас.ndmsv хрен.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 хрип.= :
   LLAAO+ or LLAWQ+ or LLBWA+;
 
-хрип.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
-
 хрип.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+хрип.vnndpms :  <morph-Г,нс,нп,дст,прш,мр,ед>;
 
 хрип.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -42463,11 +42455,11 @@
 хром.= :
   LLAAQ+ or LLDXR+ or LLAKZ+ or LLAYJ+ or LLCIR+ or LLCIS+;
 
+хром.ndmsi :  <morph-С,мр,но,ед,им>;
+
 хром.amss :  <morph-П,мр,ед,кр>;
 
 хром.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-хром.ndmsi :  <morph-С,мр,но,ед,им>;
 
 микрофильмир.= персонифицир.= платинир.= фаршир.= хромир.= эксгумир.= 
 :
@@ -42479,11 +42471,11 @@
 хлюп.= хруп.= :
   LLAAQ+ or LLAEL+ or LLDTP+ or LLBSW+;
 
+хлюп.ndmsi хруп.ndmsi :  <morph-С,мр,но,ед,им>;
+
 хлюп.xn хруп.xn :  <morph-ПРЕДК,нст>;
 
 хлюп.ndmsv хруп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-хлюп.ndmsi хруп.ndmsi :  <morph-С,мр,но,ед,им>;
 
 хруст.= :
   LLAAO+ or LLBSW+;
@@ -42515,9 +42507,9 @@
 царев.= :
   LLFUO+ or LLBUX+;
 
-царев.amsi :  <morph-П,мр,ед,им>;
-
 царев.admsv :  <morph-П,мр,ед,вн,но>;
+
+царев.amsi :  <morph-П,мр,ед,им>;
 
 актериш.= аристократиш.= батюш.= братиш.= вориш.= гостюш.= 
 дедуш.= детинуш.= дядеч.= дядюш.= зайчиш.= зятюш.= 
@@ -42533,9 +42525,9 @@
 
 цац.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-цац.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 цац.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+цац.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 цве.= :
   LLCRA+ or LLCXI+ or LLCYK+;
@@ -42580,9 +42572,9 @@
 цеп.= :
   LLAAQ+ or LLAVM+ or LLBRK+ or LLBSW+ or LLDNF+;
 
-цеп.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 цеп.ndmsi :  <morph-С,мр,но,ед,им>;
+
+цеп.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 цепн.= :
   LLCIZ+ or LLDQH+;
@@ -42637,11 +42629,11 @@
 цирлих-манирлих.= :
   LLADB+ or LLADL+ or LLAEG+ or LLAEK+;
 
+цирлих-манирлих.a :  <morph-П,0>;
+
 цирлих-манирлих.e :  <morph-Н,0>;
 
 цирлих-манирлих.ndn :  <morph-С,ср,но,0>;
-
-цирлих-манирлих.a :  <morph-П,0>;
 
 цист.= :
   LLEEN+ or LLAFX+;
@@ -42695,13 +42687,13 @@
 чад.= :
   LLAAX+ or LLDWW+ or LLBYU+ or LLCAQ+;
 
-чад.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 чад.nlnpg :  <morph-С,ср,од,мн,рд>;
 
-чад.nlnpv :  <morph-С,ср,од,мн,вн>;
+чад.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 чад.ndmsi :  <morph-С,мр,но,ед,им>;
+
+чад.nlnpv :  <morph-С,ср,од,мн,вн>;
 
 нещеч.= чадоч.= чадуш.= :
   LLBTK+;
@@ -42715,29 +42707,29 @@
 чал.= :
   LLAAQ+ or LLBIA+ or LLBNU+ or LLBRK+ or LLDJZ+ or LLDKF+;
 
+чал.ndmsi :  <morph-С,мр,но,ед,им>;
+
 чал.amss :  <morph-П,мр,ед,кр>;
 
 чал.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-чал.ndmsi :  <morph-С,мр,но,ед,им>;
-
 чан.= :
   LLAAS+ or LLBYZ+ or LLEAN+;
 
-чан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 чан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+чан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 чар.= :
   LLDWW+ or LLAFX+ or LLBRK+ or LLCCZ+ or LLCGW+ or LLDJS+;
 
 чар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-чар.ndfpg :  <morph-С,жр,но,мн,рд>;
+чар.npg :  <morph-С,мн,мн,рд>;
 
 чар.ndmsi :  <morph-С,мр,но,ед,им>;
 
-чар.npg :  <morph-С,мн,мн,рд>;
+чар.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 чароде.= :
   LLBPS+ or LLBPY+ or LLBQI+;
@@ -42745,16 +42737,16 @@
 чарыш.= :
   LLDWW+ or LLDXM+;
 
-чарыш.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 чарыш.ndmsi :  <morph-С,мр,но,ед,им>;
+
+чарыш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 час.= :
   LLAAS+ or LLCJW+ or LLDJV+;
 
-час.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 час.ndmsi :  <morph-С,мр,но,ед,им>;
+
+час.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 часов.= :
   LLBZO+ or LLCIR+ or LLCJC+;
@@ -42762,9 +42754,9 @@
 по-моему.= часом.= :
   LLAEK+ or LLFGK+;
 
-по-моему.e часом.e :  <morph-Н,0>;
-
 по-моему.y часом.y :  <morph-ВВОДН,0>;
+
+по-моему.e часом.e :  <morph-Н,0>;
 
 мочегонн.= пирожн.= подушн.= придан.= прилагательн.= сказуем.= 
 слагаем.= существительн.= частн.= :
@@ -42790,9 +42782,9 @@
 
 чекан.nlmsi :  <morph-С,мр,од,ед,им>;
 
-чекан.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 чекан.ndmsi :  <morph-С,мр,но,ед,им>;
+
+чекан.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 будораж.= булгач.= итож.= калеч.= кореж.= мастач.= 
 множ.= мороч.= мурыж.= пророч.= руш.= талдыч.= 
@@ -42879,9 +42871,9 @@
 чернобыл.= :
   LLAAQ+ or LLAYK+ or LLDML+ or LLDNT+;
 
-чернобыл.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 чернобыл.ndmsi :  <morph-С,мр,но,ед,им>;
+
+чернобыл.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 чернов.= :
   LLFQF+ or LLFOU+ or LLCIZ+ or LLEAI+;
@@ -42910,9 +42902,9 @@
 черт.= :
   LLACJ+ or LLAFX+;
 
-черт.nlmsi :  <morph-С,мр,од,ед,им>;
-
 черт.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+черт.nlmsi :  <morph-С,мр,од,ед,им>;
 
 бесен.= чертен.= :
   LLCKF+;
@@ -42920,9 +42912,9 @@
 чертов.= :
   LLFUO+ or LLBRO+ or LLDKP+;
 
-чертов.amsi :  <morph-П,мр,ед,им>;
-
 чертов.amss :  <morph-П,мр,ед,кр>;
+
+чертов.amsi :  <morph-П,мр,ед,им>;
 
 чертов.admsv :  <morph-П,мр,ед,вн,но>;
 
@@ -42996,9 +42988,9 @@
 чикан.= :
   LLAGT+ or LLDNT+;
 
-чикан.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 чикан.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+чикан.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 чили.= :
   LLDWY+ or LLDXF+ or LLAYG+ or LLBPY+;
@@ -43008,11 +43000,11 @@
 
 чин.nlmsi :  <morph-С,мр,од,ед,им>;
 
-чин.ndmsv :  <morph-С,мр,но,ед,вн>;
+чин.ndmsi :  <morph-С,мр,но,ед,им>;
 
 чин.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-чин.ndmsi :  <morph-С,мр,но,ед,им>;
+чин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 чир.= :
   LLATX+ or LLAVH+ or LLCKD+;
@@ -43038,14 +43030,14 @@
 щелк.= :
   LLAAM+ or LLAEL+ or LLDTP+;
 
-бряк.xn звяк.xn кряк.xn тук.xn хрюк.xn чих.xn 
-щелк.xn :  <morph-ПРЕДК,нст>;
-
 бряк.ndmsv звяк.ndmsv кряк.ndmsv тук.ndmsv хрюк.ndmsv чих.ndmsv 
 щелк.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бряк.ndmsi звяк.ndmsi кряк.ndmsi тук.ndmsi хрюк.ndmsi чих.ndmsi 
 щелк.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бряк.xn звяк.xn кряк.xn тук.xn хрюк.xn чих.xn 
+щелк.xn :  <morph-ПРЕДК,нст>;
 
 чихво.= :
   LLESY+ or LLCTA+;
@@ -43063,11 +43055,11 @@
 член.= :
   LLAAQ+ or LLACI+ or LLBHS+ or LLBNP+ or LLBYZ+;
 
+член.ndmsi :  <morph-С,мр,но,ед,им>;
+
 член.nlmsi :  <morph-С,мр,од,ед,им>;
 
 член.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-член.ndmsi :  <morph-С,мр,но,ед,им>;
 
 чт.= :
   LLESZ+ or LLETA+;
@@ -43080,9 +43072,9 @@
 
 чуб.nlmsi :  <morph-С,мр,од,ед,им>;
 
-чуб.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 чуб.ndmsi :  <morph-С,мр,но,ед,им>;
+
+чуб.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 консьерж.= чуваш.= :
   LLACD+ or LLBRM+;
@@ -43097,13 +43089,13 @@
 чувяк.= :
   LLABS+ or LLBCA+;
 
-чувяк.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-чувяк.ndmpg :  <morph-С,мр,но,мн,рд>;
-
 чувяк.ndmsi :  <morph-С,мр,но,ед,им>;
 
 чувяк.npg :  <morph-С,мн,мн,рд>;
+
+чувяк.ndmpg :  <morph-С,мр,но,мн,рд>;
+
+чувяк.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 чугун.= :
   LLAAQ+ or LLBRK+ or LLBYU+ or LLCJW+;
@@ -43129,9 +43121,9 @@
 чудовищ.= :
   LLASC+ or LLBYU+;
 
-чудовищ.nlnpg :  <morph-С,ср,од,мн,рд>;
-
 чудовищ.nlnpv :  <morph-С,ср,од,мн,вн>;
+
+чудовищ.nlnpg :  <morph-С,ср,од,мн,рд>;
 
 чуж.= :
   LLAKY+ or LLCIH+ or LLCIQ+ or LLCIX+;
@@ -43175,9 +43167,9 @@
 чучел.= :
   LLCAG+ or LLCAQ+ or LLDOO+;
 
-чучел.nlnpg :  <morph-С,ср,од,мн,рд>;
-
 чучел.ndnpg :  <morph-С,ср,но,мн,рд>;
+
+чучел.nlnpg :  <morph-С,ср,од,мн,рд>;
 
 чучел.nlnpv :  <morph-С,ср,од,мн,вн>;
 
@@ -43196,9 +43188,9 @@
 шабаш.= :
   LLAAH+ or LLAEL+ or LLBFZ+ or LLBRI+;
 
-шабаш.xn :  <morph-ПРЕДК,нст>;
-
 шабаш.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+шабаш.xn :  <morph-ПРЕДК,нст>;
 
 шабаш.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -43226,11 +43218,11 @@
 шалав.= :
   LLAGT+ or LLDKF+;
 
-шалав.amss :  <morph-П,мр,ед,кр>;
-
 шалав.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 шалав.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+шалав.amss :  <morph-П,мр,ед,кр>;
 
 шале.= :
   LLADL+ or LLCZE+;
@@ -43253,9 +43245,9 @@
 шар.= :
   LLAAQ+ or LLBGR+ or LLCCZ+ or LLFWB+ or LLCGW+;
 
-шар.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 шар.ndmsi :  <morph-С,мр,но,ед,им>;
+
+шар.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 зенкер.= калибр.= репетир.= шаржир.= шплинт.= шредер.= 
 :
@@ -43290,20 +43282,20 @@
 шатун.= :
   LLAAQ+ or LLACI+ or LLBYU+ or LLDPO+;
 
-шатун.nlmsi :  <morph-С,мр,од,ед,им>;
-
 шатун.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+шатун.nlmsi :  <morph-С,мр,од,ед,им>;
 
 шатун.ndmsi :  <morph-С,мр,но,ед,им>;
 
 шах.= :
   LLAAM+ or LLACG+ or LLCCZ+ or LLCGW+;
 
-шах.nlmsi :  <morph-С,мр,од,ед,им>;
-
 шах.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 шах.ndmsi :  <morph-С,мр,но,ед,им>;
+
+шах.nlmsi :  <morph-С,мр,од,ед,им>;
 
 шахин.= :
   LLFJJ+ or LLDQR+;
@@ -43339,11 +43331,11 @@
 швартов.= :
   LLAAQ+ or LLBIU+ or LLBNS+ or LLBRK+ or LLBYZ+ or LLDKJ+;
 
-швартов.amss :  <morph-П,мр,ед,кр>;
+швартов.ndmsi :  <morph-С,мр,но,ед,им>;
 
 швартов.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-швартов.ndmsi :  <morph-С,мр,но,ед,им>;
+швартов.amss :  <morph-П,мр,ед,кр>;
 
 шве.= :
   LLBPW+ or LLBPY+ or LLBQK+ or LLDQQ+;
@@ -43381,11 +43373,11 @@
 
 шельм.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-шельм.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 шельм.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 шельм.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+шельм.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 фуг.= шелюг.= штук.= :
   LLAFU+ or LLCCZ+ or LLCGW+;
@@ -43397,6 +43389,10 @@
 :
   LLFQF+ or LLFUS+;
 
+бабкин.admsv батюшкин.admsv ильин.admsv иудин.admsv кузькин.admsv кукушкин.admsv 
+левин.admsv мишин.admsv панин.admsv светкин.admsv шемякин.admsv юрин.admsv 
+:  <morph-П,мр,ед,вн,но>;
+
 бабкин.amsi батюшкин.amsi ильин.amsi иудин.amsi кузькин.amsi кукушкин.amsi 
 левин.amsi мишин.amsi панин.amsi светкин.amsi шемякин.amsi юрин.amsi 
 :  <morph-П,мр,ед,им>;
@@ -43404,10 +43400,6 @@
 бабкин.nlmsi батюшкин.nlmsi ильин.nlmsi иудин.nlmsi кузькин.nlmsi кукушкин.nlmsi 
 левин.nlmsi мишин.nlmsi панин.nlmsi светкин.nlmsi шемякин.nlmsi юрин.nlmsi 
 :  <morph-С,мр,од,ед,им>;
-
-бабкин.admsv батюшкин.admsv ильин.admsv иудин.admsv кузькин.admsv кукушкин.admsv 
-левин.admsv мишин.admsv панин.admsv светкин.admsv шемякин.admsv юрин.admsv 
-:  <morph-П,мр,ед,вн,но>;
 
 шеп.= :
   LLCUQ+ or LLCVF+;
@@ -43428,22 +43420,6 @@
 /ru/words/words.242:
   LLAAO+;
 
-анальгин.ndmsv аспирин.ndmsv ацетон.ndmsv ацидофилин.ndmsv батист.ndmsv биос.ndmsv 
-бурелом.ndmsv вазелин.ndmsv валидол.ndmsv валокардин.ndmsv ванилин.ndmsv ватин.ndmsv 
-вельвет.ndmsv вермут.ndmsv винегрет.ndmsv виноград.ndmsv габардин.ndmsv гам.ndmsv 
-гарнир.ndmsv гвалт.ndmsv глазет.ndmsv глинтвейн.ndmsv глицерин.ndmsv гогот.ndmsv 
-гонор.ndmsv град.ndmsv джем.ndmsv джин.ndmsv драп.ndmsv дуст.ndmsv 
-загар.ndmsv и-мейл.ndmsv кагор.ndmsv карбонад.ndmsv кардамон.ndmsv клекот.ndmsv 
-клокот.ndmsv коверкот.ndmsv кодеин.ndmsv коленкор.ndmsv крепдешин.ndmsv крюшон.ndmsv 
-лепет.ndmsv лосьон.ndmsv мадаполам.ndmsv майонез.ndmsv маргарин.ndmsv маркизет.ndmsv 
-матерьял.ndmsv мозельвейн.ndmsv морс.ndmsv муслин.ndmsv нафталин.ndmsv парафин.ndmsv 
-пиломатериал.ndmsv пирамидон.ndmsv пластилин.ndmsv поплин.ndmsv портвейн.ndmsv ратин.ndmsv 
-рейнвейн.ndmsv репс.ndmsv рокот.ndmsv рокфор.ndmsv сатин.ndmsv сидр.ndmsv 
-скрежет.ndmsv стрекот.ndmsv стрептоцид.ndmsv топот.ndmsv файдешин.ndmsv формалин.ndmsv 
-херес.ndmsv хлам.ndmsv хлороформ.ndmsv хряст.ndmsv цокот.ndmsv чернозем.ndmsv 
-чернослив.ndmsv чипсет.ndmsv шарм.ndmsv шевиот.ndmsv шербет.ndmsv шнапс.ndmsv 
-щебет.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 анальгин.ndmsi аспирин.ndmsi ацетон.ndmsi ацидофилин.ndmsi батист.ndmsi биос.ndmsi 
 бурелом.ndmsi вазелин.ndmsi валидол.ndmsi валокардин.ndmsi ванилин.ndmsi ватин.ndmsi 
 вельвет.ndmsi вермут.ndmsi винегрет.ndmsi виноград.ndmsi габардин.ndmsi гам.ndmsi 
@@ -43459,6 +43435,22 @@
 херес.ndmsi хлам.ndmsi хлороформ.ndmsi хряст.ndmsi цокот.ndmsi чернозем.ndmsi 
 чернослив.ndmsi чипсет.ndmsi шарм.ndmsi шевиот.ndmsi шербет.ndmsi шнапс.ndmsi 
 щебет.ndmsi :  <morph-С,мр,но,ед,им>;
+
+анальгин.ndmsv аспирин.ndmsv ацетон.ndmsv ацидофилин.ndmsv батист.ndmsv биос.ndmsv 
+бурелом.ndmsv вазелин.ndmsv валидол.ndmsv валокардин.ndmsv ванилин.ndmsv ватин.ndmsv 
+вельвет.ndmsv вермут.ndmsv винегрет.ndmsv виноград.ndmsv габардин.ndmsv гам.ndmsv 
+гарнир.ndmsv гвалт.ndmsv глазет.ndmsv глинтвейн.ndmsv глицерин.ndmsv гогот.ndmsv 
+гонор.ndmsv град.ndmsv джем.ndmsv джин.ndmsv драп.ndmsv дуст.ndmsv 
+загар.ndmsv и-мейл.ndmsv кагор.ndmsv карбонад.ndmsv кардамон.ndmsv клекот.ndmsv 
+клокот.ndmsv коверкот.ndmsv кодеин.ndmsv коленкор.ndmsv крепдешин.ndmsv крюшон.ndmsv 
+лепет.ndmsv лосьон.ndmsv мадаполам.ndmsv майонез.ndmsv маргарин.ndmsv маркизет.ndmsv 
+матерьял.ndmsv мозельвейн.ndmsv морс.ndmsv муслин.ndmsv нафталин.ndmsv парафин.ndmsv 
+пиломатериал.ndmsv пирамидон.ndmsv пластилин.ndmsv поплин.ndmsv портвейн.ndmsv ратин.ndmsv 
+рейнвейн.ndmsv репс.ndmsv рокот.ndmsv рокфор.ndmsv сатин.ndmsv сидр.ndmsv 
+скрежет.ndmsv стрекот.ndmsv стрептоцид.ndmsv топот.ndmsv файдешин.ndmsv формалин.ndmsv 
+херес.ndmsv хлам.ndmsv хлороформ.ndmsv хряст.ndmsv цокот.ndmsv чернозем.ndmsv 
+чернослив.ndmsv чипсет.ndmsv шарм.ndmsv шевиот.ndmsv шербет.ndmsv шнапс.ndmsv 
+щебет.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 шерст.= :
   LLBIL+ or LLBNQ+ or LLBRK+ or LLBYU+ or LLDNF+;
@@ -43535,9 +43527,9 @@
 шип.= :
   LLAAQ+ or LLACI+ or LLAWQ+ or LLFRF+ or LLEUU+;
 
-шип.nlmsi :  <morph-С,мр,од,ед,им>;
-
 шип.ndmsv :  <morph-С,мр,но,ед,вн>;
+
+шип.nlmsi :  <morph-С,мр,од,ед,им>;
 
 шип.ndmsi :  <morph-С,мр,но,ед,им>;
 
@@ -43551,9 +43543,9 @@
 
 болтун.nlmsi вертун.nlmsi едун.nlmsi ревун.nlmsi шипун.nlmsi :  <morph-С,мр,од,ед,им>;
 
-болтун.ndmsv вертун.ndmsv едун.ndmsv ревун.ndmsv шипун.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 болтун.ndmsi вертун.ndmsi едун.ndmsi ревун.ndmsi шипун.ndmsi :  <morph-С,мр,но,ед,им>;
+
+болтун.ndmsv вертун.ndmsv едун.ndmsv ревун.ndmsv шипун.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 живуч.= летуч.= липуч.= пахуч.= текуч.= трясуч.= 
 шипуч.= :
@@ -43568,16 +43560,16 @@
 ширин.= :
   LLDWW+ or LLAGL+ or LLBRK+;
 
-ширин.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 ширин.ndmsi :  <morph-С,мр,но,ед,им>;
+
+ширин.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бисер.= шифер.= :
   LLAAW+ or LLBYU+;
 
-бисер.ndmsv шифер.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 бисер.ndmsi шифер.ndmsi :  <morph-С,мр,но,ед,им>;
+
+бисер.ndmsv шифер.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 плюсов.= путев.= пухов.= флюсов.= шихтов.= :
   LLBRK+ or LLCJC+ or LLDKJ+;
@@ -43587,22 +43579,22 @@
 шиш.= :
   LLAAJ+ or LLACF+ or LLDWW+ or LLBRI+ or LLBRM+;
 
-шиш.nlmsi :  <morph-С,мр,од,ед,им>;
-
 шиш.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 шиш.ndmsi :  <morph-С,мр,но,ед,им>;
 
+шиш.nlmsi :  <morph-С,мр,од,ед,им>;
+
 шишимор.= :
   LLAFH+ or LLAGT+;
 
-шишимор.nlfpg :  <morph-С,жр,од,мн,рд>;
+шишимор.nlmpg :  <morph-С,мр,од,мн,рд>;
 
 шишимор.nlfpv :  <morph-С,жр,од,мн,вн>;
 
-шишимор.nlmpv :  <morph-С,мр,од,мн,вн>;
+шишимор.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-шишимор.nlmpg :  <morph-С,мр,од,мн,рд>;
+шишимор.nlmpv :  <morph-С,мр,од,мн,вн>;
 
 шкал.= :
   LLAFX+ or LLCAM+;
@@ -43631,9 +43623,9 @@
 
 шкур.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-шкур.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 шкур.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+шкур.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 абук.= андрощук.= бабук.= балхудук.= башук.= бондарук.= 
 будук.= вильгаук.= витрук.= волощук.= глушук.= гончарук.= 
@@ -43662,16 +43654,16 @@
 шлюз.= :
   LLAAQ+ or LLBYZ+ or LLCCZ+ or LLFWB+ or LLCGW+;
 
-шлюз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 шлюз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+шлюз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 шнур.= :
   LLAAQ+ or LLCCZ+ or LLCGW+ or LLCJW+;
 
-шнур.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 шнур.ndmsi :  <morph-С,мр,но,ед,им>;
+
+шнур.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 бинтов.= винтов.= курсов.= кустов.= лежнев.= листов.= 
 лит.= лубян.= лугов.= льнян.= межев.= пропит.= 
@@ -43683,29 +43675,29 @@
 шойгу.= :
   LLEBR+ or LLEBV+;
 
-шойгу.nlmsi :  <morph-С,мр,од,ед,им>;
-
-шойгу.nlmpi :  <morph-С,мр,од,мн,им>;
-
-шойгу.nlmpt :  <morph-С,мр,од,мн,тв>;
+шойгу.nlmsp :  <morph-С,мр,од,ед,пр>;
 
 шойгу.nlmst :  <morph-С,мр,од,ед,тв>;
 
-шойгу.nlmpd :  <morph-С,мр,од,мн,дт>;
-
-шойгу.nlmsp :  <morph-С,мр,од,ед,пр>;
-
-шойгу.nlmsv :  <morph-С,мр,од,ед,вн>;
-
-шойгу.nlmsd :  <morph-С,мр,од,ед,дт>;
+шойгу.nlmsi :  <morph-С,мр,од,ед,им>;
 
 шойгу.nlmsg :  <morph-С,мр,од,ед,рд>;
 
 шойгу.nlmpv :  <morph-С,мр,од,мн,вн>;
 
-шойгу.nlmpp :  <morph-С,мр,од,мн,пр>;
+шойгу.nlmpd :  <morph-С,мр,од,мн,дт>;
 
 шойгу.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+шойгу.nlmpi :  <morph-С,мр,од,мн,им>;
+
+шойгу.nlmpp :  <morph-С,мр,од,мн,пр>;
+
+шойгу.nlmpt :  <morph-С,мр,од,мн,тв>;
+
+шойгу.nlmsd :  <morph-С,мр,од,ед,дт>;
+
+шойгу.nlmsv :  <morph-С,мр,од,ед,вн>;
 
 шор.= :
   LLAYI+ or LLBRK+ or LLBRO+ or LLBYZ+ or LLBZO+ or LLDJS+;
@@ -43740,11 +43732,11 @@
 лак.= песчаник.= шпик.= :
   LLAAK+ or LLACG+;
 
-лак.nlmsi песчаник.nlmsi шпик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 лак.ndmsv песчаник.ndmsv шпик.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 лак.ndmsi песчаник.ndmsi шпик.ndmsi :  <morph-С,мр,но,ед,им>;
+
+лак.nlmsi песчаник.nlmsi шпик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 монопол.= шпил.= :
   LLDML+ or LLDNX+;
@@ -43759,20 +43751,20 @@
 шпиц.= :
   LLAAD+ or LLACC+;
 
+шпиц.ndmsi :  <morph-С,мр,но,ед,им>;
+
 шпиц.nlmsi :  <morph-С,мр,од,ед,им>;
 
 шпиц.ndmsv :  <morph-С,мр,но,ед,вн>;
-
-шпиц.ndmsi :  <morph-С,мр,но,ед,им>;
 
 шпор.= :
   LLAAQ+ or LLAFX+ or LLAXZ+ or LLBIW+ or LLBNU+ or LLDHY+;
 
 шпор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-шпор.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 шпор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+шпор.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 винтокрыл.= остролист.= шпринтов.= :
   LLAAQ+ or LLDLO+;
@@ -43784,13 +43776,13 @@
 шпрот.= :
   LLACI+ or LLAGT+ or LLBYU+ or LLDJS+;
 
-шпрот.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-шпрот.nlmsi :  <morph-С,мр,од,ед,им>;
-
 шпрот.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 шпрот.npg :  <morph-С,мн,мн,рд>;
+
+шпрот.nlmsi :  <morph-С,мр,од,ед,им>;
+
+шпрот.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 недел.= пилюл.= шпул.= :
   LLDNX+ or LLDOO+ or LLDQC+;
@@ -43814,11 +43806,11 @@
 штейн.= :
   LLAAQ+ or LLFHI+;
 
-штейн.nlmsi :  <morph-С,мр,од,ед,им>;
-
 штейн.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 штейн.ndmsi :  <morph-С,мр,но,ед,им>;
+
+штейн.nlmsi :  <morph-С,мр,од,ед,им>;
 
 штемпел.= :
   LLFSI+ or LLEWL+ or LLDMN+;
@@ -43949,11 +43941,11 @@
 щип.= :
   LLAAQ+ or LLAEL+ or LLETD+ or LLAJX+ or LLAYB+ or LLBRK+ or LLCJW+;
 
-щип.xn :  <morph-ПРЕДК,нст>;
-
 щип.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 щип.ndmsi :  <morph-С,мр,но,ед,им>;
+
+щип.xn :  <morph-ПРЕДК,нст>;
 
 щит.= :
   LLAAQ+ or LLAVM+ or LLCJW+;
@@ -43984,9 +43976,9 @@
 
 бацилл.nlfpg эвглен.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-бацилл.nlfpv эвглен.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 бацилл.ndfpg эвглен.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+бацилл.nlfpv эвглен.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 эвенки.= :
   LLBPY+ or LLEBA+;
@@ -44005,9 +43997,9 @@
 эк.= :
   LLAEK+ or LLDTS+ or LLDUU+;
 
-эк.e :  <morph-Н,0>;
-
 эк.p :  <morph-ЧАСТ,0>;
+
+эк.e :  <morph-Н,0>;
 
 норматив.= подотчет.= приоритет.= эквивалент.= :
   LLAAQ+ or LLBZH+;
@@ -44019,9 +44011,9 @@
 экзамен.= :
   LLAAQ+ or LLCCZ+;
 
-экзамен.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 экзамен.ndmsi :  <morph-С,мр,но,ед,им>;
+
+экзамен.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 эконом.= :
   LLACI+ or LLBIU+ or LLBNS+ or LLBRO+ or LLBYU+;
@@ -44049,9 +44041,9 @@
 электрик.= :
   LLACG+ or LLAEG+;
 
-электрик.nlmsi :  <morph-С,мр,од,ед,им>;
-
 электрик.a :  <morph-П,0>;
+
+электрик.nlmsi :  <morph-С,мр,од,ед,им>;
 
 пролонгир.= реформир.= синтезир.= унифицир.= утилизир.= электрифицир.= 
 эмитир.= :
@@ -44063,9 +44055,9 @@
 электромассаж.= :
   LLAAH+ or LLAAJ+;
 
-электромассаж.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 электромассаж.ndmsi :  <morph-С,мр,но,ед,им>;
+
+электромассаж.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 электромашин.= :
   LLAFY+ or LLDLU+;
@@ -44096,11 +44088,11 @@
 буйволов.= эолов.= :
   LLFUO+ or LLDKJ+;
 
-буйволов.amsi эолов.amsi :  <morph-П,мр,ед,им>;
-
 буйволов.amss эолов.amss :  <morph-П,мр,ед,кр>;
 
 буйволов.admsv эолов.admsv :  <morph-П,мр,ед,вн,но>;
+
+буйволов.amsi эолов.amsi :  <morph-П,мр,ед,им>;
 
 эр.= :
   LLADL+ or LLAFX+;
@@ -44126,9 +44118,9 @@
 эскалатор.= :
   LLAAQ+ or LLBZC+;
 
-эскалатор.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 эскалатор.ndmsi :  <morph-С,мр,но,ед,им>;
+
+эскалатор.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 эт.= :
   LLFFU+ or LLDVV+;
@@ -44141,20 +44133,20 @@
 
 эф.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-эф.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 эф.ndn :  <morph-С,ср,но,0>;
+
+эф.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 эфемерид.= :
   LLAFX+ or LLAGT+ or LLDJS+;
 
-эфемерид.nlfpg :  <morph-С,жр,од,мн,рд>;
-
-эфемерид.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 эфемерид.ndfpg :  <morph-С,жр,но,мн,рд>;
 
+эфемерид.nlfpg :  <morph-С,жр,од,мн,рд>;
+
 эфемерид.npg :  <morph-С,мн,мн,рд>;
+
+эфемерид.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 эх.= :
   LLDTP+ or LLCAG+;
@@ -44164,9 +44156,9 @@
 юл.= :
   LLAGE+ or LLAGT+ or LLBGI+ or LLBRO+;
 
-юл.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 юл.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+юл.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 магарадж.= радж.= юнош.= :
   LLAEZ+;
@@ -44176,9 +44168,9 @@
 
 юр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-юр.ndfpg :  <morph-С,жр,но,мн,рд>;
-
 юр.ndmsi :  <morph-С,мр,но,ед,им>;
+
+юр.ndfpg :  <morph-С,жр,но,мн,рд>;
 
 юров.= :
   LLFOU+ or LLEDS+;
@@ -44186,11 +44178,11 @@
 юрьев.= :
   LLFQF+ or LLFUO+ or LLDYG+;
 
+юрьев.admsv :  <morph-П,мр,ед,вн,но>;
+
 юрьев.amsi :  <morph-П,мр,ед,им>;
 
 юрьев.nlmsi :  <morph-С,мр,од,ед,им>;
-
-юрьев.admsv :  <morph-П,мр,ед,вн,но>;
 
 юстир.= :
   LLBYZ+ or LLCCZ+ or LLFWB+ or LLCGW+;
@@ -44212,17 +44204,17 @@
 громадин.nlfpg дохлятин.nlfpg кислятин.nlfpg крикс.nlfpg мерзлятин.nlfpg орясин.nlfpg 
 шкод.nlfpg шушер.nlfpg ябед.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-громадин.ndfpg дохлятин.ndfpg кислятин.ndfpg крикс.ndfpg мерзлятин.ndfpg орясин.ndfpg 
-шкод.ndfpg шушер.ndfpg ябед.ndfpg :  <morph-С,жр,но,мн,рд>;
-
-громадин.nlfpv дохлятин.nlfpv кислятин.nlfpv крикс.nlfpv мерзлятин.nlfpv орясин.nlfpv 
-шкод.nlfpv шушер.nlfpv ябед.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 громадин.nlmpv дохлятин.nlmpv кислятин.nlmpv крикс.nlmpv мерзлятин.nlmpv орясин.nlmpv 
 шкод.nlmpv шушер.nlmpv ябед.nlmpv :  <morph-С,мр,од,мн,вн>;
 
+громадин.ndfpg дохлятин.ndfpg кислятин.ndfpg крикс.ndfpg мерзлятин.ndfpg орясин.ndfpg 
+шкод.ndfpg шушер.ndfpg ябед.ndfpg :  <morph-С,жр,но,мн,рд>;
+
 громадин.nlmpg дохлятин.nlmpg кислятин.nlmpg крикс.nlmpg мерзлятин.nlmpg орясин.nlmpg 
 шкод.nlmpg шушер.nlmpg ябед.nlmpg :  <morph-С,мр,од,мн,рд>;
+
+громадин.nlfpv дохлятин.nlfpv кислятин.nlfpv крикс.nlfpv мерзлятин.nlfpv орясин.nlfpv 
+шкод.nlfpv шушер.nlfpv ябед.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 яв.= :
   LLDXR+ or LLFWK+ or LLFXQ+ or LLBRK+ or LLBYU+ or LLDNF+;
@@ -44243,18 +44235,18 @@
 яз.= :
   LLAAQ+ or LLDMT+;
 
-яз.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 яз.ndmsi :  <morph-С,мр,но,ед,им>;
+
+яз.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 язв.= :
   LLAFX+ or LLAGT+ or LLBII+ or LLBNN+;
 
 язв.nlfpg :  <morph-С,жр,од,мн,рд>;
 
-язв.nlfpv :  <morph-С,жр,од,мн,вн>;
-
 язв.ndfpg :  <morph-С,жр,но,мн,рд>;
+
+язв.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 гротескн.= матрацн.= миазменн.= мороженн.= оглашенн.= песенн.= 
 фирменн.= язвенн.= :
@@ -44275,9 +44267,9 @@
 якутск.= :
   LLDWW+ or LLDXU+ or LLBEL+;
 
-якутск.ndmsv :  <morph-С,мр,но,ед,вн>;
-
 якутск.ndmsi :  <morph-С,мр,но,ед,им>;
+
+якутск.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 нитчат.= ялов.= :
   LLBRK+ or LLBRO+ or LLDKJ+;
@@ -44287,11 +44279,11 @@
 подбор.= подвод.= ям.= :
   LLAAQ+ or LLAFX+ or LLBRK+ or LLBYZ+;
 
-подбор.ndmsv подвод.ndmsv ям.ndmsv :  <morph-С,мр,но,ед,вн>;
+подбор.ndmsi подвод.ndmsi ям.ndmsi :  <morph-С,мр,но,ед,им>;
 
 подбор.ndfpg подвод.ndfpg ям.ndfpg :  <morph-С,жр,но,мн,рд>;
 
-подбор.ndmsi подвод.ndmsi ям.ndmsi :  <morph-С,мр,но,ед,им>;
+подбор.ndmsv подвод.ndmsv ям.ndmsv :  <morph-С,мр,но,ед,вн>;
 
 ямск.= :
   LLDXT+ or LLDYV+ or LLEDR+ or LLCJF+;
@@ -44299,36 +44291,23 @@
 ян.= :
   LLFKO+ or LLDXR+ or LLFIQ+;
 
-ян.nlfpg :  <morph-С,жр,од,мн,рд>;
+ян.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 ян.nlmsi :  <morph-С,мр,од,ед,им>;
 
-ян.nlfpv :  <morph-С,жр,од,мн,вн>;
+ян.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 яр.= :
   LLAAS+ or LLBHS+ or LLBNP+ or LLBRO+ or LLBSX+ or LLCJW+ or LLDKF+ or LLDNF+;
+
+яр.ndmsi :  <morph-С,мр,но,ед,им>;
 
 яр.amss :  <morph-П,мр,ед,кр>;
 
 яр.ndmsv :  <morph-С,мр,но,ед,вн>;
 
-яр.ndmsi :  <morph-С,мр,но,ед,им>;
-
 /ru/words/words.248:
   LLFJT+;
-
-авдашин.nlfpg авершин.nlfpg авилин.nlfpg акулин.nlfpg аллабердин.nlfpg андрюшин.nlfpg 
-антишин.nlfpg апарин.nlfpg асатулин.nlfpg астраханкин.nlfpg астрелин.nlfpg бабанин.nlfpg 
-базурин.nlfpg балыбердин.nlfpg басаргин.nlfpg бачин.nlfpg бедякин.nlfpg бобошин.nlfpg 
-боткин.nlfpg валиулин.nlfpg верютин.nlfpg гашунин.nlfpg губайдулин.nlfpg данилин.nlfpg 
-деревянкин.nlfpg дильдин.nlfpg дроботухин.nlfpg дубынин.nlfpg дугушкин.nlfpg ермошин.nlfpg 
-жалыбин.nlfpg заблудин.nlfpg заборин.nlfpg завозин.nlfpg загидуллин.nlfpg зацепин.nlfpg 
-зыкин.nlfpg каренин.nlfpg лощинин.nlfpg малахаткин.nlfpg малыгин.nlfpg марамышкин.nlfpg 
-мемячкин.nlfpg мешалкин.nlfpg мизулин.nlfpg мишустин.nlfpg ойкин.nlfpg останин.nlfpg 
-петрухин.nlfpg петрушин.nlfpg полубенин.nlfpg полынин.nlfpg помятихин.nlfpg поплыгин.nlfpg 
-потрошилин.nlfpg потякин.nlfpg прилепин.nlfpg пронякин.nlfpg рагулин.nlfpg распутин.nlfpg 
-сапегин.nlfpg серпуховитин.nlfpg синичкин.nlfpg хайруллин.nlfpg храпылин.nlfpg шеин.nlfpg 
-шушарин.nlfpg яблочкин.nlfpg ярагин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 авдашин.nlfpv авершин.nlfpv авилин.nlfpv акулин.nlfpv аллабердин.nlfpv андрюшин.nlfpv 
 антишин.nlfpv апарин.nlfpv асатулин.nlfpv астраханкин.nlfpv астрелин.nlfpv бабанин.nlfpv 
@@ -44342,6 +44321,19 @@
 потрошилин.nlfpv потякин.nlfpv прилепин.nlfpv пронякин.nlfpv рагулин.nlfpv распутин.nlfpv 
 сапегин.nlfpv серпуховитин.nlfpv синичкин.nlfpv хайруллин.nlfpv храпылин.nlfpv шеин.nlfpv 
 шушарин.nlfpv яблочкин.nlfpv ярагин.nlfpv :  <morph-С,жр,од,мн,вн>;
+
+авдашин.nlfpg авершин.nlfpg авилин.nlfpg акулин.nlfpg аллабердин.nlfpg андрюшин.nlfpg 
+антишин.nlfpg апарин.nlfpg асатулин.nlfpg астраханкин.nlfpg астрелин.nlfpg бабанин.nlfpg 
+базурин.nlfpg балыбердин.nlfpg басаргин.nlfpg бачин.nlfpg бедякин.nlfpg бобошин.nlfpg 
+боткин.nlfpg валиулин.nlfpg верютин.nlfpg гашунин.nlfpg губайдулин.nlfpg данилин.nlfpg 
+деревянкин.nlfpg дильдин.nlfpg дроботухин.nlfpg дубынин.nlfpg дугушкин.nlfpg ермошин.nlfpg 
+жалыбин.nlfpg заблудин.nlfpg заборин.nlfpg завозин.nlfpg загидуллин.nlfpg зацепин.nlfpg 
+зыкин.nlfpg каренин.nlfpg лощинин.nlfpg малахаткин.nlfpg малыгин.nlfpg марамышкин.nlfpg 
+мемячкин.nlfpg мешалкин.nlfpg мизулин.nlfpg мишустин.nlfpg ойкин.nlfpg останин.nlfpg 
+петрухин.nlfpg петрушин.nlfpg полубенин.nlfpg полынин.nlfpg помятихин.nlfpg поплыгин.nlfpg 
+потрошилин.nlfpg потякин.nlfpg прилепин.nlfpg пронякин.nlfpg рагулин.nlfpg распутин.nlfpg 
+сапегин.nlfpg серпуховитин.nlfpg синичкин.nlfpg хайруллин.nlfpg храпылин.nlfpg шеин.nlfpg 
+шушарин.nlfpg яблочкин.nlfpg ярагин.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 влажност.= сущност.= яркост.= :
   LLBZE+ or LLDNF+;
@@ -44369,18 +44361,18 @@
 ясер.= :
   LLFLG+ or LLFJA+;
 
-ясер.nlfpg :  <morph-С,жр,од,мн,рд>;
-
 ясер.nlmsi :  <morph-С,мр,од,ед,им>;
+
+ясер.nlfpg :  <morph-С,жр,од,мн,рд>;
 
 ясер.nlfpv :  <morph-С,жр,од,мн,вн>;
 
 войск.= средств.= яств.= :
   LLAHC+ or LLCAG+;
 
-войск.ndnpg средств.ndnpg яств.ndnpg :  <morph-С,ср,но,мн,рд>;
-
 войск.npg средств.npg яств.npg :  <morph-С,мн,мн,рд>;
+
+войск.ndnpg средств.ndnpg яств.ndnpg :  <morph-С,ср,но,мн,рд>;
 
 ястреб.= :
   LLACQ+ or LLAVH+ or LLCJW+ or LLCKD+;

--- a/data/ru/tools/mkdict.pl
+++ b/data/ru/tools/mkdict.pl
@@ -413,18 +413,20 @@ foreach my $stems ( sort keys %fwd ) {
     # write inline if less than 40 words, else dump to a file
     foreach my $key (keys %emptysuflinks ) {
         my $cnt = 0;
+        my $tot = 0;
         foreach my $w ( @words ) {
              my $wkey = $w.".".parse($key);
              next if ( defined $skipwords{$wkey} );
              next if ( defined $skipwords{$w} );
              print RTS eu($wkey)." ";
              $cnt++;
+             $tot++;
              if (5 < $cnt) {
                  print RTS "\n";
                  $cnt = 0;
              }
         }
-        print RTS ":  ".eu("<morph-$key>").";\n\n";
+        print RTS ":  ".eu("<morph-$key>").";\n\n" if $tot > 0;
     }
 }
 # print "% duude revers=$revcnt\n";

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1739,6 +1739,12 @@ static bool read_entry(Dictionary dict)
 		goto syntax_error;
 	}
 
+	if (dn == NULL)
+	{
+		dict_error(dict, "Expecting a token before \":\".");
+		goto syntax_error;
+	}
+
 	/* At this point, dn points to a list of Dict_nodes connected by
 	 * their left pointers. These are to be inserted into the dictionary */
 	i = 0;


### PR DESCRIPTION
Encountered in a WIP.
There is currently no use of an empty word list so it indicates an error.
So instead of special-case it I flagged it as an error.