### PR TITLE
Fix problems related to the recent wordvec cache implementation

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -134,6 +134,7 @@ struct Sentence_s
 	String_set *   string_set;  /* Used for assorted strings */
 	Pool_desc * fm_Match_node;  /* Fast-matcher Match_node memory pool */
 	Pool_desc * Table_connector_pool; /* Count memoizing memory pool */
+	Pool_desc * wordvec_pool;   /* For tracon-word zero-count memoizing */
 	Pool_desc * Exp_pool;
 	Pool_desc * X_node_pool;
 	Pool_desc * Disjunct_pool;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -523,6 +523,7 @@ void sentence_delete(Sentence sent)
 	global_rand_state = sent->rand_state;
 	pool_delete(sent->fm_Match_node);
 	pool_delete(sent->Table_connector_pool);
+	pool_delete(sent->wordvec_pool);
 	pool_delete(sent->Exp_pool);
 	pool_delete(sent->X_node_pool);
 	if (IS_DB_DICT(sent->dict))

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -213,11 +213,6 @@ inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 	return alloc_next;
 }
 
-void *pool_alloc(Pool_desc *mp)
-{
-	return pool_alloc_vec(mp, 1);
-}
-
 /**
  * Reuse the given memory pool.
  * Reset the pool pointers without freeing its memory.
@@ -263,7 +258,7 @@ void pool_free(Pool_desc *mp, void *e)
 /*
  * Allocate an element by using malloc() directly.
  */
-inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
+void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 {
 	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
 	        vecsize, mp->num_elements);
@@ -289,11 +284,6 @@ inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 	if (mp->zero_out) memset(alloc_next, 0, alloc_size);
 
 	return alloc_next;
-}
-
-void *pool_alloc(Pool_desc *mp)
-{
-	return pool_alloc_vec(mp, 1);
 }
 
 /*

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -25,7 +25,6 @@
 typedef struct Pool_desc_s Pool_desc;
 
 Pool_desc *pool_new(const char *, const char *, size_t, size_t, bool, bool, bool);
-void *pool_alloc(Pool_desc *) GNUC_MALLOC;
 void *pool_alloc_vec(Pool_desc *, size_t) GNUC_MALLOC;
 
 void pool_reuse(Pool_desc *);
@@ -88,6 +87,11 @@ typedef struct
 	char *block_end;
 	size_t element_number;
 } Pool_location;
+
+static inline void *pool_alloc(Pool_desc *mp)
+{
+	return pool_alloc_vec(mp, 1);
+}
 
 /**
  * Return the next element in the pool.

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -220,14 +220,11 @@ static void free_table_lrcnt(count_context_t *ctxt)
 {
 	if (verbosity_level(D_COUNT))
 	{
-		unsigned int nonzero = 0;
-		unsigned int any_null = 0;
-		unsigned int zero = 0;
-		unsigned int non_max_null = 0;
-#if POOL_NEXT
-
+		unsigned int nonzero = 0, any_null = 0, zero = 0, non_max_null = 0;
 		Pool_location loc = { 0 };
-		while ((Table_lrcnt *t = pool_next(ctxt->wordvec_pool, &loc)) != NULL)
+		Table_lrcnt *t;
+
+		while ((t = pool_next(ctxt->wordvec_pool, &loc)) != NULL)
 		{
 			if (t->status == -1) continue;
 			if (t->status == 1)
@@ -239,7 +236,6 @@ static void free_table_lrcnt(count_context_t *ctxt)
 			else if (ctxt->sent->null_count == t->null_count)
 				zero++;
 		}
-#endif
 
 		const unsigned int num_values = ctxt->wordvec_pool->curr_elements;
 		lgdebug(+0, "Values %u (usage = non_max_null %u + other %u, "

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1267,9 +1267,6 @@ int do_parse(Sentence sent, fast_matcher_t *mchxt, count_context_t *ctxt,
 	ctxt->mchxt = mchxt;
 	ctxt->is_short = sent->length <= min_len_word_vector;
 
-	/* Cannot reuse since its content is invalid on an increased null_count. */
-	init_table_lrcnt(ctxt, sent);
-
 	hist = do_count(ctxt, -1, sent->length, NULL, NULL, sent->null_count+1);
 
 	table_stat(ctxt);
@@ -1282,11 +1279,11 @@ count_context_t * alloc_count_context(Sentence sent, Tracon_sharing *ts)
 	count_context_t *ctxt = (count_context_t *) xalloc (sizeof(count_context_t));
 	memset(ctxt, 0, sizeof(count_context_t));
 
-	/* 1. next_id keeps the last tracon_id used, so we need +1 for array size.
-	 * 2. In do_count(), le and re are right and left connectors respectively.
-	 */
+	/* next_id keeps the last tracon_id used, so we need +1 for array size.  */
 	for (unsigned int dir = 0; dir < 2; dir++)
 		ctxt->table_lrcnt_size[dir] = ts->next_id[!dir] + 1;
+
+	init_table_lrcnt(ctxt, sent);
 
 	ctxt->sent = sent;
 	/* consecutive blocks of this many words are considered as

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -376,16 +376,15 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 		if (NULL != ts_pruning)
 		{
+
+			free_tracon_sharing(ts_parsing);
 			ts_parsing = pack_sentence_for_parsing(sent);
 			print_time(opts, "Encoded for parsing");
-
-			free_count_context(ctxt, sent);
-			ctxt = alloc_count_context(sent, ts_parsing);
 
 			if (!more_pruning_possible)
 			{
 				/* At this point no further pruning will be done. Free the
-				 * pruning and parsing tracon stuff here instead of at the end. */
+				 * pruning tracon stuff here instead of at the end. */
 				if (NULL != ts_pruning)
 				{
 					free(ts_pruning->memblock);
@@ -394,9 +393,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 					if (NULL != saved_memblock)
 						free(saved_memblock);
 				}
-
-				free_tracon_sharing(ts_parsing);
-				ts_parsing = NULL;
 			}
 
 			gword_record_in_connector(sent);
@@ -408,6 +404,9 @@ void classic_parse(Sentence sent, Parse_Options opts)
 		}
 
 		free_linkages(sent);
+
+		free_count_context(ctxt, sent);
+		ctxt = alloc_count_context(sent, ts_parsing);
 
 		sent->num_linkages_found = do_parse(sent, mchxt, ctxt, opts);
 
@@ -423,9 +422,6 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			sent->num_linkages_found = 0;
 			goto parse_end_cleanup;
 		}
-
-		free_tracon_sharing(ts_parsing);
-		ts_parsing = NULL;
 
 		if (sent->num_linkages_found > 0)
 		{
@@ -469,9 +465,7 @@ parse_end_cleanup:
 		free_tracon_sharing(ts_pruning);
 		free(saved_memblock);
 	}
-	if (NULL != ts_parsing)
-		free_tracon_sharing(ts_parsing);
-
+	free_tracon_sharing(ts_parsing);
 	free_count_context(ctxt, sent);
 	free_fast_matcher(sent, mchxt);
 }

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -352,21 +352,21 @@ void classic_parse(Sentence sent, Parse_Options opts)
 			more_pruning_possible =
 				one_step_parse && (current_prune_level != MAX_SENTENCE);
 
-			unsigned int expexted_null_count =
+			unsigned int expected_null_count =
 				pp_and_power_prune(sent, ts_pruning, current_prune_level, opts,
 				                   ncu);
-			if (expexted_null_count > nl)
+			if (expected_null_count > nl)
 			{
 				if (opts->verbosity >= D_USER_TIMES)
 				{
 					prt_error("#### Skip parsing (w/%u ", nl);
-					if (expexted_null_count-1 > nl)
-						prt_error("to %u nulls)\n", expexted_null_count-1);
+					if (expected_null_count-1 > nl)
+						prt_error("to %u nulls)\n", expected_null_count-1);
 					else
 						prt_error("null%s)\n", (nl != 1) ? "s" : "");
 				}
 				notify_no_complete_linkages(nl, max_null_count);
-				nl = expexted_null_count-1;
+				nl = expected_null_count-1;
 				/* To get a result, parse w/null count which is at most one less
 				 * than the number of tokens (w/all nulls there is no linkage). */
 				if (nl == sent->length-1) nl--;


### PR DESCRIPTION
Fix problems in PR #1132.

Changes:

- Fix a memory leak when parsing with nulls.
- Simplify memory handling in `classic_parse()`.
- Fix disabled table_lrcnt stats.
- Speed up wordvec memory allocation for parsing with nulls.
- Fix inefficient inline.

- On the same occasion: Fix a variable typo in the touched code.
