### PR TITLE
Fix a potential postprocessing problem (due to qsort())

### DIFF
--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -694,6 +694,8 @@ static void left_depth_first_search(Postprocessor *pp, Linkage sublinkage,
 
 static int domain_compare(const Domain * d1, const Domain * d2)
 {
+	if (d1->size == d2->size)
+		return (d1 > d2);
 	return (d1->size - d2->size); /* for sorting the domains by size */
 }
 


### PR DESCRIPTION
I noted that on Windows some wrong sentences get a full parse (when on Linux they are not).

For example (from the "basic" corpus):
__*Does there want to be a dog in the park?__
On Linux, all the full parses have P.P. violations.
On Windows 3 sentences (with similar parsings) pass the P.P. checks.
``` text
LEFT-WALL does.v there.r want.v to.r be.v a   dog.n in.r the park.n ?

 (e)       LEFT-WALL      Xp            ----Xp-----  Xp              ?
 (m) (e)   LEFT-WALL      hWV           >---WV---->  dWV             be.v
 (m) (e)   LEFT-WALL      hQd           >---Qd-----  Qd              does.v
 (m)       does.v         I*d           ----I*d----  I               want.v
 (m) (e)   does.v         SFIs          ----SFIst->  dSFIst          there.r
 (m)       want.v         MV            ----MVi----  MVi             to.r
 (m) (e)   to.r           I             ----Ix-----  Ix              be.v
 (m) (e)   be.v           MV            ----MVp----  MVp             in.r
 (m) (e)   be.v           O*t           ----Ost----  Os              dog.n
 (m) (e)   dog.n          M             ----Mp-----  Mp              in.r
 (m) (e)   a              Ds**c         ----Ds**c--  Ds**c           dog.n
 (m) (e)   in.r           J             ----Js-----  Js              park.n
 (m) (e)   the            D             ----Ds**c--  Ds**c           park.n
 (e)       ?             / RW            ----RW-----  RW              RIGHT-WALL
```
The difference is due to `qsort()`:
https://github.com/opencog/link-grammar/blob/8c804ee65d8077f4d04e28725c517fce9cc05a6f/link-grammar/post-process/post-process.c#L757-L761

On Linux items with identical sort keys remain in the same order, but on Windows (and Mac) they may change their order. The manpage specifies that they sort order is unspecified. There may be a relatively recent change in `qsort()` on Mac and Windows, as I  didn't notice this problem before.

In the example sentence, on Linux, the index of the domain `m`is 0 and of the domain `e` is 1. On Windows, their order is the opposite.
I don't have any clue why the results are incorrect if the order of identical size domains is not preserved.
I tried to remove the sorting altogether, but then many sentences get wrong P.P. handling. (I also tried to remove the `break` statement in the following loop, with bad results too.)

My solution, for now, is to preserve the order of domains with identical sizes.

Notes:
**1.** A  problem may also happen on sorting linkages, when linkages with identical metrics may appear in a different order, depending on the `qsort()` implementation. I can send a PR to fix that too (in a similar way).
**2.** When I debugged the problem, I noted that when using `!bad !links`, the domains don't appear. This is undesired, as it makes it more difficult to debug domain issues. For now, I don't know how to fix that, maybe you can take a look.
3. I once started to rewrite the processing code. It seems a high speedup factor is possible. Currently, the postprocessing code takes about 25% on the "fix-long" batch, and about 35% on the "basic" batch (really more because this doesn't include external function calls from the preprocessing code like memory and string handling).
4. I guess that it may be a good idea to add an order-preserving condition in `qsort()` to improve the validity of testing and for consistent program results. A better approach for testing may be to use (while testing) a special `qsort()` with random order of identical sort keys,  repeat the test several times and compare the results, but this is not easy to do.

