### PR TITLE
Speed up counting by 1. word-vector 0-count cache; 2.Boyer-Moore-like word skips

### DIFF
--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -13,7 +13,7 @@
 
 #include "error.h"
 #include "memory-pool.h"
-#include "utilities.h"                  // MIN/MAX, aligned alloc, lg_strerror
+#include "utilities.h"                  // MIN/MAX, aligned_alloc, lg_strerror
 
 /* TODO: Add valgrind descriptions. See:
  * http://valgrind.org/docs/manual/mc-manual.html#mc-manual.mempools */

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -62,16 +62,14 @@ Pool_desc *pool_new(const char *func, const char *name,
 		mp->element_size = align_size(element_size);
 		mp->alignment = MAX(MIN_ALIGNMENT, mp->element_size);
 		mp->alignment = MIN(MAX_ALIGNMENT, mp->alignment);
-		mp->data_size = num_elements * mp->element_size;
-		mp->block_size = ALIGN(mp->data_size + FLDSIZE_NEXT, mp->alignment);
 	}
 	else
 	{
 		mp->element_size = element_size;
 		mp->alignment = MIN_ALIGNMENT;
-		mp->data_size = num_elements * mp->element_size;
-		mp->block_size = mp->data_size + FLDSIZE_NEXT;
 	}
+	mp->data_size = ALIGN(num_elements * mp->element_size, FLDSIZE_NEXT);
+	mp->block_size = ALIGN(mp->data_size + FLDSIZE_NEXT, mp->alignment);
 
 	mp->zero_out = zero_out;
 #ifdef POOL_EXACT

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -119,7 +119,9 @@ void pool_delete (const char *func, Pool_desc *mp)
 	for (char *c = mp->chain; c != NULL; c = c_next)
 	{
 #if !POOL_ALLOCATOR
+#ifdef POOL_FREE
 		ASAN_UNPOISON_MEMORY_REGION(c, mp->element_size + FLDSIZE_NEXT);
+#endif
 #endif
 		c_next = POOL_NEXT_BLOCK(c, alloc_size);
 #if POOL_ALLOCATOR
@@ -150,7 +152,9 @@ void *pool_alloc(Pool_desc *mp)
 	if (NULL != mp->free_list)
 	{
 		void *alloc_next = mp->free_list;
+#ifdef POOL_FREE
 		ASAN_UNPOISON_MEMORY_REGION(alloc_next, mp->element_size);
+#endif
 		mp->free_list = *(char **)mp->free_list;
 		if (mp->zero_out) memset(alloc_next, 0, mp->element_size);
 		return alloc_next;
@@ -283,7 +287,9 @@ void pool_reuse(Pool_desc *mp)
 	char *c_next;
 	for (char *c = mp->chain; c != NULL; c = c_next)
 	{
+#ifdef POOL_FREE
 		ASAN_UNPOISON_MEMORY_REGION(c, mp->element_size + FLDSIZE_NEXT);
+#endif
 		c_next = POOL_NEXT_BLOCK(c, mp->element_size);
 		free(c);
 	}

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -10,6 +10,7 @@
 /*************************************************************************/
 
 #include <errno.h>                      // errno
+#include <stddef.h>                     // max_align_t
 
 #include "error.h"
 #include "memory-pool.h"
@@ -17,6 +18,17 @@
 
 /* TODO: Add valgrind descriptions. See:
  * http://valgrind.org/docs/manual/mc-manual.html#mc-manual.mempools */
+
+#if !POOL_ALLOCATOR
+typedef union
+{
+	struct{
+		char *next;
+		size_t size;
+	};
+	max_align_t dymmy;
+} alloc_attr;
+#endif
 
 /**
  * Align given size to the nearest upper power of 2
@@ -90,6 +102,7 @@ Pool_desc *pool_new(const char *func, const char *name,
 	return mp;
 }
 
+#if POOL_ALLOCATOR
 /**
  * Delete the given memory pool.
  */
@@ -109,31 +122,17 @@ void pool_delete (const char *func, Pool_desc *mp)
 	        mp->curr_elements, mp->num_elements, from_func, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */
+	size_t alloc_size = mp->data_size;
 	char *c_next;
-	size_t alloc_size;
-#if POOL_ALLOCATOR
-	alloc_size = mp->data_size;
-#else
-	alloc_size = mp->element_size;
-#endif
+
 	for (char *c = mp->chain; c != NULL; c = c_next)
 	{
-#if !POOL_ALLOCATOR
-#ifdef POOL_FREE
-		ASAN_UNPOISON_MEMORY_REGION(c, mp->element_size + FLDSIZE_NEXT);
-#endif
-#endif
 		c_next = POOL_NEXT_BLOCK(c, alloc_size);
-#if POOL_ALLOCATOR
 		aligned_free(c);
-#else
-		free(c);
-#endif
 	}
 	free(mp);
 }
 
-#if POOL_ALLOCATOR
 /**
  * Allocate an element from the requested pool.
  * This function uses the feature that pointers to void and char are
@@ -144,12 +143,15 @@ void pool_delete (const char *func, Pool_desc *mp)
  * 2. Zero the block if required;
  * 3. Return element pointer.
  */
-void *pool_alloc(Pool_desc *mp)
+inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 {
-	mp->curr_elements++; /* For stats. */
+	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
+	        vecsize, mp->num_elements);
+
+	mp->curr_elements += vecsize; /* skipped space disregarded when vecsize > 1 */
 
 #ifdef POOL_FREE
-	if (NULL != mp->free_list)
+	if ((NULL != mp->free_list) && (vecsize == 1))
 	{
 		void *alloc_next = mp->free_list;
 #ifdef POOL_FREE
@@ -161,7 +163,9 @@ void *pool_alloc(Pool_desc *mp)
 	}
 #endif // POOL_FREE
 
-	if ((NULL == mp->alloc_next) || (mp->alloc_next == mp->ring + mp->data_size))
+	size_t alloc_size = mp->element_size * vecsize;
+	if ((NULL == mp->alloc_next) ||
+	    (mp->alloc_next + alloc_size >= mp->ring + mp->data_size))
 	{
 #ifdef POOL_EXACT
 		assert(!mp->exact || (NULL == mp->alloc_next),
@@ -195,7 +199,7 @@ void *pool_alloc(Pool_desc *mp)
 			else
 				POOL_NEXT_BLOCK(prev, mp->data_size) = mp->ring;
 			POOL_NEXT_BLOCK(mp->ring, mp->data_size) = NULL;
-			//printf("New ring %p next %p\n", mp->ring,
+			//printf("New ring %p next %p ", mp->ring,
 			       //POOL_NEXT_BLOCK(mp->ring, mp->data_size));
 		} /* Else reuse existing block. */
 
@@ -205,8 +209,13 @@ void *pool_alloc(Pool_desc *mp)
 
 	/* Grab a new element. */
 	void *alloc_next = mp->alloc_next;
-	mp->alloc_next += mp->element_size;
+	mp->alloc_next +=  alloc_size;
 	return alloc_next;
+}
+
+void *pool_alloc(Pool_desc *mp)
+{
+	return pool_alloc_vec(mp, 1);
 }
 
 /**
@@ -254,9 +263,13 @@ void pool_free(Pool_desc *mp, void *e)
 /*
  * Allocate an element by using malloc() directly.
  */
-void *pool_alloc(Pool_desc *mp)
+inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 {
-	mp->curr_elements++;
+	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
+	        vecsize, mp->num_elements);
+	mp->curr_elements += vecsize;
+	size_t alloc_size = mp->num_elements * vecsize;
+
 #ifdef POOL_EXACT
 	assert(!mp->exact || mp->curr_elements <= mp->num_elements,
 	       "Too many elements (%zu>%zu) (pool '%s' created in %s())",
@@ -265,13 +278,22 @@ void *pool_alloc(Pool_desc *mp)
 
 	/* Allocate a new element and chain it. */
 	char *next = mp->chain;
-	mp->chain = malloc(mp->element_size + FLDSIZE_NEXT);
-	POOL_NEXT_BLOCK(mp->chain, mp->element_size) = next;
 
-	void *alloc_next = mp->chain;
-	if (mp->zero_out) memset(alloc_next, 0, mp->element_size);
+	mp->chain = malloc(sizeof(alloc_attr) + alloc_size);
+
+	alloc_attr *at = (alloc_attr *)mp->chain;
+	at->next = next;
+	at->size = alloc_size;
+
+	char *alloc_next = mp->chain + sizeof(alloc_attr);
+	if (mp->zero_out) memset(alloc_next, 0, alloc_size);
 
 	return alloc_next;
+}
+
+void *pool_alloc(Pool_desc *mp)
+{
+	return pool_alloc_vec(mp, 1);
 }
 
 /*
@@ -285,12 +307,14 @@ void pool_reuse(Pool_desc *mp)
 
 	/* Free its chained memory blocks. */
 	char *c_next;
+
 	for (char *c = mp->chain; c != NULL; c = c_next)
 	{
+		alloc_attr *at = (alloc_attr *)c;
 #ifdef POOL_FREE
-		ASAN_UNPOISON_MEMORY_REGION(c, mp->element_size + FLDSIZE_NEXT);
+		ASAN_UNPOISON_MEMORY_REGION(c,  sizeof(alloc_attr) + at->size);
 #endif
-		c_next = POOL_NEXT_BLOCK(c, mp->element_size);
+		c_next = at->next;
 		free(c);
 	}
 
@@ -298,16 +322,52 @@ void pool_reuse(Pool_desc *mp)
 	mp->curr_elements = 0;
 }
 
+/*
+ * Delete the given memory pool.
+ */
+#undef pool_delete
+#ifndef DEBUG
+void pool_delete (Pool_desc *mp)
+#else
+void pool_delete (const char *func, Pool_desc *mp)
+#endif
+{
+	if (NULL == mp) return;
+	const char *from_func = "";
+#ifdef DEBUG /* Macro-added first argument. */
+	from_func = func;
+#endif
+	lgdebug(+D_MEMPOOL, "Used %zu (%zu) elements (%s deleted pool '%s' created in %s())\n",
+	        mp->curr_elements, mp->num_elements, from_func, mp->name, mp->func);
+
+	/* Free its chained memory blocks. */
+	char *c_next;
+
+	for (char *c = mp->chain; c != NULL; c = c_next)
+	{
+		alloc_attr *at = (alloc_attr *)c;
+#ifdef POOL_FREE
+		ASAN_UNPOISON_MEMORY_REGION(c, sizeof(alloc_attr) + at->size);
+#endif
+		c_next = at->next;
+		free(c);
+	}
+	free(mp);
+}
+
+
 #ifdef POOL_FREE
 void pool_free(Pool_desc *mp, void *e)
 {
+	mp->curr_elements--;
+#ifdef POOL_FREE
 	if (ASAN_ADDRESS_IS_POISONED(e))
 	{
 		prt_error("Fatal error: Double pool free of %p\n", e);
 		exit(1);
 	}
-	mp->curr_elements--;
-	ASAN_POISON_MEMORY_REGION(e, mp->element_size + FLDSIZE_NEXT);
+	ASAN_POISON_MEMORY_REGION(e, sizeof(alloc_attr) + ((alloc_attr *)e)->size);
+#endif
 }
 #endif // POOL_FREE
 #endif // POOL_ALLOCATOR

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -24,9 +24,10 @@
 
 typedef struct Pool_desc_s Pool_desc;
 
-/* See below the definition of pool_new(). */
 Pool_desc *pool_new(const char *, const char *, size_t, size_t, bool, bool, bool);
 void *pool_alloc(Pool_desc *) GNUC_MALLOC;
+void *pool_alloc_vec(Pool_desc *, size_t) GNUC_MALLOC;
+
 void pool_reuse(Pool_desc *);
 #ifndef DEBUG
 void pool_delete(Pool_desc *);

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -39,7 +39,7 @@ void pool_free(Pool_desc *, void *e);
 #endif // POOL_FREE
 
 /* Pool allocator debug facility:
- * If configured with "CFLAGS=-DPOOL_ALLOCATOR=0", a fake pool allocator
+ * If configured with "CPPFLAGS=-DPOOL_ALLOCATOR=0", a fake pool allocator
  * that uses malloc() for each allocation is defined, in order that ASAN
  * or valgrind can be used to find memory usage bugs.
  */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -40,9 +40,12 @@ struct Table_connector_s
 typedef uint8_t null_count_m;  /* Storage representation of null_count */
 typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 
-/* Table of ranges [tracon_id, w) that would yield a zero
- * leftcount/rightcount up to null_count. */
 typedef struct
+/* An element in a table indexed by tracon_id and w.
+ * The status field indicates if parsing the range [tracon_id, w) would
+ * yield a zero/none-zero leftcount/rightcount and this prediction
+ * is valid for null counts up to null_count (or for any null count if
+ * it is null_count is ANY_NULL_COUNT). */
 {
 	int tracon_id;
 	WordIdx_m w;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -564,6 +564,7 @@ static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
 			memset(*wv, -1, sizeof(Table_lrcnt) * wordvec_size);
 
 			*null_start = 0;
+			assert(wordvec_index < ctxt->sent->length, "Bad wordvec index");
 			return &(*wv)[wordvec_index]; /* Needs update */
 		}
 		return NULL;
@@ -600,15 +601,13 @@ static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
 	return lp;
 }
 
-#ifdef FIXME
-bool no_count(count_context_t *ctxt, int dir, Connector *c, int cw, int w,
-              unsigned int null_count)
+bool no_count(count_context_t *ctxt, int dir, Connector *c,
+              unsigned int wordvec_index, unsigned int null_count)
 {
 	return
 		&lrcnt_cache_zero ==
-		is_lrcnt(ctxt, dir, w - c->nearest_word, null_count, NULL);
+		is_lrcnt(ctxt, dir, c, wordvec_index, null_count, NULL);
 }
-#endif
 
 static bool lrcnt_cache_update(Table_lrcnt *lrcnt_cache, bool lrcnt_found,
                               bool match_list, unsigned int null_count)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -826,14 +826,12 @@ static Count_bin do_count(
 
 	for (w = start_word; w < end_word; w = next_word)
 	{
-#if 1
-		if (wv != NULL)
+		if ((wv != NULL) && (w != end_word -1))
 		{
 			next_word = wv[w - le->nearest_word].check_next;
 			if (next_word == INCREMENT_WORD) next_word = w + 1;
 		}
 		else
-#endif
 		{
 			next_word = w + 1;
 		}

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -40,12 +40,12 @@ struct Table_connector_s
 typedef uint8_t null_count_m;  /* Storage representation of null_count */
 typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 
-typedef struct
 /* An element in a table indexed by tracon_id and w.
  * The status field indicates if parsing the range [tracon_id, w) would
  * yield a zero/none-zero leftcount/rightcount and this prediction
  * is valid for null counts up to null_count (or for any null count if
  * it is null_count is ANY_NULL_COUNT). */
+typedef struct
 {
 	int tracon_id;
 	WordIdx_m w;

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -24,6 +24,6 @@ Count_bin* table_lookup(count_context_t *, int, int,
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 bool no_count(count_context_t *, int, Connector *, int, int, unsigned int);
 
-count_context_t* alloc_count_context(Sentence);
+count_context_t* alloc_count_context(Sentence, Tracon_sharing*);
 void free_count_context(count_context_t*, Sentence);
 #endif /* _COUNT_H */

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -22,7 +22,7 @@ Count_bin* table_lookup(count_context_t *, int, int,
                         const Connector *, const Connector *,
                         unsigned int, unsigned int *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
-bool no_count(count_context_t *, int, Connector *, int, int, unsigned int);
+bool no_count(count_context_t *, int, Connector *, unsigned int, unsigned int);
 
 count_context_t* alloc_count_context(Sentence, Tracon_sharing*);
 void free_count_context(count_context_t*, Sentence);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -448,18 +448,25 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 	 * it may omit some optimizations. */
 	if (UINT_MAX == null_count) return NULL;
 
+#ifdef FIXME
+	wordvecp lwv, rwv;
+	if (!get_lrcnt_wordvec(ctxt, le, re, lw, rw, &lwv, &rwv))
+		return &xt->set;
+#endif
+
 	RECOUNT({xt->set.recount = 0;})
 	for (w = start_word; w < end_word; w++)
 	{
 		/* Start of nonzero leftcount/rightcount range cache check. */
 		Connector *fml_re = re;       /* For form_match_list() only */
 
+#ifdef FIXME
 		if (le != NULL)
 		{
-			if (no_count(ctxt, 0, le, lw, w, null_count)) continue;
+			if (no_count(wlv, le, null_count, NULL)) continue;
 			if (re != NULL)
 			{
-				if (no_count(ctxt, 1, re, rw, w, null_count))
+				if (no_count(wrv, re, null_count, NULL))
 					fml_re = NULL;
 			}
 		}
@@ -469,6 +476,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 			if (no_count(ctxt, 1, re, rw, w, null_count)) continue;
 		}
 		/* End of nonzero leftcount/rightcount range cache check. */
+#endif
 
 		size_t mlb = form_match_list(mchxt, w, le, lw, fml_re, rw);
 		if (pex->sort_match_list) sort_match_list(mchxt, mlb);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -448,35 +448,27 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 	 * it may omit some optimizations. */
 	if (UINT_MAX == null_count) return NULL;
 
-#ifdef FIXME
-	wordvecp lwv, rwv;
-	if (!get_lrcnt_wordvec(ctxt, le, re, lw, rw, &lwv, &rwv))
-		return &xt->set;
-#endif
-
 	RECOUNT({xt->set.recount = 0;})
 	for (w = start_word; w < end_word; w++)
 	{
 		/* Start of nonzero leftcount/rightcount range cache check. */
 		Connector *fml_re = re;       /* For form_match_list() only */
 
-#ifdef FIXME
 		if (le != NULL)
 		{
-			if (no_count(wlv, le, null_count, NULL)) continue;
-			if (re != NULL)
+			if (no_count(ctxt, 0, le, w - le->nearest_word, null_count)) continue;
+			if ((re != NULL) && (re->farthest_word <= w))
 			{
-				if (no_count(wrv, re, null_count, NULL))
+				if (no_count(ctxt, 1, re, w - re->farthest_word, null_count))
 					fml_re = NULL;
 			}
 		}
 		else
 		{
 			/* Here re != NULL. */
-			if (no_count(ctxt, 1, re, rw, w, null_count)) continue;
+			if (no_count(ctxt, 1, re, w - re->farthest_word, null_count)) continue;
 		}
 		/* End of nonzero leftcount/rightcount range cache check. */
-#endif
 
 		size_t mlb = form_match_list(mchxt, w, le, lw, fml_re, rw);
 		if (pex->sort_match_list) sort_match_list(mchxt, mlb);

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -379,6 +379,9 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			ts_parsing = pack_sentence_for_parsing(sent);
 			print_time(opts, "Encoded for parsing");
 
+			free_count_context(ctxt, sent);
+			ctxt = alloc_count_context(sent, ts_parsing);
+
 			if (!more_pruning_possible)
 			{
 				/* At this point no further pruning will be done. Free the
@@ -397,9 +400,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			}
 
 			gword_record_in_connector(sent);
-
-			free_count_context(ctxt, sent);
-			ctxt = alloc_count_context(sent);
 
 			free_fast_matcher(sent, mchxt);
 			mchxt = alloc_fast_matcher(sent, ncu);


### PR DESCRIPTION
The changes here have the following speedups on my computer:
|Batch file|~Speedup|
|--|--|
|fix-long|9%|
|failures|5%|
|pandp-union|1.2%|

The actual speedup of `do_count()` in several times this figure since `do_count()` itself takes <30% of the total CPU (see the table in the first comment of PR #1127).

The speedup is due to two main changes:
1. Implementation of the 0-count tracon-word cache by a word-vector indexed by the tracon number. Instead of the current cache which is a hash table, this cache is an array, indexed by the tracon number. The vector includes elements only from/until the farthest_word of the left/right tracon. One cache access is needed to locate the prediction for all the words relevant for each tracon, as opposed to the current hash access per word. This implements a FIXME.
2. A Boyer-Moore style word skipping is implemented to skip over a range of words that are known to yield a zero count due to previously cached results (the idea got mentioned in the first comment of the demo PR #887). This saves word-vector cache lookups.

The last commit updates a comment with a detailed explanation of how these changes work.

This PR also introduces `pool_alloc_vec()`, which is used for the allocation of the word-vector cache elements.