### PR TITLE
Dictionary_s: Add dialect_info for additional dialect cache verification

### DIFF
--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -236,11 +236,14 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 	if (dinfo->cost_table != NULL)
 	{
 		/* Cached table. */
-		if (dinfo->dict != dict)
+		if ((dinfo->dict != dict) || (dict->cached_dialect != dinfo))
 		{
-			/* XXX In principle this may still be another dictionary if it got
-			 * the same address. Can be fixed by adding dictionary_create()
-			 * ordinal number. */
+			/* XXX It may still be a stale cache if the dictionary got the
+			 * same address as a previously-closed one and also "opts" got the
+			 * same address as a previously-deleted "opts" (very unlikely).
+			 * Can be fixed by adding dictionary_create() ordinal number +
+			 * stack address at the time of grabbing the ordinal number:
+			 * dict_id = ++static_id; dict_stack_address_stamp = &auto_var; */
 			lgdebug(+D_DIALECT,
 			        "Debug: Resetting dialect cache of a different dictionary.\n");
 			free_cost_table(opts);
@@ -257,6 +260,7 @@ bool setup_dialect(Dictionary dict, Parse_Options opts)
 	}
 
 	dinfo->dict = dict;
+	dict->cached_dialect = dinfo;
 
 	if (dt->num != 0)
 	{

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -94,7 +94,8 @@ struct Dictionary_s
 
 	Dialect *dialect;                  /* "4.0.dialect" info */
 	expression_tag dialect_tag;        /* Expression dialect tag info */
-	expression_tag *macro_tag;          /* Macro tags for expression debug */
+	expression_tag *macro_tag;         /* Macro tags for expression debug */
+	void *cached_dialect;              /* Only for dialect cache validation */
 
 	/* Affixes are used during the tokenization stage. */
 	Dictionary      affix_table;


### PR DESCRIPTION
Use dialect_info as an additional verification of the relevancy of the `Parse_options` Dialect cache.

With these two verifications it seems very unlikely that an irrelevant cache will remain undetected (for now I don't have an example for that).

In case a fool-proof solution will be needed, I documented my proposal in a comment.

To verify the using of the dialect cache in normal cases:
`link-parser -v=9 -debug=dialect.c`
Enter two sentences one after the other. For the first one the dialect cache will be created. The second one will just use it.
Then set a new dialect: `!dialect=headline`
Now enter something like `this is test`. The dialect cache will be recalculated due to the new dialect.
A more complex verification requires an added test in tests.py that maybe captures debug messages.