### PR TITLE
Fix DEBUG compilation break

### DIFF
--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -569,7 +569,7 @@ static void dyn_print_connector_list(dyn_str *s, const Connector *e, int dir,
 
 /* Special flags here: Initial "-" or "+" for direction sign. */
 
-char *sprint_connector_list(const Connector *e, const char *flags)
+char *print_connector_list_str(const Connector *e, const char *flags)
 {
 	dyn_str *s = dyn_str_new();
 	int dir = -1;
@@ -583,7 +583,7 @@ char *sprint_connector_list(const Connector *e, const char *flags)
 	return dyn_str_take(s);
 }
 
-char *sprint_one_connector(const Connector *e, const char *flags)
+char *print_one_connector_str(const Connector *e, const char *flags)
 {
 	dyn_str *s = dyn_str_new();
 	int dir = -1;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -363,7 +363,7 @@ static void prt_con(Connector *c, dyn_str * p, char dir)
 	}
 }
 
-char * print_one_disjunct(const Disjunct *dj)
+char *print_one_disjunct_str(const Disjunct *dj)
 {
 	dyn_str *p = dyn_str_new();
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -72,11 +72,11 @@ void free_tracon_sharing(Tracon_sharing *);
 void count_disjuncts_and_connectors(Sentence, unsigned int *, unsigned int *);
 
 /* Print disjunct/connector */
-char *print_one_disjunct(const Disjunct *);
+char *print_one_disjunct_str(const Disjunct *);
+char *print_one_connector_str(const Connector *, const char *);
+char *print_connector_list_str(const Connector *, const char *);
 void print_one_connector(const Connector *, const char *);
-char *sprint_one_connector(const Connector *, const char *);
 void print_connector_list(const Connector *, const char *);
-char *sprint_connector_list(const Connector *, const char *);
 void print_disjunct_list(const Disjunct *, const char *);
 void print_all_disjuncts(Sentence);
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -143,19 +143,9 @@ struct prune_context_s
 #ifdef DEBUG
 GNUC_UNUSED static void print_power_table_entry(power_table *pt, int w, int dir)
 {
-	C_list **t;
-	unsigned int size;
+	C_list **t = pt->table[w][dir];
+	unsigned int size = pt->table_size[w][dir];
 
-	if (dir == 0)
-	{
-		t = pt->l_table[w];
-		size = pt->l_table_size[w];
-	}
-	else
-	{
-		t = pt->r_table[w];
-		size = pt->r_table_size[w];
-	}
 	if (size == 1) return;
 	printf("w%d dir%d size=%u:\n", w, dir, size);
 

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -447,9 +447,10 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 static void clean_table(unsigned int size, C_list **t)
 {
 	/* Table entry tombstone. */
+#define UC_NUM_TOMBSTONE ((connector_hash_t)-1)
 	static condesc_t desc_no_match =
 	{
-		.uc_num = (connector_hash_t)-1, /* get_power_table_entry() will skip. */
+		.uc_num = UC_NUM_TOMBSTONE, /* get_power_table_entry() will skip. */
 	};
 	static Connector con_no_match =
 	{

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -450,6 +450,7 @@ static void clean_table(unsigned int size, C_list **t)
 #define UC_NUM_TOMBSTONE ((connector_hash_t)-1)
 	static condesc_t desc_no_match =
 	{
+		.string = "TOMBSTONE",
 		.uc_num = UC_NUM_TOMBSTONE, /* get_power_table_entry() will skip. */
 	};
 	static Connector con_no_match =


### PR DESCRIPTION
The print_power_table_entry() that I recently added was broken in DEBUG mode due to previous changes.
This patch fixes it and also add a missing function that it calls.

On the same occasion, some more connector/disjunct debug printing functions are added/modified here.
Also added here is a symbolic name for onnector TOMBSTONEs  (used in the power table).