### PR TITLE
Fix assert() problems

### DIFF
--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -413,7 +413,7 @@ const char *feature_enabled(const char * list, ...)
 #elif defined __GNUC__ || defined __clang_analyzer__
 	#define DEBUG_TRAP __builtin_trap()
 #else
-	#define DEBUG_TRAP ((void(*)(void))0)()
+	#define DEBUG_TRAP abort()
 #endif
 
 void (* assert_failure_trap)(void);

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -440,9 +440,10 @@ void assert_failure(const char cond_str[], const char func[],
 	}
 	va_end(args);
 
-	if (assert_failure_trap != NULL)
+	if (assert_failure_trap == NULL)
 		DEBUG_TRAP;  /* leave stack trace in debugger */                      \
+	else
+		assert_failure_trap();
 
-	assert_failure_trap();
 	exit(1);
 }

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -421,7 +421,7 @@ void assert_failure(const char cond_str[], const char func[],
                     const char *src_location, const char *fmt, ...)
 {
 	va_list args;
-	const char sevfmt[] = "Fatal error: \nAssertion (%s) failed at %s() (%s): ";
+	const char sevfmt[] = "Fatal error: \nAssertion (%s) failed in %s() (%s): ";
 
 	va_start(args, fmt);
 	if ((lg_error.handler == default_error_handler) ||

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -410,7 +410,7 @@ const char *feature_enabled(const char * list, ...)
 
 #ifdef _WIN32
 	#define DEBUG_TRAP (*((volatile int*) 0x0) = 42)
-#elif defined GNUC || defined __clang_analyzer__
+#elif defined __GNUC__ || defined __clang_analyzer__
 	#define DEBUG_TRAP __builtin_trap()
 #else
 	#define DEBUG_TRAP ((void(*)(void))0)()

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -114,7 +114,7 @@ void assert_failure(const char[], const char[], const char *, const char *, ...)
 #undef assert
 #define assert(ex, ...) \
 do { \
-	if (!(ex)) assert_failure(STRINGIFY(ex), __func__, FILELINE, __VA_ARGS__); }\
+	if (!(ex)) assert_failure(#ex, __func__, FILELINE, __VA_ARGS__); }\
 while(0)
 
 #endif


### PR DESCRIPTION
Fix old commit 5c2aa75352851dc55460653bd0ef85b4647e91fb:
- Fix wrong preprocessor symbol.
- Call `abort()` instead of `0()`.
The rest are fixes to the recent PR #1106.

Possible FIXMEs:
- Use `AX_GCC_BUILTIN(__builtin_trap)`.
- Use debug_break (GitHub `debugbreak`) if avaliable.