### PR TITLE
Yet more assert() fixes

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -72,7 +72,7 @@ Connector * connector_new(Pool_desc *connector_pool, const condesc_t *desc,
 
 	c->desc = desc;
 	set_connector_length_limit(c, opts);
-	//assert(0 != c->length_limit, "Connector_new(): Zero length_limit");
+	dassert(0 != c->length_limit, "Connector_new(): Zero length_limit");
 
 	return c;
 }

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -416,6 +416,9 @@ const char *feature_enabled(const char * list, ...)
 	#define DEBUG_TRAP abort()
 #endif
 
+/**
+ * Issue the assert() macro (see error.h) error message.
+ */
 void (* assert_failure_trap)(void);
 void assert_failure(const char cond_str[], const char func[],
                     const char *src_location, const char *fmt, ...)

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -423,6 +423,8 @@ void assert_failure(const char cond_str[], const char func[],
 	va_list args;
 	const char sevfmt[] = "Fatal error: \nAssertion (%s) failed in %s() (%s): ";
 
+	fflush(stdout);
+
 	va_start(args, fmt);
 	if ((lg_error.handler == default_error_handler) ||
 	    (lg_error.handler == NULL))

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -424,6 +424,7 @@ void assert_failure(const char cond_str[], const char func[],
 	const char sevfmt[] = "Fatal error: \nAssertion (%s) failed in %s() (%s): ";
 
 	fflush(stdout);
+	lg_error_flush();
 
 	va_start(args, fmt);
 	if ((lg_error.handler == default_error_handler) ||

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -438,7 +438,7 @@ void assert_failure(const char cond_str[], const char func[],
 	else
 	{
 		prt_error(sevfmt, cond_str, func, src_location);
-		verr_msg(NULL, 0, fmt, args);
+		verr_msg(NULL, lg_Fatal, fmt, args);
 		prt_error("\n");
 	}
 	va_end(args);

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -111,6 +111,8 @@ extern void (* assert_failure_trap)(void);
 void assert_failure(const char[], const char[], const char *, const char *, ...)
 	GNUC_PRINTF(4,5) GNUC_NORETURN;
 
+/* Define a private version of assert() with a printf-like error
+ * message. The C one is not used. */
 #undef assert
 #define assert(ex, ...) \
 do { \

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -117,4 +117,13 @@ do { \
 	if (!(ex)) assert_failure(#ex, __func__, FILELINE, __VA_ARGS__); }\
 while(0)
 
+/* Generally, our asserts should always remain in the code, even for
+ * non-DEBUG images. However, some asserts may impose non-negligible
+ * overhead and thus used only in DEBUG mode. */
+#ifdef DEBUG
+#define dassert assert
+#else
+#define dassert(...)
+#endif
+
 #endif

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -114,7 +114,8 @@ void assert_failure(const char[], const char[], const char *, const char *, ...)
 #undef assert
 #define assert(ex, ...) \
 do { \
-	if (!(ex)) assert_failure(#ex, __func__, FILELINE, __VA_ARGS__); }\
+	if (!(ex)) assert_failure(#ex, __func__, FILELINE, __VA_ARGS__); \
+} \
 while(0)
 
 /* Generally, our asserts should always remain in the code, even for


### PR DESCRIPTION
The main fix is adding `flush(stdout)` that got omitted by mistake (again).
