### PR TITLE
extract-links comment updates + minor  changes

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -711,19 +711,19 @@ static void issue_links_for_choice(Linkage lkg, Parse_choice *pc)
 
 static void list_links(Linkage lkg, const Parse_set * set, int index)
 {
-	 Parse_choice *pc;
-	 s64 n;
+	Parse_choice *pc;
+	int n; /* No overflow here - see extract_links() and process_linkages() */
 
-	 if (set == NULL || set->first == NULL) return;
-	 for (pc = set->first; pc != NULL; pc = pc->next) {
-		  n = pc->set[0]->count * pc->set[1]->count;
-		  if (index < n) break;
-		  index -= n;
-	 }
-	 assert(pc != NULL, "walked off the end in list_links");
-	 issue_links_for_choice(lkg, pc);
-	 list_links(lkg, pc->set[0], index % pc->set[0]->count);
-	 list_links(lkg, pc->set[1], index / pc->set[0]->count);
+	if (set == NULL || set->first == NULL) return;
+	for (pc = set->first; pc != NULL; pc = pc->next) {
+		n = pc->set[0]->count * pc->set[1]->count;
+		if (index < n) break;
+		index -= n;
+	}
+	assert(pc != NULL, "walked off the end in list_links");
+	issue_links_for_choice(lkg, pc);
+	list_links(lkg, pc->set[0], index % pc->set[0]->count);
+	list_links(lkg, pc->set[1], index / pc->set[0]->count);
 }
 
 static void list_random_links(Linkage lkg, unsigned int *rand_state,

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -92,7 +92,7 @@ struct extractor_s
 /**
  * The first thing we do is we build a data structure to represent the
  * result of the entire parse search.  There will be a set of nodes
- * built for each call to the count() function that returned a non-zero
+ * built for each call to the do_count() function that returned a non-zero
  * value, AND which is part of a valid linkage.  Each of these nodes
  * represents a valid continuation, and contains pointers to two other
  * sets (one for the left continuation and one for the right

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -28,7 +28,12 @@
 
 typedef struct Parse_choice_struct Parse_choice;
 
-/* The parse_choice is used to extract links for a given parse */
+/* Parse_choice records a parse of the word range set[0]->lw to
+ * set[1]->rw, when the middle disjunct md is of word set[0]->rw
+ * (which is always equal to set[1]->lw, link[0]->rw, and link[1]->lw).
+ * See make_choice() below.
+ * The number of linkages in this parse is the multiplication of the
+ * counts of the two Parse_set elements. */
 typedef struct Parse_set_struct Parse_set;
 struct Parse_choice_struct
 {
@@ -38,11 +43,14 @@ struct Parse_choice_struct
 	Disjunct    *md;     /* the chosen disjunct for the middle word */
 };
 
+/* Parse_set serves as a header of Parse_choice chained elements, that
+ * describe the possible parses with the specified null_count, using
+ * tracons l_id and r_id on words lw and rw, correspondingly. */
 struct Parse_set_struct
 {
 	short          lw, rw; /* left and right word index */
 	unsigned int   null_count; /* number of island words */
-	int            l_id, r_id; /* pending, unconnected connectors */
+	int            l_id, r_id; /* tracons on words lw, rw */
 
 	s64 count;      /* The number of ways to parse. */
 #ifdef RECOUNT

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -644,17 +644,16 @@ static bool set_overflowed(extractor_t * pex)
 }
 
 /**
- * This is the top level call that computes the whole parse_set.  It
- * points whole_set at the result.  It creates the necessary hash
- * table (x_table) which will be freed at the same time the
- * whole_set is freed.
+ * This is the top level call that computes the whole parse-set.
+ * It creates the necessary hash table (x_table) which will be freed at
+ * the same time the parse-set related memory is freed.
  *
  * This assumes that do_parse() has been run, and that the count_context
  * is filled with the values thus computed.  This function is structured
  * much like do_parse(), which wraps the main workhorse do_count().
  *
  * If the number of linkages gets huge, then the counts can overflow.
- * We check if this has happened when verifying the parse set.
+ * We check if this has happened when verifying the parse-set.
  * This routine returns TRUE iff an overflow occurred.
  */
 

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -697,6 +697,8 @@ void check_link_size(Linkage lkg)
  */
 static void issue_link(Linkage lkg, bool lr, Disjunct *md, Link *link)
 {
+	if (link[0].lc == NULL) return; /* no link to generate */
+
 	if (link->rc != NULL)
 	{
 		check_link_size(lkg);
@@ -709,12 +711,8 @@ static void issue_link(Linkage lkg, bool lr, Disjunct *md, Link *link)
 
 static void issue_links_for_choice(Linkage lkg, Parse_choice *pc)
 {
-	if (pc->link[0].lc != NULL) { /* there is a link to generate */
-		issue_link(lkg, /*lr*/false, pc->md, &pc->link[0]);
-	}
-	if (pc->link[1].lc != NULL) {
-		issue_link(lkg, /*lr*/true, pc->md, &pc->link[1]);
-	}
+	issue_link(lkg, /*lr*/false, pc->md, &pc->link[0]);
+	issue_link(lkg, /*lr*/true, pc->md, &pc->link[1]);
 }
 
 static void list_links(Linkage lkg, const Parse_set * set, int index)


### PR DESCRIPTION
This PR adds a comment to `list-links()` to explain how it works and updates the comments of the data structures it uses - `Parse_set`  and `Parse_choice`.
It also updates the function comments for `build_parse_set()` and make_choice().

On the same occasion:
- list_links(): Use int for the multiplication result (very minor speedup).
- issue_link()/issue_links_for_choice(): Refactor (just easier to read).

@linas, please check if my comments, especially the complex one for `list-links()`, are clear enough.
I can force-push a fix before you apply this PR.
Or - you may find it easier to modify them yourself to make the language/explanation better.

Edit: Force-pushed to fix comment typos.