### PR TITLE
Improve efficiency of setting farthest_word and eliminate connector length_limit 

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -632,6 +632,12 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 	if (IS_DB_DICT(sent->dict))
 		condesc_setup(sent->dict);
 
+	for (WordIdx w = 0; w < sent->length; w++)
+	{
+		for (X_node *x = sent->word[w].x; x != NULL; x = x->next)
+			set_connector_farthest_word(x->exp, (int)w, (int)sent->length, opts);
+	}
+
 	/* Expressions were set up during the tokenize stage.
 	 * Prune them, and then parse.
 	 */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -105,15 +105,9 @@ typedef struct
  * Lets try to keep it that way. */
 struct Connector_struct
 {
-	union
-	{
-		uint8_t farthest_word;/* The farthest word to my left (or right)
-		                         that this could ever connect to. Computed
-		                         from length_limit by setup_connectors(). */
-		uint8_t length_limit; /* Same purpose as above but relative to the
-		                         current word. This is how it is initially
-		                         set. */
-	};
+	uint8_t farthest_word;/* The farthest word to my left (or right)
+		                      that this could ever connect to. Computed
+		                      by set_connector_farthest_word(). */
 	uint8_t nearest_word; /* The nearest word to my left (or right) that
 	                         this could ever connect to.  Initialized by
 	                         setup_connectors(). Final value is found in
@@ -180,7 +174,7 @@ static inline unsigned int connector_uc_num(const Connector * c)
 
 /* Connector utilities ... */
 Connector * connector_new(Pool_desc *, const condesc_t *, Parse_Options);
-void set_connector_length_limit(Connector *, Parse_Options);
+void set_connector_farthest_word(Exp *, int, int, Parse_Options);
 void free_connectors(Connector *);
 
 /**

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -52,9 +52,13 @@ struct Exp_struct
 {
 	Exp *operand_next;    /* Next same-level operand. */
 	Exp_type type:8;      /* One of three types: AND, OR, or connector. */
-	Exptag_type tag_type:8;
+	bool multi;         /* TRUE if a multi-connector (for connector). */
 	char dir;      /* The connector connects to the left ('-') or right ('+'). */
-	bool multi;           /* TRUE if a multi-connector (for connector). */
+	union
+	{
+		Exptag_type tag_type:8;      /* tag_id namespace (for non-terminals). */
+		unsigned char farthest_word; /* For connectors, see Connector_struct. */
+	};
 	unsigned int tag_id;  /* Index in tag_type namespace. */
 	float cost;           /* The cost of using this expression. */
 	union
@@ -63,6 +67,7 @@ struct Exp_struct
 		condesc_t *condesc; /* Only needed if it's a connector. */
 	};
 };
+
 
 bool cost_eq(double cost1, double cost2);
 const char *cost_stringify(double cost);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -532,7 +532,7 @@ static void dyn_print_one_connector(dyn_str *s, Connector *e, int dir,
 	if (is_flag(flags, 'r') && e->refcount)
 		append_string(s, "{%d}",e->refcount);
 	if (is_flag(flags, 'l'))
-		append_string(s, "(%d,%d)", e->nearest_word, e->length_limit);
+		append_string(s, "(%d,%d)", e->nearest_word, e->farthest_word);
 #if 0
 	append_string(s, "<<%d>>", e->exp_pos);
 #endif

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -35,17 +35,11 @@
  * Also recalculate length_limit to be the farthest word number that could
  * be connected.
  */
-static int set_dist_fields(Connector * c, size_t w, int delta, int w_clamp)
+static int set_dist_fields(Connector * c, size_t w, int delta)
 {
-	int i;
 	if (c == NULL) return (int) w;
-	i = set_dist_fields(c->next, w, delta, w_clamp) + delta;
-	c->nearest_word = i;
-	int farthest_word = w + (delta * c->length_limit);
-	/* Clamp it to the range [0, sent_length). */
-	if (delta * farthest_word > w_clamp) farthest_word = w_clamp;
-	c->farthest_word = farthest_word;
-	return i;
+	c->nearest_word = set_dist_fields(c->next, w, delta) + delta;
+	return c->nearest_word;
 }
 
 /**
@@ -64,9 +58,8 @@ static void setup_connectors(Sentence sent)
 		for (Disjunct *d = sent->word[w].d; d != NULL; d = xd)
 		{
 			xd = d->next;
-			if ((set_dist_fields(d->left, w, -1, 0) < 0) ||
-			    (set_dist_fields(d->right, w, 1, (int)(sent->length-1)) >=
-			     (int) sent->length))
+			if ((set_dist_fields(d->left, w, -1) < 0) ||
+			    (set_dist_fields(d->right, w, 1) >= (int)sent->length))
 			{
 				; /* Skip this disjunct. */
 			}

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -286,6 +286,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 
 			n->exp_pos = t->exp_pos;
 			n->multi = t->e->multi;
+			n->farthest_word = t->e->farthest_word;
 			n->next = *loc;   /* prepend the connector to the current list */
 			*loc = n;         /* update the connector list */
 		}

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -169,14 +169,7 @@ static inline bool matches_S(connector_table **ct, int w, condesc_t * c)
 
 	for (e = ct[hash_S(c)]; e != NULL; e = e->next)
 	{
-		if (e->farthest_word <= 0)
-		{
-			if (w < -e->farthest_word) continue;
-		}
-		else
-		{
-			if (w > e->farthest_word) continue;
-		}
+		if (w > e->farthest_word) continue;
 		if (easy_match_desc(e->condesc, c)) return true;
 	}
 	return false;
@@ -292,7 +285,7 @@ static Exp* purge_Exp(exprune_context *ctxt, int w, Exp *e, char dir)
 	{
 		if (e->dir == dir)
 		{
-			if (!matches_S(ctxt->ct, w, e->condesc))
+			if (!matches_S(ctxt->ct, (dir == '-') ? w : -w, e->condesc))
 			{
 				ctxt->N_deleted++;
 				return NULL;

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -334,7 +334,8 @@ static void zero_connector_table(exprune_context *ctxt)
  * This function puts connector c into the connector table
  * if one like it isn't already there.
  */
-static void insert_connector(exprune_context *ctxt, int farthest_word, condesc_t * c)
+static void insert_connector(exprune_context *ctxt, int farthest_word,
+                             condesc_t *c)
 {
 	unsigned int h;
 	connector_table *e;
@@ -368,11 +369,7 @@ static void insert_connectors(exprune_context *ctxt, int w, Exp * e, int dir)
 		if (e->dir == dir)
 		{
 			assert(NULL != e->condesc, "NULL connector");
-			Connector c = { .desc = e->condesc };
-
-			set_connector_length_limit(&c, ctxt->opts);
-			int farthest_word = (dir == '-') ? -MAX(0, w-c.length_limit) :
-				                              w+c.length_limit;
+			int farthest_word = (dir == '-') ? -e->farthest_word : e->farthest_word;
 			insert_connector(ctxt, farthest_word, e->condesc);
 		}
 	}

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -33,7 +33,7 @@ struct PositionConnector
     // Initialize some fields in the connector struct.
     connector.desc = e->condesc;
     connector.multi = e->multi;
-    set_connector_length_limit(&connector, opts);
+    connector.farthest_word = e->farthest_word;
     connector.originating_gword = &w_xnode->word->gword_set_head;
 
     /*
@@ -178,9 +178,8 @@ public:
 
   bool match(int w1, Connector& cntr1, char dir, int w2, Connector& cntr2)
   {
-      int dist = w2 - w1;
-      assert(0 < dist, "match() did not receive words in the natural order.");
-      if (dist > cntr1.length_limit || dist > cntr2.length_limit) return false;
+      assert(w1 < w2, "match() did not receive words in the natural order.");
+      if (cntr1.farthest_word < w2 || cntr2.farthest_word > w1) return false;
       if (!alt_connectivity_possible(cntr1, cntr2)) return false;
       return easy_match_desc(cntr1.desc, cntr2.desc);
   }


### PR DESCRIPTION
Currently, length_limit is set per each new connector that is created. This takes ~1% of CPU.
The expression pruning then computes from it the farthest word for each connector that is inserted into the connector table.
Before power pruning, the connectors length_limit is converted in place to farthest_word.

This patch adds a farthest_word field to `Exp` and first set it there. This setting involves order of magnitude fewer connectors.
Setting it later into Disjunct connectors involved only copying it (instead of a full computation per connector). The expression pruning code is then able to directly use it.

On the same occasion of looking into the expression pruning code, I found a way to save a potential branching per iteration in the connector set matching loop.