### PR TITLE
count.c fixes

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -312,6 +312,7 @@ static inline unsigned int pair_hash(int lw, int rw,
 	i = r_id + (i << 6) + (i << 16) - i;
 #endif
 
+	if (i == 0) i = 1; /* Allow for table hash field validation. */
 	return i;
 }
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -140,6 +140,7 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 
 	if (shift == 0)
 		shift = ctxt->log2_table_size + 1; /* Double the table size */
+	lgdebug(+D_COUNT, "Connector table log2 size %u\n", shift);
 
 	/* Keep the table indefinitely (or until exiting), so that it can
 	 * be reused. This avoids a large overhead in malloc/free when
@@ -210,7 +211,6 @@ static void init_table(count_context_t *ctxt, Sentence sent)
 #endif
 
 	if (MAX_LOG2_TABLE_SIZE < shift) shift = MAX_LOG2_TABLE_SIZE;
-	lgdebug(+D_COUNT, "Initial connector table log2 size %u\n", shift);
 
 	table_alloc(ctxt, shift);
 }

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -552,19 +552,18 @@ static void generate_word_skip_vector(count_context_t *ctxt, wordvecp wv,
  * Is the range [c, w) going to yield a nonzero leftcount / rightcount?
  *
  * @param ctxt Count context.
- * @param dir Direction - 0: leftcount, 1: rightcount.
+ * @param dir Direction - 0: leftcount; 1: rightcount.
  * @param c The connector that starts the range.
- * @param w The word that ends the range.
- * @param null_count The current null_count to check.
- * @param cw The word of this connector.
+ * @param wordvec_index Word-vector index.
+ * @param null_count The current null-count to check.
  *
  * Return these values:
  * @param lnull_start First null count to check (the previous ones can be
  * skipped because the cache indicates they yield a zero count.)
  * @return Cache entry for the given range. Possible values:
- *    NULL - A nonzero count may be encountered for null_count>=lnull_start.
+ *    NULL - A nonzero count may be encountered for \c null_count>=lnull_start.
  *    Table_lrcnt_zero - A zero count would result.
- *    Cache pointer - An update for null_count>=lnull_start is needed.
+ *    Cache pointer - An update for \c null_count>=lnull_start is needed.
  */
 static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
                              unsigned int wordvec_index,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -318,9 +318,25 @@ static void table_stat(count_context_t *ctxt)
 
 	for (unsigned int i = 0; i < ctxt->table_size; i++)
 	{
-		c = 0;
 		Table_connector *t = ctxt->table[i];
-		if (t == NULL) N++;
+
+		c = 0;
+		if (t == NULL)
+		{
+			N++;
+		}
+		else
+		{
+			assert(t->hash != 0, "Invalid hash value: 0");
+			assert((hist_total(&t->count)>=0)&&(hist_total(&t->count) <= INT_MAX),
+			       "Invalid count %lld", hist_total(&t->count));
+			assert(t->l_id < (int)ctxt->sent->length ||
+			       ((t->l_id >= 255)&&(t->l_id < (int)ctxt->table_lrcnt_size[0])),
+			       "invalid l_id %d", t->l_id);
+			assert(t->r_id <= (int)ctxt->sent->length ||
+			       ((t->r_id > 255)&&(t->r_id < (int)ctxt->table_lrcnt_size[1])),
+			       "invalid r_id %d", t->r_id);
+		}
 		for (; t != NULL; t = t->next)
 		{
 			c++;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -609,7 +609,10 @@ static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
 	 * on the first one that succeeds. */
 
 	if (lp->status == -1)
+	{
+		if (null_start != NULL) *null_start = 0;
 		return lp; /* Needs update */
+	}
 
 	if  (lp->status == 1)
 	{


### PR DESCRIPTION
The main fix here is fixing an uninitialized variable in this commit:
* is_lrcnt(): Fix returning without assigning a value to null_start

It looks like it could have bad implications. However, with a detailed parsing with nulls of all the "basic" corpuses + "en/fixes" (with `limit=150000`) it makes absolutely no difference. Strangely, ASAN doesn't show any problem - I found it with valgrind.

Another important change (for debugging only) is adding a Table_connector validation:
* table_stat(): Validate the table

The uninitialized variable fix can be yet another reason to issue a new version "soon" (but it still not "urgent").
However, with the stress tests of using the `en` dict for sentence generation, I may detect some more problems.

---
The next thing I would like to fix in `count.c` is the Table_connector size.
Currently, the maximum size is 2^24.  But it seems there is no reason to limit it since it can still consume more memory by added buckets, which consume most of its memory anyway. Limiting it just causes a vast slowness if the table becomes very loaded (long bucket lists).
However, it uses an `unsigned int` for its size and its size is a power-of-2, so it cannot go over 2^31 entries without additional changes. But the main issue is that using `size_t` hash values will enlarge the bucket size (memory inefficiency) since it holds the hash value (for efficient table growth) and will make it (the bucket size) not a power-of-2 (indexing inefficiency). This can be solved by making the count 24-bit (I have an old patch for that but I will need to apply it by hand...).
Another thing that I would like to try is allocating a table size of a few bytes less than a power-of-2 (say by 16 bytes). Currently `malloc()` may allocate internal double allocations since it needs a few bytes for bookkeeping. This will allow a table size of 2^32-16 entries (the last 16 entries can be `folded` over other entries). Preventing double allocation for Table_connector may not be so important for systems that allow overcommitted memory (some don't allow), but the same problem exists for pool allocation, which is potentially more problematic.