### PR TITLE
Fixes for MSVC

### DIFF
--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -132,7 +132,8 @@ static unsigned int dialect_table_add(Dialect *di, const char *token,
 
 		di->table = realloc(di->table, *size * sizeof(*di->table));
 	}
-	di->table[di->num_table_tags] = (dialect_tag){ .name = token, .cost = cost };
+	di->table[di->num_table_tags] =
+		(dialect_tag){ .name = token, .cost = (float)cost };
 
 	return di->num_table_tags++;
 }

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -131,7 +131,7 @@ void pool_delete (const char *func, Pool_desc *mp)
  * 2. Zero the block if required;
  * 3. Return element pointer.
  */
-inline void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
+void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 {
 	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
 	        vecsize, mp->num_elements);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -459,7 +459,7 @@ static Count_bin table_store(count_context_t *ctxt,
  * the entry is not found).
  * @return The count for this quintuple if there, NULL otherwise.
  */
-inline Count_bin *
+Count_bin *
 table_lookup(count_context_t *ctxt, int lw, int rw,
                    const Connector *le, const Connector *re,
                    unsigned int null_count, unsigned int *hash)

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -768,7 +768,7 @@ bool strtodC(const char *s, float *r)
 
 	if ('\0' != *err) return false; /* *r unaffected */
 
-	*r = val;
+	*r = (float)val;
 	return true;
 }
 


### PR DESCRIPTION
- Remove inline directives that cause MSVC build break.
MSVC doesn't make external linkage on functions that have an `inline` attribute.
The `inline` attribute on `pool_alloc_vect()` has been left there by mistake.
However, the `inline` attribute on `table_lookup()` was intentional, and its actual inlining are to be checked again on the next planned changes there.
- Use explicit double to float conversions to avoid warnings
This removes all the double-to-float conversion warnings.
The count-related conversion warnings (64 to 32 bit) will be handled on the upcoming 32-bit count patch.
The remaining ones are to be gradually eliminated.
