### PR TITLE
Specify `-O3` as overridable default in configure.ac

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 5.8.1 (XXX 2020)
  * English dict: fix numerical identifiers used as adjectives.
  * English dict: fix post-posed Latin adjectival modifiers.
  * Merge upstream gentoo patches. #1102
+ * Make -O3 default for CFLAGS/CXXFLAGS, but overridable by the user.
 
 Version 5.8.0 (28 February 2020)
  * Java bindings: Remove the obsolete senses API.

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,20 @@
 AC_INIT([link-grammar],[5.8.0],[https://github.com/opencog/link-grammar],,
 		  [https://www.abisource.com/projects/link-grammar])
 
+dnl Check whether we want to set defaults for CFLAGS and CXXFLAGS
+AC_MSG_CHECKING([whether configure should try to set CFLAGS/CXXFLAGS])
+AS_IF([test "x${CFLAGS+set}" = "xset" || test "x${CXXFLAGS+set}" = "xset"], [
+    enable_flags_setting=no
+    : ${CFLAGS=""}
+    : ${CXXFLAGS=""}
+  ], [
+    enable_flags_setting=yes
+    dnl Set to -O3 here so AC_PROG_CC and AC_PROG_CXX do not add -g -O2
+    CFLAGS="-O3"
+    CXXFLAGS="-O3"
+  ])
+AC_MSG_RESULT([${enable_flags_setting}])
+
 DISCUSSION_GROUP=https://groups.google.com/d/forum/link-grammar
 AC_SUBST(DISCUSSION_GROUP)
 OVERVIEW=https://en.wikipedia.org/wiki/Link_grammar
@@ -137,8 +151,7 @@ HOST_OS="$host_os"
 AC_SUBST(HOST_OS)
 # ====================================================================
 
-CFLAGS="${CFLAGS} -O3"
-CXXFLAGS="${CXXFLAGS} -O3 -Wall"
+CXXFLAGS="${CXXFLAGS} -Wall"
 
 # The std=c11 flag provides the proper float-pt math decls working,
 # e.g. fmax  However, it also undefined _BSD_SOURCE, etc. which is


### PR DESCRIPTION
* Inspired by
  https://lists.gnu.org/archive/html/autoconf/2006-04/msg00022.html

@linas 
overriding `CXXFLAGS`:
```
./configure CXXFLAGS="-O1"
[...]
checking whether configure should try to set CFLAGS/CXXFLAGS... no
[...]
C compiler:                     gcc  -D_DEFAULT_SOURCE -std=c11 -D_BSD_SOURCE -D_SVID_SOURCE -D_GNU_SOURCE -D_ISOC11_SOURCE 
C++ compiler:                   g++  -D_DEFAULT_SOURCE -std=c++11 -O1 -Wall
```

Without overriding (the default):
```
./configure
[...]
checking whether configure should try to set CFLAGS/CXXFLAGS... yes
[...]
C compiler:                     gcc  -D_DEFAULT_SOURCE -std=c11 -D_BSD_SOURCE -D_SVID_SOURCE -D_GNU_SOURCE -D_ISOC11_SOURCE -O3
C++ compiler:                   g++  -D_DEFAULT_SOURCE -std=c++11 -O3 -Wall
```
as you can see, with a vanilla `./configure` call, `-O3` is back.