### PR TITLE
Additional fixes related to the recent panic-mode changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.9.0 (XXX 2021)
  * Use #define for custom configuration in dictionaries. #1128
+ * Panic-mode fixes and extensions. In link-parser see !help panic_variables.
  * English dict: fix silly mistake with "I love cats and dogs".
  * Disable maintainer-mode in `configure.ac`.
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -745,8 +745,13 @@ static int handle_help_command(const Switch *as, char *line,
 			{
 				if (strncasecmp(s, as[i].string, strlen(s)) == 0)
 				{
-					count++;
 					j = i;
+					if (strlen(as[i].string) == strlen(s))
+					{
+						count = 1;
+						break;
+					}
+					count++;
 				}
 			}
 

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -780,7 +780,6 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 	char *s, *x, *y;
 	int count, j;
 	const Switch *as = default_switches;
-	int  fullname = -1; /* Allow full name even if it is a prefix. */
 
 	line = &line[strspn(line, WHITESPACE)]; /* Trim initial whitespace */
 
@@ -831,28 +830,21 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if (((Bool == as[i].param_type) || (Cmd == as[i].param_type)) &&
 			    strncasecmp(s, as[i].string, strcspn(s, WHITESPACE)) == 0)
 			{
+				j = i;
 				if (strlen(as[i].string) == strcspn(s, WHITESPACE))
 				{
-					fullname = i;
+					count = 1;
+					break;
 				}
-				else
-				{
-					if (UNDOC[0] == as[i].description[0]) continue;
-				}
+				if (UNDOC[0] == as[i].description[0]) continue;
 				count++;
-				j = i;
 			}
 		}
 
 		if (count > 1)
 		{
-			if (fullname == -1)
-			{
-				prt_error("Ambiguous command \"%s\".  %s\n", s, helpmsg);
-				return -1;
-			}
-			j = fullname;
-			count = 1;
+			prt_error("Ambiguous command \"%s\".  %s\n", s, helpmsg);
+			return -1;
 		}
 		if (count == 1)
 		{
@@ -899,15 +891,13 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			if (Cmd == as[i].param_type) continue;
 			if (strncasecmp(x, as[i].string, strlen(x)) == 0)
 			{
+				j = i;
 				if (strlen(as[i].string) == strlen(x))
 				{
-					fullname = i;
+					count = 1;
+					break;
 				}
-				else
-				{
-					if (UNDOC[0] == as[i].description[0]) continue;
-				}
-				j = i;
+				if (UNDOC[0] == as[i].description[0]) continue;
 				count ++;
 			}
 		}
@@ -920,12 +910,8 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 
 		if (count > 1)
 		{
-			if (fullname == -1)
-			{
-				prt_error("Error: Ambiguous variable \"%s\".  %s\n", x, helpmsg);
-				return -1;
-			}
-			j = fullname;
+			prt_error("Error: Ambiguous variable \"%s\".  %s\n", x, helpmsg);
+			return -1;
 		}
 
 		if ((as[j].param_type == Int) || (as[j].param_type == Bool))


### PR DESCRIPTION
- Fix "!help panic" (it doesn't work because "panic" is now a prefix of other variables/commands).
- Simplify the previous fix of setting the "panic" variable.
- Update the ChangeLog on the new panic-mode implementation.

(2 additional PRs are awaiting a rebase on the new master (and retesting) after this and the pending PR are applied.)