### PR TITLE
General cleanup

### DIFF
--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -2,8 +2,6 @@
 # -*- coding: utf8 -*-
 """Link Grammar example usage"""
 
-from __future__ import print_function, division  # We require Python 2.6 or later
-
 from linkgrammar import Sentence, ParseOptions, Dictionary, Clinkgrammar as clg
 
 print ("Version:", clg.linkgrammar_get_version())

--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -4,14 +4,14 @@
 
 from linkgrammar import Sentence, ParseOptions, Dictionary, Clinkgrammar as clg
 
-print ("Version:", clg.linkgrammar_get_version())
+print("Version:", clg.linkgrammar_get_version())
 po = ParseOptions(verbosity=1)
 
 def desc(lkg):
-    print (lkg.diagram())
-    print ('Postscript:')
-    print (lkg.postscript())
-    print ('---')
+    print(lkg.diagram())
+    print('Postscript:')
+    print(lkg.postscript())
+    print('---')
 
 def s(q):
     return '' if q == 1 else 's'
@@ -24,7 +24,7 @@ def linkage_stat(psent, lang, lkgs, sent_po):
              format(clg.sentence_num_linkages_post_processed((psent._obj))) \
              if clg.sentence_num_linkages_found(psent._obj) > sent_po.linkage_limit else ''
 
-    print ('{}: Found {} linkage{} ({}{} had no P.P. violations)'. \
+    print('{}: Found {} linkage{} ({}{} had no P.P. violations)'. \
           format(lang, clg.sentence_num_linkages_found(psent._obj),
                  s(clg.sentence_num_linkages_found(psent._obj)), len(lkgs), random))
 

--- a/bindings/python-examples/example.py
+++ b/bindings/python-examples/example.py
@@ -24,7 +24,7 @@ def linkage_stat(psent, lang, lkgs, sent_po):
              format(clg.sentence_num_linkages_post_processed((psent._obj))) \
              if clg.sentence_num_linkages_found(psent._obj) > sent_po.linkage_limit else ''
 
-    print('{}: Found {} linkage{} ({}{} had no P.P. violations)'. \
+    print('{}: Found {} linkage{} ({}{} had no P.P. violations)'.
           format(lang, clg.sentence_num_linkages_found(psent._obj),
                  s(clg.sentence_num_linkages_found(psent._obj)), len(lkgs), random))
 

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -21,7 +21,6 @@ Sentence has 1 unlinked word:
 4: LEFT-WALL this.p is.v a [the] test.n of bfgiuing[!].g and.j-n xxxvfrg[?].a RIGHT-WALL
 """
 
-from __future__ import print_function
 import sys
 from sys import stdin
 import re

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -22,10 +22,8 @@ Sentence has 1 unlinked word:
 """
 
 import sys
-from sys import stdin
 import re
 import argparse
-import readline
 
 from linkgrammar import (Sentence, ParseOptions, Dictionary,
                          LG_Error, LG_TimerExhausted, Clinkgrammar as clg)

--- a/bindings/python-examples/sentence-check.py
+++ b/bindings/python-examples/sentence-check.py
@@ -45,7 +45,7 @@ PROMPT = "sentence-check: " if is_stdin_atty else ""
 DISPLAY_GUESSES = True   # Display regex and POS guesses
 BATCH_LABELS = '*: '
 
-print ("Version:", clg.linkgrammar_get_version())
+print("Version:", clg.linkgrammar_get_version())
 
 args = argparse.ArgumentParser(formatter_class=Formatter)
 args.add_argument('lang', nargs='?', default='en',

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -2,7 +2,6 @@
 # coding: utf8
 """Python3 link-grammar test script"""
 
-from __future__ import print_function
 import sys, os, re
 import locale
 import unittest

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -344,7 +344,7 @@ are automatically escaped if no other regex meta characters in the string):
   !!test.n/Ds**x+/
 
 Show selected disjuncts according to the supplied regex:
-  !!test.n/ Wd-.*<-->.*@M\+/
+  !!test.n/ Wd-.*<>.*@M\+/
   !!test.n/ J[sk]- D[\w*]+c\-/
 Regexes are automatically detected. The r flag forces a regex interpretation
 but it is not needed on normal use.
@@ -374,7 +374,7 @@ A sample output of a disjunct-list display:
     test.n 4273/4501 disjuncts
 
     ...
-          test.n: [3493]2.600= @AN- @A- Ds**x- <--> NM+ R+ Bs+ Bsm+
+          test.n: [3493]2.600= @AN- @A- Ds**x- <> NM+ R+ Bs+ Bsm+
     ...
 
 In this sample output:
@@ -384,7 +384,7 @@ In this sample output:
    3493     Disjunct ordinal number.
    2.600    Disjunct cost.
    =        A separator to enable regex anchoring.
-   <-->     A separator of the "-" (LHS) and "+" (RHS) connector lists.
+   <>       A separator of the "-" (LHS) and "+" (RHS) connector lists.
 
 These variables affect the output:
 Disjuncts, expressions: !dialect

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -377,7 +377,7 @@ A sample output of a disjunct-list display:
           test.n: [3493]2.600= @AN- @A- Ds**x- <--> NM+ R+ Bs+ Bsm+
     ...
 
-In the this sample output:
+In this sample output:
    8509     Number of disjuncts in the dictionary expression.
    4501     Number of disjuncts after applying cost-max.
    4273     Number of disjuncts w/o duplicates.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3030,7 +3030,7 @@ rest.w: Ix- & Pv+;
 % MV+ & Pa+: "I was, before Friday, quite unhappy."
 % Pa+ & {<verb-wall>}: the wall is optional: "A player who is injured
 %     must leave the field" cannot take a wall.
-% [Pa+]0.05: perfer gerund over adjective.
+% [Pa+]0.05: prefer gerund over adjective.
 % [I*v+].2: the cost should maybe be evenn higher, to avoid linking
 %     past-tense 'were' to infinitives. "The rooms were let."
 % PFb- & <verb-wall> & Pa+: "cheaper than direct, slime is greener."
@@ -7950,7 +7950,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 % ======================================================================
 % QUESTION WORDS
 
-% Allow a question to be preceeded by a clause opener.
+% Allow a question to be preceded by a clause opener.
 % "By the way, how was it?"
 <clause-q>: {hCO-} & Wq-;
 
@@ -10954,7 +10954,7 @@ as.#that: [[that.j-c]0.05]colloquial;
 % (a)'ccount (a)'greed (a)'noint (a)'pothecary (a)'rray (a)'rrest (at)'tend
 % (be)'gin (be)'havior (be)'long (con)'cern (e)'scape (e)'stablish.
 %
-% Need to include capitalized versions becuase automatic
+% Need to include capitalized versions because automatic
 % downcasing does not work
 'Cause.#because ’Cause.#because 'cause.#because ’cause.#because cause.#because: [because]colloquial;
 'Fore.#before ’Fore.#before 'fore.#before ’fore.#before fore.#before: [before]colloquial;

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -116,7 +116,7 @@ static bool apply_table_entry(Dictionary dict, Dialect *from,
 		/* Apply components and sub-dialects. */
 		lgdebug(+D_DIALECT, "Apply %s %s%s\n",
 		        from->table[i].name, cost_stringify(from->table[i].cost),
-		        (to == from) ? "" : " (user setup");
+		        (to == from) ? "" : " (user setup)");
 		if (!cost_eq(from->table[i].cost, DIALECT_SUB))
 		{
 			if (!apply_component(dict, from, i, dinfo->cost_table)) return false;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -806,8 +806,8 @@ static void notify_ignoring_flag(const char *flag)
 }
 
 /**
- * Copy \p characters from \p src to \p dst, while quoting with \c '\\'
- * the characters in \p q.
+ * Copy bytes from \p src to \p dst, while quoting with \c '\\'
+ * the bytes in \p q.
  * Note: This is not a general-purpose function, since:
  * - It assumes \p dst has enough space.
  * - \p src is not checked for NUL.
@@ -815,7 +815,7 @@ static void notify_ignoring_flag(const char *flag)
  *
  * @param src Source buffer.
  * @param dst[out] Destination buffer.
- * @return Number of characters add to \p dst.
+ * @return Number of bytes added to \p dst.
  */
 static size_t copy_quoted(const char *q, char *dst, const char *src, size_t len)
 {

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -82,7 +82,7 @@ static void print_dialect_components(Dictionary dict)
 	lg_error_flush();
 }
 
-#define LINEBUF_SZ 8
+#define LINEBUF_SZ 16
 static const char *suppress_0(unsigned int line, char *buf)
 {
 	if (line == 0) return "";

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -508,7 +508,7 @@ void count_disjuncts_and_connectors(Sentence sent, unsigned int *dca,
  * counts because some alternatives-connectivity checks (to the middle
  * disjunct) are done in the fast-matcher. These restrictions are
  * implemented by using a different tracon ID per Gword (FIXME - this is
- * more strict then needed - a different tracon IDs per alternative would
+ * more strict then needed - a different tracon ID per alternative would
  * suffice).
  * The tracon memory sharing is currently not directly used in the
  * parsing algo besides reducing the needed CPU cache by a large factor.

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -776,7 +776,7 @@ static Count_bin do_count(
 		 * speedup is expected.
 		 *
 		 * FIXME 2: Change the lrcnt_cache structure to use one cache entry
-		 * per [connector , word-vector) instead of per [connector, word).
+		 * per [connector, word-vector) instead of per [connector, word).
 		 * This will reduce the lookup complexity by O(sent_length).
 		 */
 
@@ -944,10 +944,10 @@ static Count_bin do_count(
 			TRACE_LABEL(c, do_count) : c; \
 		how_to_count; \
 	}
-			 /* If the pseudocounting above indicates one of the terms
-			 * in the count multiplication is zero,
-			 * we know that the true total is zero. So we don't
-			 * bother counting the other term at all, in that case. */
+				/* If the pseudocounting above indicates one of the terms
+				 * in the count multiplication is zero,
+				 * we know that the true total is zero. So we don't
+				 * bother counting the other term at all, in that case. */
 				Count_bin leftcount = zero;
 				Count_bin rightcount = zero;
 				if (leftpcount &&

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1495,7 +1495,7 @@ static bool all_connectors_exist(multiset_table *cmt, const char *pp_link)
 	return true;
 }
 
-static bool connecor_has_direction(Cms *cms, int dir)
+static bool connector_has_direction(Cms *cms, int dir)
 {
 	return ((dir == 0) && cms->left) || ((dir == 1) && cms->right);
 }
@@ -1511,12 +1511,12 @@ static bool any_possible_connection(multiset_table *cmt, const char *criterion)
 		ppdebug("TRY %s%s\n", connector_string(cms1->c), connector_signs(cms1));
 		for (int dir = 0; dir < 2; dir++)
 		{
-			if (!connecor_has_direction(cms1, dir)) continue;
+			if (!connector_has_direction(cms1, dir)) continue;
 			Connector *c = cms1->c;
 
 			for (Cms *cms2 = cmt->cms_table[h]; cms2 != NULL; cms2 = cms2->next)
 			{
-				if (!connecor_has_direction(cms2, 1-dir)) continue;
+				if (!connector_has_direction(cms2, 1-dir)) continue;
 				Connector *cfl = cms2->c;
 
 				if (easy_match_desc(cfl->desc, c->desc))

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -795,7 +795,7 @@ right_table_search(prune_context *pc, int w, Connector *c,
 }
 
 /**
- * This returns TRUE if the right table of word w contains
+ * This returns TRUE if the left table of word w contains
  * a connector that can match to c.  shallow tells if c is shallow
  */
 static bool
@@ -1129,8 +1129,8 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 
 		if (pruning_pass_end(pc, "r->l", &total_deleted)) break;
 
-		/* The verbose debug printouts revealed that the xlink counter is
-		 * never set after the first 2 passes. So neutralize the mlink table
+		/* The verbose debug printouts revealed that the xlink counter doesn't
+		 * get increased after the first 2 passes. So neutralize the mlink table
 		 * here to save a slight overhead. */
 		pc->ml = NULL;
 	}
@@ -1140,7 +1140,7 @@ static int power_prune(Sentence sent, prune_context *pc, Parse_Options opts)
 	if ((verbosity >= D_USER_TIMES) && !extra_null_word && (pc->null_words > 0))
 		snprintf(found_nulls, sizeof(found_nulls), ", found %u", pc->null_words);
 	print_time(opts, "power pruned (for %u null%s%s%s)",
-	           pc->null_links, (pc->null_links != 1) ? "s" : "",
+					  pc->null_links, (pc->null_links != 1) ? "s" : "",
 	           extra_null_word ? ", extra null" : "", found_nulls);
 	if (verbosity_level(D_PRUNE))
 	{

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1537,7 +1537,7 @@ static bool mprefix_split(Sentence sent, Gword *unsplit_word, const char *word)
 #if 0
 		else
 		{
-			/* Uneeded? */
+			/* Unneeded? */
 			w = newword;
 		}
 #endif

--- a/msvc/make-check.py
+++ b/msvc/make-check.py
@@ -17,7 +17,6 @@ console-prompt>make-check.py x64\Debug\Python2 example.py
 The following starts an interactive python program:
 console-prompt>make-check.py x64\Debug\Python2 ""
 """
-from __future__ import print_function
 import os
 import sys
 import re

--- a/msvc/make-check.py
+++ b/msvc/make-check.py
@@ -70,7 +70,7 @@ def get_prop(prop, default=NODEFAULT):
         if prop_repval is None:
             prop_repval = os.getenv(prop_rep)
             if prop_repval is None:
-                error('Property "{}" not found in "{}" and also not in the environment'. \
+                error('Property "{}" not found in "{}" and also not in the environment'.
                       format(prop_rep, local_prop_file))
         prop_val = str.replace(prop_val, '$('+prop_rep+')', prop_repval)
 


### PR DESCRIPTION
- Comments  typos / wording / whitespace.
- Python unneeded includes / whitespace / backslashes.
- Command help typos and <-->.
- Fix variable name typo.