### PR TITLE
Link parser fixes

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -196,7 +196,17 @@ void parse_options_set_debug(Parse_Options opts, const char * dummy)
 }
 
 char * parse_options_get_debug(Parse_Options opts) {
-	return opts->debug;
+	static char buff[256]; /* see parse_options_set_debug() */
+	char *buffp = buff;
+
+	/* Remove the added commas. */
+	strcpy(buff, opts->debug);
+	if (buffp[0] == ',')
+		buffp++;
+	if ((buffp[0] != '\0') && buffp[strlen(buffp)-1] == ',')
+		buffp[strlen(buffp)-1] = '\0';
+
+	return buffp;
 }
 
 void parse_options_set_test(Parse_Options opts, const char * dummy)
@@ -233,7 +243,17 @@ void parse_options_set_test(Parse_Options opts, const char * dummy)
 }
 
 char * parse_options_get_test(Parse_Options opts) {
-	return opts->test;
+	static char buff[256]; /* see parse_options_set_test() */
+	char *buffp = buff;
+
+	/* Remove the added commas. */
+	strcpy(buff, opts->test);
+	if (buffp[0] == ',')
+		buffp++;
+	if ((buffp[0] != '\0') && buffp[strlen(buffp)-1] == ',')
+		buffp[strlen(buffp)-1] = '\0';
+
+	return buffp;
 }
 
 void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -450,7 +450,7 @@ void display_1line_help(const Switch *sp, bool is_completion)
 
 static void display_help(const Switch *sp, Command_Options *copts)
 {
-	char line[MAX_INPUT]; /* Maximum number of character in a help file line */
+	char line[MAX_INPUT_LINE]; /* Maximum number of character in a help file line */
 
 	display_1line_help(sp, /*is_completion*/false);
 	if (Cmd != sp->param_type)
@@ -478,7 +478,7 @@ static void display_help(const Switch *sp, Command_Options *copts)
 			 * in a hope that the same help text can be used for the
 			 * language bindings too (which have different option names
 			 * from historical reasons).
-			 * Note: We suppose the lines are not longer than MAX_INPUT.
+			 * Note: We suppose the lines are not longer than MAX_INPUT_LINE.
 			 * Longer lines may render the help text incorrectly.
 			 * FIXME: Add command reference notation in the help text if
 			 * needed.
@@ -521,7 +521,7 @@ static void display_help(const Switch *sp, Command_Options *copts)
 		while (NULL != fgets(line, sizeof(line), hf))
 		{
 			const size_t len = strlen(line);
-			if ((MAX_INPUT == len-1) && '\n' != line[MAX_INPUT-2])
+			if ((MAX_INPUT_LINE == len-1) && '\n' != line[MAX_INPUT_LINE-2])
 			{
 				prt_error("Warning: Help-file text line too long at offset %ld\n",
 							 ftell(hf));

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -87,9 +87,9 @@ static char * get_terminal_line(char *input_string, FILE *in, FILE *out)
 	if (!running_under_cygwin)
 		pline = get_console_line();
 	else
-		pline = fgets(input_string, MAX_INPUT, in);
+		pline = fgets(input_string, MAX_INPUT_LINE, in);
 #else
-	pline = fgets(input_string, MAX_INPUT, in);
+	pline = fgets(input_string, MAX_INPUT_LINE, in);
 #endif /* _WIN32 */
 #endif /* HAVE_EDITLINE */
 
@@ -99,7 +99,7 @@ static char * get_terminal_line(char *input_string, FILE *in, FILE *out)
 static char * fget_input_string(FILE *in, FILE *out, bool check_return)
 {
 	static char *pline;
-	static char input_string[MAX_INPUT];
+	static char input_string[MAX_INPUT_LINE];
 	static bool input_pending = false;
 
 	if (input_pending)
@@ -108,12 +108,12 @@ static char * fget_input_string(FILE *in, FILE *out, bool check_return)
 		return pline;
 	}
 
-	input_string[MAX_INPUT-2] = '\0';
+	input_string[MAX_INPUT_LINE-2] = '\0';
 
 	if (((in != stdin) && !check_return) || !isatty_stdin)
 	{
 		/* Get input from a file. */
-		pline = fgets(input_string, MAX_INPUT, in);
+		pline = fgets(input_string, MAX_INPUT_LINE, in);
 	}
 	else
 	{
@@ -123,10 +123,10 @@ static char * fget_input_string(FILE *in, FILE *out, bool check_return)
 
 	if (NULL == pline) return NULL;      /* EOF or error */
 
-	if (('\0' != input_string[MAX_INPUT-2]) &&
-	    ('\n' != input_string[MAX_INPUT-2]))
+	if (('\0' != input_string[MAX_INPUT_LINE-2]) &&
+	    ('\n' != input_string[MAX_INPUT_LINE-2]))
 	{
-		prt_error("Warning: Input line too long (>%d)\n", MAX_INPUT-1);
+		prt_error("Warning: Input line too long (>%d)\n", MAX_INPUT_LINE-1);
 		/* TODO: Ignore it and its continuation part(s). */
 	}
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -682,10 +682,22 @@ int main(int argc, char * argv[])
 	parse_options_set_disjunct_cost(opts,
 	   linkgrammar_get_dict_max_disjunct_cost(dict));
 
+	/* Remember the debug setting, because we temporary neglect it below. */
+	int verbosity_tmp = parse_options_get_verbosity(opts);
+	char *debug_tmp = strdup(parse_options_get_debug(opts));
+	char *test_tmp = strdup(parse_options_get_test(opts));
+
 	parse_options_set_verbosity(opts, 1); /* XXX assuming 1 is the default */
 	parse_options_set_debug(opts, "");
 	parse_options_set_test(opts, "");
 	save_default_opts(copts); /* Options so far are the defaults */
+
+	/* Restore the debug setting. */
+	parse_options_set_verbosity(opts, verbosity_tmp);
+	parse_options_set_debug(opts, debug_tmp);
+	parse_options_set_test(opts, test_tmp);
+	free(debug_tmp);
+	free(test_tmp);
 
 	/* Process options used by GNU programs. */
 	int quiet_start = 0; /* Iff > 0, inhibit the initial messages */

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -115,9 +115,9 @@ char *expand_homedir(const char *filename)
 char *get_console_line(void)
 {
 	static HANDLE console_handle = NULL;
-	wchar_t winbuf[MAX_INPUT];
+	wchar_t winbuf[MAX_INPUT_LINE];
 	/* Worst-case: 4 bytes per UTF-8 char, 1 UTF-8 char per wchar_t char. */
-	static char utf8inbuf[MAX_INPUT*4+1];
+	static char utf8inbuf[MAX_INPUT_LINE*4+1];
 
 	if (NULL == console_handle)
 	{
@@ -131,7 +131,7 @@ char *get_console_line(void)
 	}
 
 	DWORD nchar;
-	if (!ReadConsoleW(console_handle, &winbuf, MAX_INPUT-sizeof(wchar_t), &nchar, NULL))
+	if (!ReadConsoleW(console_handle, &winbuf, MAX_INPUT_LINE-sizeof(wchar_t), &nchar, NULL))
 	{
 		prt_error("Error: ReadConsoleW: Error %d\n", (int)GetLastError());
 		return NULL;

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -21,7 +21,7 @@ char *expand_homedir(const char *fn);
 void set_screen_width(Command_Options*);
 void initialize_screen_width(Command_Options *);
 
-#define MAX_INPUT 2048
+#define MAX_INPUT_LINE 2048
 
 #ifdef _WIN32
 #ifndef __MINGW32__

--- a/man/link-parser.1
+++ b/man/link-parser.1
@@ -292,6 +292,12 @@ Flat, treebank-style tree (A like (B this))
 .BR !cost-max \ (2.7)
 Largest cost to be considered.
 .TP
+.BR !dialect \ (no\ value)
+Use the specified (comma-separated) names.
+.br
+They modify the disjunct cost of dictionary words
+whose expressions contain symbolic cost specifications.
+.TP
 .BR !disjuncts \ (off)
 Display of disjuncts used.
 .TP
@@ -432,6 +438,9 @@ Values of entities used in tokenization.
 Regular expressions (see
 .BR regex (7))
 that are used to match tokens not found in the dictionary.
+.TP
+.IR LL /4.0.dialect
+Dialect component definitions.
 .TP
 .IR LL /4.0.knowledge
 Post-processing definitions.

--- a/man/link-parser.1
+++ b/man/link-parser.1
@@ -374,6 +374,8 @@ Normal verbosity
 .IP 2
 Show times of the parsing steps
 .IP 3
+Display some more information messages
+.IP 4
 Display data file search and locale setup
 .IP  5-9
 Tokenizer and parser debugging

--- a/man/link-parser.1
+++ b/man/link-parser.1
@@ -344,6 +344,8 @@ When a word matches a RegEx, show the matching dictionary entry.
 .TP
 .BR !panic \ (on)
 Use "panic mode" if a parse cannot be quickly found.
+.br
+The command \%\fB!panic_variables\fP prints the special variables that are used only in "panic mode".
 .TP
 .BR !postscript \ (off)
 Generate postscript output.

--- a/man/link-parser.1
+++ b/man/link-parser.1
@@ -324,6 +324,14 @@ of two or more words that are in the \%link\-grammar dictionary.
 This word found in the dictionary as word.POS.
 .IP word.#CORRECTION
 This word is probably a typo - got linked as an alternative word CORRECTION.
+.PP
+For dictionaries that support morphology (enable with !morphology=1):
+.IP word=
+A prefix morpheme
+.IP =word
+A suffix morpheme
+.IP word.=
+A stem
 .RE
 .TP
 .BR !islands-ok \ (on)


### PR DESCRIPTION
1. Fix `parse_oprions_get_test()` and `parse_options_get_debug()` to strip the added commas .
This also makes cleaner their value display in `link-parser` (the internally-used start/end commas are not shown anymore).

2. Restore the ability to use `verbosity=`, `-debug=` and `-test=` for dict debugging. For example `-verbosity=101` to print all the connectors. It was not easy to do it using the current `link-parser` infrastructure. If I think on this some more, maybe I will be able to simplify it.

More details are in the commit messages.

3. Update the manpage.
