### PR TITLE
Free kept_table on thread-exit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Version 5.9.0 (XXX 2021)
  * Fix very rare crash/corruption introduced in v.5.8.1 #1142
  * English dict: fix problems with "just/only".
  * English dict: work on hesitation markers.
+ * Fix multi-threading mem-leak. #1149
 
 Version 5.8.1 (8 January 2021)
  * Fix macOS/SunOS build break.

--- a/configure.ac
+++ b/configure.ac
@@ -538,7 +538,6 @@ if test "$do_aspell" = yes ; then
 	CPPFLAGS=$save_cpp_flags
 	if test  "x${ASpellFound}" = "xyes"; then
 		AC_DEFINE(HAVE_ASPELL, 1, [Define for compilation])
-		ASPELL_LIBS="${ASPELL_LIBS} -lpthread"
 		AC_SUBST(ASPELL_LIBS)
 		AC_SUBST(ASPELL_CFLAGS)
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,9 @@ lg_tls=no
 AX_TLS(,:)
 test "$ac_cv_tls" != "none" && lg_tls=yes
 
+AX_PTHREAD
+CFLAGS="${CFLAGS} ${PTHREAD_CFLAGS}"
+
 dnl Check for specific OSs
 # ====================================================================
 

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -52,8 +52,6 @@ liblink_grammar_la_LDFLAGS = -version-info @VERSION_INFO@ \
 
 liblink_grammar_la_LIBADD  =  ${REGEX_LIBS}
 
-liblink_grammar_la_LIBADD  +=  ${REGEX_LIBS}
-
 if HAVE_HUNSPELL
 liblink_grammar_la_LIBADD  +=  ${HUNSPELL_LIBS}
 endif
@@ -77,6 +75,9 @@ else !LIBMINISAT_BUNDLED
 liblink_grammar_la_LIBADD  += ${MINISAT_LIBS}
 endif !LIBMINISAT_BUNDLED
 endif WITH_SAT_SOLVER
+
+# Needed for tss_create and tss_set
+liblink_grammar_la_LIBADD  += -lpthread
 
 # Math libraries are needed for floorf, etc.
 liblink_grammar_la_LIBADD  += -lm

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -77,7 +77,7 @@ endif !LIBMINISAT_BUNDLED
 endif WITH_SAT_SOLVER
 
 # Needed for tss_create and tss_set
-liblink_grammar_la_LIBADD  += -lpthread
+liblink_grammar_la_LIBADD  += ${PTHREAD_LIBS}
 
 # Math libraries are needed for floorf, etc.
 liblink_grammar_la_LIBADD  += -lm

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -157,9 +157,8 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 	static TLS unsigned int log2_kept_table_size = 0;
 
 #if HAVE_PTHREAD
-	static once_flag flag = ONCE_FLAG_INIT;
-
 	// Install a thread-exit handler, to free kept_table on thread-exit.
+	static once_flag flag = ONCE_FLAG_INIT;
 	call_once(&flag, make_key);
 
 	if (NULL == kept_table)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -152,13 +152,6 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 			prt_error("Error: unexpected failure of thread alloc\n");
 	}
 
-	if (ctxt == NULL)
-	{
-		free(kept_table);
-		kept_table = NULL;
-		return;
-	}
-
 	if (shift == 0)
 		shift = ctxt->log2_table_size + 1; /* Double the table size */
 	lgdebug(+D_COUNT, "Connector table log2 size %u\n", shift);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -192,7 +192,7 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 }
 
 /**
- * Allocate the table with a sentence-depent table size.  Use
+ * Allocate the table with a sentence-dependent table size.  Use
  * sent->length as a hint for the initial table size. Usually, this
  * saves on dynamic table growth, which is costly.
  * */


### PR DESCRIPTION
Some users of link-grammar create hundreds of thousands of threads.
The tables leaked RAM very quickly in this case.