### PR TITLE
Upstreaming Gentoo patches

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -4,8 +4,8 @@
 # Created by Linas Vepstas February 2014
 #
 #
-SWIG_SOURCES = ../swig/link_grammar.i
-SWIG_INCLUDES = ../../link-grammar/link-includes.h
+SWIG_SOURCES = $(top_srcdir)/bindings/swig/link_grammar.i
+SWIG_INCLUDES = $(top_srcdir)/link-grammar/link-includes.h
 built_c_sources = lg_python_wrap.cc
 built_py_sources = $(top_builddir)/bindings/python/clinkgrammar.py
 
@@ -18,16 +18,16 @@ pkgpyexecdir=$(pythondir)/linkgrammar
 
 # Files that get installed in $pkgpythondir
 pkgpython_PYTHON =                                 \
-   linkgrammar.py                                  \
+   $(srcdir)/linkgrammar.py                        \
    $(top_builddir)/bindings/python/__init__.py     \
-   $(top_builddir)/bindings/python/clinkgrammar.py
+   $(built_py_sources)
 
 # Apparently, anaconda does not work without this!?
 # This seems wrong and lame to me, but see issue #298
 # https://github.com/opencog/link-grammar/issues/298
 pkgpypathdir=$(pythondir)
 pkgpypath_PYTHON =                                 \
-   linkgrammar.pth
+   $(srcdir)/linkgrammar.pth
 
 # The make uninstall target should remove directories we created.
 uninstall-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -137,8 +137,7 @@ HOST_OS="$host_os"
 AC_SUBST(HOST_OS)
 # ====================================================================
 
-CFLAGS="${CFLAGS} -O3"
-CXXFLAGS="${CXXFLAGS} -O3 -Wall"
+CXXFLAGS="${CXXFLAGS} -Wall"
 
 # The std=c11 flag provides the proper float-pt math decls working,
 # e.g. fmax  However, it also undefined _BSD_SOURCE, etc. which is
@@ -907,10 +906,6 @@ LINK_CC_TRY_FLAG([-Wmaybe-uninitialized -Werror], [AC_DEFINE(HAVE_MAYBE_UNINITIA
 # ===================================================================
 
 AC_FUNC_STRERROR_R
-
-AC_SUBST(CFLAGS)
-AC_SUBST(CPPFLAGS)
-AC_SUBST(CXXFLAGS)
 
 dnl Save the compilation definitions for an extended version printout
 AC_OUTPUT_MAKE_DEFS()


### PR DESCRIPTION
Hi @linas 
we have a number of patches in Gentoo for link-grammar.

1. Allow building link-grammar out-of-source. We build multiple python bindings, and that requires building everything out-of-source.
2. Do not inject pure user flags. You should *never* inject flags that affect optimizations and such, which should be left to the user. I usually compile with `-O2`, only to notice that `-O3` gets added by the `configure` script.