### PR TITLE
Additional pruning in is_cross_mlink()

### DIFF
--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -52,6 +52,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 /* Per-word minimum/maximum link distance descriptor.
  * The dimension of the 2-element arrays below is used as follows:
  * [0] - left side; [1] - right side.
+ *
  * nw is the minimum nearest_word of the shallow connectors.
  * fw is the maximum farthest_word of the shallow connectors.
  *
@@ -60,6 +61,19 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  * (nw) this is signified by value w for word w. For farthest word (fw)
  * this is signified by 0 for fw[0] and UNLIMITED_LEN for fw[1].
  *
+ * nw_perjet is similar to nw, but its computation ignores the
+ * abovementioned case in which a jet is missing in the relevant
+ * direction. Moreover, if there are no jets at all at the given
+ * direction, nw_perjet[0] is 0 and nw_perjet[1] is UNLIMITED_LEN (as if
+ * the nearest word a missing jet can connect to is beyond the sentence
+ * boundary, i.e. no connection is possible). NOTE: The use of 0 here
+ * (instead of -1) is not optimal as word 0 is still inside the sentence,
+ * so the checks in is_cross_mlink() when rword==0 are not optimal.
+ *
+ * nw_unidir is also similar to nw, but its computation ignores jets that
+ * have an opposite jet in the other directions. Naturally, there are no
+ * missing jets in the relevant direction.
+ *
  * The connection of the shallow connector is to a greater distance than
  * the connections from the deeper ones. For word w, words in the ranges
  * (nw[0], w) or (w, nw[1]) cannot connect to words to the left or to the
@@ -67,12 +81,16 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  * connector of w. In addition, words in (nw[0], w) cannot connect to
  * words before fw[0] (and similarly after fw[1] for the other direction).
  *
+ * The values for words which don't have disjuncts are undefined.
+ *
  * These values are computed by build_mlink_table() after the first
  * power_prune() call, before invoking an additional power_prune(). */
 typedef struct
 {
-	WordIdx_m nw[2];   /* minimum link distance */
-	WordIdx_m fw[2];   /* maximum link distance */
+	WordIdx_m nw[2];         /* minimum link distance */
+	WordIdx_m nw_perjet[2];  /* the same, ignoring missing jets */
+	WordIdx_m nw_unidir[2];  /* the same, but only for unidirectional jets */
+	WordIdx_m fw[2];         /* maximum link distance */
 } mlink_table;
 
 typedef struct c_list_s C_list;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -62,10 +62,10 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  *
  * The connection of the shallow connector is to a greater distance than
  * the connections from the deeper ones. For word w, words in the ranges
- * (nw[0], w) or (w, nw[1]) cannot connect to words outside its
- * corresponding range without crossing a link to a shallow connector of
- * w. In addition, words in (nw[0], w) cannot connect to words before
- * fw[0] (and similarly for the other range).
+ * (nw[0], w) or (w, nw[1]) cannot connect to words to the left or to the
+ * right of w (correspondingly) without crossing a link to a shallow
+ * connector of w. In addition, words in (nw[0], w) cannot connect to
+ * words before fw[0] (and similarly after fw[1] for the other direction).
  *
  * These values are computed by build_mlink_table() after the first
  * power_prune() call, before invoking an additional power_prune(). */

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -58,7 +58,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  * In case at least one jet is missing in a particular direction, there
  * are no link distance constraints in that direction. For nearest_word
  * (nw) this is signified by value w for word w. For farthest word (fw)
- * this is signified by unlimited length limit.
+ * this is signified by 0 for fw[0] and UNLIMITED_LEN for fw[1].
  *
  * The connection of the shallow connector is to a greater distance than
  * the connections from the deeper ones. For word w, words in the ranges

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -523,8 +523,9 @@ static bool is_cross_mlink(prune_context *pc,
 		if ((pc->ml[w].nw[1] > rword) && PR(R)) goto null_word_found;
 #endif
 
+		/* If w has a link to an edge word, links from the deepest
+		 * connectors of this word is not allowed to cross a link to w. */
 #if 1
-		/* Links from the deepest edge connectors cannot cross a link to w. */
 		if (lword == pc->ml[w].nw[0])
 		{
 			/* w has a link to lword, or it's a null word. */


### PR DESCRIPTION
This patch adds a significant pruning for any null count.
It implements a combination of new ideas:
- Using minimum nearest_word without taking into account unidirectional disjuncts.
- Using minimum nearest_word of only unidirectional disjuncts.

And most important:
- Using `*_table_search()` for a check of `possible_connection()`.
`*_table_search()` calls `possible_connection()` again, but the recursion stops in that because it returns near its start. I intend to test a full recursive version of `power_prune()`.

For short sentences, there is a drastic reduction in the parsing time, but since it is only about 2.5% for the `basic` and `fixes` batches, the result is only a slight speedup for them.
For long sentences there is 6-8% speedup (`failures` and `pandp-union` batches, the last one with `!short=20` to make it comparable to the other batches).
