### PR TITLE
Convert lgdebug() and verbosity_level() to use functions

### DIFF
--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -44,17 +44,34 @@ automatically adjusted when the terminal window is resized.
 
 [verbosity]
 The level of descriptive debug messages that will be printed.
-Values 1-4 are appropriate for use by the program user.  Higher
+Values 1-4 are appropriate for use by the program/library user.  Higher
 values are intended for LG dictionary authors and library developers.
+For each level, unless otherwise is noted, messages of lower verbosity
+levels are included.
 
 Some useful values:
+
  0      No prompt, minimal library messages
- 1      Normal verbosity
+ 1      Normal verbosity (its messages are included in all higher levels)
  2      Show times of the parsing steps
- 3      Display data file search and locale setup
+ 3      More info messages
+ 4      Display data file search and locale setup
+
+In the levels below, the messages of levels 2-4 are not included:
+
  5-9    Tokenizer and parser debugging
  10-19  Dictionary debugging
+The output of these levels may be restricted to particular files and/or
+functions that are listed (comma-separated) in the !debug variable.
+
+The following levels are for particular information. The messages of levels
+greater than 1 are not included in their output:
+
  101    Print all the dictionary connectors, along with their length limit
+ 102    Print all the disjuncts, before and after pruning
+ 103    Show unsubscripted dictionary words and subscripted ones which
+        share the same base word
+ 104    Memory pool statistics
 
 [morphology]
 When False, whole words are displayed, without indicating any

--- a/debug/README.md
+++ b/debug/README.md
@@ -61,6 +61,9 @@ messages of the lower ones.
 
 * 104: Memory pool statistics.
 
+(These level descriptions appear also in the command-help file `command-help-en.txt`
+so if something is changed here there may be a need to change it there too.)
+
 ### 2) -debug=LOCATIONS (-de=LOCATIONS)
 Show only messages from these LOCATIONS. The LOCATIONS string is a
 comma-separated list of source file names (without specifying their

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -453,3 +453,30 @@ void assert_failure(const char cond_str[], const char func[],
 
 	exit(1);
 }
+
+bool verbosity_check(int level, int v, char print_func , const char func[],
+                     const char file[], const char *filter)
+{
+	if ((((D_SPEC >= v) && (v >= level)) || (v == level)) &&
+	    ((level <= 1) || !((level <= D_USER_MAX) && (v > D_USER_MAX))) &&
+	    ((debug[0] == '\0') || feature_enabled(debug, func, file, filter)))
+	{
+		if (print_func == '+') err_msg(0, "%s: ", func);
+		return true;
+	}
+
+	return false;
+}
+
+void debug_msg(int level, int v, char print_func, const char func[],
+               const char file[], const char *fmt, ...)
+{
+	va_list args;
+
+	if (verbosity_check(level, v, print_func, func, file, ""))
+	{
+		va_start(args, fmt);
+		verr_msg(NULL, lg_Trace, fmt, args);
+		va_end(args);
+	}
+}

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -454,6 +454,11 @@ void assert_failure(const char cond_str[], const char func[],
 	exit(1);
 }
 
+/*
+ * Implement lgdebug() and verbosity_level() (see these macros and their
+ * comments in error.h).
+ */
+
 bool verbosity_check(int level, int v, char print_func , const char func[],
                      const char file[], const char *filter)
 {

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -40,20 +40,23 @@ void debug_msg(int, int, char, const char[], const char[], const char *fmt, ...)
 bool verbosity_check(int, int, char, const char[], const char[], const char *);
 
 /**
- * Print a debug message according to their level.
+ * Print a debug messages according to their level.
  * Print the messages at levels <= the specified verbosity, with the
  * following restrictions:
  * - Level numbers 2 to D_USER_MAX are not printed on verbosity>D_USER_MAX,
  *   because they are designed only for extended user information.
  * - When verbosity > D_SPEC, print messages only when level==verbosity.
  * - The !debug variable can be set to a comma-separated list of functions
- *   or source filenames in order to restrict the debug messages to these
- *   functions or filenames only.
+ *   and/or source filenames in order to restrict the debug messages to these
+ *   functions and/or filenames only.
+ *
+ * Preceding the level number by a + (+level) adds printing of the
+ * function name.
  *
  * Invoking lgdebug() with a level number preceded by a + (+level) adds
  * printing of the function name.
  * FIXME: The level is then Trace and if the message starts with a level
- * it is ignored.
+ * this level is ignored.
  */
 #define lgdebug(level, ...) \
 	do { \
@@ -65,11 +68,6 @@ bool verbosity_check(int, int, char, const char[], const char[], const char *);
 
 /**
  * Wrap-up a debug-messages block.
- * Preceding the level number by a + (+level) adds printing of the
- * function name.
- * The !debug variable can be set to a comma-separated list of functions
- * in order to restrict the debug messages to these functions only.
- *
  * Return true if the debug-messages block should be executed, else false.
  *
  * Usage example, for debug messages at verbosity V:
@@ -78,14 +76,10 @@ bool verbosity_check(int, int, char, const char[], const char[], const char *);
  *    print_disjunct(d);
  * }
  *
- * The optional printing of the function name is done here by prt_error()
- * and not err_msg(), in order to not specify the message severity.
- * Also note there is no trailing newline in that case. These things
- * ensured the message severity will be taken from a following message
- * which includes a newline. So verbosity_level(V) can be used for any
- * desired message severity.
- * The optional argument is used for additional names that can be used
- * in the "debug" option (in addition to the current function and file names).
+ * A single optional argument can be used to add names for the "debug"
+ * option (in addition to the current function and file names). (Several
+ * names may be supplied using backslash-escaped comma separators - not
+ * actually used for now.)
  */
 #define verbosity_level(level, ...) \
 	((verbosity >= (level)) && \

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -258,7 +258,7 @@ static const char *switch_value_string(const Switch *as)
 #define HELPFILE_LANG_TEMPLATE_SIZE (sizeof(HELPFILE_LANG_TEMPLATE)-1)
 #define HELPFILE_TEMPLATE_SIZE \
 	(sizeof(HELPFILE_BASE HELPFILE_EXT)+HELPFILE_LANG_TEMPLATE_SIZE)
-#define D_USER_FILES 3 /* Debug level for files */
+#define D_USER_FILES 4 /* Debug level for files, see error.h. */
 #define DEFAULT_HELP_LANG "en"
 
 static FILE *help_file;


### PR DESCRIPTION
This change saves about 1.5-2% of the library code (when compiled with and without the sat parser).
This is because there are about ~240 such calls in the code and these macros are not trivial.
In addition:
- `verbosity >= level` is no checked first and this normally saves one branching.
- The logic of checking the verbosity level is now in one place.
- The functions are more readable than the previous macros.
- The new code is easier to maintain.
The speed improvement is negligible.

On the same occasion, I fixed a verbosity level in `command-line.c` that I once changed and forgot to update there.
Also updated here:
- The relevant comments.
- The command help (`!help verbosity`).