### PR TITLE
extract-links speed improvement

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -481,6 +481,12 @@ static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir,
 	return lrcnt_cache;
 }
 
+bool no_count(count_context_t *ctxt, int dir, Connector *c, int cw, int w,
+              unsigned int null_count)
+{
+	return &lrcnt_cache_zero == is_lrcnt(ctxt, dir, c, cw, w, null_count, NULL);
+}
+
 static void lrcnt_cache_update(Table_lrcnt *lrcnt_cache, bool lrcnt_found,
                               bool match_list, unsigned int null_count)
 {

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -20,6 +20,7 @@ typedef struct count_context_s count_context_t;
 
 Count_bin* table_lookup(count_context_t *, int, int, Connector *, Connector *, unsigned int);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
+bool no_count(count_context_t *, int, Connector *, int, int, unsigned int);
 
 count_context_t* alloc_count_context(Sentence);
 void free_count_context(count_context_t*, Sentence);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -18,19 +18,13 @@
 #include "disjunct-utils.h"             // Disjunct
 #include "extract-links.h"
 #include "fast-match.h"
+#include "memory-pool.h"
 #include "utilities.h"                  // Windows rand_r()
 #include "linkage/linkage.h"
 #include "tokenize/word-structures.h"   // Word_Struct
 
 //#define RECOUNT
-
 //#define DEBUG_X_TABLE
-#ifdef DEBUG_X_TABLE
-#undef DEBUG_X_TABLE
-#define DEBUG_X_TABLE(...) __VA_ARGS__
-#else
-#define DEBUG_X_TABLE(...)
-#endif
 
 typedef struct Parse_choice_struct Parse_choice;
 
@@ -80,6 +74,8 @@ struct extractor_s
 	Word           *words;
 	bool           islands_ok;
 	bool           sort_match_list;
+	Pool_desc *    Pset_bucket_pool;
+	Pool_desc *    Parse_choice_pool;
 
 	/* thread-safe random number state */
 	unsigned int rand_state;
@@ -95,24 +91,13 @@ struct extractor_s
  * continuation).
  */
 
-static void free_set(Parse_set *s)
-{
-	Parse_choice *p, *xp;
-	if (s == NULL) return;
-	for (p=s->first; p != NULL; p = xp)
-	{
-		xp = p->next;
-		xfree((void *)p, sizeof(*p));
-	}
-}
-
 static Parse_choice *
 make_choice(Parse_set *lset, Connector * llc, Connector * lrc,
             Parse_set *rset, Connector * rlc, Connector * rrc,
-            Disjunct *md)
+            Disjunct *md, extractor_t* pex)
 {
 	Parse_choice *pc;
-	pc = (Parse_choice *) xalloc(sizeof(*pc));
+	pc = pool_alloc(pex->Parse_choice_pool);
 	pc->next = NULL;
 	pc->set[0] = lset;
 	pc->link[0].link_name = NULL;
@@ -151,11 +136,11 @@ static void put_choice_in_set(Parse_set *s, Parse_choice *pc)
 static void record_choice(
     Parse_set *lset, Connector * llc, Connector * lrc,
     Parse_set *rset, Connector * rlc, Connector * rrc,
-    Disjunct *md, Parse_set *s)
+    Disjunct *md, Parse_set *s, extractor_t* pex)
 {
 	put_choice_in_set(s, make_choice(lset, llc, lrc,
 	                                 rset, rlc, rrc,
-	                                 md));
+	                                 md, pex));
 }
 
 /**
@@ -188,12 +173,22 @@ extractor_t * extractor_new(int nwords, unsigned int ranstat)
 	pex->log2_x_table_size = log2_table_size;
 	pex->x_table_size = (1 << log2_table_size);
 
-	DEBUG_X_TABLE(
+#ifdef DEBUG_X_TABLE
 		printf("Allocating x_table of size %u (nwords %d)\n",
 		       pex->x_table_size, nwords);
-	)
+#endif /* DEBUG_X_TABLE */
+
 	pex->x_table = (Pset_bucket**) xalloc(pex->x_table_size * sizeof(Pset_bucket*));
 	memset(pex->x_table, 0, pex->x_table_size * sizeof(Pset_bucket*));
+
+	pex->Pset_bucket_pool =
+		pool_new(__func__, "Pset_bucket",
+		         /*num_elements*/1024, sizeof(Pset_bucket),
+		         /*zero_out*/false, /*align*/false, /*exact*/false);
+	pex->Parse_choice_pool =
+		pool_new(__func__, "Parse_choice",
+		         /*num_elements*/1024, sizeof(Parse_choice),
+		         /*zero_out*/false, /*align*/false, /*exact*/false);
 
 	return pex;
 }
@@ -205,39 +200,35 @@ extractor_t * extractor_new(int nwords, unsigned int ranstat)
  */
 void free_extractor(extractor_t * pex)
 {
-	unsigned int i;
-	Pset_bucket *t, *x;
 	if (!pex) return;
 
-	DEBUG_X_TABLE(int N = 0;)
-	for (i=0; i<pex->x_table_size; i++)
+#ifdef DEBUG_X_TABLE
+	int N = 0;
+	for (unsigned int i = 0; i < pex->x_table_size; i++)
 	{
-		DEBUG_X_TABLE(int c = 0;)
-		for (t = pex->x_table[i]; t!= NULL; t=x)
-		{
-			DEBUG_X_TABLE(c++;)
-			x = t->next;
-			free_set(&t->set);
-			xfree((void *) t, sizeof(Pset_bucket));
-		}
-		DEBUG_X_TABLE(
-			if (c > 0)
-				;//printf("I %d: chain %d\n", i, c);
-			else
-				N++;
-		)
+		int c = 0;
+		for (Pset_bucket *t = pex->x_table[i]; t != NULL; t = t->next)
+			c++;
+
+		if (c > 0)
+			;//printf("I %d: chain %d\n", i, c);
+		else
+			N++;
 	}
-	DEBUG_X_TABLE(
-		printf("Used x_table %u/%u %.2f%%\n",
-				 pex->x_table_size-N, pex->x_table_size,
-				 100.0f*(pex->x_table_size-N)/pex->x_table_size);
-	)
+	printf("Used x_table %u/%u %.2f%%\n",
+	       pex->x_table_size-N, pex->x_table_size,
+	       100.0f*(pex->x_table_size-N)/pex->x_table_size);
+#endif /* DEBUG_X_TABLE */
+
 	pex->parse_set = NULL;
 
 	//printf("Freeing x_table of size %d\n", pex->x_table_size);
 	xfree((void *) pex->x_table, pex->x_table_size * sizeof(Pset_bucket*));
 	pex->x_table_size = 0;
 	pex->x_table = NULL;
+
+	pool_delete(pex->Pset_bucket_pool);
+	pool_delete(pex->Parse_choice_pool);
 
 	xfree((void *) pex, sizeof(extractor_t));
 }
@@ -273,7 +264,7 @@ static Pset_bucket * x_table_store(int lw, int rw,
 	Pset_bucket *t, *n;
 	unsigned int h;
 
-	n = (Pset_bucket *) xalloc(sizeof(Pset_bucket));
+	n = pool_alloc(pex->Pset_bucket_pool);
 	n->set.lw = lw;
 	n->set.rw = rw;
 	n->set.null_count = null_count;
@@ -410,7 +401,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 					dummy = dummy_set(lw, w, null_count-1, pex);
 					record_choice(dummy, NULL, NULL,
 									  pset, dis->right, NULL,
-									  dis, &xt->set);
+									  dis, &xt->set, pex);
 					RECOUNT({xt->set.recount += pset->recount;})
 				}
 			}
@@ -422,7 +413,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 				dummy = dummy_set(lw, w, null_count-1, pex);
 				record_choice(dummy, NULL, NULL,
 								  pset,  NULL, NULL,
-								  NULL, &xt->set);
+								  NULL, &xt->set, pex);
 				RECOUNT({xt->set.recount += pset->recount;})
 			}
 		}
@@ -539,7 +530,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 								record_choice(ls[i], le, d->left,
 								              rset,  NULL /* d->right */,
 								              re,  /* the NULL indicates no link*/
-								              d, &xt->set);
+								              d, &xt->set, pex);
 								RECOUNT({xt->set.recount += ls[i]->recount * rset->recount;})
 							}
 						}
@@ -586,7 +577,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 									record_choice(lset, NULL /* le */,
 									              d->left,  /* NULL indicates no link */
 									              rs[j], d->right, re,
-									              d, &xt->set);
+									              d, &xt->set, pex);
 									RECOUNT({xt->set.recount += lset->recount * rs[j]->recount;})
 								}
 							}
@@ -603,7 +594,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 									if (rs[j] == NULL) continue;
 									record_choice(ls[i], le, d->left,
 									              rs[j], d->right, re,
-									              d, &xt->set);
+									              d, &xt->set, pex);
 									RECOUNT({xt->set.recount += ls[i]->recount * rs[j]->recount;})
 								}
 							}

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -459,7 +459,26 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 	RECOUNT({xt->set.recount = 0;})
 	for (w = start_word; w < end_word; w++)
 	{
-		size_t mlb = form_match_list(mchxt, w, le, lw, re, rw);
+		/* Start of nonzero leftcount/rightcount range cache check. */
+		Connector *fml_re = re;       /* For form_match_list() only */
+
+		if (le != NULL)
+		{
+			if (no_count(ctxt, 0, le, lw, w, null_count)) continue;
+			if (re != NULL)
+			{
+				if (no_count(ctxt, 1, re, rw, w, null_count))
+					fml_re = NULL;
+			}
+		}
+		else
+		{
+			/* Here re != NULL. */
+			if (no_count(ctxt, 1, re, rw, w, null_count)) continue;
+		}
+		/* End of nonzero leftcount/rightcount range cache check. */
+
+		size_t mlb = form_match_list(mchxt, w, le, lw, fml_re, rw);
 		if (pex->sort_match_list) sort_match_list(mchxt, mlb);
 
 		for (size_t mle = mlb; get_match_list_element(mchxt, mle) != NULL; mle++)

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -74,7 +74,7 @@ struct Pset_bucket_struct
 struct extractor_s
 {
 	unsigned int   x_table_size;
-	unsigned int   log2_x_table_size;
+	unsigned int   log2_x_table_size; /* Not used */
 	Pset_bucket ** x_table;  /* Hash table */
 	Parse_set *    parse_set;
 	Word           *words;
@@ -175,8 +175,8 @@ extractor_t * extractor_new(int nwords, unsigned int ranstat)
 	pex->rand_state = ranstat;
 
 	/* Alloc the x_table */
-	if (nwords > 96) {
-		log2_table_size = 15 + nwords / 48;
+	if (nwords >= 72) {
+		log2_table_size = 15 + nwords / 36;
 	} else if (nwords >= 10) {
 		log2_table_size = 14 + nwords / 24;
 	} else if (nwords >= 4) {
@@ -184,7 +184,7 @@ extractor_t * extractor_new(int nwords, unsigned int ranstat)
 	} else {
 		log2_table_size = 5;
 	}
-	/* if (log2_table_size > 21) log2_table_size = 21; */
+	/* At nwords>=252, log2_table_size is 15+7=22. */
 	pex->log2_x_table_size = log2_table_size;
 	pex->x_table_size = (1 << log2_table_size);
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -400,6 +400,9 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		           sent->num_linkages_found, sent->null_count,
 		           (sent->null_count != 1) ? "s" : "");
 
+		free_tracon_sharing(ts_parsing);
+		ts_parsing = NULL;
+
 		if (sent->num_linkages_found > 0)
 		{
 			extractor_t * pex = extractor_new(sent->length, sent->rand_state);
@@ -426,9 +429,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 		if ((0 == nl) && (0 < max_null_count) && verbosity > 0)
 			prt_error("No complete linkages found.\n");
-
-		free_tracon_sharing(ts_parsing);
-		ts_parsing = NULL;
 	}
 	sort_linkages(sent, opts);
 
@@ -438,7 +438,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		free_tracon_sharing(ts_pruning);
 		free(saved_memblock);
 	}
-	free_tracon_sharing(ts_parsing);
 
 	free_count_context(ctxt, sent);
 	free_fast_matcher(sent, mchxt);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -415,7 +415,8 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			{
 				if ((sent->num_valid_linkages == 0) &&
 				    (sent->num_linkages_post_processed > 0) &&
-				    ((int)opts->linkage_limit < sent->num_linkages_found))
+				    ((int)opts->linkage_limit < sent->num_linkages_found) &&
+				    (PARSE_NUM_OVERFLOW >= sent->num_linkages_found))
 					prt_error("Info: All examined linkages (%zu) had P.P. violations.\n"
 					          "Consider increasing the linkage limit.\n"
 					          "At the command line, use !limit\n",

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -400,24 +400,27 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		           sent->num_linkages_found, sent->null_count,
 		           (sent->null_count != 1) ? "s" : "");
 
-		extractor_t * pex = extractor_new(sent->length, sent->rand_state);
-		bool ovfl = setup_linkages(sent, pex, mchxt, ctxt, opts);
-		process_linkages(sent, pex, ovfl, opts);
-		free_extractor(pex);
-
-		post_process_lkgs(sent, opts);
-
-		if (sent->num_valid_linkages > 0) break;
-
-		if (verbosity >= D_USER_INFO)
+		if (sent->num_linkages_found > 0)
 		{
-			if ((sent->num_valid_linkages == 0) &&
-			    (sent->num_linkages_post_processed > 0) &&
-			    ((int)opts->linkage_limit < sent->num_linkages_found))
-				prt_error("Info: All examined linkages (%zu) had P.P. violations.\n"
-				          "Consider increasing the linkage limit.\n"
-				          "At the command line, use !limit\n",
-				          sent->num_linkages_post_processed);
+			extractor_t * pex = extractor_new(sent->length, sent->rand_state);
+			bool ovfl = setup_linkages(sent, pex, mchxt, ctxt, opts);
+			process_linkages(sent, pex, ovfl, opts);
+			free_extractor(pex);
+
+			post_process_lkgs(sent, opts);
+
+			if (sent->num_valid_linkages > 0) break;
+
+			if (verbosity >= D_USER_INFO)
+			{
+				if ((sent->num_valid_linkages == 0) &&
+				    (sent->num_linkages_post_processed > 0) &&
+				    ((int)opts->linkage_limit < sent->num_linkages_found))
+					prt_error("Info: All examined linkages (%zu) had P.P. violations.\n"
+					          "Consider increasing the linkage limit.\n"
+					          "At the command line, use !limit\n",
+					          sent->num_linkages_post_processed);
+			}
 		}
 
 		if ((0 == nl) && (0 < max_null_count) && verbosity > 0)


### PR DESCRIPTION
Changes:
1. Change `mk_parse_set()` to use the shortcuts used in `do_count()`.
2. Use memory pools. Most of this speedup is in `free_extractor().`
3. Enlarge x_table for long sentences.

On the same occasion:
1. ￼Skip extracting links if there are none.
2. Improve clarity of invoking free_tracon_sharing(ts_parsing).
3. Don't warn when all linkages have P.P. violations if there is a combinatorial explosion.

The speedups in `extract-links.c` for long sentences batches are ~50%. However, the total speedup is only a few percents at most because preparing the parse set is only a few percent of the CPU.
