### PR TITLE
read-dict.c: Fix handling of missing ';' at end of dict

### DIFF
--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1072,6 +1072,7 @@ void add_empty_word(Sentence sent, X_node *x)
  */
 static bool is_number(const char * str)
 {
+	if (str[0] == '\0') return false; /* End of file. */
 	if ('+' == str[0] || '-' == str[0]) str++;
 	size_t numlen = strspn(str, "0123456789.");
 


### PR DESCRIPTION
Fix a minor problem that I encountered on a test dict, when I forgot the ending `;` on the last line.