### PR TITLE
Implement dynamic connector table for do_count()

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -285,10 +285,9 @@ static inline uint32_t string_hash(const char *s)
 /**
  * Hash function for the classic parser linkage memoization.
  */
-static inline unsigned int pair_hash(unsigned int table_size,
-                            int lw, int rw,
-                            int l_id, const int r_id,
-                            unsigned int null_count)
+static inline unsigned int pair_hash(int lw, int rw,
+                                     int l_id, const int r_id,
+                                     unsigned int null_count)
 {
 	unsigned int i;
 
@@ -313,7 +312,7 @@ static inline unsigned int pair_hash(unsigned int table_size,
 	i = r_id + (i << 6) + (i << 16) - i;
 #endif
 
-	return i & (table_size-1);
+	return i;
 }
 
 /**

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -61,15 +61,16 @@ struct  Pool_desc_s
 	size_t block_size;          // Block size for pool extension.
 	size_t data_size;           // Size of data inside block_size.
 	size_t alignment;           // Alignment of element allocation.
+	size_t num_elements;        // Number of elements per block.
 
 	/* Common to the real and fake pool allocators. */
 	char *chain;                // Allocated blocks.
 	size_t element_size;        // Allocated memory per element.
 	const char *name;           // Pool name.
 	const char *func;           // Invoker of pool_new().
+	/* num_elements is also used by the fake allocator if the POOL_EXACT
+	 * feature is used (it is not used for now). */
 
-	/* For debug and stats. */
-	size_t num_elements;
 	size_t curr_elements;
 
 	/* Flags that are used by pool_alloc(). */

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -53,7 +53,6 @@ void pool_free(Pool_desc *, void *e);
 struct  Pool_desc_s
 {
 	/* Used only by the real pool allocator. */
-	char *chain;                // Allocated blocks. */
 	char *ring;                 // Current area for allocation.
 	char *alloc_next;           // Next element to be allocated.
 #ifdef POOL_FREE
@@ -64,6 +63,7 @@ struct  Pool_desc_s
 	size_t alignment;           // Alignment of element allocation.
 
 	/* Common to the real and fake pool allocators. */
+	char *chain;                // Allocated blocks.
 	size_t element_size;        // Allocated memory per element.
 	const char *name;           // Pool name.
 	const char *func;           // Invoker of pool_new().

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -615,11 +615,15 @@ static Count_bin do_count(int lineno, count_context_t *ctxt,
 	return r;
 }
 
-static Count_bin do_count1(int lineno,
-#define do_count(...) do_count(__LINE__, __VA_ARGS__)
+#define do_count do_count1
 #else
 #define TRACE_LABEL(l, do_count) (do_count)
+#endif /* DO_COUNT TRACE */
 static Count_bin do_count(
+#ifdef DO_COUNT_TRACE
+#undef do_count
+#define do_count(...) do_count(__LINE__, __VA_ARGS__)
+                          int lineno,
 #endif
                           count_context_t *ctxt,
                           int lw, int rw,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -567,7 +567,7 @@ static void lrcnt_cache_update(Table_lrcnt *lrcnt_cache, bool lrcnt_found,
 
 #define NO_COUNT -1
 #ifdef PERFORM_COUNT_HISTOGRAMMING
-#define INIT_NO_COUNT {.total = NO_COUNT}
+#define INIT_NO_COUNT (Count_bin){.total = NO_COUNT}
 #else
 #define INIT_NO_COUNT NO_COUNT
 #endif
@@ -919,7 +919,7 @@ static Count_bin do_count(
 				Count_bin r_cmulti = INIT_NO_COUNT;
 				Count_bin r_dmulti = INIT_NO_COUNT;
 				Count_bin r_dcmulti = INIT_NO_COUNT;
-				Count_bin r_bnl = (le == NULL) ? INIT_NO_COUNT : 0;
+				Count_bin r_bnl = (le == NULL) ? INIT_NO_COUNT : hist_zero();
 
 				/* Now, we determine if (based on table only) we can see that
 				   the current range is not parsable. */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -124,6 +124,14 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 		ctxt->table_available_count = MAX_TABLE_SIZE(ctxt->table_size);
 }
 
+/**
+ * This function is called on program exit so no memory remains allocated.
+ * This is not really necessary because even for debug the message on
+ * memory that left allocated can be put in an ignore-list.
+ *
+ * FIXME: Fix thread memory leak resulted by not freeing table memory
+ * on thread exit.
+ */
 static void free_kept_table(void)
 {
 	table_alloc(NULL, 0);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -449,7 +449,7 @@ static Count_bin table_store(count_context_t *ctxt,
  * the entry is not found).
  * @return The count for this quintuple if there, NULL otherwise.
  */
-Count_bin *
+inline Count_bin *
 table_lookup(count_context_t *ctxt, int lw, int rw,
                    const Connector *le, const Connector *re,
                    unsigned int null_count, unsigned int *hash)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -84,7 +84,7 @@ static void free_kept_table(void);
 static void table_alloc(count_context_t *ctxt, unsigned int shift)
 {
 	static TLS Table_connector **kept_table = NULL;
-	static TLS unsigned int log2_table_size = 0;
+	static TLS unsigned int log2_kept_table_size = 0;
 
 	if (ctxt == NULL)
 	{
@@ -105,10 +105,10 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 	 * system calls to mmap/munmap that eat up a lot of time.
 	 * (Up to 20%, depending on the sentence and CPU.) */
 	ctxt->table_size = (1U << shift);
-	if (shift > log2_table_size)
+	if ((shift > log2_kept_table_size) || (kept_table == NULL))
 	{
-		if (log2_table_size == 0) atexit(free_kept_table);
-		log2_table_size = shift;
+		if (log2_kept_table_size == 0) atexit(free_kept_table);
+		log2_kept_table_size = shift;
 
 		if (kept_table) free(kept_table);
 		kept_table = malloc(sizeof(Table_connector *) * ctxt->table_size);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -326,17 +326,12 @@ static void table_stat(count_context_t *ctxt, Sentence sent)
 		//if (c != 0) printf("Connector table [%d] c=%d\n", i, c);
 	}
 
-#if __GNUC__
-#define msb(x) ((int)(CHAR_BIT*sizeof(int)-1)-__builtin_clz(x))
-#else
-#define msb(x) 0
-#endif
 	int used_slots = ctxt->table_size-N;
 	/* The used= value is TotalValues/TableSize (not UsedSlots/TableSize). */
-	printf("Connector table: msb=%d slots=%6d/%6u (%5.2f%%) avg-chain=%4.2f "
-	       "values=%6d (z=%5d nz=%5d N=%5d) used=%5.2f%% "
+	printf("Connector table: num_growth=%u msb=%u slots=%6d/%6u (%5.2f%%) "
+	       "avg-chain=%4.2f values=%6d (z=%5d nz=%5d N=%5d) used=%5.2f%% "
 	       "acc=%zu (hit=%zu miss=%zu) (sent_len=%zu)\n",
-	       msb(ctxt->table_size), used_slots, ctxt->table_size,
+	       ctxt->num_growth, ctxt->log2_table_size, used_slots, ctxt->table_size,
 			 100.0f*used_slots/ctxt->table_size, 1.0f*total_c/used_slots,
 	       z+nz, z, nz, N, 100.0f*(z+nz)/ctxt->table_size,
 	       hit+miss, hit, miss, sent->length);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -344,11 +344,11 @@ static void table_stat(count_context_t *ctxt)
 	/* The used= value is TotalValues/TableSize (not UsedSlots/TableSize). */
 	printf("Connector table: num_growth=%u msb=%u slots=%6d/%6u (%5.2f%%) "
 	       "avg-chain=%4.2f values=%6d (z=%5d nz=%5d N=%5d) used=%5.2f%% "
-	       "acc=%zu (hit=%zu miss=%zu) (sent_len=%zu)\n",
+	       "acc=%zu (hit=%zu miss=%zu) (sent_len=%zu dis=%u)\n",
 	       ctxt->num_growth, ctxt->log2_table_size, used_slots, ctxt->table_size,
 			 100.0f*used_slots/ctxt->table_size, 1.0f*total_c/used_slots,
 	       z+nz, z, nz, N, 100.0f*(z+nz)/ctxt->table_size,
-	       hit+miss, hit, miss, ctxt->sent->length);
+	       hit+miss, hit, miss, ctxt->sent->length, ctxt->sent->num_disjuncts);
 
 	printf("Chain length:\n");
 	for (size_t i = 1; i < ARRAY_SIZE(chain_length); i++)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -294,7 +294,7 @@ static size_t hit, miss;  /* Table value found/not found */
  * Provide data for insights on the effectively of the connector pair table.
  * Hits, misses, chain length, number of elements with zero/nonzero counts.
  */
-static void table_stat(count_context_t *ctxt, Sentence sent)
+static void table_stat(count_context_t *ctxt)
 {
 	int z = 0, nz = 0;  /* Number of entries with zero and non-zero counts */
 	int c, total_c = 0; /* Chain length */
@@ -334,7 +334,7 @@ static void table_stat(count_context_t *ctxt, Sentence sent)
 	       ctxt->num_growth, ctxt->log2_table_size, used_slots, ctxt->table_size,
 			 100.0f*used_slots/ctxt->table_size, 1.0f*total_c/used_slots,
 	       z+nz, z, nz, N, 100.0f*(z+nz)/ctxt->table_size,
-	       hit+miss, hit, miss, sent->length);
+	       hit+miss, hit, miss, ctxt->sent->length);
 
 	printf("Chain length:\n");
 	for (size_t i = 1; i < ARRAY_SIZE(chain_length); i++)
@@ -1089,7 +1089,7 @@ int do_parse(Sentence sent, fast_matcher_t *mchxt, count_context_t *ctxt,
 
 	hist = do_count(ctxt, -1, sent->length, NULL, NULL, sent->null_count+1);
 
-	DEBUG_TABLE_STAT(if (verbosity_level(+D_COUNT)) table_stat(ctxt, sent));
+	DEBUG_TABLE_STAT(if (verbosity_level(+D_COUNT)) table_stat(ctxt));
 
 	return hist;
 }

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -30,10 +30,11 @@
 typedef struct Table_connector_s Table_connector;
 struct Table_connector_s
 {
-	Table_connector  *next;      /* FIXME: eliminate */
+	Table_connector  *next;
 	int              l_id, r_id;
 	Count_bin        count;
-	unsigned int     null_count; /* FIXME: eliminate */
+	unsigned int     null_count;
+	unsigned int     hash;
 };
 
 typedef uint8_t null_count_m;  /* Storage representation of null_count */
@@ -401,7 +402,7 @@ find_table_pointer(count_context_t *ctxt,
 	int l_id = (NULL != le) ? le->tracon_id : lw;
 	int r_id = (NULL != re) ? re->tracon_id : rw;
 
-	unsigned int h = pair_hash(ctxt->table_size, lw, rw, l_id, r_id, null_count);
+	unsigned int h = pair_hash(lw, rw, l_id, r_id, null_count);
 	Table_connector *t = ctxt->table[h];
 
 	for (; t != NULL; t = t->next)
@@ -631,7 +632,7 @@ static Count_bin do_count(
 	/* TODO: static_assert() that null_count is an unsigned int. */
 	assert (null_count < INT_MAX, "Bad null count %d", (int)null_count);
 
-	unsigned int h;
+	unsigned int h = 0; /* Initialized value only needed to prevent a warning. */
 	{
 		Table_connector * const t =
 			find_table_pointer(ctxt, lw, rw, le, re, null_count, &h);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -42,7 +42,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 
 /* Table of ranges [tracon_id, w) that would yield a zero
  * leftcount/rightcount up to null_count. */
-typedef struct Table_lrcnt_s
+typedef struct
 {
 	int tracon_id;
 	WordIdx_m w;
@@ -496,8 +496,8 @@ table_lookup(count_context_t *ctxt, int lw, int rw,
  *    Cache pointer - An update for null_count>=lnull_start is needed.
  */
 static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir,
-                              Connector *c, int cw, int w,
-                              unsigned int null_count, unsigned int *null_start)
+                             Connector *c, int cw, int w,
+                             unsigned int null_count, unsigned int *null_start)
 {
 	const int rhs_id = 0x40000000;
 	int tracon_id = c->tracon_id | (dir * rhs_id);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1136,7 +1136,7 @@ int do_parse(Sentence sent, fast_matcher_t *mchxt, count_context_t *ctxt,
 	hist = do_count(ctxt, -1, sent->length, NULL, NULL, sent->null_count+1);
 
 	table_stat(ctxt);
-	return hist;
+	return (int)hist_total(&hist);
 }
 
 count_context_t * alloc_count_context(Sentence sent)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -574,15 +574,15 @@ Count_bin count_unknown = INIT_NO_COUNT;
 
 /**
  * psuedocount is used to check to see if a parse is even possible,
- * so that we don't waste cpu time performing an actual count, only
+ * so that we don't waste CPU time performing an actual count, only
  * to discover that it is zero.
  *
- * Returns false if and only if this entry is in the hash table
- * with a count value of 0. If an entry is not in the hash table,
- * we have to assume the worst case: that the count might be non-zero,
- * and since we don't know, we return true.  However, if the entry is
- * in the hash table, and its zero, then we know, for sure, that the
- * count is zero.
+ * A table entry with a count 0 indicates that the parse is not possible.
+ * In that case we can skip parsing. If it is not 0, it is the parse
+ * result and we can use it and skip parsing too.
+ * However, if an entry is not in the hash table, we have to assume the
+ * worst case: that the count might be non-zero.  To indicate that case,
+ * return the special sentinel value \c count_unknown.
  */
 static Count_bin pseudocount(count_context_t * ctxt,
                        int lw, int rw, Connector *le, Connector *re,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -622,7 +622,6 @@ static Count_bin do_count(
                           Connector *le, Connector *re,
                           unsigned int null_count)
 {
-	Count_bin zero = hist_zero();
 	Count_bin total;
 	int start_word, end_word, w;
 	Table_connector *t;
@@ -653,7 +652,7 @@ static Count_bin do_count(
 		}
 		else
 		{
-			t->count = zero;
+			t->count = hist_zero();
 		}
 		return t->count;
 	}
@@ -682,7 +681,7 @@ static Count_bin do_count(
 			}
 			else
 			{
-				t->count = zero;
+				t->count = hist_zero();
 			}
 			return t->count;
 		}
@@ -695,7 +694,7 @@ static Count_bin do_count(
 		 * rest of the sentence must contain one less null-word. Else
 		 * the rest of the sentence still contains the required number
 		 * of null words. */
-		t->count = zero;
+		t->count = hist_zero();
 		w = lw + 1;
 		for (int opt = 0; opt <= (int)ctxt->sent->word[w].optional; opt++)
 		{
@@ -775,7 +774,7 @@ static Count_bin do_count(
 			end_word = re->nearest_word + 1;
 	}
 
-	total = zero;
+	total = hist_zero();
 	fast_matcher_t *mchxt = ctxt->mchxt;
 
 	for (w = start_word; w < end_word; w++)
@@ -962,8 +961,8 @@ static Count_bin do_count(
 				 * in the count multiplication is zero,
 				 * we know that the true total is zero. So we don't
 				 * bother counting the other term at all, in that case. */
-				Count_bin leftcount = zero;
-				Count_bin rightcount = zero;
+				Count_bin leftcount = hist_zero();
+				Count_bin rightcount = hist_zero();
 				if (leftpcount &&
 				    (!lrcnt_optimize || rightpcount || (0 != hist_total(&l_bnr))))
 				{

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -18,7 +18,9 @@
 
 typedef struct count_context_s count_context_t;
 
-Count_bin* table_lookup(count_context_t *, int, int, Connector *, Connector *, unsigned int);
+Count_bin* table_lookup(count_context_t *, int, int,
+                        const Connector *, const Connector *,
+                        unsigned int, unsigned int *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 bool no_count(count_context_t *, int, Connector *, int, int, unsigned int);
 

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -346,7 +346,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 
 	assert(null_count < 0x7fff, "mk_parse_set() called with null_count < 0.");
 
-	count = table_lookup(ctxt, lw, rw, le, re, null_count);
+	count = table_lookup(ctxt, lw, rw, le, re, null_count, NULL);
 
 	/* If there's no counter, then there's no way to parse. */
 	if (NULL == count) return NULL;

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -245,7 +245,8 @@ static Pset_bucket * x_table_pointer(int lw, int rw,
 	Pset_bucket *t;
 	int l_id = (NULL != le) ? le->tracon_id : lw;
 	int r_id = (NULL != re) ? re->tracon_id : rw;
-	t = pex->x_table[pair_hash(pex->x_table_size, lw, rw, l_id, r_id, null_count)];
+	unsigned int hash = pair_hash(lw, rw, l_id, r_id, null_count);
+	t = pex->x_table[hash & (pex->x_table_size-1)];
 
 	for (; t != NULL; t = t->next) {
 		if ((t->set.l_id == l_id) && (t->set.r_id == r_id) &&
@@ -261,7 +262,7 @@ static Pset_bucket * x_table_store(int lw, int rw,
                                   Connector *le, Connector *re,
                                   unsigned int null_count, extractor_t * pex)
 {
-	Pset_bucket *t, *n;
+	Pset_bucket **t, *n;
 	unsigned int h;
 
 	n = pool_alloc(pex->Pset_bucket_pool);
@@ -274,10 +275,10 @@ static Pset_bucket * x_table_store(int lw, int rw,
 	n->set.first = NULL;
 	n->set.tail = NULL;
 
-	h = pair_hash(pex->x_table_size, lw, rw, n->set.l_id, n->set.r_id, null_count);
-	t = pex->x_table[h];
-	n->next = t;
-	pex->x_table[h] = n;
+	h = pair_hash(lw, rw, n->set.l_id, n->set.r_id, null_count);
+	t = &pex->x_table[h & (pex->x_table_size -1)];
+	n->next = *t;
+	*t = n;
 	return n;
 }
 


### PR DESCRIPTION
The main change here is a dynamic connector table for do_count().
It has several benefits:
1. More memory reference localization due to smaller tables.
2.  Less table loading for unpredictable cases that need large tables.
3. Adapt to table-entry exhausting due to parsing with null links, especially more than one.
4. Less table clear overhead due to smaller tables on average.

Other changes:
1 . Using `table_store()` just before returning from `do_count()`. This also creates an infrastructure for selective storing (in case it is known a lookup would not be needed due to a dead-end) and more storing optimization can be implemented.  It's still in the works.
2. Use the table-keep strategy from the unapplied PR #1024 (always keep, not just the biggest one). THis still causes a thread memory-leak, to be fixed in the next release.
3. Some cleanup.
4. Eliminate `find_table_pointer()` to save some overhead.
5. 2 histogram bug fixes.
6. pool_next(): New function for iterating memory pool elements. It saves significant time in `table_grow()`.
7. Improve comments.

The CPU saving is several percent for the long sentences batches. (For the `pandp-union` batch is also speedup from the sole change of the initial table size).

For language-learning dicts that have parsing bottlenecks (as opposed to `build_disjuncts()` and other bottlenecks) the speedup may be larger. For example, I tested an old Singularity language-learning dict `v.0.7 2019-03-28 18:54:36 UTC` with its test batch `gc_test_clear.txt` and got ~0% speedup.

I have yet another PR to send for the upcoming release (a diary addition that documents the CPU profiling of the processing of the various corpus batch files).