### PR TITLE
Fix problems in PR #1130 (!panic variable and DEBUG compilation break)

### DIFF
--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -775,6 +775,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 	char *s, *x, *y;
 	int count, j;
 	const Switch *as = default_switches;
+	int  fullname = -1; /* Allow full name even if it is a prefix. */
 
 	line = &line[strspn(line, WHITESPACE)]; /* Trim initial whitespace */
 
@@ -825,8 +826,14 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if (((Bool == as[i].param_type) || (Cmd == as[i].param_type)) &&
 			    strncasecmp(s, as[i].string, strcspn(s, WHITESPACE)) == 0)
 			{
-				if ((UNDOC[0] == as[i].description[0]) &&
-				    (strlen(as[i].string) != strlen(s))) continue;
+				if (strlen(as[i].string) == strcspn(s, WHITESPACE))
+				{
+					fullname = i;
+				}
+				else
+				{
+					if (UNDOC[0] == as[i].description[0]) continue;
+				}
 				count++;
 				j = i;
 			}
@@ -834,8 +841,13 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 		if (count > 1)
 		{
-			prt_error("Ambiguous command \"%s\".  %s\n", s, helpmsg);
-			return -1;
+			if (fullname == -1)
+			{
+				prt_error("Ambiguous command \"%s\".  %s\n", s, helpmsg);
+				return -1;
+			}
+			j = fullname;
+			count = 1;
 		}
 		if (count == 1)
 		{
@@ -882,8 +894,14 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if (Cmd == as[i].param_type) continue;
 			if (strncasecmp(x, as[i].string, strlen(x)) == 0)
 			{
-				if ((UNDOC[0] == as[i].description[0]) &&
-				    (strlen(as[i].string) != strlen(x))) continue;
+				if (strlen(as[i].string) == strlen(x))
+				{
+					fullname = i;
+				}
+				else
+				{
+					if (UNDOC[0] == as[i].description[0]) continue;
+				}
 				j = i;
 				count ++;
 			}
@@ -897,8 +915,12 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 		if (count > 1)
 		{
-			prt_error("Error: Ambiguous variable \"%s\".  %s\n", x, helpmsg);
-			return -1;
+			if (fullname == -1)
+			{
+				prt_error("Error: Ambiguous variable \"%s\".  %s\n", x, helpmsg);
+				return -1;
+			}
+			j = fullname;
 		}
 
 		if ((as[j].param_type == Int) || (as[j].param_type == Bool))

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -539,13 +539,6 @@ static void print_usage(FILE *out, char *argv0, Command_Options *copts, int exit
 	exit(exit_value);
 }
 
-#ifdef INTERRUPT_EXIT
-static void interrupt_exit(int n)
-{
-	exit(128+n);
-}
-#endif
-
 int main(int argc, char * argv[])
 {
 	FILE            *input_fh = stdin;

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -399,6 +399,13 @@ void set_screen_width(Command_Options* copts)
 	copts->screen_width = screen_width;
 }
 
+#ifdef INTERRUPT_EXIT
+static void interrupt_exit(int n)
+{
+	exit(128+n);
+}
+#endif
+
 void initialize_screen_width(Command_Options *copts)
 {
 #ifdef SIGWINCH


### PR DESCRIPTION
Fix problems in PR #1130:

- Just adding `!panic_*` as regular variables prevents the ability to change the value of the `!panic` variable (by assigning or toggling) because `!panic` became ambiguous.
Fix that by always allowing the full name of a variable to take precedence.

- Fix also compilation break in DEBUG mode that happened in the SIGWINCH handling implementation in that PR.