### PR TITLE
Some commits from the `generate` branch

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -53,8 +53,8 @@
  % remain, below.
 
 % Capitalization handling (null effect for now- behave as empty words).
-1stCAP.zzz: ZZZ-;
-nonCAP.zzz: ZZZ-;
+<1stCAP>: ZZZ-;
+<nonCAP>: ZZZ-;
 
 % Null links. These are used to drop the requirement for certain words
 % to appear during parsing. Basically, if a parse fails at a given cost,

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -62,8 +62,8 @@ changecom(`%')
  % remain, below.
 
 % Capitalization handling (null effect for now- behave as empty words).
-1stCAP.zzz: ZZZ-;
-nonCAP.zzz: ZZZ-;
+<1stCAP>: ZZZ-;
+<nonCAP>: ZZZ-;
 
 % Null links. These are used to drop the requirement for certain words
 % to appear during parsing. Basically, if a parse fails at a given cost,

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -163,6 +163,12 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 
 	setup_connectors(sent);
 
+	if (verbosity_level(D_PREP))
+	{
+		prt_error("Debug: After setting connectors:\n");
+		print_disjunct_counts(sent);
+	}
+
 	if (verbosity_level(D_SPEC+2))
 	{
 		printf("prepare_to_parse:\n");

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -27,7 +27,7 @@
 #include "tokenize/word-structures.h"   // Word_struct
 #include "tokenize/wordgraph.h"
 
-#define D_PRUNE 5      /* Debug level for this file. */
+#define D_PRUNE 5      /* Debug level for this file (6 for pp_prune()) */
 
 /* To debug pp_prune(), touch this file, run "make CPPFLAGS=-DDEBUG_PP_PRUNE",
  * and then run: link-parser -v=5 -debug=prune.c . */
@@ -36,7 +36,7 @@
 #endif
 
 #ifdef DEBUG_PP_PRUNE
-#define ppdebug(...) lgdebug(+D_PRUNE, __VA_ARGS__)
+#define ppdebug(...) lgdebug(+D_PRUNE+1, __VA_ARGS__)
 #else
 #define ppdebug(...)
 #endif
@@ -1759,7 +1759,7 @@ static int pp_prune(Sentence sent, Tracon_sharing *ts, Parse_Options opts)
 		}
 	}
 
-	lgdebug(+D_PRUNE, "Deleted %d (%d connector names)\n",
+	lgdebug(+D_PRUNE+1, "Deleted %d (%d connector names)\n",
 	        D_deleted, Cname_deleted);
 
 	cms_table_delete(cmt);

--- a/link-grammar/tokenize/README.md
+++ b/link-grammar/tokenize/README.md
@@ -110,8 +110,8 @@ Not as in previous releases, capital letters which got downcased are not
 restored for display if the affected words have a linkage.
 
 A new experimental handling of capital words using the dictionary has been
-introduced. It inserts the token `1stCAP` before the uc version, and `nonCAP`
-before the lc one, as discussed in:
+introduced. It inserts the token `<1stCAP>` before the uc version, and
+`<nonCAP>` before the lc one, as discussed in:
 https://groups.google.com/forum/?hl=en#!topic/link-grammar/hmK5gjXYWbk
 It is enabled by `!test=dictcap`. The special "dictcap" tokens are not yet
 discarded, so in order to compare results to previous library versions, the

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -58,8 +58,8 @@ typedef const char *stripped_t[MAX_STRIP];
 #define REPLACEMENT_MARK "~" /* a mark for a replacement word */
 
 /* Dictionary capitalization handling */
-#define CAP1st "1stCAP" /* Next word is capitalized */
-#define CAPnon "nonCAP" /* Next word the lc version of a capitalized word */
+#define CAP1st "<1stCAP>" /* Next word is capitalized */
+#define CAPnon "<nonCAP>" /* Next word the lc version of a capitalized word */
 
 
 /**


### PR DESCRIPTION
Some commits from the `generate` branch are not dependent on the generation code and are a good idea anyway.
Applying them right away is a part of my effort to keep both branches as identical as possible.
