### PR TITLE
is_expression_optional(): Fix comparison to Exptag_none

### DIFF
--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -143,7 +143,7 @@ static bool is_expression_optional(const Exp *e)
 
 	return (e->type == OR_type) && (o != NULL) && (o->type == AND_type) &&
 	    (NULL == o->operand_first) && (o->cost == 0) &&
-	    (o->tag_type = Exptag_none);
+	    (o->tag_type == Exptag_none);
 }
 
 static void print_expression_parens(Dictionary dict, dyn_str *e, const Exp *n,


### PR DESCRIPTION
The infamous bug of assignment instead of comparison has hit me here (preventing nice display of optional connectors).
Many times I use `constant == variable`, especially if the old code already uses that.
But since I somewhat dislike this, I sometimes use in new code `variable == constant`.
The compiler can warn on an assignment in something like `if (variable = constant)`, but not when it has extra parens for "clarity" like in this case.