### PR TITLE
Exact power_table sizing

### DIFF
--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -249,6 +249,7 @@ failure:
 /**
  * Use filenames of six different files to put together the dictionary.
  */
+NO_SAN_DICT
 Dictionary
 dictionary_six(const char * lang, const char * dict_name,
                const char * pp_name, const char * cons_name,

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -850,9 +850,10 @@ void free_tracon_sharing(Tracon_sharing *ts)
 			ts->csid[dir] = NULL;
 		}
 
-		free(ts->uc_seen[dir]);
-		free(ts->num_cnctrs_per_word[dir]);
 	}
+
+	free(ts->uc_seen[0]);
+	free(ts->num_cnctrs_per_word[0]);
 
 	if (NULL != ts->d) free(ts->d);
 	free(ts->tracon_list);

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -663,10 +663,6 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 	return head.next;
 }
 
-/**
- * Pack the given disjunct chain in a contiguous memory block.
- * If the disjunct is NULL, return NULL.
- */
 static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 {
 	Disjunct *newd;
@@ -693,6 +689,10 @@ static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 	return newd;
 }
 
+/**
+ * Pack the given disjunct chain in a contiguous memory block.
+ * If the disjunct is NULL, return NULL.
+ */
 static Disjunct *pack_disjuncts(Sentence sent, Tracon_sharing *ts,
                                 Disjunct *origd, int w)
 {

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -105,7 +105,6 @@ typedef struct
 
 typedef struct
 {
-	unsigned int *num_cnctrs_per_word[2]; /* Indexed by word number */
 	/* Table of tracons. A 32bit index into the connector array in
 	 * memblock (instead of (Connector*)) is used for better use of the
 	 * CPU cache on 64-bit CPUs. */
@@ -134,6 +133,14 @@ struct tracon_sharing_s
 	int word_offset;            /* Start number for connector tracon_id */
 	bool is_pruning;            /* false: Parsing step, true: Pruning step */
 	Tracon_list *tracon_list;   /* Used only for pruning */
+
+	/* The number of different uppercase connector parts per side / word,
+	 * for sizing the prune power table. */
+	uint8_t *uc_seen[2];        /* The last word number in which an
+										  * uppercase connector part has been seen,
+										  * (hence doesn't need clearing between words).
+										  * Indexed by uc_num. */
+	unsigned int *num_cnctrs_per_word[2]; /* Indexed by word number */
 };
 
 void *save_disjuncts(Sentence, Tracon_sharing *);

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -256,9 +256,9 @@ static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list **t,
 static void power_table_alloc(Sentence sent, power_table *pt)
 {
 	pt->power_table_size = sent->length;
-	pt->table_size[0] = xalloc (2 * sent->length * sizeof(unsigned int));
+	pt->table_size[0] = malloc (2 * sent->length * sizeof(unsigned int));
 	pt->table_size[1] = pt->table_size[0] + sent->length;
-	pt->table[0] = xalloc (2 * sent->length * sizeof(C_list **));
+	pt->table[0] = malloc (2 * sent->length * sizeof(C_list **));
 	pt->table[1] = pt->table[0] + sent->length;
 }
 


### PR DESCRIPTION
The current power pruning is a bottleneck when there are a vast number of different uppercase connector parts in each disjunct.
This is because their number is overestimated by a large factor. This is not so important for the current dicts because this number is low for them.

For testing, I used a dict with ~500K different uppercase connectors and a sentence with length ~190 and 8 nulls when parsed.
After expression pruning, there were a few thousands of different upper case parts on most disjuncts, in each direction.
W/o this patch, it took about 100 seconds to get a result, and with this patch only 15 seconds (`power_prune()` was about ~10 times more efficient in this test).

BTW:
This doesn't solve the huge slowness that is seen in some language learning runs. It is due to two additional things (one of them or both at once): 1. Inefficiencies in build_disjuncts(). 2. The parsing `Table_connector` is too small for some sentences.
Both can be fixed. (My dynamic `Table_connector` resizing patch is very old but was not important until the long-sentence speedup and the language-learning huge dictionaries. It needs to be adapted to the current `count.c`. In addition, by now I have other related ideas that I still have to test.)

Important: I need the current PRs and this one to be applied before I can send additional ones.


