### PR TITLE
bindings/java/Makefile.am: Fix comment start location

### DIFF
--- a/bindings/java/Makefile.am
+++ b/bindings/java/Makefile.am
@@ -42,7 +42,7 @@ endif
 install-data-hook:
 	${LN_SF} ${javadir}/${java_DATA} ${DESTDIR}${javadir}/linkgrammar.jar
 if HAVE_MVN
-	# Install linkgrammar into the local maven repository
+	: # Install linkgrammar into the local maven repository
 	mvn install:install-file \
 	  -Dfile=${java_DATA} \
 	  -DgroupId=org.opencog \


### PR DESCRIPTION
Fix this error that happens when generation `configure`:
`bindings/java/Makefile.am:45: error: '#' comment at start of rule is unportable`

