### PR TITLE
print_dict.c cleanup

### DIFF
--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -890,8 +890,8 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 		notify_ignoring_flag(is_full);
 		notify_ignoring_flag(is_anyorder);
 
-		const char added_chars[] = "\\[]";
-		regpat = alloca(pat_len + sizeof(added_chars));
+		const size_t added_chars_len = sizeof("\\[]");
+		regpat = alloca(pat_len + added_chars_len);
 		strcpy(regpat, "\\[");
 		strcat(regpat, pattern);
 		strcat(regpat, "]");
@@ -925,8 +925,8 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 		}
 
 		/* Note: This section is sensitive to the disjunct print format. */
-		const char added_chars[] = "= <> $";
-		const size_t regpat_size = 2 * (pat_len + sizeof(added_chars));
+		const size_t added_chars_len = sizeof("= <> $");
+		const size_t regpat_size = 2 * (pat_len + added_chars_len);
 		regpat = alloca(regpat_size);
 
 		size_t dst_pos = lg_strlcpy(regpat, "= ", regpat_size);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -970,7 +970,7 @@ static Regex_node *make_disjunct_pattern(const char *pattern, const char *flags)
 						alloca(strlen(constring) + sizeof(added_chars));
 					word_boundary_constring[0] = ' ';
 					strcpy(word_boundary_constring+1, constring);
-					strcat(word_boundary_constring+1, "( |$)");
+					strcat(word_boundary_constring+1, added_chars+1);
 					constring = word_boundary_constring;
 
 				}

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -395,6 +395,8 @@ static const char *stringify_Exp_tag(Exp *e, Dictionary dict)
 {
 	static TLS char tag_info[64];
 
+	if (e->type == CONNECTOR_type) return "";
+
 		switch (e->tag_type)
 		{
 			case Exptag_none:

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -643,7 +643,8 @@ static void dyn_print_disjunct_list(dyn_str *s, const Disjunct *dj,
 		if (print_disjunct_address) append_string(s, "(%p)", dj);
 		dyn_strcat(l, ": ");
 
-		append_string(l, "[%d]%s= ", djn++, cost_stringify(dj->cost));
+		const char *cost_str = cost_stringify(dj->cost);
+		append_string(l, "[%d]%s%s= ", djn++, &" "[(*cost_str == '-')], cost_str);
 		dyn_print_connector_list(l, dj->left, /*dir*/0, flags);
 		dyn_strcat(l, " <> ");
 		dyn_print_connector_list(l, dj->right, /*dir*/1, flags);


### PR DESCRIPTION
- Don't use tag info for connectors - an additional fix
Original commit was b87f1d373b01a4761836743155ab39e39f0d49ea  Don't use tag info for connectors.
- dyn_print_disjunct_list(): Align negative and positive costs
Fix misalligned output when there are negtavie costs on disjuncts, e.g. when doing `!!<adj-conjoined>//`:
``` text
 <adj-conjoined>: [0]-0.100= EAm- <> dAJlc+
 <adj-conjoined>: [1]-0.100= EAm- <> @mv+ dAJlc+
 <adj-conjoined>: [2]0.000=  <> @mv+ dAJla+
 <adj-conjoined>: [3]0.000=  <> dAJla+
 <adj-conjoined>: [4]-0.100= EAm- dAJrc- <>
```
- The other two are a "cosmetic" change.