### PR TITLE
alloc_fast_matcher(): Eliminate max_tsize

### DIFF
--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -256,7 +256,6 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 	sortbin *sbin = alloca(sent->length * sizeof(sortbin));
 
 	/* Calculate the sizes of the hash tables. */
-	size_t max_tsize = next_power_of_two_up(sent->dict->contable.num_uc);
 	unsigned int num_headers = 0;
 	Match_node **memblock_headers;
 	Match_node **hash_table_header;
@@ -275,7 +274,6 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 			else
 			{
 				tsize = next_power_of_two_up(3 * n); /* At least 66% free. */
-				tsize = MIN(max_tsize,  tsize);
 			}
 
 			ncu[dir][w] = tsize;


### PR DESCRIPTION
Fix two problems:
1. A crash if the number of different uppercase parts on a word direction (left/right) is equal to `num_uc` (the number of different    uppercase parts in the dict, and it is an exact power of 2.  (I guess  this may happen when testing dicts.)
2. It is not a good idea to limit the size of the hash table in case there are a lot of connectors in it because plenty of free space is needed to efficiently stop searching a value that is not in the table. In any case, it will not be more than (`3*num_uc`).