### PR TITLE
Fix SunOS build

### DIFF
--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -757,7 +757,7 @@ bool strtodC(const char *s, float *r)
 {
 	char *err;
 
-#ifdef HAVE_LOCALE_T
+#if defined(HAVE_LOCALE_T) && !defined(__sun__)
 	double val = strtod_l(s, &err, get_C_LC_NUMERIC());
 #else
 	/* dictionary_setup_locale() invokes setlocale(LC_NUMERIC, "C") */


### PR DESCRIPTION
SunOS otherwise satisfies the HAVE_LOCALE_T check, but does not provide strtod_l(3), so this needs to fall back to strtod(3) instead. (At any rate, this is true for recent releases of illumos, OmniOS, and SmartOS.)