### PR TITLE
Even more !!word/ functionality

### DIFF
--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -338,13 +338,26 @@ The above command is more useful for a single disjunct (1234 is an example
 for a disjunct number, see below for disjunct print format):
   !!test.n/1234/m
 
+
+Show selected disjuncts according to the supplied string (* and +
+are automatically escaped if no other regex meta characters in the string):
+  !!test.n/Ds**x+/
+
 Show selected disjuncts according to the supplied regex:
   !!test.n/ Wd-.*<-->.*@M\+/
   !!test.n/ J[sk]- D[\w*]+c\-/
+Regexes are automatically detected. The r flag forces a regex interpretation
+but it is not needed on normal use.
 
-Show selected disjuncts according to the supplied string (supposing the regex
-engine is PCRE, which supports "\Q"):
-  !!test.n/\Q Ds**x+/
+Show a particular disjunct from the output of !disjuncts:
+  !!test.n/Ds**c- Os-/f
+The f flag means a full specification of a disjunct. It is most useful
+along with the m flag:
+  !!test.n/Ds**c- Os-/fm
+
+Search for connectors in any order:
+  !!test.n/Os- Ds**c-/a
+Regretfully, adding the f flag is not supported yet.
 
 Display all the words that start with "test":
   !!test*

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -60,9 +60,9 @@ Some useful values:
 When False, whole words are displayed, without indicating any
 morphological analysis that might have been performed. When True,
 morphemes are shown as separate tokens, together with the link types
-between them.  See "!help graphics" for additonal info on morpheme
+between them.  See "!help graphics" for additional info on morpheme
 markup. The English dictionaries do not do morphological markup,
-so this flag has amost no effect on English sentences.
+so this flag has almost no effect on English sentences.
 
 This flag has one side-effect: if set to true, and a word is matched
 by a RegEx, then matching dictionary entry is shown.
@@ -131,10 +131,10 @@ quickly.
 
 [use-sat]
 Use the Boolean-SAT parser instead of the traditional parser. The SAT
-parser was an experimental alternative to the tradiational parser.
+parser was an experimental alternative to the traditional parser.
 
 This parser has several limitations, and offers no real advantages over
-the traditional parser. Problems includ that it is not able to find
+the traditional parser. Problems include that it is not able to find
 linkages with null-links.  It does not honor the `!timeout` option.
 
 [walls]

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -48,6 +48,20 @@ const char *cost_stringify(double cost)
 	return buf;
 }
 
+/* Check for an existing newline before issuing "\n" in order to prevent
+ * empty lines when printing connector macros. This allow to use the
+ * same print_expression_tag_*() function for printing expressions
+ * with macros and also disjunct connectors with macros. */
+static void dyn_ensure_empty_line(dyn_str *e)
+{
+	if (dyn_strlen(e) > 0)
+	{
+		dyn_trimback(e);
+		if ((dyn_str_value(e)[dyn_strlen(e)-1]) != '\n')
+			dyn_strcat(e, "\n");
+	}
+}
+
 #define MACRO_INDENTATION 4
 
 static void print_expression_tag_start(Dictionary dict, dyn_str *e, const Exp *n,
@@ -62,7 +76,7 @@ static void print_expression_tag_start(Dictionary dict, dyn_str *e, const Exp *n
 			break;
 		case Exptag_macro:
 			if (*indent < 0) break;
-			dyn_strcat(e, "\n");
+			dyn_ensure_empty_line(e);
 			for(int i = 0; i < *indent; i++) dyn_strcat(e, " ");
 			dyn_strcat(e, dict->macro_tag->name[n->tag_id]);
 			dyn_strcat(e, ": ");
@@ -90,15 +104,7 @@ static void print_expression_tag_end(Dictionary dict, dyn_str *e, const Exp *n,
 			break;
 		case Exptag_macro:
 			if (*indent < 0) break;
-			/* The sole purpose of the checks before issuing "\n" is to prevent
-			 * empty lines when printing connector macros w/o introducing a
-			 * separate version of this function for connector macro printing. */
-			if (dyn_strlen(e) > 0)
-			{
-				dyn_trimback(e);
-				if ((dyn_str_value(e)[dyn_strlen(e)-1]) != '\n')
-					dyn_strcat(e, "\n");
-			}
+			dyn_ensure_empty_line(e);
 			for(int i = 0; i < *indent - MACRO_INDENTATION/2; i++)
 				dyn_strcat(e, " ");
 			(*indent) -= MACRO_INDENTATION;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -599,7 +599,7 @@ static void dyn_print_disjunct_list(dyn_str *s, Disjunct *dj, uint32_t flags,
 
 		append_string(l, "[%d]%s= ", djn++, cost_stringify(dj->cost));
 		dyn_print_connector_list(l, dj->left, /*dir*/0, flags);
-		dyn_strcat(l, " <--> ");
+		dyn_strcat(l, " <> ");
 		dyn_print_connector_list(l, dj->right, /*dir*/1, flags);
 
 		char *ls = dyn_str_take(l);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -820,7 +820,7 @@ static Regex_node *new_disjunct_regex_node(Regex_node *current, char *regpat)
 	Regex_node *rn = malloc(sizeof(Regex_node));
 
 	rn->name = strdup("Disjunct regex");
-	rn->pattern = regpat;
+	rn->pattern = strdup(regpat);
 	rn->re = NULL;
 	rn->neg = false;
 	rn->next = current;
@@ -846,7 +846,7 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 		notify_ignoring_flag(is_anyorder);
 
 		const char added_chars[] = "\\[]";
-		regpat = malloc(pat_len + sizeof(added_chars));
+		regpat = alloca(pat_len + sizeof(added_chars));
 		strcpy(regpat, "\\[");
 		strcat(regpat, pattern);
 		strcat(regpat, "]");
@@ -882,7 +882,7 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 		/* Note: This section is sensitive to the disjunct print format. */
 		const char added_chars[] = "= <> $";
 		const size_t regpat_size = 2 * (pat_len + sizeof(added_chars));
-		regpat = malloc(regpat_size);
+		regpat = alloca(regpat_size);
 
 		size_t dst_pos = lg_strlcpy(regpat, "= ", regpat_size);
 		if (rhs_pos == 0)
@@ -900,7 +900,7 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 	{
 		if ((is_regex != NULL) || pattern[strcspn(pattern, "({[.?$\\")] != '\0')
 		{
-			regpat = strdup(pattern);
+			regpat = strdupa(pattern);
 			is_regex = "r";
 		}
 		else
@@ -914,11 +914,8 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 		if (is_anyorder != NULL)
 		{
 			/* Assume this is an unordered list of blank-separated connectors. */
-			char *ulist = strdupa(regpat);
-			free(regpat);
-
 			char *constring;
-			while ((constring = strtok_r(ulist, " ", &ulist)))
+			while ((constring = strtok_r(regpat, " ", &regpat)))
 			{
 				if (is_regex == NULL)
 				{
@@ -932,7 +929,7 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 					constring = word_boundary_constring;
 
 				}
-				rn = new_disjunct_regex_node(rn, strdup(constring));
+				rn = new_disjunct_regex_node(rn, constring);
 			}
 		}
 	}

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -615,7 +615,7 @@ static void dyn_print_disjunct_list(dyn_str *s, Disjunct *dj, uint32_t flags,
 			dyn_strcat(s, ls);
 			dyn_strcat(s, "\n");
 
-			if (criterion->exp != NULL)
+			if ((criterion != NULL) && (criterion->exp != NULL))
 			{
 				int ccnt = 1;
 				for (Connector *c = dj->left; c != NULL; c = c->next)

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -572,7 +572,7 @@ static int ascending_int(const void *a, const void *b)
 
 typedef struct
 {
-	const void *regex;
+	const Regex_node *regex;
 	Exp *exp;
 	Dictionary dict;
 	unsigned int num_selected;
@@ -683,7 +683,7 @@ static bool select_disjunct(const char *dj_str, select_data *criterion)
 static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
                                const void **arg)
 {
-	const void *rn = arg[0];
+	const Regex_node *rn = arg[0];
 	const char *flags = arg[1];
 	const Parse_Options opts = (Parse_Options)arg[2];
 	double max_cost = opts->disjunct_cost;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1259,6 +1259,23 @@ static char *display_word_expr(Dictionary dict, const char *word,
 	return NULL;
 }
 
+static char *find_unescaped_slash(char *word)
+{
+	size_t len = strlen(word);
+	for (char *src = word, *dst = word; *src != '\0'; src++, dst++)
+	{
+		if (('\\' == *src) && (('\\' == src[1]) || ('/' == src[1])))
+		{
+			memmove(dst, src+1, len - (src - word));
+		}
+		else
+		{
+			if ('/' == *src) return dst;
+		}
+	}
+	return NULL;
+}
+
 /**
  * Break "word", "word/flags" or "word/regex/flags" into components.
  * "regex" and "flags" are optional.  "word/" means an empty regex.
@@ -1273,13 +1290,14 @@ static const char *display_word_extract(char *word, const char **re,
 	if (re != NULL) *re = NULL;
 	if (flags != NULL) *flags = NULL;
 
-	char *r = strchr(word, '/');
+	char *r = find_unescaped_slash(word);
+
 	if (r == NULL) return word;
 	*r = '\0';
 
 	if (re != NULL)
 	{
-		char *f = strchr(r + 1, '/');
+		char *f = find_unescaped_slash(r + 1);
 		if (f != NULL)
 		{
 			*re = r + 1;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -788,7 +788,7 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 
 static void notify_ignoring_flag(const char *flag)
 {
-	if (flag != NULL) prt_error("Warning: Ignoring flag \"%s\".\n", flag);
+	if (flag != NULL) prt_error("Warning: Ignoring flag \"%c\".\n", *flag);
 }
 
 /**

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1320,6 +1320,11 @@ char *dict_display_word_info(Dictionary dict, const char *word,
 {
 	char *wordbuf = strdupa(word);
 	word = display_word_extract(wordbuf, NULL, NULL);
+	if ('\0' == *word)
+	{
+		prt_error("Error: Missing word argument.\n");
+		return strdup(" ");
+	}
 
 	return display_word_split(dict, word, opts, display_word_info, NULL);
 }
@@ -1332,6 +1337,7 @@ char *dict_display_word_expr(Dictionary dict, const char * word, Parse_Options o
 	const char *arg[2];
 	char *wordbuf = strdupa(word);
 	word = display_word_extract(wordbuf, &arg[0], &arg[1]);
+	if ('\0' == *word) return strdup(" ");
 
 	/* If no regex component, then it's a request to display expressions. */
 	if (arg[0] == NULL) arg[0] = &do_display_expr;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -787,6 +787,10 @@ static size_t unknown_flag(const char *display_type, const char *flags)
  * Wild-card search is supported; the command-line user can type in !!word* or
  * !!word*.sub and get a list of all words that match up to the wild-card.
  * In this case no split is done.
+ *
+ * @arg arg[0] specifies the display type. If it is equal to &do_display_expr
+ * than this is request to display expressions. Else it is a request to
+ * display disjuncts. arg[2] specifies the request flags.
  */
 static char *display_word_split(Dictionary dict,
                const char * word, Parse_Options opts,

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -774,7 +774,7 @@ static size_t unknown_flag(const char *display_type, const char *flags)
 	if (&do_display_expr == display_type)
 		known_flags = "lm";
 	else
-		known_flags = "m";
+		known_flags = "mr";
 
 	return strspn(flags, known_flags);
 }
@@ -854,7 +854,7 @@ static char *display_word_split(Dictionary dict,
 		}
 		else if (arg[0] != NULL)
 		{
-			/* A regex is specified, which means displaying disjuncts. */
+			/* A pattern is specified, which means displaying disjuncts. */
 			if (arg[0][0] != '\0')
 			{
 				rn = malloc(sizeof(Regex_node));


### PR DESCRIPTION
Mainly per discussion at PR #1085.
Main changes:
- Replace <--> by <>.
- Add flag 'a' for connector matching in any order.
- Add 'f' for full disjunct specification string (as copied fro !disjuncts).
The flag is needed to prevent a lot of output from partial matches.
- Add "r" flag to request a regex match. This is not normally needed as the code added here automatically detects regular expression and automatically quote `*` and `+` when a regular expression is not intended. So no need to use`\Q` any more.

More additions:
- Add flag summary on unknown flag.
- Fix the error message when the word argument is missing (the current error message on `!!/` is misleading).
- Prevent an empty line before first connector macro (for consistent spacing).
- Update the help text.

Edit:
Pushed more commits:
1. Fix false positive of Clang static analyzer.
2. Fix ignored flag warning.
3. Fix a NULL dereference on normal disjunct printing (e.g. using `-v=102`).

Edit:
Forced push to fix 3 bugs.