### PR TITLE
print.c cleanup

### DIFF
--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -298,7 +298,7 @@ build_linkage_postscript_string(const Linkage linkage,
 {
 	int link, i,j;
 	int d;
-	bool print_word_0, print_word_N;
+	bool print_word_0 = true, print_word_N = true;
 	int N_links = linkage->num_links;
 	Link *ppla = linkage->link_array;
 	dyn_str * string;
@@ -306,38 +306,42 @@ build_linkage_postscript_string(const Linkage linkage,
 
 	string = dyn_str_new();
 
-	if (!display_walls) {
+	/* Do we want to print the left and right walls? */
+	if (!display_walls)
+	{
 		int N_wall_connectors = 0;
-		bool suppressor_used = false;
-		for (j=0; j<N_links; j++) {
-			if (ppla[j].lw == 0) {
+		for (j=0; j<N_links; j++)
+		{
+			if (0 == ppla[j].lw)
+			{
 				if (ppla[j].rw == linkage->num_words-1) continue;
-				N_wall_connectors ++;
-				if (easy_match(connector_string(ppla[j].lc), LEFT_WALL_SUPPRESS)) {
-					suppressor_used = true;
-				}
-			}
-		}
-		print_word_0 = (((!suppressor_used) && (N_wall_connectors != 0))
-						|| (N_wall_connectors != 1));
-	}
-	else print_word_0 = true;
+				if (easy_match(connector_string(ppla[j].lc), LEFT_WALL_SUPPRESS))
+					print_word_0 = false;
 
-	if (!display_walls) {
-		int N_wall_connectors = 0;
-		bool suppressor_used = false;
-		for (j=0; j<N_links; j++) {
-			if (ppla[j].rw == linkage->num_words-1) {
-				N_wall_connectors ++;
-				if (easy_match(connector_string(ppla[j].lc), RIGHT_WALL_SUPPRESS)) {
-					suppressor_used = true;
+				if (++N_wall_connectors > 1)
+				{
+					print_word_0 = true;
+					break;
 				}
 			}
 		}
-		print_word_N = (((!suppressor_used) && (N_wall_connectors != 0))
-						|| (N_wall_connectors != 1));
+
+		N_wall_connectors = 0;
+		for (j=0; j<N_links; j++)
+		{
+			if (ppla[j].rw == linkage->num_words-1)
+			{
+				if (easy_match(connector_string(ppla[j].lc), RIGHT_WALL_SUPPRESS))
+					print_word_N = false;
+
+				if (++N_wall_connectors > 1)
+				{
+					print_word_N = true;
+					break;
+				}
+			}
+		}
 	}
-	else print_word_N = true;
 
 	if (print_word_0) d=0; else d=1;
 
@@ -446,7 +450,7 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 	unsigned int i, j, k, cl, cr, inc, row, top_row, top_row_p1;
 	const char *s;
 	char *t;
-	bool print_word_0 , print_word_N;
+	bool print_word_0 = true, print_word_N = true;
 	int *center = alloca((linkage->num_words+1)*sizeof(int));
 	int *word_offset = alloca((linkage->num_words+1) * sizeof(*word_offset));
 	unsigned int link_length;
@@ -460,48 +464,42 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 
 	string = dyn_str_new();
 
-	/* Do we want to print the left wall? */
+	/* Do we want to print the left and right walls? */
 	if (!display_walls)
 	{
 		int N_wall_connectors = 0;
-		bool suppressor_used = false;
 		for (j=0; j<N_links; j++)
 		{
 			if (0 == ppla[j].lw)
 			{
 				if (ppla[j].rw == linkage->num_words-1) continue;
-				N_wall_connectors ++;
 				if (easy_match(connector_string(ppla[j].lc), LEFT_WALL_SUPPRESS))
+					print_word_0 = false;
+
+				if (++N_wall_connectors > 1)
 				{
-					suppressor_used = true;
+					print_word_0 = true;
+					break;
 				}
 			}
 		}
-		print_word_0 = (((!suppressor_used) && (N_wall_connectors != 0))
-					|| (N_wall_connectors != 1));
-	}
-	else print_word_0 = true;
 
-	/* Do we want to print the right wall? */
-	if (!display_walls)
-	{
-		int N_wall_connectors = 0;
-		bool suppressor_used = false;
+		N_wall_connectors = 0;
 		for (j=0; j<N_links; j++)
 		{
 			if (ppla[j].rw == linkage->num_words-1)
 			{
-				N_wall_connectors ++;
 				if (easy_match(connector_string(ppla[j].lc), RIGHT_WALL_SUPPRESS))
+					print_word_N = false;
+
+				if (++N_wall_connectors > 1)
 				{
-					suppressor_used = true;
+					print_word_N = true;
+					break;
 				}
 			}
 		}
-		print_word_N = (((!suppressor_used) && (N_wall_connectors != 0))
-					|| (N_wall_connectors != 1));
 	}
-	else print_word_N = true;
 
 	N_words_to_print = linkage->num_words;
 	if (!print_word_N) N_words_to_print--;

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -604,8 +604,6 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 		}
 		if (row > top_row) top_row = row;
 
-		picture[row][cl] = '+';
-		picture[row][cr] = '+';
 		for (k=cl+1; k<cr; k++) {
 			picture[row][k] = '-';
 		}
@@ -633,7 +631,6 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 		if (DEPT_CHR == connector_string(lnk->rc)[0]) { picture[row][cr-1] = '>'; }
 		if (HEAD_CHR == connector_string(lnk->rc)[0]) { *t = '<'; }
 
-		/* The direction indicators may have clobbered these. */
 		picture[row][cl] = '+';
 		picture[row][cr] = '+';
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -65,7 +65,7 @@ set_centers(const Linkage linkage, int center[], int word_offset[],
 	{
 		Link *l = &linkage->link_array[n];
 
-		if ((l->lw + 1 == l->rw) && (NULL != l->link_name))
+		if (l->lw + 1 == l->rw)
 		{
 			link_len[l->rw] = strlen(l->link_name) +
 				(DEPT_CHR == connector_string(l->rc)[0]) +
@@ -533,7 +533,6 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 		for (j=0; j<N_links; j++)
 		{
 			assert (ppla[j].lw != SIZE_MAX);
-			if (NULL == ppla[j].link_name) continue;
 			if (((unsigned int) (ppla[j].rw - ppla[j].lw)) != link_length)
 			  continue;
 			if (!print_word_0 && (ppla[j].lw == 0)) continue;

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -359,7 +359,6 @@ build_linkage_postscript_string(const Linkage linkage,
 	for (link=0; link<N_links; link++) {
 		if (!print_word_0 && (ppla[link].lw == 0)) continue;
 		if (!print_word_N && (ppla[link].rw == linkage->num_words-1)) continue;
-		// if (ppla[link]->lw == SIZE_MAX) continue;
 		assert (ppla[link].lw != SIZE_MAX);
 		if ((j%7 == 0) && (j>0)) dyn_strcat(string,"\n");
 		j++;
@@ -588,7 +587,6 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			}
 
 			/* Add direction indicator */
-			// if (DEPT_CHR == ppla[j]->lc->string[0]) { *(t-1) = '<'; }
 			if (DEPT_CHR == connector_string(ppla[j].lc)[0] &&
 			    (t > &picture[row][cl])) { picture[row][cl+1] = '<'; }
 			if (HEAD_CHR == connector_string(ppla[j].lc)[0]) { *(t-1) = '>'; }
@@ -597,7 +595,6 @@ linkage_print_diagram_ctxt(const Linkage linkage,
 			while ((*s != '\0') && (*t == '-')) *t++ = *s++;
 
 			/* Add direction indicator */
-			// if (DEPT_CHR == ppla[j]->rc->string[0]) { *t = '>'; }
 			if (DEPT_CHR == connector_string(ppla[j].rc)[0]) { picture[row][cr-1] = '>'; }
 			if (HEAD_CHR == connector_string(ppla[j].rc)[0]) { *t = '<'; }
 


### PR DESCRIPTION
Initial general changes from the fake-xlink branch.
Due to using `qsort()` instead of a per-word link_array loop, massive diagram printouts became faster by a few percents. A modified sorting is used later (WIP) for printing cross links.