### PR TITLE
Dictionary #define

### DIFF
--- a/data/ar/4.0.dict
+++ b/data/ar/4.0.dict
@@ -2,7 +2,7 @@
 %
 % Copyright (c) 2006 Warren Casbeer and Jon Dehdari
 %
-#define dictionary-version-number 5.0.1;
+#define dictionary-version-number 5.9.0
 #define dictionary-locale C; % Only the English alphabet is in use here
 
 

--- a/data/ar/4.0.dict
+++ b/data/ar/4.0.dict
@@ -3,7 +3,7 @@
 % Copyright (c) 2006 Warren Casbeer and Jon Dehdari
 %
 #define dictionary-version-number 5.0.1;
-<dictionary-locale>: C+; % Only the English alphabet is in use here
+#define dictionary-locale C; % Only the English alphabet is in use here
 
 
 % Link Types:  [Forms in brackets roughly equate with English Link Grammar]

--- a/data/ar/4.0.dict
+++ b/data/ar/4.0.dict
@@ -2,8 +2,7 @@
 %
 % Copyright (c) 2006 Warren Casbeer and Jon Dehdari
 %
-% Dictionary version number is 5.0.1 (formatted as V5v0v1+)
-<dictionary-version-number>: V5v0v1+;
+#define dictionary-version-number 5.0.1;
 <dictionary-locale>: C+; % Only the English alphabet is in use here
 
 

--- a/data/de/4.0.dict
+++ b/data/de/4.0.dict
@@ -7,7 +7,7 @@
  %                                                                           %
  %***************************************************************************%
 
-#define dictionary-version-number 5.0.2;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         de_DE.UTF-8;
 
 % NOUNS, PRONOUNS

--- a/data/de/4.0.dict
+++ b/data/de/4.0.dict
@@ -7,8 +7,7 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.0.2 (formatted as V5v0v2+)
-<dictionary-version-number>: V5v0v2+;
+#define dictionary-version-number 5.0.2;
 <dictionary-locale>: DE4de+;
 
 % NOUNS, PRONOUNS

--- a/data/de/4.0.dict
+++ b/data/de/4.0.dict
@@ -8,7 +8,7 @@
  %***************************************************************************%
 
 #define dictionary-version-number 5.0.2;
-<dictionary-locale>: DE4de+;
+#define dictionary-locale         de_DE.UTF-8;
 
 % NOUNS, PRONOUNS
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -11,7 +11,7 @@
  %***************************************************************************%
 
 #define dictionary-version-number 5.8.1;
-<dictionary-locale>: EN4us+;
+#define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.
 #define max-disjunct-cost 2.7;

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -14,6 +14,9 @@
 <dictionary-version-number>: V5v8v1+;
 <dictionary-locale>: EN4us+;
 
+% The default largest disjunct cost to consider during parsing.
+#define max-disjunct-cost 2.7;
+
  % _ORGANIZATION OF THE DICTIONARY_
  %
  % I. NOUNS

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -15,6 +15,7 @@
 
 % The default largest disjunct cost to consider during parsing.
 #define max-disjunct-cost 2.7;
+#define max-disjunct-cost 2.7;
 
  % _ORGANIZATION OF THE DICTIONARY_
  %

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10,8 +10,7 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.8.1 (formatted as V5v8v1+)
-<dictionary-version-number>: V5v8v1+;
+#define dictionary-version-number 5.8.1;
 <dictionary-locale>: EN4us+;
 
 % The default largest disjunct cost to consider during parsing.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10,7 +10,7 @@
  %                                                                           %
  %***************************************************************************%
 
-#define dictionary-version-number 5.8.1;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -20,7 +20,7 @@ changecom(`%')
  %***************************************************************************%
 
 #define dictionary-version-number 5.8.1;
-<dictionary-locale>: EN4us+;
+#define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.
 #define max-disjunct-cost 2.7;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -19,8 +19,7 @@ changecom(`%')
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.8.1 (formatted as V5v8v1+)
-<dictionary-version-number>: V5v8v1+;
+#define dictionary-version-number 5.8.1;
 <dictionary-locale>: EN4us+;
 
 % The default largest disjunct cost to consider during parsing.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -19,7 +19,7 @@ changecom(`%')
  %                                                                           %
  %***************************************************************************%
 
-#define dictionary-version-number 5.8.1;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -23,6 +23,9 @@ changecom(`%')
 <dictionary-version-number>: V5v8v1+;
 <dictionary-locale>: EN4us+;
 
+% The default largest disjunct cost to consider during parsing.
+#define max-disjunct-cost 2.7;
+
  % _ORGANIZATION OF THE DICTIONARY_
  %
  % I. NOUNS

--- a/data/fa/4.0.dict
+++ b/data/fa/4.0.dict
@@ -11,7 +11,7 @@
 %*****************************************************************************
 
 #define dictionary-version-number 5.0.1;
-<dictionary-locale>: FA4ir+;
+#define dictionary-locale         fa_IR.UTF-8;
 
 % PERSIAN SYNTAX NOTES:
 %	-Normal Order:	(S) (PP) (O) V

--- a/data/fa/4.0.dict
+++ b/data/fa/4.0.dict
@@ -10,7 +10,7 @@
 %
 %*****************************************************************************
 
-#define dictionary-version-number 5.0.1;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         fa_IR.UTF-8;
 
 % PERSIAN SYNTAX NOTES:

--- a/data/fa/4.0.dict
+++ b/data/fa/4.0.dict
@@ -10,8 +10,7 @@
 %
 %*****************************************************************************
 
-% Dictionary version number is 5.0.1 (formatted as V5v0v1+)
-<dictionary-version-number>: V5v0v1+;
+#define dictionary-version-number 5.0.1;
 <dictionary-locale>: FA4ir+;
 
 % PERSIAN SYNTAX NOTES:

--- a/data/he/4.0.dict
+++ b/data/he/4.0.dict
@@ -40,8 +40,7 @@
 % Among numerous other things, changes to handle count/uncountable changes
 % have not been done yet. The created infrastructure for that may still need changes.
 
-% Dictionary version number is 5.3.15 (formatted as V5v3v15+)
-<dictionary-version-number>: V5v3v15+;
+#define dictionary-version-number 5.3.15;
 <dictionary-locale>: HE4il+;
 
 % For now.

--- a/data/he/4.0.dict
+++ b/data/he/4.0.dict
@@ -40,7 +40,7 @@
 % Among numerous other things, changes to handle count/uncountable changes
 % have not been done yet. The created infrastructure for that may still need changes.
 
-#define dictionary-version-number 5.3.15;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         he_IL.UTF-8;
 
 % For now.

--- a/data/he/4.0.dict
+++ b/data/he/4.0.dict
@@ -41,7 +41,7 @@
 % have not been done yet. The created infrastructure for that may still need changes.
 
 #define dictionary-version-number 5.3.15;
-<dictionary-locale>: HE4il+;
+#define dictionary-locale         he_IL.UTF-8;
 
 % For now.
 LEFT-WALL: {Wa+} or {Wd+} or ();

--- a/data/id/4.0.dict
+++ b/data/id/4.0.dict
@@ -7,8 +7,7 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.4.5 (formatted as V5v4v5+)
-<dictionary-version-number>: V5v4v5+;
+#define dictionary-version-number 5.4.5;
 <dictionary-locale>: ID4id+;
 
 anjing kucing wanita cewek pria cowok lelaki laki-laki taman lapangan tulang

--- a/data/id/4.0.dict
+++ b/data/id/4.0.dict
@@ -7,7 +7,7 @@
  %                                                                           %
  %***************************************************************************%
 
-#define dictionary-version-number 5.4.5;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         id_ID.UTF-8;
 
 anjing kucing wanita cewek pria cowok lelaki laki-laki taman lapangan tulang

--- a/data/id/4.0.dict
+++ b/data/id/4.0.dict
@@ -8,7 +8,7 @@
  %***************************************************************************%
 
 #define dictionary-version-number 5.4.5;
-<dictionary-locale>: ID4id+;
+#define dictionary-locale         id_ID.UTF-8;
 
 anjing kucing wanita cewek pria cowok lelaki laki-laki taman lapangan tulang
 tetangga toko jalan burung palu hidung pesta teman rumah film sinetron kakak adik

--- a/data/kz/4.0.dict
+++ b/data/kz/4.0.dict
@@ -2,8 +2,7 @@
 % Kazakh dictionary -- experimental -- 2016
 % -- Tatiana Batura, Aigerim Bakiyeva, Aigerim Yerimbetova
 %
-% Dictionary version number is 5.3.15 (formatted as V5v3v15+)
-<dictionary-version-number>: V5v3v15+;
+#define dictionary-version-number 5.3.15;
 <dictionary-locale>: KK4kz+;
 
 мен.pron: {W-} & S1s+;

--- a/data/kz/4.0.dict
+++ b/data/kz/4.0.dict
@@ -3,7 +3,7 @@
 % -- Tatiana Batura, Aigerim Bakiyeva, Aigerim Yerimbetova
 %
 #define dictionary-version-number 5.3.15;
-<dictionary-locale>: KK4kz+;
+#define dictionary-locale         kk_KZ.UTF-8;
 
 мен.pron: {W-} & S1s+;
 сен.pron: {W-} & S2s+;

--- a/data/kz/4.0.dict
+++ b/data/kz/4.0.dict
@@ -2,7 +2,7 @@
 % Kazakh dictionary -- experimental -- 2016
 % -- Tatiana Batura, Aigerim Bakiyeva, Aigerim Yerimbetova
 %
-#define dictionary-version-number 5.3.15;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         kk_KZ.UTF-8;
 
 мен.pron: {W-} & S1s+;

--- a/data/lt/4.0.dict
+++ b/data/lt/4.0.dict
@@ -11,8 +11,7 @@
 % If editing with "vi", be sure to "set encoding=utf-8"
 % and also be sure to configure the terminal to use utf-8 encoding.
 %
-% Dictionary version number is 5.1.0 (formatted as V5v1v0+)
-<dictionary-version-number>: V5v1v0+;
+#define dictionary-version-number 5.1.0;
 <dictionary-locale>: LT4lt+;
 
 % Ženklai:

--- a/data/lt/4.0.dict
+++ b/data/lt/4.0.dict
@@ -12,7 +12,7 @@
 % and also be sure to configure the terminal to use utf-8 encoding.
 %
 #define dictionary-version-number 5.1.0;
-<dictionary-locale>: LT4lt+;
+#define dictionary-locale         lt_LT.UTF-8;
 
 % Ženklai:
 % Ą Č Ę Ė Į Š Ų Ū Ž

--- a/data/lt/4.0.dict
+++ b/data/lt/4.0.dict
@@ -11,7 +11,7 @@
 % If editing with "vi", be sure to "set encoding=utf-8"
 % and also be sure to configure the terminal to use utf-8 encoding.
 %
-#define dictionary-version-number 5.1.0;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         lt_LT.UTF-8;
 
 % Ženklai:

--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -7,8 +7,7 @@
 %%
 %% This file uses the utf8 encoding
 
-%% Dictionary version number is 5.3.15 (formatted as V5v3v15+)
-<dictionary-version-number>: V5v3v15+;
+#define dictionary-version-number 5.3.15;
 <dictionary-locale>: RU4ru+;
 
 <costly-null>: [[[[]]]];

--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -8,7 +8,7 @@
 %% This file uses the utf8 encoding
 
 #define dictionary-version-number 5.3.15;
-<dictionary-locale>: RU4ru+;
+#define dictionary-locale         ru_RU.UTF-8;
 
 <costly-null>: [[[[]]]];
 

--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -7,7 +7,7 @@
 %%
 %% This file uses the utf8 encoding
 
-#define dictionary-version-number 5.3.15;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         ru_RU.UTF-8;
 
 <costly-null>: [[[[]]]];

--- a/data/tr/4.0.dict
+++ b/data/tr/4.0.dict
@@ -1,8 +1,7 @@
 %
 % Turkish dictionary -- experimental -- 2016 -- Tatiana Batura, Maria Mitkovskaya, Natalya Semenova
 %
-% Dictionary version number is 5.3.15 (formatted as V5v3v15+)
-<dictionary-version-number>: V5v3v15+;
+#define dictionary-version-number 5.3.15;
 <dictionary-locale>: TR4tr+;
 
 % adjectives

--- a/data/tr/4.0.dict
+++ b/data/tr/4.0.dict
@@ -2,7 +2,7 @@
 % Turkish dictionary -- experimental -- 2016 -- Tatiana Batura, Maria Mitkovskaya, Natalya Semenova
 %
 #define dictionary-version-number 5.3.15;
-<dictionary-locale>: TR4tr+;
+#define dictionary-locale         tr_TR.UTF-8;
 
 % adjectives
 kırmızı şişman hasta kızgın güzel genç yasli iyi kötü hos üzücü mutlu aç siyah beyaz mavi yeşil mor pembe sarı: {AO+};

--- a/data/tr/4.0.dict
+++ b/data/tr/4.0.dict
@@ -1,7 +1,7 @@
 %
 % Turkish dictionary -- experimental -- 2016 -- Tatiana Batura, Maria Mitkovskaya, Natalya Semenova
 %
-#define dictionary-version-number 5.3.15;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         tr_TR.UTF-8;
 
 % adjectives

--- a/data/vn/4.0.dict
+++ b/data/vn/4.0.dict
@@ -1,6 +1,6 @@
 % Vietnamese Dictionary
 
-#define dictionary-version-number 5.4.5;
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale         vi_VN.UTF-8;
 
 % See https://bitbucket.org/ngocminh/lienkate for the master

--- a/data/vn/4.0.dict
+++ b/data/vn/4.0.dict
@@ -1,7 +1,6 @@
 % Vietnamese Dictionary
 
-% Dictionary version number is 5.4.5 (formatted as V5v4v5+)
-<dictionary-version-number>: V5v4v5+;
+#define dictionary-version-number 5.4.5;
 <dictionary-locale>: VI4vn+;
 
 % See https://bitbucket.org/ngocminh/lienkate for the master

--- a/data/vn/4.0.dict
+++ b/data/vn/4.0.dict
@@ -1,7 +1,7 @@
 % Vietnamese Dictionary
 
 #define dictionary-version-number 5.4.5;
-<dictionary-locale>: VI4vn+;
+#define dictionary-locale         vi_VN.UTF-8;
 
 % See https://bitbucket.org/ngocminh/lienkate for the master
 % project; this includes a version of the link-grammar parser

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "api-structures.h"
+#include "dict-common/dict-defines.h"
 #include "dict-common/dialect.h"
 #include "dict-common/dict-utils.h"
 #include "disjunct-utils.h"             // free_sentence_disjuncts
@@ -88,11 +89,8 @@ Parse_Options parse_options_create(void)
 
 	/* A cost of 2.7 allows the usual cost-2 connectors, plus the
 	 * assorted fractional costs, without going to cost 3.0, which
-	 * is used only during panic-parsing.
-	 * XXX In the long run, this should be fetched from the dictionary
-	 * (and should probably not be a parse option).
-	 */
-	po->disjunct_cost = 2.7;
+	 * is used only during panic-parsing. */
+	po->disjunct_cost = UNINITIALIZED_MAX_DISJUNCT_COST;
 	po->min_null_count = 0;
 	po->max_null_count = 0;
 	po->islands_ok = false;
@@ -596,6 +594,9 @@ int sentence_link_cost(Sentence sent, LinkageIdx i)
 int sentence_parse(Sentence sent, Parse_Options opts)
 {
 	int rc;
+
+	if (opts->disjunct_cost == UNINITIALIZED_MAX_DISJUNCT_COST)
+		opts->disjunct_cost = sent->dict->default_max_disjunct_cost;
 
 	sent->num_valid_linkages = 0;
 

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -305,7 +305,8 @@ void dictionary_delete(Dictionary dict)
 	string_id_delete(dict->dialect_tag.set);
 	if (dict->macro_tag != NULL) free(dict->macro_tag->name);
 	free(dict->macro_tag);
-
+	string_id_delete(dict->define->name);
+	free(dict->define->value);
 	free((void *)dict->suppress_warning);
 	free_regexs(dict->regex_root);
 	free_anysplit(dict);

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -305,8 +305,9 @@ void dictionary_delete(Dictionary dict)
 	string_id_delete(dict->dialect_tag.set);
 	if (dict->macro_tag != NULL) free(dict->macro_tag->name);
 	free(dict->macro_tag);
-	string_id_delete(dict->define->name);
-	free(dict->define->value);
+	string_id_delete(dict->define.set);
+	free(dict->define.name);
+	free(dict->define.value);
 	free((void *)dict->suppress_warning);
 	free_regexs(dict->regex_root);
 	free_anysplit(dict);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -67,6 +67,14 @@ struct Afdict_class_struct
 #define IS_DB_DICT(dict) false
 #endif /* HAVE_SQLITE */
 
+/* "#define name value" */
+typedef struct
+{
+	String_id *name;
+	const char **value;
+	unsigned int size;                 /* Allocated value array size */
+} define_s;
+
 typedef struct
 {
 	String_id *set;                    /* Expression tag names */
@@ -85,6 +93,7 @@ struct Dictionary_s
 	const char * locale;    /* Locale name */
 	locale_t     lctype;    /* Locale argument for the *_l() functions */
 	int          num_entries;
+	define_s     define;    /* Name-value definitions */
 
 	bool         use_unknown_word;
 	bool         unknown_word_defined;

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -70,7 +70,8 @@ struct Afdict_class_struct
 /* "#define name value" */
 typedef struct
 {
-	String_id *name;
+	String_id *set;                    /* "define" name set */
+	const char **name;
 	const char **value;
 	unsigned int size;                 /* Allocated value array size */
 } define_s;

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -92,6 +92,7 @@ struct Dictionary_s
 	const char * lang;
 	const char * version;
 	const char * locale;    /* Locale name */
+	double default_max_disjunct_cost;
 	locale_t     lctype;    /* Locale argument for the *_l() functions */
 	int          num_entries;
 	define_s     define;    /* Name-value definitions */

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -20,10 +20,12 @@
 
 #define UNKNOWN_WORD "<UNKNOWN-WORD>"
 
-/* If the maximum disjunct cost is yet uninitialized, the value defined
- * in the dictionary (or if not defined then DEFAULT_MAX_COST) is used. */
+/* If the maximum disjunct cost is yet uninitialized, the value defined in the
+ * dictionary (or if not defined then DEFAULT_MAX_DISJUNCT_COST) is used. */
 static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
 static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
+/* We need some of these as literal strings. */
+#define LG_DISJUNCT_COST                        "max-disjunct-cost"
 
 /*      Some size definitions.  Reduce these for small machines */
 /* MAX_WORD is large, because Unicode entries can use a lot of space */

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -26,6 +26,7 @@ static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
 static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
 /* We need some of these as literal strings. */
 #define LG_DISJUNCT_COST                        "max-disjunct-cost"
+#define LG_DICTIONARY_VERSION_NUMBER            "dictionary-version-number"
 #define LG_DICTIONARY_LOCALE                    "dictionary-locale"
 
 /*      Some size definitions.  Reduce these for small machines */

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -20,6 +20,11 @@
 
 #define UNKNOWN_WORD "<UNKNOWN-WORD>"
 
+/* If the maximum disjunct cost is yet uninitialized, the value defined
+ * in the dictionary (or if not defined then DEFAULT_MAX_COST) is used. */
+static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
+static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
+
 /*      Some size definitions.  Reduce these for small machines */
 /* MAX_WORD is large, because Unicode entries can use a lot of space */
 #define MAX_WORD 180          /* maximum number of bytes in a word */

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -26,6 +26,7 @@ static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
 static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
 /* We need some of these as literal strings. */
 #define LG_DISJUNCT_COST                        "max-disjunct-cost"
+#define LG_DICTIONARY_LOCALE                    "dictionary-locale"
 
 /*      Some size definitions.  Reduce these for small machines */
 /* MAX_WORD is large, because Unicode entries can use a lot of space */

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -292,6 +292,11 @@ const char * linkgrammar_get_dict_version(Dictionary dict)
 	return dict->version;
 }
 
+double linkgrammar_get_dict_max_disjunct_cost(Dictionary dict)
+{
+	return dict->default_max_disjunct_cost;
+}
+
 /* ======================================================================= */
 
 void dictionary_setup_locale(Dictionary dict)

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -346,6 +346,29 @@ void dictionary_setup_locale(Dictionary dict)
 	dict->locale = string_set_add(dict->locale, dict->string_set);
 }
 
+static bool dictionary_setup_max_disjunct_cost(Dictionary dict)
+{
+	const char *disjunct_cost_str =
+		linkgrammar_get_dict_define(dict, LG_DISJUNCT_COST);
+	if (NULL == disjunct_cost_str)
+	{
+		dict->default_max_disjunct_cost = DEFAULT_MAX_DISJUNCT_COST;
+	}
+	else
+	{
+		float disjunct_cost_value;
+		if (!strtodC(disjunct_cost_str, &disjunct_cost_value))
+		{
+			prt_error("Error: %s: Invalid cost \"%s\"", LG_DISJUNCT_COST,
+			          disjunct_cost_str);
+			return false;
+		}
+		dict->default_max_disjunct_cost = disjunct_cost_value;
+	}
+
+	return true;
+}
+
 /**
  * Perform initializations according to definitions in the dictionary.
  * There are 3 kind of definitions:
@@ -372,6 +395,8 @@ bool dictionary_setup_defines(Dictionary dict)
 	}
 
 	dict->shuffle_linkages = false;
+
+	if (!dictionary_setup_max_disjunct_cost(dict)) return false;
 
 	return true;
 }

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -342,7 +342,7 @@ double linkgrammar_get_dict_max_disjunct_cost(Dictionary dict)
 
 /* ======================================================================= */
 
-void dictionary_setup_locale(Dictionary dict)
+static void dictionary_setup_locale(Dictionary dict)
 {
 	/* Get the locale for the dictionary. The first one of the
 	 * following which exists, is used:
@@ -445,6 +445,7 @@ bool dictionary_setup_defines(Dictionary dict)
 	dict->shuffle_linkages = false;
 
 	if (!dictionary_setup_max_disjunct_cost(dict)) return false;
+	dictionary_setup_locale(dict);
 
 	return true;
 }

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -346,7 +346,16 @@ void dictionary_setup_locale(Dictionary dict)
 	dict->locale = string_set_add(dict->locale, dict->string_set);
 }
 
-void dictionary_setup_defines(Dictionary dict)
+/**
+ * Perform initializations according to definitions in the dictionary.
+ * There are 3 kind of definitions:
+ * 1. Special expressions.
+ * 2. #define name value;
+ * 3. Currently not in the dictionary (FIXME).
+ *
+ * @return \c true on success, \c false on failure.
+ */
+bool dictionary_setup_defines(Dictionary dict)
 {
 	dict->left_wall_defined  = dict_has_word(dict, LEFT_WALL_WORD);
 	dict->right_wall_defined = dict_has_word(dict, RIGHT_WALL_WORD);
@@ -363,6 +372,8 @@ void dictionary_setup_defines(Dictionary dict)
 	}
 
 	dict->shuffle_linkages = false;
+
+	return true;
 }
 
 /* ======================================================================= */

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -171,6 +171,7 @@ static const char * format_locale(Dictionary dict,
  * - Else use the locale from the environment.
  * - On Windows, if no environment locale use the default locale.
  *
+ * Old style dictionary domain definition:
  * <dictionary-locale>: LL4cc+;
  * LL is the ISO639 language code in uppercase,
  * cc is the ISO3166 territory code in lowercase.
@@ -179,6 +180,10 @@ static const char * format_locale(Dictionary dict,
  * For transliterated dictionaries:
  * <dictionary-locale>: C+;
  *
+ * New style dictionary domain definition:
+ * #define dictionary-locale ll-CC;
+ * #define dictionary-locale C;
+ *
  * @param dict The dictionary for which the locale is needed.
  * @return The locale, in a format suitable for use by setlocale().
  */
@@ -186,34 +191,60 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 {
 	if (dict->locale) return dict->locale;
 
-	const char *locale;
-	Dict_node *dn = dict->lookup_list(dict, "<dictionary-locale>");
+	Dict_node *dn = NULL;
+	const char *locale =
+		linkgrammar_get_dict_define(dict, LG_DICTIONARY_LOCALE);
 
-	if (NULL == dn)
+	if (NULL == locale)
 	{
-		lgdebug(D_USER_FILES, "Debug: Dictionary '%s': Locale is not defined.\n",
-		        dict->name);
-		goto locale_error;
+		dn = dict->lookup_list(dict, "<"LG_DICTIONARY_LOCALE">");
+		if (NULL == dn)
+		{
+			lgdebug(D_USER_FILES, "Debug: Dictionary '%s': Locale is not defined.\n",
+			        dict->name);
+			goto locale_error;
+		}
+		else
+		{
+			locale = dn->exp->condesc->string;
+		}
 	}
 
-	if (0 == strcmp(dn->exp->condesc->string, "C"))
+	if (0 == strcmp(locale, "C"))
 	{
 		locale = string_set_add("C", dict->string_set);
 	}
 	else
 	{
-		char c;
-		char locale_ll[4], locale_cc[3];
-		int locale_numelement = sscanf(dn->exp->condesc->string, "%3[A-Z]4%2[a-z]%c",
-										locale_ll, locale_cc, &c);
-		if (2 != locale_numelement)
+		char locale_ll[4], locale_cc[3], c;
+
+		if (NULL == dn)
 		{
-			prt_error("Error: \"<dictionary-locale>: %s\" "
-			          "should be in the form LL4cc+\n"
-						 "\t(LL: language code; cc: territory code) "
-						 "\tor C+ for transliterated dictionaries.\n",
-						 dn->exp->condesc->string);
-			goto locale_error;
+			int locale_numelement = sscanf(locale, "%3[a-z]_%2[A-Z].UTF-8%c",
+			                               locale_ll, locale_cc, &c);
+			if (2 != locale_numelement)
+			{
+				prt_error("Error: "LG_DICTIONARY_LOCALE": \"%s\" "
+				          "should be in the form ll_CC.UTF-8\n"
+				          "\t(ll: language code; CC: territory code) "
+				          "or \"C\" for transliterated dictionaries.\n",
+				          locale);
+				goto locale_error;
+			}
+		}
+		else
+		{
+			int locale_numelement = sscanf(locale, "%3[A-Z]4%2[a-z]%c",
+			                               locale_ll, locale_cc, &c);
+			if (2 != locale_numelement)
+			{
+				prt_error("Error: <"LG_DICTIONARY_LOCALE">: \"%s\" "
+				          "should be in the form LL4cc+\n"
+				          "\t(LL: language code; cc: territory code) "
+				          "or \"C\" for transliterated dictionaries.\n",
+				          locale);
+				goto locale_error;
+			}
 		}
 
 		locale = format_locale(dict, locale_ll, locale_cc);
@@ -226,7 +257,8 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 		}
 	}
 
-	dict->free_lookup(dict, dn);
+
+	if (NULL != dn) dict->free_lookup(dict, dn);
 	lgdebug(D_USER_FILES, "Debug: Dictionary locale: \"%s\"\n", locale);
 	dict->locale = locale;
 	return locale;

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -21,6 +21,7 @@
 #include "regex-morph.h"
 #include "dict-structures.h"
 #include "string-set.h"
+#include "string-id.h"
 #include "utilities.h"
 
 /* ======================================================================= */
@@ -60,6 +61,16 @@ int callGetLocaleInfoEx(LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, in
 #else
 #define callGetLocaleInfoEx GetLocaleInfoEx
 #endif // _WINVER == 0x501
+
+/* ======================================================================= */
+
+const char *linkgrammar_get_dict_define(Dictionary dict, const char *name)
+{
+	if (IS_DB_DICT(dict)) return NULL; /* Not supported yet */
+	unsigned int id = string_id_lookup(name, dict->define.set);
+	if (id == 0) return NULL;
+	return dict->define.value[id - 1];
+}
 
 /* ======================================================================= */
 

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -262,19 +262,30 @@ const char * linkgrammar_get_version(void)
 
 const char * linkgrammar_get_dict_version(Dictionary dict)
 {
+	if (dict->version) return dict->version;
+
+	const char *version =
+		linkgrammar_get_dict_define(dict, LG_DICTIONARY_VERSION_NUMBER);
+	if (NULL != version)
+	{
+		dict->version = version;
+		return dict->version;
+	}
+
+	/* Original code is left for backward compatibility. Note that the
+	 * check for now version should be moved up if it is ever removed. */
+
 	char * ver;
 	char * p;
 	Dict_node *dn;
 	Exp *e;
-
-	if (dict->version) return dict->version;
 
 	/* The newer dictionaries should contain a macro of the form:
 	 * <dictionary-version-number>: V4v6v6+;
 	 * which would indicate dictionary version 4.6.6
 	 * Older dictionaries contain no version info.
 	 */
-	dn = dict->lookup_list(dict, "<dictionary-version-number>");
+	dn = dict->lookup_list(dict, "<"LG_DICTIONARY_VERSION_NUMBER">");
 	if (NULL == dn) return "[unknown]";
 
 	e = dn->exp;

--- a/link-grammar/dict-common/dict-impl.h
+++ b/link-grammar/dict-common/dict-impl.h
@@ -9,7 +9,7 @@
 // const char * linkgrammar_get_dict_version(Dictionary dict);
 
 void dictionary_setup_locale(Dictionary dict);
-void dictionary_setup_defines(Dictionary dict);
+bool dictionary_setup_defines(Dictionary dict);
 void afclass_init(Dictionary dict);
 bool afdict_init(Dictionary dict);
 void affix_list_add(Dictionary afdict, Afdict_class *, const char *);

--- a/link-grammar/dict-common/dict-impl.h
+++ b/link-grammar/dict-common/dict-impl.h
@@ -8,7 +8,6 @@
 // const char * linkgrammar_get_version(void);
 // const char * linkgrammar_get_dict_version(Dictionary dict);
 
-void dictionary_setup_locale(Dictionary dict);
 bool dictionary_setup_defines(Dictionary dict);
 void afclass_init(Dictionary dict);
 bool afdict_init(Dictionary dict);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -148,7 +148,7 @@ dictionary_six_str(const char * lang,
 			memset(dict->macro_tag, 0, sizeof(*dict->macro_tag));
 		}
 
-		dict->define->name = string_id_create();
+		dict->define.set = string_id_create();
 	}
 	else
 	{

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -233,7 +233,9 @@ dictionary_six_str(const char * lang,
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	dict->hpsg_knowledge  = pp_knowledge_open(cons_name);
 
-	dictionary_setup_defines(dict);
+	if (!dictionary_setup_defines(dict))
+		goto failure;
+
 	condesc_setup(dict);
 
 	// Special-case hack.

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -147,6 +147,8 @@ dictionary_six_str(const char * lang,
 			dict->macro_tag = malloc(sizeof(*dict->macro_tag));
 			memset(dict->macro_tag, 0, sizeof(*dict->macro_tag));
 		}
+
+		dict->define->name = string_id_create();
 	}
 	else
 	{

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -16,6 +16,7 @@
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"
+#include "dict-common/dict-defines.h"
 #include "dict-common/dict-impl.h"
 #include "dict-common/dict-utils.h"
 #include "dict-common/file-utils.h"

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -196,7 +196,8 @@ dictionary_six_str(const char * lang,
 		dict->dialect_tag.set = NULL;
 	}
 
-	dictionary_setup_locale(dict);
+	if (!dictionary_setup_defines(dict))
+		goto failure;
 
 	dict->affix_table = dictionary_six(lang, affix_name, NULL, NULL, NULL, NULL);
 	if (dict->affix_table == NULL)
@@ -233,9 +234,6 @@ dictionary_six_str(const char * lang,
 
 	dict->base_knowledge  = pp_knowledge_open(pp_name);
 	dict->hpsg_knowledge  = pp_knowledge_open(cons_name);
-
-	if (!dictionary_setup_defines(dict))
-		goto failure;
 
 	condesc_setup(dict);
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1633,15 +1633,25 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 
 static void add_define(Dictionary dict, const char *name, const char *value)
 {
-	dict->define.size++;
-	dict->define.value =
-		realloc(dict->define.value, dict->define.size * sizeof(char *));
-	dict->define.name =
-		realloc(dict->define.name, dict->define.size * sizeof(char *));
 	int id = string_id_add(name, dict->define.set);
-	assert(dict->define.size == (unsigned int)id,
-	       "\"define\" array size inconsistency");
-	dict->define.name[id - 1] = string_set_add(name, dict->string_set);
+
+	if (!IS_DB_DICT(dict) && (dict->define.size >= (unsigned int)id))
+	{
+		prt_error("Warning: Redefinition of \"%s\", "
+		          "found near line %d of \"%s\"\n",
+		          name, dict->line_number, dict->name);
+	}
+	else
+	{
+		dict->define.size++;
+		dict->define.value =
+			realloc(dict->define.value, dict->define.size * sizeof(char *));
+		dict->define.name =
+			realloc(dict->define.name, dict->define.size * sizeof(char *));
+		assert(dict->define.size == (unsigned int)id,
+		       "\"define\" array size inconsistency");
+		dict->define.name[id - 1] = string_set_add(name, dict->string_set);
+	}
 	dict->define.value[id - 1] = string_set_add(value, dict->string_set);
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1631,6 +1631,20 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	insert_list(dict, dn_second_half, l-k-1);
 }
 
+static void add_define(Dictionary dict, const char *name, const char *value)
+{
+	dict->define.size++;
+	dict->define.value =
+		realloc(dict->define.value, dict->define.size * sizeof(char *));
+	dict->define.name =
+		realloc(dict->define.name, dict->define.size * sizeof(char *));
+	int id = string_id_add(name, dict->define.set);
+	assert(dict->define.size == (unsigned int)id,
+	       "\"define\" array size inconsistency");
+	dict->define.name[id - 1] = string_set_add(name, dict->string_set);
+	dict->define.value[id - 1] = string_set_add(value, dict->string_set);
+}
+
 /**
  * read_entry() -- read one dictionary entry
  * Starting with the current token, parse one dictionary entry.
@@ -1729,6 +1743,22 @@ static bool read_entry(Dictionary dict)
 
 			return true;
 		}
+		else if (0 == strcmp(dict->token, "#define"))
+		{
+			if (!link_advance(dict)) goto syntax_error;
+			const char *name = strdupa(dict->token);
+
+			/* Get the value. */
+			if (!link_advance(dict)) goto syntax_error;
+			add_define(dict, name, dict->token);
+
+			if (!link_advance(dict)) goto syntax_error;
+			if (!is_equal(dict, ';'))
+			{
+				dict_error(dict, "Expecting \";\" at the end of #define.");
+				goto syntax_error;
+			}
+		}
 		else
 		{
 			Dict_node * dn_new = dict_node_new();
@@ -1802,6 +1832,16 @@ syntax_error:
 	return false;
 }
 
+void print_dictionary_defines(Dictionary dict)
+{
+	for (size_t i = 0; i < dict->define.size; i++)
+	{
+		const char *value = dict->define.value[i];
+		int q = (int)(strcspn(value, SPECIAL) == strlen(value));
+		printf("#define %s %s%s%s\n",
+		       dict->define.name[i], &"\""[q], value, &"\""[q]);
+	}
+}
 
 static void rprint_dictionary_data(Dict_node * n)
 {

--- a/link-grammar/dict-file/read-dict.h
+++ b/link-grammar/dict-file/read-dict.h
@@ -17,6 +17,7 @@
 
 void print_dictionary_data(Dictionary dict);
 void print_dictionary_words(Dictionary dict);
+void print_dictionary_defines(Dictionary dict);
 
 Dictionary dictionary_six(const char *lang, const char *dict_name,
                           const char *pp_name, const char *cons_name,

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -499,8 +499,6 @@ Dictionary dictionary_create_from_db(const char *lang)
 	if (!afdict_init(dict))
 		goto failure;
 
-	dictionary_setup_locale(dict);
-
 	if (!dictionary_setup_defines(dict))
 		goto failure;
 

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -501,7 +501,8 @@ Dictionary dictionary_create_from_db(const char *lang)
 
 	dictionary_setup_locale(dict);
 
-	dictionary_setup_defines(dict);
+	if (!dictionary_setup_defines(dict))
+		goto failure;
 
 	return dict;
 

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -3,6 +3,7 @@ linkgrammar_get_configuration
 linkgrammar_open_data_file
 linkgrammar_get_dict_version
 linkgrammar_get_dict_locale
+linkgrammar_get_dict_definition
 dictionary_create_lang
 dictionary_create_default_lang
 dictionary_get_lang

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -55,6 +55,9 @@ link_public_api(const char *)
 link_public_api(const char *)
 	linkgrammar_get_dict_define(Dictionary, const char *);
 
+link_public_api(double)
+	linkgrammar_get_dict_max_disjunct_cost(Dictionary);
+
 /**********************************************************************
  *
  * Functions and definitions for the error handler.

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -52,6 +52,9 @@ link_public_api(const char *)
 link_public_api(const char *)
 	linkgrammar_get_dict_locale(Dictionary);
 
+link_public_api(const char *)
+	linkgrammar_get_dict_define(Dictionary, const char *);
+
 /**********************************************************************
  *
  * Functions and definitions for the error handler.


### PR DESCRIPTION
See issue #785.

- Add dict support for `#define name value;`.
- Convert the domain and locale definitions to use `#define`.
- Accept also the old-style domain and locale definition support (for backward compatibility).
- Add support for reading the max-cost from the dict.
- Define max-cost only for the `en` dict for now. The other dicts are to be updated later.

The correct naming of some variables and definitions (as I mentioned in issue #785) was not clear to me and may need updates.