### PR TITLE
Remove vesitigal reference to regex_tokenizer_test

### DIFF
--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -118,5 +118,4 @@ lg_error_clearall
 lg_error_flush
 lg_exp_stringify
 prt_error
-regex_tokenizer_test
 utf8_strwidth


### PR DESCRIPTION
The lingering reference in link-grammar.def to regex_tokenizer_test was causing failures to link on macOS and SunOS. (This functionality was removed in #1078.)

I doubt you need to see the details, but just in case:

macOS

`Undefined symbols for architecture x86_64:`
`  "_regex_tokenizer_test", referenced from:`
`     -exported_symbol[s_list] command line option`
`ld: symbol(s) not found for architecture x86_64`
`clang: error: linker command failed with exit code 1 (use -v to see invocation)`
`gnumake[2]: *** [liblink-grammar.la] Error 1`

SunOS

`CCLD     link-parser`
`Undefined                       first referenced`
` symbol                             in file`
`regex_tokenizer_test                ../link-grammar/.libs/liblink-grammar.so`
`ld: fatal: symbol referencing errors. No output written to .libs/link-parser`
