### PR TITLE
Dialect bug fix and improvements

### DIFF
--- a/bindings/python-examples/parses-en.txt
+++ b/bindings/python-examples/parses-en.txt
@@ -45,3 +45,14 @@ O    +-->Wd---+--Sp*i--+--I*t--+Osm+    +-Dsu-+
 O    |        |        |       |   |    |     |
 OLEFT-WALL y'.#you gotta.v-d do.v it this.d way.n
 O
+
+% Check that the default dialect setting doesn't enable "headline"
+-max_null_count=1
+
+IThieves rob bank
+O
+O    +---------->WV---------->+
+O    +--->Wd---+------Sp------+
+O    |         |              |
+OLEFT-WALL thieves.n [rob] bank.v
+O

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -236,6 +236,14 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 	if (dinfo->cost_table != NULL)
 	{
 		/* Cached table. */
+		if (dinfo->dict != dict)
+		{
+			/* XXX In principle this may still be another dictionary if it got
+			 * the same address. Can be fixed by adding dictionary_create()
+			 * ordinal number. */
+			prt_error("Error: Dialect setup belongs to a different dictionary.\n");
+			return false;
+		}
 		lgdebug(D_DIALECT, "Debug: Cached cost table found\n");
 
 		if (verbosity_level(+D_DIALECT+1))
@@ -243,6 +251,8 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 
 		return true;
 	}
+
+	dinfo->dict = dict;
 
 	if (et->num != 0)
 	{

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -46,7 +46,7 @@ Dialect *dialect_alloc(void)
 	return di;
 }
 
-Exptag *exptag_add(Dictionary dict, const char *tag)
+Exptag *exptag_dialect_add(Dictionary dict, const char *tag)
 {
 	expression_tag *et = &dict->tag;
 	unsigned int tag_index = string_id_lookup(tag, et->set);

--- a/link-grammar/dict-common/dialect.h
+++ b/link-grammar/dict-common/dialect.h
@@ -69,7 +69,7 @@ typedef struct dialect_option_s dialect_info;
 
 Dialect *dialect_alloc(void);
 void free_dialect(Dialect *);
-Exptag *exptag_add(Dictionary, const char *);
+Exptag *exptag_dialect_add(Dictionary, const char *);
 bool setup_dialect(Dictionary, Parse_Options);
 void free_cost_table(Parse_Options opts);
 bool apply_dialect(Dictionary, Dialect *, unsigned int, Dialect *, dialect_info *);

--- a/link-grammar/dict-common/dialect.h
+++ b/link-grammar/dict-common/dialect.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/* Copyright (C) 2019 Amir Plivatsky                                     */
+/* Copyright (C) 2019-2020 Amir Plivatsky                                     */
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */
@@ -61,7 +61,8 @@ struct Dialect_s
 /* Dialect object for parse_options_*_dialect(). */
 struct dialect_option_s
 {
-	char *conf;
+	Dictionary dict;
+	char *conf;                    /* User dialect setup */
 	float *cost_table;             /* Indexed by Exptag index field */
 };
 
@@ -69,7 +70,7 @@ typedef struct dialect_option_s dialect_info;
 
 Dialect *dialect_alloc(void);
 void free_dialect(Dialect *);
-Exptag *exptag_dialect_add(Dictionary, const char *);
+unsigned int exptag_dialect_add(Dictionary, const char *);
 bool setup_dialect(Dictionary, Parse_Options);
 void free_cost_table(Parse_Options opts);
 bool apply_dialect(Dictionary, Dialect *, unsigned int, Dialect *, dialect_info *);

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -301,8 +301,8 @@ void dictionary_delete(Dictionary dict)
 	string_set_delete(dict->string_set);
 
 	free_dialect(dict->dialect);
-	free(dict->tag.array);
-	string_id_delete(dict->tag.set);
+	free(dict->dialect_tag.name);
+	string_id_delete(dict->dialect_tag.set);
 
 	free((void *)dict->suppress_warning);
 	free_regexs(dict->regex_root);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -70,7 +70,7 @@ struct Afdict_class_struct
 typedef struct
 {
 	String_id *set;                    /* Expression tag names */
-	Exptag *array;                     /* Exp. tag array (indexed by their id) */
+	const char **name;                 /* Tag name (indexed by tag id) */
 	unsigned int num;                  /* Number of tags */
 	unsigned int size;                 /* Allocated tag array size */
 } expression_tag;
@@ -93,7 +93,7 @@ struct Dictionary_s
 	bool         shuffle_linkages;
 
 	Dialect *dialect;                  /* "4.0.dialect" info */
-	expression_tag tag;                /* Expression tag info */
+	expression_tag dialect_tag;        /* Expression dialect tag info */
 
 	/* Affixes are used during the tokenization stage. */
 	Dictionary      affix_table;

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -38,12 +38,7 @@ static const int cost_max_dec_places = 3;
 static const double cost_epsilon = 1E-5;
 
 #define EXPTAG_SZ 100 /* Initial size for the Exptag array. */
-typedef struct Exptag_s Exptag;
-struct Exptag_s
-{
-	const char *name;
-	unsigned int index;
-};
+typedef enum { Exptag_none=0, Exptag_dialect } Exptag_type;
 
 /**
  * The Exp structure defined below comprises the expression trees that are
@@ -55,17 +50,18 @@ struct Exptag_s
  */
 struct Exp_struct
 {
-	Exp *operand_next; /* Next same-level operand. */
-	Exp_type type:8;   /* One of three types: AND, OR, or connector. */
+	Exp *operand_next;    /* Next same-level operand. */
+	Exp_type type:8;      /* One of three types: AND, OR, or connector. */
+	Exptag_type tag_type:8;
 	char dir;      /* The connector connects to the left ('-') or right ('+'). */
-	bool multi;        /* TRUE if a multi-connector (for connector). */
-	float cost;        /* The cost of using this expression. */
+	bool multi;           /* TRUE if a multi-connector (for connector). */
+	unsigned int tag_id;  /* Index in tag_type namespace. */
+	float cost;           /* The cost of using this expression. */
 	union
 	{
 		Exp *operand_first; /* First operand (for non-terminals). */
 		condesc_t *condesc; /* Only needed if it's a connector. */
 	};
-	Exptag *tag;       /* Used for dialect cost. */
 };
 
 bool cost_eq(double cost1, double cost2);

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -68,8 +68,8 @@ Exp *copy_Exp(Exp *e, Pool_desc *Exp_pool, Parse_Options opts)
 	Exp *new_e = pool_alloc(Exp_pool);
 
 	*new_e = *e;
-	if (NULL != e->tag)
-		new_e->cost += opts->dialect.cost_table[new_e->tag->index];
+	if (Exptag_dialect == e->tag_type)
+		new_e->cost += opts->dialect.cost_table[new_e->tag_id];
 
 #if 0 /* Not used - left here for documentation. */
 	new_e->operand_next = copy_Exp(e->operand_next, Exp_pool);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -138,7 +138,7 @@ dictionary_six_str(const char * lang,
 		dict->lookup_wild = file_lookup_wild;
 		dict->free_lookup = free_llist;
 		dict->lookup = file_boolean_lookup;
-		dict->tag.set = string_id_create();
+		dict->dialect_tag.set = string_id_create();
 		condesc_init(dict, 1<<13);
 		Exp_pool_size = 1<<13;
 	}
@@ -181,10 +181,10 @@ dictionary_six_str(const char * lang,
 		return dict;
 	}
 
-	if (dict->tag.num == 0)
+	if (dict->dialect_tag.num == 0)
 	{
-		string_id_delete(dict->tag.set);
-		dict->tag.set = NULL;
+		string_id_delete(dict->dialect_tag.set);
+		dict->dialect_tag.set = NULL;
 	}
 
 	dictionary_setup_locale(dict);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -795,7 +795,7 @@ static Dict_node * strict_lookup_list(const Dictionary dict, const char *s)
 Exp *Exp_create(Pool_desc *mp)
 {
 	Exp *e = pool_alloc(mp);
-	e->tag = NULL;
+	e->tag_type = Exptag_none;
 	return e;
 }
 
@@ -1181,11 +1181,12 @@ static Exp *make_expression(Dictionary dict)
 					           badchar);
 					return NULL;
 				}
-				if (nl->tag != NULL)
+				if (nl->tag_id != Exptag_none)
 				{
 					nl = make_unary_node(dict->Exp_pool, nl);
 				}
-				nl->tag = exptag_dialect_add(dict, dict->token);
+				nl->tag_id = exptag_dialect_add(dict, dict->token);
+				nl->tag_type = Exptag_dialect;
 				if (!link_advance(dict)) {
 					return NULL;
 				}

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1185,7 +1185,7 @@ static Exp *make_expression(Dictionary dict)
 				{
 					nl = make_unary_node(dict->Exp_pool, nl);
 				}
-				nl->tag = exptag_add(dict, dict->token);
+				nl->tag = exptag_dialect_add(dict, dict->token);
 				if (!link_advance(dict)) {
 					return NULL;
 				}


### PR DESCRIPTION
- Dialect implementation bug fix: realloc() may change address.
This is a design bug which may cause a wild pointer reference crash if there are > 100 different dialect components.
- Ensure that Parse_Options' dialect info refers to the sentence's dict.
Indicate an error in case the user apples a parse-option with dialect that has previously applied to another dict. (Maybe just invalidating the dialect cache could be better in such a case, I'm not sure and this may not bee too important).
- Add a test suite check that the initial dialect definitions get applied.
- exptag_add(): Rename to exptag_dialect_add()
This is a preparation to adding another tag type.

An additional known bug remains: `!!word` doesn't apply the dialect costs as was initially intended.
This is fixed in the next PR (that implements `!!word/regex/`).

