### PR TITLE
Generate fixes 1

### DIFF
--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -422,7 +422,7 @@ static int classname_cb(void *user_data, int argc, char **argv, char **colName)
 
 	snprintf(dict->category[dict->num_categories].category_string,
 		sizeof(dict->category[0].category_string),
-		"%x", dict->num_categories);
+		" %x", dict->num_categories); /* ' ': See comment in build_disjuncts() */
 
 	return 0;
 }

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -305,7 +305,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			ndis->category =
 				malloc(sizeof(ndis->category) * ndis->num_categories_alloced);
 			ndis->num_categories = 1;
-			sscanf(string, " %x", &ndis->category[0].num);
+			ndis->category[0].num = strtol(string, NULL, 16);
 			assert((ndis->category[0].num > 0) && (ndis->category[0].num < 64*1024),
 			       "Insane category %u", ndis->category[0].num);
 			ndis->category[0].cost = cl->cost;

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -34,7 +34,7 @@ static struct argp_option options[] =
 	{"length", 's', "length", 0, "Sentence length. If 0 - get sentence template from stdin."},
 	{"count", 'c', "count", 0, "Count of number of sentences to generate."},
 	{"version", 'v', 0, 0, "Print version and exit."},
-	{"disjuncts", 'd'},
+	{"disjuncts", 'd', 0, 0, "Display linkage disjuncts"},
 	{0, 0, 0, 0, "Library options:", 1},
 	{"cost-max", '\4', "float"},
 	{"dialect", '\5', "dialect_list"},
@@ -189,9 +189,12 @@ int main (int argc, char* argv[])
 			printf(" %s", words[w]);
 		}
 		printf("\n");
-		char *disjuncts = linkage_print_disjuncts(linkage);
-		printf("%s\n", disjuncts);
-		free(disjuncts);
+		if (parms.display_disjuncts)
+		{
+			char *disjuncts = linkage_print_disjuncts(linkage);
+			printf("%s\n", disjuncts);
+			free(disjuncts);
+		}
 
 		linkage_delete(linkage);
 	}


### PR DESCRIPTION
- Use `strtol()` instead of `scanf()`.
- Fix `read-sql.c` to use the initial blank mark for category pseudo-words.
- link-generator.c: Complete --disjuncts addition

Meanwhile, due to tests done on the `generate` branch, I found bugs and possible improvements in `master`  (PRs soon).