### PR TITLE
Generate WIP 3

### DIFF
--- a/link-grammar/dict-common/dict-affix.h
+++ b/link-grammar/dict-common/dict-affix.h
@@ -84,5 +84,6 @@ typedef enum {
 
 Afdict_class * afdict_find(Dictionary, const char *, bool);
 bool is_stem(const char *);
+bool is_macro(const char *); /* Not an affix but best include file to use */
 
 #endif /* _LG_DICT_AFFIX_H_ */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -35,7 +35,7 @@
 #define STEM_MARK '='
 
 /* ======================================================================== */
-/* Affix type finding */
+/* Identifying dictionary word formats */
 
 /**
  * Return TRUE if the word seems to be in stem form.
@@ -50,6 +50,17 @@ bool is_stem(const char* w)
 	if (subscrmark == w) return false;
 	if (STEM_MARK != subscrmark[1]) return false;
 	return true;
+}
+
+bool is_macro(const char *w)
+{
+	if (w[0] == '<')
+	{
+		char *end = strchr(w, '>');
+		if (end == NULL) return false;
+		if ((end[1] == '\0') || (end[1] == SUBSCRIPT_MARK)) return true;
+	}
+	return false;
 }
 
 /* ======================================================================== */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -89,7 +89,6 @@ typedef struct
 typedef struct
 {
 	unsigned int num_words;
-	char category_string[8];
 	const char* category_name;
 	Exp *exp;
 	char const ** word;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -124,8 +124,18 @@ dictionary_six_str(const char * lang,
 
 	if (NULL != affix_name)
 	{
-		/* To disable spell-checking, just set the checker to NULL */
-		dict->spell_checker = spellcheck_create(dict->lang);
+		if (test_enabled("generate")) /* Sentence generation. */
+		{
+			const size_t initial_allocation = 256;
+			dict->num_categories_alloced = initial_allocation;
+			dict->category = malloc(initial_allocation * sizeof(dict_category));
+			dict->leave_subscripts = test_enabled("leave-subscripts");
+			dict->spell_checker = NULL; /* Disable spell-checking. */
+		}
+		else
+		{
+			dict->spell_checker = spellcheck_create(dict->lang);
+		}
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
 		if (verbosity_level(D_USER_BASIC) && (NULL == dict->spell_checker))
@@ -150,14 +160,6 @@ dictionary_six_str(const char * lang,
 		}
 
 		dict->define.set = string_id_create();
-
-		if (test_enabled("generate")) /* Sentence generation. */
-		{
-			const size_t initial_allocation = 256;
-			dict->num_categories_alloced = initial_allocation;
-			dict->category = malloc(initial_allocation * sizeof(dict_category));
-			dict->leave_subscripts = test_enabled("leave-subscripts");
-		}
 	}
 	else
 	{

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1718,9 +1718,10 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 	else
 	{
 		assert(dict->num_categories < 1024 * 1024, "Insane number of categories");
-		snprintf(dict->category[dict->num_categories].category_string,
-		         sizeof(dict->category[0].category_string),
-		         " %x", dict->num_categories); /* FIXME ' ' is a category mark. */
+		char category_string[16]; /* For the tokenizer - not used here */
+		snprintf(category_string, sizeof(category_string), " %x",
+		         dict->num_categories);
+		string_set_add(category_string, dict->string_set);
 		e->category = dict->num_categories;
 		dict->category[dict->num_categories].exp = e;
 		dict->category[dict->num_categories].num_words = n;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1655,15 +1655,8 @@ static void add_define(Dictionary dict, const char *name, const char *value)
 	dict->define.value[id - 1] = string_set_add(value, dict->string_set);
 }
 
-static bool is_macro(const char *s)
+static bool is_wall(const char *s)
 {
-	if (s[0] == '<')
-	{
-		char *end = strchr(s, '>');
-		if (end == NULL) return false;
-		if ((end[1] == '\0') || (end[1] == SUBSCRIPT_MARK)) return true;
-		return false;
-	}
 	if (0 == strcmp(s, LEFT_WALL_WORD)) return true;
 	if (0 == strcmp(s, RIGHT_WALL_WORD)) return true;
 
@@ -1689,6 +1682,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 	if (n == 1)
 	{
 		if (is_macro(dn->string)) return;
+		if (is_wall(dn->string)) return;
 		if (is_correction(dn->string)) return;
 		if (is_directive(dn->string)) return;
 	}
@@ -1709,6 +1703,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 	for (Dict_node *dnx = dn; dnx != NULL; dnx = dnx->left)
 	{
 		if (is_macro(dnx->string)) continue;
+		if (is_wall(dnx->string)) continue;
 		if (is_correction(dnx->string)) continue;
 		if (is_directive(dnx->string)) return;
 		dict->category[dict->num_categories].word[n] = dnx->string;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -420,9 +420,10 @@ static int classname_cb(void *user_data, int argc, char **argv, char **colName)
 	dict->category[dict->num_categories].category_name =
 		string_set_add(argv[0], dict->string_set);
 
-	snprintf(dict->category[dict->num_categories].category_string,
-		sizeof(dict->category[0].category_string),
-		" %x", dict->num_categories); /* ' ': See comment in build_disjuncts() */
+	char category_string[16];     /* For the tokenizer - not used here */
+	snprintf(category_string, sizeof(category_string), " %x",
+	         dict->num_categories); /* ' ': See comment in build_disjuncts() */
+	string_set_add(category_string, dict->string_set);
 
 	return 0;
 }

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2992,7 +2992,12 @@ static Dict_node *dictionary_all_categories(Dictionary dict)
 	for (size_t i = 0; i < dict->num_categories; i++)
 	{
 		dn[i].exp = dict->category[i + 1].exp;
-		dn[i].string = dict->category[i + 1].category_string;
+		char category_string[16];
+		snprintf(category_string, sizeof(category_string), " %x",
+		         (unsigned int)i + 1);
+		dn[i].string = string_set_lookup(category_string, dict->string_set);
+		assert(dn[i].string != NULL, "Missing string for category %u",
+		       dict->num_categories);
 		dn[i].right = &dn[i + 1];
 	}
 	dn[dict->num_categories-1].right = NULL;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2284,12 +2284,16 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 		issue_word_alternative(sent, unsplit_word, "W", 0,NULL, 1,&word, 0,NULL);
 		unsplit_word->status |= WS_INDICT;
 		word_is_known = true;
+
+		if (IS_GENERATION(sent->dict) && is_macro(word))
+			unsplit_word->tokenizing_step = TS_DONE;
 	}
 
-	if (unsplit_word->status & (WS_SPELL|WS_RUNON))
+	if (unsplit_word->status & (WS_SPELL|WS_RUNON) ||
+	    (unsplit_word->tokenizing_step == TS_DONE))
 	{
-		/* The word is a result of spelling, so it doesn't need right/left
-		 * stripping. Skip it. */
+		/* The word is a result of spelling, or is a dictionary macro, so it
+		 * doesn't need right/left stripping. Skip it. */
 	}
 	else
 	{

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -120,7 +120,6 @@ int main (int argc, char* argv[])
 	printf("# Dictionary version %s\n", linkgrammar_get_dict_version(dict));
 
 	parse_options_set_linkage_limit(opts, parms.corpus_size);
-	parse_options_set_spell_guess(opts, 0);
 
 	if (parms.sentence_length < 0)
 	{


### PR DESCRIPTION
I got stuck in debugging memory leak due to not freeing disjunct categories in some cases on a sqlite3 dict.
But I have some work progress which is included here.
- Don't split macros in generation-mode.
- Get rid of `category_string` in `dict_category`.
- Disable spell-check for generation-mode in the **library** because it is not appropriate with generation.

BTW, I had a hard time creating this PR, because certain commits that are already in the repository got included again.
I guess I did something wrong but I have no clue what it could be.
I had to `pull -f` and apply my commits again.

EDIT: Force-pushed to fix a compile warning.