### PR TITLE
Fix a dialect code NULL-dereferencing crash

### DIFF
--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -391,6 +391,12 @@ bool dialect_file_read(Dictionary dict, const char *fname)
 			prt_error("warning: No dialect file\n");
 		return true; /* Not an error for now. */
 	}
+	if (dict->dialect_tag.num == 0)
+	{
+		prt_error("Warning: "
+		          "File '%s' found but no dialects in the dictionary.\n", fname);
+		return true;
+	}
 
 	Dialect *di = dict->dialect = dialect_alloc();
 

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -387,9 +387,11 @@ bool dialect_file_read(Dictionary dict, const char *fname)
 	char *input = get_file_contents(fname);
 	if (input == NULL)
 	{
-		if (dict->dialect_tag.num != 0)
-			prt_error("warning: No dialect file\n");
-		return true; /* Not an error for now. */
+		if (dict->dialect_tag.num == 0) return true;
+
+		prt_error("Error: "
+		          "Dialects found in the dictionary but no dialect file.\n");
+		return false; /* Parsing results may be wrong */
 	}
 	if (dict->dialect_tag.num == 0)
 	{


### PR DESCRIPTION
Fix a crash that happens when there is a dialect file but no dialects in the dict.
On the same occasion: Make it an error not to have a dialect file when there are dialects in the dict (because the parses may be incorrect due to incorrect costs).

