### PR TITLE
Panic mode fixes + SIGWINCH handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,7 @@ AC_LANG([C])
 
 AC_C_CONST
 
-AC_CHECK_FUNCS(strndup strtok_r)
+AC_CHECK_FUNCS(strndup strtok_r sigaction)
 AC_CHECK_FUNCS(aligned_alloc posix_memalign _aligned_malloc)
 
 AC_FUNC_ALLOCA

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -423,7 +423,7 @@ Here are their names, roles and initial values, as shown by
  Variable             Controls                              Default value
  --------             --------                              -------------
  panic_short          Max length of all links                          12
- panic_cost-max       Largest cost to be considered                  4.00
+ panic_cost-max       Largest cost to be considered                  4.00 [*]
  panic_limit          The maximum linkages processed                 1000
  panic_max-null-count Max number of null links allowed                 10
  panic_spell          Up to this many spell-guesses per unknown word    0
@@ -431,12 +431,13 @@ Here are their names, roles and initial values, as shown by
 
 Their values are used in panic mode according to the following rules:
 
- !panic_short          - replaces !short if its value is lower.
- !panic_cost-max       - replaces !cost-max if its value is higher [*].
+ !panic_short          - replaces !short if its value is lower. [**]
+ !panic_cost-max       - replaces !cost-max if its value is higher.
  !panic_limit          - replaces !limit if its value is lower.
  !panic_max-null-count - the maximum allowed null links.
  !panic_spell          - replaces !spell if its value is lower.
  !panic_timeout        - the timeout of the panic mode parsing.
 
-[*] The library all_short_connectors parse option is always set in panic
-mode, so !short determines the maximum length of all the links.
+[*]  Unless set in the dictionary to another value.
+[**] The library all_short_connectors parse option is always set in panic
+mode, so !panic_short determines the maximum length of all the links.

--- a/data/command-help-en.txt
+++ b/data/command-help-en.txt
@@ -144,7 +144,7 @@ possible number of null links.
 If enabled, then a "panic-mode" will be entered when a parse cannot be
 found within the time limit set by !timeout. When in panic mode, various
 parse options are loosened so that a less accurate parse can be found
-quickly.
+quickly. See "!help panic_variables" for info on these parse options.
 
 [use-sat]
 Use the Boolean-SAT parser instead of the traditional parser. The SAT
@@ -406,3 +406,37 @@ In this sample output:
 These variables affect the output:
 Disjuncts, expressions: !dialect
 Disjuncts only:         !cost-max
+
+[panic_variables]
+Show the variables that may take effect in panic mode (see "!help panic")
+and their current values.  They may replace the value of the similar named
+variables (without the prefix "panic_") according to certain replacement
+rules - see "!help panic_timeout".
+
+[panic_short,panic_cost-max,panic_limit,panic_max-null-count,panic_spell,panic_timeout]
+The following variables are panic mode variables, meaning that they may take
+effect in panic mode according to the rules that are listed below.
+
+Here are their names, roles and initial values, as shown by
+!panic_variables:
+
+ Variable             Controls                              Default value
+ --------             --------                              -------------
+ panic_short          Max length of all links                          12
+ panic_cost-max       Largest cost to be considered                  4.00
+ panic_limit          The maximum linkages processed                 1000
+ panic_max-null-count Max number of null links allowed                 10
+ panic_spell          Up to this many spell-guesses per unknown word    0
+ panic_timeout        Abort panic parsing after this many seconds      30
+
+Their values are used in panic mode according to the following rules:
+
+ !panic_short          - replaces !short if its value is lower.
+ !panic_cost-max       - replaces !cost-max if its value is higher [*].
+ !panic_limit          - replaces !limit if its value is lower.
+ !panic_max-null-count - the maximum allowed null links.
+ !panic_spell          - replaces !spell if its value is lower.
+ !panic_timeout        - the timeout of the panic mode parsing.
+
+[*] The library all_short_connectors parse option is always set in panic
+mode, so !short determines the maximum length of all the links.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -14,8 +14,8 @@
 #define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.
-#define max-disjunct-cost 2.7;
-#define max-disjunct-cost 2.7;
+#define max-disjunct-cost         2.7;
+#define panic-max-disjunct-cost   4.0;
 
  % _ORGANIZATION OF THE DICTIONARY_
  %

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -23,7 +23,8 @@ changecom(`%')
 #define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.
-#define max-disjunct-cost 2.7;
+#define max-disjunct-cost         2.7;
+#define panic-max-disjunct-cost   4.0;
 
  % _ORGANIZATION OF THE DICTIONARY_
  %

--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -9,6 +9,8 @@
 
 #define dictionary-version-number 5.9.0;
 #define dictionary-locale         ru_RU.UTF-8;
+#define max-disjunct-cost         2.7;
+#define panic_max-disjunct-cost   4.0;
 
 <costly-null>: [[[[]]]];
 

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -669,8 +669,10 @@ int sentence_parse(Sentence sent, Parse_Options opts)
  * Definitions for linkgrammar_get_configuration().
  */
 
+#define MACVAL(macro) #macro lg_str(=macro) " "
+
 #ifdef __STDC_VERSION__
-#define LG_S1 "__STDC_VERSION__=" lg_xstr(__STDC_VERSION__)
+#define LG_S1 MACVAL(__STDC_VERSION__)
 #else
 #define LG_S1
 #endif
@@ -685,13 +687,13 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 #endif
 
 #ifdef __VERSION__
-#define LG_V1 "__VERSION__=" lg_xstr(__VERSION__)
+#define LG_V1 MACVAL(__VERSION__)
 #else
 #define LG_V1
 #endif
 
 #ifdef _MSC_FULL_VER
-#define LG_V2 "_MSC_FULL_VER=" lg_xstr(_MSC_FULL_VER)
+#define LG_V2 MACVAL(_MSC_FULL_VER)
 #else
 #define LG_V2
 #endif

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -677,6 +677,22 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 #define LG_S1
 #endif
 
+#ifdef _POSIX_C_SOURCE
+#define LG_S2 MACVAL(_POSIX_C_SOURCE)
+#else
+#define LG_S2
+#endif
+
+#if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE == 0
+ #ifdef _POSIX_SOURCE
+ #define LG_S3 MACVAL(_POSIX_SOURCE)
+ #else
+ #define LG_S3
+ #endif
+#else
+#define LG_S3
+#endif
+
 /* -DCC=$(CC) is added in the Makefile. */
 #ifdef CC
 #define LG_CC CC
@@ -699,7 +715,7 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 #endif
 
 #define LG_COMP LG_CC " " LG_V1 " " LG_V2
-#define LG_STD LG_S1
+#define LG_STD LG_S1 LG_S2 LG_S3
 
 #ifdef __unix__
 #define LG_unix "__unix__ "

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -52,11 +52,13 @@ link_public_api(const char *)
 link_public_api(const char *)
 	linkgrammar_get_dict_locale(Dictionary);
 
-link_public_api(const char *)
-	linkgrammar_get_dict_define(Dictionary, const char *);
-
 link_public_api(double)
 	linkgrammar_get_dict_max_disjunct_cost(Dictionary);
+
+#define LG_PANIC_DISJUNCT_COST "panic-max-disjunct-cost"
+
+link_public_api(const char *)
+	linkgrammar_get_dict_define(Dictionary, const char *);
 
 /**********************************************************************
  *

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -568,11 +568,11 @@ static bool is_panic(count_context_t *ctxt)
 	 * exhausted.  checktimer is a device to avoid a gazillion system calls
 	 * to get the timer value. On circa-2018 machines, it results in
 	 * several timer calls per second. */
+	if (ctxt->exhausted) return true;
 	ctxt->checktimer++;
-	if (ctxt->exhausted || ((0 == ctxt->checktimer%(1<<18)) &&
-	                        (ctxt->current_resources != NULL) &&
-	                        //fprintf(stderr, "T") &&
-	                        resources_exhausted(ctxt->current_resources)))
+	if (((0 == ctxt->checktimer%(1<<18)) && (ctxt->current_resources != NULL) &&
+	     //fprintf(stderr, "T") &&
+	     resources_exhausted(ctxt->current_resources)))
 	{
 		ctxt->exhausted = true;
 		return true;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -569,7 +569,7 @@ static bool is_panic(count_context_t *ctxt)
 	 * to get the timer value. On circa-2018 machines, it results in
 	 * several timer calls per second. */
 	ctxt->checktimer++;
-	if (ctxt->exhausted || ((0 == ctxt->checktimer%(1<<22)) &&
+	if (ctxt->exhausted || ((0 == ctxt->checktimer%(1<<18)) &&
 	                        (ctxt->current_resources != NULL) &&
 	                        //fprintf(stderr, "T") &&
 	                        resources_exhausted(ctxt->current_resources)))

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -408,6 +408,15 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		           sent->num_linkages_found, sent->null_count,
 		           (sent->null_count != 1) ? "s" : "");
 
+		/* In case of a timeout, the linkage is partial and may be
+		 * inconsistent. It is also usually different on each run.
+		 * So in that case, pretend that the linkage count is 0. */
+		if (resources_exhausted(opts->resources))
+		{
+			sent->num_linkages_found = 0;
+			goto parse_end_cleanup;
+		}
+
 		free_tracon_sharing(ts_parsing);
 		ts_parsing = NULL;
 
@@ -419,6 +428,13 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			free_extractor(pex);
 
 			post_process_lkgs(sent, opts);
+			if (resources_exhausted(opts->resources))
+			{
+				sent->num_linkages_found = 0;
+				sent->num_valid_linkages = 0;
+				sent->num_linkages_post_processed = 0;
+				goto parse_end_cleanup;
+			}
 
 			if (sent->num_valid_linkages > 0) break;
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -229,6 +229,13 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
 	print_time(opts, "Sorted all linkages");
 }
 
+static void notify_no_complete_linkages(unsigned int null_count,
+                                        unsigned int max_null_count)
+{
+		if ((0 == null_count) && (0 < max_null_count) && verbosity > 0)
+			prt_error("No complete linkages found.\n");
+}
+
 /**
  * classic_parse() -- parse the given sentence.
  * Perform parsing, using the original link-grammar parsing algorithm
@@ -350,6 +357,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 					else
 						prt_error("null%s)\n", (nl != 1) ? "s" : "");
 				}
+				notify_no_complete_linkages(nl, max_null_count);
 				nl = expexted_null_count-1;
 				/* To get a result, parse w/null count which is at most one less
 				 * than the number of tokens (w/all nulls there is no linkage). */
@@ -427,8 +435,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			}
 		}
 
-		if ((0 == nl) && (0 < max_null_count) && verbosity > 0)
-			prt_error("No complete linkages found.\n");
+		notify_no_complete_linkages(nl, max_null_count);
 	}
 	sort_linkages(sent, opts);
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -397,7 +397,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			}
 
 			gword_record_in_connector(sent);
-			if (resources_exhausted(opts->resources)) goto parse_end_cleanup;
 
 			free_count_context(ctxt, sent);
 			ctxt = alloc_count_context(sent);
@@ -405,9 +404,9 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			free_fast_matcher(sent, mchxt);
 			mchxt = alloc_fast_matcher(sent, ncu);
 			print_time(opts, "Initialized fast matcher");
+			if (resources_exhausted(opts->resources)) goto parse_end_cleanup;
 		}
 
-		if (resources_exhausted(opts->resources)) goto parse_end_cleanup;
 		free_linkages(sent);
 
 		sent->num_linkages_found = do_parse(sent, mchxt, ctxt, opts);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -330,6 +330,14 @@ void classic_parse(Sentence sent, Parse_Options opts)
 	{
 		sent->null_count = nl;
 
+		/* We may be here again for parsing with a higher null_count since
+		 * num_valid_linkages of the previous parse was 0 because all the
+		 * linkages had P.P. violations. Ensure that in case of a timeout we
+		 * will not end up with the previous num_linkages_found. */
+		sent->num_linkages_found = 0;
+		sent->num_valid_linkages = 0;
+		sent->num_linkages_post_processed = 0;
+
 		if (needed_prune_level > current_prune_level)
 		{
 			current_prune_level = needed_prune_level;

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -104,10 +104,16 @@ void resources_reset_space(Resources r)
 
 bool resources_exhausted(Resources r)
 {
-	if (r->timer_expired) return true;
-	if (resources_timer_expired(r)) r->timer_expired = true;
+	if (!r->timer_expired && !resources_timer_expired(r)) return false;
 
-	return r->timer_expired;
+	if (!r->timer_expired && (verbosity_level(D_USER_TIMES)))
+	{
+		prt_error("#### Timeout (%.2f seconds)\n",
+		          current_usage_time() - r->time_when_parse_started);
+	}
+	r->timer_expired = true;
+
+	return true;
 }
 
 #if 0 /* max_memory is not being set any more. */

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -51,7 +51,7 @@ static struct
 	int display_disjuncts;
 	int display_morphology;
 	int display_wordgraph;
-} local, local_saved;
+} local, saved_defaults;
 
 static const char *value_type[] =
 {
@@ -116,12 +116,12 @@ static void put_opts_in_local_vars(Command_Options *);
 void save_default_opts(Command_Options *copts)
 {
 	put_opts_in_local_vars(copts);
-	local_saved = local;
+	saved_defaults = local;
 }
 
 static void restore_default_local_vars(void)
 {
-	local = local_saved;
+	local = saved_defaults;
 }
 
 /**

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -1004,7 +1004,7 @@ Command_Options* command_options_create(void)
 	co->allow_null = true;
 	co->batch_mode = false;
 	co->echo_on = false;
-	co->panic_mode = false;
+	co->panic_mode = true;
 	co->display_on = true;
 	co->display_walls = false;
 	co->display_postscript = false;

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -51,6 +51,8 @@ static struct
 	int display_disjuncts;
 	int display_morphology;
 	int display_wordgraph;
+
+	panic_options panic;
 } local, saved_defaults;
 
 static const char *value_type[] =
@@ -925,6 +927,8 @@ static void put_opts_in_local_vars(Command_Options* copts)
 	local.display_links = copts->display_links;
 
 	local.display_morphology = parse_options_get_display_morphology(opts);
+
+	local.panic = copts->panic;
 }
 
 static void put_local_vars_in_opts(Command_Options* copts)
@@ -963,6 +967,8 @@ static void put_local_vars_in_opts(Command_Options* copts)
 	copts->display_bad = local.display_bad;
 	copts->display_disjuncts = local.display_disjuncts;
 	copts->display_links = local.display_links;
+
+	copts->panic = local.panic;
 }
 
 int issue_special_command(const char * line, Command_Options* opts, Dictionary dict)
@@ -1015,6 +1021,13 @@ Command_Options* command_options_create(void)
 	co->display_disjuncts = false;
 	co->display_links = false;
 	co->display_wordgraph = 0;
+
+	co->panic.max_cost = 4.0f;
+	co->panic.linkage_limit = 1000;
+	co->panic.max_null_count = 10;
+	co->panic.short_length = 12;
+	co->panic.spell_guess = 0;
+	co->panic.timeout = 30;
 	return co;
 }
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -579,22 +579,22 @@ static int help_cmd(const Switch *uc, int n)
 	printf("Special commands always begin with \"!\".  Command and variable names\n");
 	printf("can be abbreviated.  Here is a list of the commands:\n\n");
 
-	printf(" !help command   Show a detailed help for the given command.\n");
+	printf(" !help command    Show a detailed help for the given command.\n");
 	for (int i = 0; uc[i].string != NULL; i++)
 	{
 		if (Cmd != uc[i].param_type) continue;
 		if (UNDOC[0] == uc[i].description[0]) continue;
-		printf(" !%-14s ", uc[i].string);
+		printf(" !%-15s ", uc[i].string);
 		printf("%s.\n", uc[i].description);
 	}
 
 	printf("\n");
-	printf(" !!<string>      Print all the dictionary words that match <string>.\n");
-	printf("                 A wildcard * may be used to find multiple matches.\n");
-	printf("                 Issue \"!help !\" for more details.\n");
+	printf(" !!<string>       Print all the dictionary words that match <string>.\n");
+	printf("                  A wildcard * may be used to find multiple matches.\n");
+	printf("                  Issue \"!help !\" for more details.\n");
 	printf("\n");
-	printf(" !<var>          Toggle the specified Boolean variable.\n");
-	printf(" !<var>=<val>    Assign that value to that variable.\n");
+	printf(" !<var>           Toggle the specified Boolean variable.\n");
+	printf(" !<var>=<val>     Assign that value to that variable.\n");
 
 	print_url_info();
 

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -41,7 +41,6 @@ typedef struct
 
 typedef struct {
 	Parse_Options popts;
-	Parse_Options panic_opts;
 	panic_options panic;
 
 	unsigned int screen_width; /* width of screen for displaying linkages */
@@ -60,6 +59,9 @@ typedef struct {
 	bool display_links;     /* if true, a list o' links is printed out */
 	int  display_wordgraph; /* if nonzero, the word-graph is displayed */
 } Command_Options;
+
+void put_local_vars_in_opts(Command_Options *);
+void setup_panic_parse_options(Command_Options *, int);
 
 typedef enum
 {

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -29,9 +29,20 @@
 #define MAX(X,Y)  (((X) > (Y)) ? (X) : (Y))
 #endif
 
+typedef struct
+{
+	double max_cost;
+	int linkage_limit;
+	int max_null_count;
+	int short_length;
+	int spell_guess;
+	int timeout;
+} panic_options;
+
 typedef struct {
 	Parse_Options popts;
 	Parse_Options panic_opts;
+	panic_options panic;
 
 	unsigned int screen_width; /* width of screen for displaying linkages */
 	bool batch_mode;        /* if true, process sentences non-interactively */

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -33,7 +33,7 @@ typedef struct {
 	Parse_Options popts;
 	Parse_Options panic_opts;
 
-	size_t screen_width;    /* width of screen for displaying linkages */
+	unsigned int screen_width; /* width of screen for displaying linkages */
 	bool batch_mode;        /* if true, process sentences non-interactively */
 	bool allow_null;        /* true if we allow null links in parsing */
 	bool echo_on;           /* true if we should echo the input sentence */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -939,46 +939,49 @@ open_error:
 			continue;
 		}
 
-#if 0
-		/* Try again, this time omitting the requirement for
-		 * definite articles, etc. This should allow for the parsing
-		 * of newspaper headlines and other clipped speech.
-		 *
-		 * XXX Unfortunately, this also allows for the parsing of
-		 * all sorts of ungrammatical sentences which should not
-		 * parse, and leads to bad parses of many other unparsable
-		 * but otherwise grammatical sentences.  Thus, this trick
-		 * pretty much fails; we leave it here to document the
-		 * experiment.
-		 */
-		if (num_linkages == 0)
+		if (!(copts->panic_mode && parse_options_resources_exhausted(opts)))
 		{
-			parse_options_set_disjunct_cost(opts, 4.5);
-			num_linkages = sentence_parse(sent, opts);
-			if (num_linkages < 0) continue;
-		}
+#if 0
+			/* Try again, this time omitting the requirement for
+			 * definite articles, etc. This should allow for the parsing
+			 * of newspaper headlines and other clipped speech.
+			 *
+			 * XXX Unfortunately, this also allows for the parsing of
+			 * all sorts of ungrammatical sentences which should not
+			 * parse, and leads to bad parses of many other unparsable
+			 * but otherwise grammatical sentences.  Thus, this trick
+			 * pretty much fails; we leave it here to document the
+			 * experiment.
+			 */
+			if (num_linkages == 0)
+			{
+				parse_options_set_disjunct_cost(opts, 4.5);
+				num_linkages = sentence_parse(sent, opts);
+				if (num_linkages < 0) continue;
+			}
 #endif /* 0 */
 
-		/* If asked to show bad linkages, then show them. */
-		if ((num_linkages == 0) && (!copts->batch_mode))
-		{
-			if (copts->display_bad)
+			/* If asked to show bad linkages, then show them. */
+			if ((num_linkages == 0) && (!copts->batch_mode))
 			{
-				num_linkages = sentence_num_linkages_found(sent);
+				if (copts->display_bad)
+				{
+					num_linkages = sentence_num_linkages_found(sent);
+				}
 			}
-		}
 
-		/* Now parse with null links */
-		if (!one_step_parse && num_linkages == 0 && !copts->batch_mode)
-		{
-			if (verbosity > 0) fprintf(stdout, "No complete linkages found.\n");
-
-			if (copts->allow_null)
+			/* Now parse with null links */
+			if (!one_step_parse && num_linkages == 0 && !copts->batch_mode)
 			{
-				/* XXX should use expanded disjunct list here too */
-				parse_options_set_min_null_count(opts, 1);
-				parse_options_set_max_null_count(opts, sentence_length(sent));
-				num_linkages = sentence_parse(sent, opts);
+				if (verbosity > 0) fprintf(stdout, "No complete linkages found.\n");
+
+				if (copts->allow_null)
+				{
+					/* XXX should use expanded disjunct list here too */
+					parse_options_set_min_null_count(opts, 1);
+					parse_options_set_max_null_count(opts, sentence_length(sent));
+					num_linkages = sentence_parse(sent, opts);
+				}
 			}
 		}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -671,7 +671,6 @@ int main(int argc, char * argv[])
 	opts = copts->popts;
 
 	setup_panic_parse_options(copts->panic_opts);
-	copts->panic_mode = true;
 
 	parse_options_set_max_parse_time(opts, 30);
 	parse_options_set_linkage_limit(opts, 1000);

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -164,6 +164,9 @@ static void process_linkage(Linkage linkage, Command_Options* copts)
 	}
 	if (copts->display_on)
 	{
+#ifdef SIGWINCH
+		set_screen_width(copts);
+#endif
 		string = linkage_print_diagram(linkage, copts->display_walls, copts->screen_width);
 		fprintf(stdout, "%s", string);
 		linkage_free_diagram(string);
@@ -950,7 +953,9 @@ open_error:
 
 		if (verbosity > 1) parse_options_print_total_time(opts);
 
+#ifndef SIGWINCH
 		set_screen_width(copts);
+#endif
 
 		const char *rc = "";
 		if (copts->batch_mode)

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -857,7 +857,7 @@ open_error:
 		}
 
 		/* First parse with the default disjunct_cost as set by the library
-		 * (currently 2.7). Usually parse here with no null links.
+		 * (typically 2.7). Usually parse here with no null links.
 		 * However, if "-test=one-step-parse" is used and we are said to
 		 * parse with null links, allow parsing here with null links too. */
 		bool one_step_parse = !copts->batch_mode && copts->allow_null &&

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -803,7 +803,6 @@ int main(int argc, char * argv[])
 		test = parse_options_get_test(opts);
 
 		input_string = fget_input_string(input_fh, stdout, /*check_return*/false);
-		set_screen_width(copts);
 
 		if (NULL == input_string)
 		{
@@ -827,6 +826,7 @@ int main(int argc, char * argv[])
 		if (strspn(input_string, WHITESPACE) == strlen(input_string))
 			continue;
 
+		set_screen_width(copts);
 		int command = special_command(input_string, copts, dict);
 		if ('e' == command) break;    /* It was an exit command */
 		if ('c' == command) continue; /* It was another command */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -644,6 +644,13 @@ int main(int argc, char * argv[])
 		}
 	}
 
+	/* This is not absolutely needed because the library set it after
+	 * the first parse. However, it is initialized here so !variables,
+	 * "link-parser DICT -variables" and "!help cost-max" show the
+	 * correct value. */
+	parse_options_set_disjunct_cost(opts,
+	   linkgrammar_get_dict_max_disjunct_cost(dict));
+
 	save_default_opts(copts); /* Options so far are the defaults */
 
 	/* Process options used by GNU programs. */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -991,9 +991,7 @@ open_error:
 				fprintf(stdout, "Memory is exhausted!\n");
 		}
 
-		if ((num_linkages == 0) &&
-			copts->panic_mode &&
-			parse_options_resources_exhausted(opts))
+		if (copts->panic_mode && parse_options_resources_exhausted(opts))
 		{
 			batch_errors++;
 			if (verbosity > 0) fprintf(stdout, "Entering \"panic\" mode...\n");

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -890,16 +890,18 @@ open_error:
 			}
 
 			/* Now parse with null links */
-			if (!one_step_parse && num_linkages == 0 && !copts->batch_mode)
+			if (!one_step_parse && num_linkages == 0)
 			{
 				if (verbosity > 0) fprintf(stdout, "No complete linkages found.\n");
-
-				if (copts->allow_null)
+				if (!copts->batch_mode)
 				{
-					/* XXX should use expanded disjunct list here too */
-					parse_options_set_min_null_count(opts, 1);
-					parse_options_set_max_null_count(opts, sentence_length(sent));
-					num_linkages = sentence_parse(sent, opts);
+					if (copts->allow_null)
+					{
+						/* XXX should use expanded disjunct list here too */
+						parse_options_set_min_null_count(opts, 1);
+						parse_options_set_max_null_count(opts, sentence_length(sent));
+						num_linkages = sentence_parse(sent, opts);
+					}
 				}
 			}
 		}

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -15,7 +15,11 @@
 
 #include "../link-grammar/link-includes.h"
 
+#include "command-line.h"
+
 char *expand_homedir(const char *fn);
+void set_screen_width(Command_Options*);
+void initialize_screen_width(Command_Options *);
 
 #define MAX_INPUT 2048
 


### PR DESCRIPTION
See issue #785.
The main changes in this PR are related to panic mode.
Handling SIGWINCH is also implemented here (it may be difficult to separate).
Some other minor changes are not related to the panic mode but are interleaved with its changes.
The `linkgrammar_get_configuration()`  commits are not directly related but I wanted to see the feature_test_macros that expose `sigsetaction()`.
Another non-related change is supporting displaying the correct max-cost even before the first parse. This change also supports its correct default value display.

`!help panic_timeout` (or `!help` on any other `panic_*` variable) shows all the settable `panic_*` variables and the rules that govern their usage in panic mode. `!panic_<TAB>` also shows the `panic_*` variables.

I also updated the `!help` text. As usual, it may need English polishing.


Other changes:
- Add `panic-max-disjunct-cost` in the `en` and `ru` dicts.
-  Add `max-disjunct-cost` in the `ru` dict for documentation of what is actually used.
- Set panic_cost-max from the dict if available.
- Fix memory leak.
- Implement accurate timeout. This doesn't include a timeout during link extraction (can be fixed).
- In case of a panic, don't display partial results, as they are inconsistent and different for each run.
- Fix 2  "No complete linkages found" notification problems.
- resources_exhausted(): Print indication on verbosity > 1. Make it easier to track panic handling with `-verbosity=2`.
- Bug fix: Don't try the 2nd step if 1st one timeouts (this fixes 3 problems).
- Support `!bad` also for `!nulls=1`.

Implementation notes:
- The panic mode for `!nuls=1` is now done using the "one step" parse.
- In `link-parser` I retained, for now, the original 2-parse step even though the library can do it in "one step", unless  `-test=one-step-parse` is used. (On the language binding, a "one step" parse is done when `min_null_count==0 && max_null_count>0`, but the user is of course free to do a 2-step parse if desired.)
- There is currently no infrastructure to test the correct behavior of timeouts in various places (correct parsing and no memory leaks). I tested it by inserting (one at a time) `do {} while (!resources_exhausted(r))` before timeout checks and using `-timeout=1 -panic_timeout=1`.
- Panic mode for SAT is still not implemented (more details at issue #785).
- resources_exhausted() (and the related parse option)  is still being used for a timeout check. To be replaced by the timer check related calls in a future cleanup.


Note that the introduction document is not up to date regarding max-cost: https://www.abisource.com/projects/link-grammar/dict/introduction.html#:~:text=only%20connectors,morphology.


