### PR TITLE
Generate - WIP 2

### DIFF
--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1725,7 +1725,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 		assert(dict->num_categories < 1024 * 1024, "Insane number of categories");
 		snprintf(dict->category[dict->num_categories].category_string,
 		         sizeof(dict->category[0].category_string),
-		         "%x", dict->num_categories);
+		         " %x", dict->num_categories); /* FIXME ' ' is a category mark. */
 		e->category = dict->num_categories;
 		dict->category[dict->num_categories].exp = e;
 		dict->category[dict->num_categories].num_words = n;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -291,7 +291,9 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			*loc = n;         /* update the connector list */
 		}
 
-		if (!IS_GENERATION(sent->dict) || !isxdigit(string[0]))
+		/* XXX add_category() starts category strings by ' '.
+		 * FIXME Replace it by a better indication. */
+		if (!IS_GENERATION(sent->dict) || (' ' != string[0]))
 		{
 			ndis->word_string = string;
 			ndis->cost = cl->cost;
@@ -303,7 +305,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			ndis->category =
 				malloc(sizeof(ndis->category) * ndis->num_categories_alloced);
 			ndis->num_categories = 1;
-			sscanf(string, "%x", &ndis->category[0].num);
+			sscanf(string, " %x", &ndis->category[0].num);
 			assert((ndis->category[0].num > 0) && (ndis->category[0].num < 64*1024),
 			       "Insane category %u", ndis->category[0].num);
 			ndis->category[0].cost = cl->cost;

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -23,6 +23,7 @@ typedef struct
 	const char* language;
 	int sentence_length;
 	int corpus_size;
+	bool display_disjuncts;
 
 	Parse_Options opts;
 } gen_parameters;
@@ -33,6 +34,7 @@ static struct argp_option options[] =
 	{"length", 's', "length", 0, "Sentence length. If 0 - get sentence template from stdin."},
 	{"count", 'c', "count", 0, "Count of number of sentences to generate."},
 	{"version", 'v', 0, 0, "Print version and exit."},
+	{"disjuncts", 'd'},
 	{0, 0, 0, 0, "Library options:", 1},
 	{"cost-max", '\4', "float"},
 	{"dialect", '\5', "dialect_list"},
@@ -51,6 +53,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 		case 'l': gp->language = arg; break;
 		case 's': gp->sentence_length = atoi(arg); break;
 		case 'c': gp->corpus_size = atoi(arg); break;
+		case 'd': gp->display_disjuncts = true; break;
 
 		case 'v':
 		{
@@ -186,6 +189,9 @@ int main (int argc, char* argv[])
 			printf(" %s", words[w]);
 		}
 		printf("\n");
+		char *disjuncts = linkage_print_disjuncts(linkage);
+		printf("%s\n", disjuncts);
+		free(disjuncts);
 
 		linkage_delete(linkage);
 	}


### PR DESCRIPTION
This PR fixes the word/category indication bug (still by a hack - FIXME).
It also adds a `link-generator` argument `--disjuncts`.

There is still a crash on macros, e.g. `This is a <noun-main-x>`. It happens in `string-set.c` when it adds `is.v`, but I still don't have any idea why.