### PR TITLE
Memory handling fixes 

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -132,7 +132,7 @@ struct Sentence_s
 	size_t length;              /* Number of words */
 	Word  *word;                /* Array of words after tokenization */
 	String_set *   string_set;  /* Used for assorted strings */
-	Pool_desc * fm_Match_node;  /* Fast-matcher Match_node memory pool */
+	Pool_desc * Match_node_pool;
 	Pool_desc * Table_connector_pool; /* Count memoizing memory pool */
 	Pool_desc * wordvec_pool;   /* For tracon-word zero-count memoizing */
 	Pool_desc * Exp_pool;

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -521,7 +521,7 @@ void sentence_delete(Sentence sent)
 	lg_exp_stringify(NULL);
 
 	global_rand_state = sent->rand_state;
-	pool_delete(sent->fm_Match_node);
+	pool_delete(sent->Match_node_pool);
 	pool_delete(sent->Table_connector_pool);
 	pool_delete(sent->wordvec_pool);
 	pool_delete(sent->Exp_pool);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -528,7 +528,9 @@ void sentence_delete(Sentence sent)
 	pool_delete(sent->X_node_pool);
 	if (IS_DB_DICT(sent->dict))
 	{
+#if 0 /* Cannot reuse in case a previous sentence is not deleted yet. */
 		condesc_reuse(sent->dict);
+#endif
 		pool_reuse(sent->dict->Exp_pool);
 	}
 

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -165,7 +165,7 @@ inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 
 	size_t alloc_size = mp->element_size * vecsize;
 	if ((NULL == mp->alloc_next) ||
-	    (mp->alloc_next + alloc_size >= mp->ring + mp->data_size))
+	    (mp->alloc_next + alloc_size > mp->ring + mp->data_size))
 	{
 #ifdef POOL_EXACT
 		assert(!mp->exact || (NULL == mp->alloc_next),

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -10,7 +10,6 @@
 /*************************************************************************/
 
 #include <errno.h>                      // errno
-#include <stddef.h>                     // max_align_t
 
 #include "error.h"
 #include "memory-pool.h"
@@ -18,17 +17,6 @@
 
 /* TODO: Add valgrind descriptions. See:
  * http://valgrind.org/docs/manual/mc-manual.html#mc-manual.mempools */
-
-#if !POOL_ALLOCATOR
-typedef union
-{
-	struct{
-		char *next;
-		size_t size;
-	};
-	max_align_t dymmy;
-} alloc_attr;
-#endif
 
 /**
  * Align given size to the nearest upper power of 2
@@ -261,7 +249,7 @@ void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
 	        vecsize, mp->num_elements);
 	mp->curr_elements += vecsize;
-	size_t alloc_size = mp->num_elements * vecsize;
+	size_t alloc_size = mp->element_size * vecsize;
 
 #ifdef POOL_EXACT
 	assert(!mp->exact || mp->curr_elements <= mp->num_elements,
@@ -311,6 +299,7 @@ void pool_reuse(Pool_desc *mp)
 }
 
 /*
+ * num_elements
  * Delete the given memory pool.
  */
 #undef pool_delete

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -154,9 +154,7 @@ inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 	if ((NULL != mp->free_list) && (vecsize == 1))
 	{
 		void *alloc_next = mp->free_list;
-#ifdef POOL_FREE
 		ASAN_UNPOISON_MEMORY_REGION(alloc_next, mp->element_size);
-#endif
 		mp->free_list = *(char **)mp->free_list;
 		if (mp->zero_out) memset(alloc_next, 0, mp->element_size);
 		return alloc_next;
@@ -350,14 +348,12 @@ void pool_delete (const char *func, Pool_desc *mp)
 void pool_free(Pool_desc *mp, void *e)
 {
 	mp->curr_elements--;
-#ifdef POOL_FREE
 	if (ASAN_ADDRESS_IS_POISONED(e))
 	{
 		prt_error("Fatal error: Double pool free of %p\n", e);
 		exit(1);
 	}
 	ASAN_POISON_MEMORY_REGION(e, sizeof(alloc_attr) + ((alloc_attr *)e)->size);
-#endif
 }
 #endif // POOL_FREE
 #endif // POOL_ALLOCATOR

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -94,10 +94,11 @@ static inline void *pool_alloc(Pool_desc *mp)
 }
 
 /**
- * Return the next element in the pool.
- * @param Pool_location Iteration state. Should be initialized to 0
- * before starting the iteration.
- * @return A different element on each call, \c NULL when there are no more.
+ * Return the next element in the pool, starting with the first one.
+ * @param l Iteration state. \c *l should be initialized to
+ * (Pool_location)0 before starting the iteration.
+ * @return The next element on each call, \c NULL when there are no
+ * more.
  */
 static inline void *pool_next(Pool_desc *mp, Pool_location *l)
 {

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -12,6 +12,8 @@
 #ifndef _MEMORY_POOL_H
 #define _MEMORY_POOL_H
 
+#include <stddef.h>                     // max_align_t
+
 #include "link-includes.h"
 #include "error.h"
 #include "utilities.h"                  // GNUC_MALLOC (XXX separate include?)
@@ -46,6 +48,17 @@ void pool_free(Pool_desc *, void *e);
 
 #ifndef POOL_ALLOCATOR
 #define POOL_ALLOCATOR 1
+#endif
+
+#if !POOL_ALLOCATOR
+typedef union
+{
+	struct{
+		char *next;     /* Next allocation. */
+		size_t size;    /* Allocation payload size. */
+	};
+	max_align_t dymmy; /* Align the payload properly for all payload sizes. */
+} alloc_attr;
 #endif
 
 #define FLDSIZE_NEXT sizeof(char *) // "next block" field size
@@ -113,9 +126,11 @@ static inline void *pool_next(Pool_desc *mp, Pool_location *l)
 		/* This is an initial request for pool traversal.
 		 * Initialize the location descriptor and return the first element. */
 		l->element_number = 1;
+#if POOL_ALLOCATOR
 		l->current_element = mp->chain;
-#ifdef POOL_ALLOCATOR
 		l->block_end = mp->chain + mp->data_size;
+#else
+		l->current_element = mp->chain + sizeof(alloc_attr);
 #endif
 
 		return l->current_element;
@@ -130,7 +145,8 @@ static inline void *pool_next(Pool_desc *mp, Pool_location *l)
 		l->block_end = l->current_element + mp->data_size;
 	}
 #else
-	l->current_element = POOL_NEXT_BLOCK(l->current_element, mp->element_size);
+	alloc_attr *at = (alloc_attr *)(l->current_element - sizeof(alloc_attr));
+	l->current_element = at->next + sizeof(alloc_attr);
 #endif
 
 	l->element_number++;

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -241,13 +241,13 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 	ctxt->match_list = xalloc(ctxt->match_list_size * sizeof(*ctxt->match_list));
 	ctxt->match_list_end = 0;
 
-	if (NULL != sent->fm_Match_node)
+	if (NULL != sent->Match_node_pool)
 	{
-		pool_reuse(sent->fm_Match_node);
+		pool_reuse(sent->Match_node_pool);
 	}
 	else
 	{
-		sent->fm_Match_node =
+		sent->Match_node_pool =
 			pool_new(__func__, "Match_node",
 			         /*num_elements*/2048, sizeof(Match_node),
 			         /*zero_out*/false, /*align*/true, /*exact*/false);
@@ -300,7 +300,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 		{
 			if (d->left != NULL)
 			{
-				Match_node *m = pool_alloc(sent->fm_Match_node);
+				Match_node *m = pool_alloc(sent->Match_node_pool);
 				m->d = d;
 				sort_by_nearest_word(m, sbin, d->left->nearest_word);
 			}
@@ -309,7 +309,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 		{
 			if (d->right != NULL)
 			{
-				Match_node *m = pool_alloc(sent->fm_Match_node);
+				Match_node *m = pool_alloc(sent->Match_node_pool);
 				m->d = d;
 				sort_by_nearest_word(m, sbin, d->right->nearest_word);
 			}


### PR DESCRIPTION
The main fixes here:
1. Fix a severe error in the combination of `pool_alloc_vec()` and `pool_next()`.
Problem description:
In the recent change of `pool_alloc()` to `pool_aloloc_vec()`, I introduced an off-by-one error that causes it not to allocate the last component of any block. This is (very) slightly wasteful but it is not harmful by itself. However, `pool_next()` iterates over all the elements of a block, including its last component (which has not been allocated and thus contains random values).
Currently, `pool_next()` is only used when growing the count table. This puts a random element every 16K elements (the number of elements in the allocated blocks there) in the table.
However, it is unlikely to cause a parsing problem because its table position needs to match the hash value, and in addition `do_count()` needs to look up this tracon combination (and also 0 is a likely value of the count field and absolutely most lookups find 0-count anyway). So it is not urgent to issue a new version immediately just due to this problem.

2. Fix a stale-memory problem when using the SQL-dict in a typical way from Python.
Problem description:
When running the test suite with ASAN and using the fake memory-pool allocator (used for memory allocation debugging), a stale-memory reference is detected in the SQL-dict parse of "This is another test" when the code produces the diagram for the first linkage of that sentence. Here is the place that causes the stale memory:
https://github.com/opencog/link-grammar/blob/9f7c4fb429c4ff4bb787306d43f66c98846cbb6d/bindings/python-examples/tests.py#L1147-L1148 
In line 1148, the linkage variable, which at this point holds the linkage of the previous sentence, is overwritten. This destroys the last reference to the Sentence object (of the **previous** sentence), which deletes it and calls  `sentence_delete() for it. Here is the relevant C code:
https://github.com/opencog/link-grammar/blob/9f7c4fb429c4ff4bb787306d43f66c98846cbb6d/link-grammar/api.c#L529-L533

The problematic line is 531. It frees the `condesc` table, which contains the connector strings. However, at this point, it already contains the connectors of the linkage of the **current** sentence, which has got parsed at line 1147 in the above Python code.
Just after that, the diagram-creating function called at line 1168 (see below) refers to this stale memory. 
https://github.com/opencog/link-grammar/blob/9f7c4fb429c4ff4bb787306d43f66c98846cbb6d/bindings/python-examples/tests.py#L1168-L1168
This problem doesn't happen (typically) when the SQL-dict is used from C, because sentences are deleted just after they are parsed (and not after an additional sentence is parsed).
\
The fix was to just disable this C line (531).

3. Fix the fake memory-pool allocator (that got miss-fixed last time I touched it). This time I made extensive tests using it.
