### PR TITLE
Generate - WIP 4

### DIFF
--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -25,14 +25,17 @@ LINK_BEGIN_DECLS
  * the public API to the link-parser system.
  */
 
-
-Dict_node * dictionary_lookup_list(const Dictionary, const char *);
-Dict_node * dictionary_lookup_wild(const Dictionary, const char *);
+link_public_api(Dict_node *)
+	dictionary_lookup_list(const Dictionary, const char *);
+link_public_api(Dict_node *)
+	dictionary_lookup_wild(const Dictionary, const char *);
 
 /* Return true if word can be found. */
-bool dictionary_word_is_known(const Dictionary, const char *);
+link_public_api(bool)
+	dictionary_word_is_known(const Dictionary, const char *);
 
-void free_lookup_list(const Dictionary, Dict_node *);
+link_public_api(void)
+	free_lookup_list(const Dictionary, Dict_node *);
 
 /* This was exported and used by mistake! */
 bool boolean_dictionary_lookup(const Dictionary, const char *);

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -32,11 +32,11 @@ LINK_BEGIN_DECLS
  ***********************************************************************/
 
 link_public_api(Dict_node *)
-	dictionary_lookup_list(const Dictionary, const char *);
+	dictionary_lookup_list(const Dictionary dict, const char *word);
 link_public_api(Dict_node *)
-	dictionary_lookup_wild(const Dictionary, const char *);
+	dictionary_lookup_wild(const Dictionary dict, const char *word);
 link_public_api(void)
-	free_lookup_list(const Dictionary, Dict_node *);
+	free_lookup_list(const Dictionary dict, Dict_node * n);
 
 /**********************************************************************
  *
@@ -45,18 +45,18 @@ link_public_api(void)
  ***********************************************************************/
 
 link_public_api(const Category *)
-	dictionary_get_categories(const Dictionary);
+	dictionary_get_categories(const Dictionary dict);
 
 link_public_api(const Category_cost *)
-	linkage_get_categories(const Linkage, WordIdx);
+	linkage_get_categories(const Linkage linkage, WordIdx w);
 
 
 /* Return true if word can be found. */
 link_public_api(bool)
-	dictionary_word_is_known(const Dictionary, const char *);
+	dictionary_word_is_known(const Dictionary dict, const char *word);
 
 /* This was exported and used by mistake! */
-bool boolean_dictionary_lookup(const Dictionary, const char *);
+bool boolean_dictionary_lookup(const Dictionary dict, const char *word);
 
 /* XXX the below probably does not belong ...  ?? */
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -25,17 +25,22 @@ LINK_BEGIN_DECLS
  * the public API to the link-parser system.
  */
 
+/**********************************************************************
+ *
+ * Lookup-list.
+ *
+ ***********************************************************************/
+
 link_public_api(Dict_node *)
 	dictionary_lookup_list(const Dictionary, const char *);
 link_public_api(Dict_node *)
 	dictionary_lookup_wild(const Dictionary, const char *);
+link_public_api(void)
+	free_lookup_list(const Dictionary, Dict_node *);
 
 /* Return true if word can be found. */
 link_public_api(bool)
 	dictionary_word_is_known(const Dictionary, const char *);
-
-link_public_api(void)
-	free_lookup_list(const Dictionary, Dict_node *);
 
 /* This was exported and used by mistake! */
 bool boolean_dictionary_lookup(const Dictionary, const char *);

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -38,6 +38,19 @@ link_public_api(Dict_node *)
 link_public_api(void)
 	free_lookup_list(const Dictionary, Dict_node *);
 
+/**********************************************************************
+ *
+ * Category. Experimental and subject to changes.
+ *
+ ***********************************************************************/
+
+link_public_api(const Category *)
+	dictionary_get_categories(const Dictionary);
+
+link_public_api(const Category_cost *)
+	linkage_get_categories(const Linkage, WordIdx);
+
+
 /* Return true if word can be found. */
 link_public_api(bool)
 	dictionary_word_is_known(const Dictionary, const char *);

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -168,6 +168,14 @@ bool dictionary_word_is_known(const Dictionary dict, const char * word)
 	return dict_has_word(dict, regex_name);
 }
 
+/**
+ * Return the dictionary Category array.
+ */
+const Category *dictionary_get_categories(const Dictionary dict)
+{
+	return dict->category + 1; /* First entry is not used */
+}
+
 /* ======================================================================== */
 /* the following functions are for handling deletion */
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -85,15 +85,6 @@ typedef struct
 	unsigned int size;                 /* Allocated tag array size */
 } expression_tag;
 
-/* List of words in a dict category, for sentence generation. */
-typedef struct
-{
-	unsigned int num_words;
-	const char* category_name;
-	Exp *exp;
-	char const ** word;
-} dict_category;
-
 struct Dictionary_s
 {
 	Dict_node *  root;
@@ -150,7 +141,7 @@ struct Dictionary_s
 	/* Sentence generation */
 	unsigned int num_categories;
 	unsigned int num_categories_alloced;
-	dict_category * category; /* Word lists - indexed by category number */
+	Category * category;      /* Word lists - indexed by category number */
 	bool leave_subscripts;    /* Leave generated-word subscripts */
 
 	/* Private data elements that come in play only while the

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -84,6 +84,13 @@ typedef struct
 	char const ** word;
 } Category;
 
+/* List of disjuncts categories and their costs. */
+typedef struct
+{
+	unsigned int num;    /* Index in the Category array. */
+	float cost;          /* Corresponding disjunct cost. */
+} Category_cost;
+
 bool cost_eq(double cost1, double cost2);
 const char *cost_stringify(double cost);
 

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -79,7 +79,7 @@ struct Exp_struct
 typedef struct
 {
 	unsigned int num_words;
-	const char* category_name;
+	const char* name;
 	Exp *exp;
 	char const ** word;
 } Category;

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -75,6 +75,14 @@ struct Exp_struct
 	Exp *operand_next;     /* Next same-level operand. */
 };
 
+/* List of words in a dictionary category. */
+typedef struct
+{
+	unsigned int num_words;
+	const char* category_name;
+	Exp *exp;
+	char const ** word;
+} Category;
 
 bool cost_eq(double cost1, double cost2);
 const char *cost_stringify(double cost);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -128,7 +128,7 @@ dictionary_six_str(const char * lang,
 		{
 			const size_t initial_allocation = 256;
 			dict->num_categories_alloced = initial_allocation;
-			dict->category = malloc(initial_allocation * sizeof(dict_category));
+			dict->category = malloc(sizeof(*dict->category) *initial_allocation);
 			dict->leave_subscripts = test_enabled("leave-subscripts");
 			dict->spell_checker = NULL; /* Disable spell-checking. */
 		}

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1725,6 +1725,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 		e->category = dict->num_categories;
 		dict->category[dict->num_categories].exp = e;
 		dict->category[dict->num_categories].num_words = n;
+		dict->category[dict->num_categories].category_name = "";
 	}
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1725,7 +1725,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 		e->category = dict->num_categories;
 		dict->category[dict->num_categories].exp = e;
 		dict->category[dict->num_categories].num_words = n;
-		dict->category[dict->num_categories].category_name = "";
+		dict->category[dict->num_categories].name = "";
 	}
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1964,6 +1964,18 @@ bool read_dictionary(Dictionary dict)
 			return false;
 		}
 	}
+
+	if (dict->category != NULL)
+	{
+		/* Create a category element which contains 0 words, to signify the
+		 * end of the category array for the user API. The number of
+		 * categories will not get changed because macros are considered an
+		 * invalid word. */
+		Exp dummy_exp;
+		add_category(dict, &dummy_exp, NULL, 0);
+		dict->category[dict->num_categories + 1].num_words = 0;
+	}
+
 	dict->root = dsw_tree_to_vine(dict->root);
 	dict->root = dsw_vine_to_tree(dict->root, dict->num_entries);
 	return true;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1694,7 +1694,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 		dict->num_categories_alloced *= 2;
 		dict->category =
 			realloc(dict->category,
-			        sizeof(dict_category) * dict->num_categories_alloced);
+			        sizeof(*dict->category) * dict->num_categories_alloced);
 	}
 	dict->category[dict->num_categories].word =
 		malloc(sizeof(dict->category[0].word) * n);

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -459,7 +459,7 @@ static void add_categories(Dictionary dict)
 
 	dict->num_categories = 0;
 	dict->num_categories_alloced = bs.count + 1;
-	dict->category = malloc((bs.count +1)* sizeof(dict_category));
+	dict->category = malloc((bs.count +1)* sizeof(*dict->category));
 
 	sqlite3_exec(db, "SELECT DISTINCT classname FROM Disjuncts;",
 		classname_cb, &bs, NULL);

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -417,7 +417,7 @@ static int classname_cb(void *user_data, int argc, char **argv, char **colName)
 	dict->num_categories++;
 	dict->category[dict->num_categories].num_words = 0;
 	dict->category[dict->num_categories].word = NULL;
-	dict->category[dict->num_categories].category_name =
+	dict->category[dict->num_categories].name =
 		string_set_add(argv[0], dict->string_set);
 
 	char category_string[16];     /* For the tokenizer - not used here */
@@ -473,7 +473,7 @@ static void add_categories(Dictionary dict)
 		dyn_str *qry = dyn_str_new();
 		dyn_strcat(qry,
 			"SELECT disjunct, cost FROM Disjuncts WHERE classname = \'");
-		dyn_strcat(qry, dict->category[i].category_name);
+		dyn_strcat(qry, dict->category[i].name);
 		dyn_strcat(qry, "\';");
 
 		bs.exp = NULL;
@@ -488,7 +488,7 @@ static void add_categories(Dictionary dict)
 		qry = dyn_str_new();
 		dyn_strcat(qry,
 			"SELECT count(*) FROM Morphemes WHERE classname = \'");
-		dyn_strcat(qry, dict->category[i].category_name);
+		dyn_strcat(qry, dict->category[i].name);
 		dyn_strcat(qry, "\';");
 
 		sqlite3_exec(db, qry->str, count_cb, &bs, NULL);
@@ -503,7 +503,7 @@ static void add_categories(Dictionary dict)
 		qry = dyn_str_new();
 		dyn_strcat(qry,
 			"SELECT subscript FROM Morphemes WHERE classname = \'");
-		dyn_strcat(qry, dict->category[i].category_name);
+		dyn_strcat(qry, dict->category[i].name);
 		dyn_strcat(qry, "\';");
 
 		dict->num_categories = i;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -396,7 +396,7 @@ static Dict_node * db_lookup_wild(Dictionary dict, const char *s)
 /* ========================================================= */
 /* Callbacks and functions to support lexical category loading. */
 
-/* Used for `SELECT count(*) FROM foo` type of quries */
+/* Used for `SELECT count(*) FROM foo` type of queries */
 static int count_cb(void *user_data, int argc, char **argv, char **colName)
 {
 	cbdata* bs = user_data;
@@ -414,7 +414,7 @@ static int classname_cb(void *user_data, int argc, char **argv, char **colName)
 	Dictionary dict = bs->dict;
 
 	/* Add a category. */
-	/* This is intetionally off-by-one, per design. */
+	/* This is intentionally off-by-one, per design. */
 	dict->num_categories++;
 	dict->category[dict->num_categories].num_words = 0;
 	dict->category[dict->num_categories].word = NULL;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -29,6 +29,7 @@
 #include "dict-common/dict-structures.h"
 #include "dict-common/file-utils.h"
 #include "dict-file/read-dict.h"         // dictionary_six()
+#include "dict-file/word-file.h"         // patch_subscript()
 #include "error.h"
 #include "externs.h"
 #include "memory-pool.h"
@@ -434,9 +435,12 @@ static int classword_cb(void *user_data, int argc, char **argv, char **colName)
 	cbdata* bs = user_data;
 	Dictionary dict = bs->dict;
 
-	/* Add then name */
+	char *word = strdupa(argv[0]);
+	patch_subscript(word);
+
+	/* Add the word. */
 	dict->category[dict->num_categories].word[bs->count] =
-		string_set_add(argv[0], dict->string_set);
+		string_set_add(word, dict->string_set);
 	bs->count++;
 
 	return 0;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -458,8 +458,9 @@ static void add_categories(Dictionary dict)
 		count_cb, &bs, NULL);
 
 	dict->num_categories = 0;
-	dict->num_categories_alloced = bs.count + 1;
-	dict->category = malloc((bs.count +1)* sizeof(*dict->category));
+	dict->num_categories_alloced = 1 + bs.count + 1; // skip slot 0 + terminator
+	dict->category = malloc(dict->num_categories_alloced *
+	                        sizeof(*dict->category));
 
 	sqlite3_exec(db, "SELECT DISTINCT classname FROM Disjuncts;",
 		classname_cb, &bs, NULL);
@@ -511,6 +512,9 @@ static void add_categories(Dictionary dict)
 		dyn_str_delete(qry);
 	}
 	dict->num_categories = ncat;
+
+	/* Set the termination entry. */
+	dict->category[dict->num_categories + 1].num_words = 0;
 }
 
 /* ========================================================= */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -350,7 +350,7 @@ Disjunct *eliminate_duplicate_disjuncts(Disjunct *dw, bool multi_string)
 
 			if (multi_string)
 			{
-				if (dx->num_categories == dx->num_categories_alloced)
+				if (dx->num_categories == dx->num_categories_alloced - 1)
 				{
 					dx->num_categories_alloced *= 2;
 					dx->category = realloc(dx->category,
@@ -361,6 +361,7 @@ Disjunct *eliminate_duplicate_disjuncts(Disjunct *dw, bool multi_string)
 				dx->category[dx->num_categories].num = d->category[0].num;
 				dx->category[dx->num_categories].cost = d->cost;
 				dx->num_categories++;
+				dx->category[dx->num_categories].num = 0; /* API array terminator.*/
 			}
 			else
 			{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -45,20 +45,35 @@ void free_disjuncts(Disjunct *c)
 	}
 }
 
-void free_sentence_disjuncts(Sentence sent, bool category_too)
+void free_categories(Sentence sent)
 {
 	if (NULL != sent->dc_memblock)
 	{
-		if (category_too)
+		for (Disjunct *d = sent->dc_memblock;
+		     d < &((Disjunct *)sent->dc_memblock)[sent->num_disjuncts]; d++)
 		{
-			for (Disjunct *d = sent->dc_memblock;
-			     d < &((Disjunct *)sent->dc_memblock)[sent->num_disjuncts]; d++)
+			if (d->is_category != 0)
+				free(d->category);
+		}
+	}
+	else
+	{
+		for (WordIdx w = 0; w < sent->length; w++)
+		{
+			for (Disjunct *d = sent->word[w].d; d != NULL; d = d->next)
 			{
 				if (d->is_category != 0)
 					free(d->category);
 			}
 		}
+	}
+}
 
+void free_sentence_disjuncts(Sentence sent, bool category_too)
+{
+	if (NULL != sent->dc_memblock)
+	{
+		if (category_too) free_categories(sent);
 		free(sent->dc_memblock);
 		sent->dc_memblock = NULL;
 	}

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -80,6 +80,7 @@ struct Disjunct_struct
 /* Disjunct utilities ... */
 void free_disjuncts(Disjunct *);
 void free_sentence_disjuncts(Sentence, bool);
+void free_categories(Sentence);
 unsigned int count_disjuncts(Disjunct *);
 Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct *, bool);

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -20,12 +20,6 @@
 #include "api-types.h"
 #include "api-structures.h"             // Sentence
 
-typedef struct
-{
-	unsigned int num;    /* Index in the "category" field of Dictionary */
-	float cost;          /* Corresponding disjunct cost. */
-} category_and_cost;
-
 // Can undefine VERIFY_MATCH_LIST when done debugging...
 #define VERIFY_MATCH_LIST
 
@@ -48,7 +42,7 @@ struct Disjunct_struct
 		struct
 		{
 			/* Dictionary category & disjunct cost (for sentence generation). */
-			category_and_cost *category;
+			Category_cost *category;
 			unsigned int num_categories_alloced;
 			unsigned int num_categories;
 		};

--- a/link-grammar/link-grammar.def
+++ b/link-grammar/link-grammar.def
@@ -120,3 +120,5 @@ lg_error_flush
 lg_exp_stringify
 prt_error
 utf8_strwidth
+dictionary_get_categories
+linkage_get_categories

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -16,6 +16,7 @@
 
 #include "api-structures.h"
 #include "connectors.h"
+#include "dict-common/dict-api.h"       // linkage_get_categories
 #include "dict-common/dict-affix.h"     // INFIX_MARK
 #include "dict-common/dict-defines.h"   // SUBSCRIPT_MARK
 #include "dict-common/idiom.h"
@@ -996,4 +997,14 @@ WordIdx linkage_get_word_char_end(const Linkage linkage, WordIdx w)
 	int pos = (int)(linkage->wg_path_display[w]->end - linkage->sent->orig_sentence);
 	char *sentchunk = strndupa(linkage->sent->orig_sentence, pos);
 	return utf8_strlen(sentchunk);
+}
+
+const Category_cost *linkage_get_categories(const Linkage linkage, WordIdx w)
+{
+	if (NULL == linkage) return NULL;
+	if (linkage->num_words <= w) return NULL; /* bounds-check */
+
+	Disjunct *dj = linkage->chosen_disjuncts[w];
+	if (dj->is_category == 0) return NULL;
+	return dj->category;
 }

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -470,6 +470,7 @@ void classic_parse(Sentence sent, Parse_Options opts)
 parse_end_cleanup:
 	if (NULL != ts_pruning)
 	{
+		free_categories(sent);
 		free(ts_pruning->memblock);
 		free_tracon_sharing(ts_pruning);
 		free(saved_memblock);

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -301,11 +301,12 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 		}
 		else
 		{
-			ndis->num_categories_alloced = 16;
+			ndis->num_categories_alloced = 4;
 			ndis->category =
 				malloc(sizeof(ndis->category) * ndis->num_categories_alloced);
 			ndis->num_categories = 1;
 			ndis->category[0].num = strtol(string, NULL, 16);
+			ndis->category[1].num = 0; /* API array terminator */
 			assert((ndis->category[0].num > 0) && (ndis->category[0].num < 64*1024),
 			       "Insane category %u", ndis->category[0].num);
 			ndis->category[0].cost = cl->cost;

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -27,7 +27,9 @@ if HAVE_SQLITE
 link_parser_LDADD += $(SQLITE3_LIBS)
 endif
 
-link_generator_SOURCES = link-generator.c
+link_generator_SOURCES = link-generator.c \
+								 generator-utilities.h \
+								 generator-utilities.c
 link_generator_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/link-grammar
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -28,6 +28,7 @@ link_parser_LDADD += $(SQLITE3_LIBS)
 endif
 
 link_generator_SOURCES = link-generator.c
+link_generator_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/link-grammar
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la
 if HAVE_SQLITE

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -1,0 +1,50 @@
+#include <string.h>
+
+#include "link-grammar/dict-common/dict-api.h"
+
+#include "generator-utilities.h"
+
+void dump_categories(Dictionary dict, const Category *category)
+{
+#define TAB "   "
+	const int maxcol = 60; /* Account for initial formatting tabs. */
+
+	printf(TAB"\"categories\": [\n");
+	for (unsigned int n = 0; category[n].num_words != 0; n++)
+	{
+		printf(TAB"\{\n");
+		printf(TAB TAB"\"category_num\": %u,\n", n + 1);
+		printf(TAB TAB"\"exp\": %s,\n", lg_exp_stringify(category[n].exp));
+		printf(TAB TAB"\"num_words\": %u,\n", category[n].num_words);
+		printf(TAB TAB"\"words\": [\n");
+		printf(TAB TAB TAB);
+
+		int currcol = 0;
+		for (unsigned int wi = 0; wi < category[n].num_words; wi++)
+		{
+			const char *word = category[n].word[wi];
+			if ((currcol > 0) && currcol + (int)strlen(word) > maxcol)
+			{
+				if (wi != category[n].num_words - 1) printf("\n"TAB TAB TAB);
+				currcol = 0;
+			}
+			currcol += printf("\"%s\"", word); /* No crash if printf() fails. */
+			if (wi != category[n].num_words - 1)
+			{
+				printf(",");
+				currcol++;
+			}
+			else
+			{
+				printf("\n");
+			}
+		}
+		printf(TAB TAB"]\n");
+		printf(TAB"}");
+		if (category[n+1].num_words != 0)
+			printf(",");
+		printf("\n");
+	}
+	printf(TAB"]\n");
+	printf("}\n");
+}

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -13,8 +13,8 @@ void dump_categories(Dictionary dict, const Category *category)
 	for (unsigned int n = 0; category[n].num_words != 0; n++)
 	{
 		printf(TAB"\{\n");
-		if (category[n].category_name != NULL)
-			printf(TAB TAB"\"category_name\": %s,\n", category[n].category_name);
+		if (category[n].name[0] != '\0')
+			printf(TAB TAB"\"name\": %s,\n", category[n].name);
 		printf(TAB TAB"\"category_num\": %u,\n", n + 1);
 		printf(TAB TAB"\"exp\": %s,\n", lg_exp_stringify(category[n].exp));
 		printf(TAB TAB"\"num_words\": %u,\n", category[n].num_words);

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -13,6 +13,8 @@ void dump_categories(Dictionary dict, const Category *category)
 	for (unsigned int n = 0; category[n].num_words != 0; n++)
 	{
 		printf(TAB"\{\n");
+		if (category[n].category_name != NULL)
+			printf(TAB TAB"\"category_name\": %s,\n", category[n].category_name);
 		printf(TAB TAB"\"category_num\": %u,\n", n + 1);
 		printf(TAB TAB"\"exp\": %s,\n", lg_exp_stringify(category[n].exp));
 		printf(TAB TAB"\"num_words\": %u,\n", category[n].num_words);

--- a/link-parser/generator-utilities.h
+++ b/link-parser/generator-utilities.h
@@ -1,0 +1,3 @@
+#include "link-grammar/dict-common/dict-api.h"
+
+void dump_categories(const Dictionary, const Category *);

--- a/link-parser/generator-utilities.h
+++ b/link-parser/generator-utilities.h
@@ -1,3 +1,5 @@
 #include "link-grammar/dict-common/dict-api.h"
 
 void dump_categories(const Dictionary, const Category *);
+const char *cond_subscript(const char *, bool);
+const char *select_word(const Category *, const Category_cost *, WordIdx);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -45,16 +45,16 @@ static struct argp_option options[] =
 	{"length", 's', "length", 0, "Sentence length. If 0 - get sentence template from stdin."},
 	{"count", 'c', "count", 0, "Count of number of sentences to generate."},
 	{"version", 'v', 0, 0, "Print version and exit."},
-	{"disjuncts", 'd', 0, 0, "Display linkage disjuncts"},
+	{"disjuncts", 'd', 0, 0, "Display linkage disjuncts."},
 	{"leave-subscripts", '.', 0, 0, "Don't remove word subscripts."},
 	{"random", 'r', 0, 0, "Don't remove word subscripts."},
 	{0, 0, 0, 0, "Library options:", 1},
-	{"cost-max", '\4', "float"},
-	{"dialect", '\5', "dialect_list"},
+	{"cost-max", 4, "float"},
+	{"dialect", 5, "dialect_list"},
 	{0, 0, 0, 0, "Library debug options:", 2},
-	{"debug", '\1', "debug_specification", 0, 0},
-	{"verbosity", '\2', "level"},
-	{"test", '\3', "test_list"},
+	{"debug", 1, "debug_specification", 0, 0},
+	{"verbosity", 2, "level"},
+	{"test", 3, "test_list"},
 	{ 0 }
 };
 

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -14,6 +14,8 @@
 #include "link-grammar/dict-common/dict-api.h"
 #include "link-grammar/error.h"
 
+#include "generator-utilities.h"
+
 #define WILDCARDWORD "\\*"
 
 static int verbosity_level; // Avoid using exposed library static variable.
@@ -135,6 +137,18 @@ int main (int argc, char* argv[])
 		exit(-1);
 	}
 	printf("# Dictionary version %s\n", linkgrammar_get_dict_version(dict));
+
+	const Category* category = dictionary_get_categories(dict);
+	unsigned int num_categories = 0;
+	for (const Category* c = category; c->num_words != 0; c++)
+		num_categories++;
+	printf("# Number of categories: %u\n", num_categories);
+
+	if (verbosity_level == 200)
+	{
+		dump_categories(dict, category);
+		exit(0);
+	}
 
 	parse_options_set_linkage_limit(opts, parms.corpus_size);
 

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -10,8 +10,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../link-grammar/link-includes.h"
-#include "../link-grammar/error.h"
+#include "link-grammar/link-includes.h"
+#include "link-grammar/dict-common/dict-api.h"
+#include "link-grammar/error.h"
 
 #define WILDCARDWORD "\\*"
 

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -45,15 +45,29 @@ static struct argp_option options[] =
 	{ 0 }
 };
 
+static void invalid_int_value(const char *name, int value)
+{
+	prt_error("Fatal error: Invalid sentence %s \"%d\".\n", name, value);
+	exit(-1);
+
+}
+
 static error_t parse_opt(int key, char *arg, struct argp_state *state)
 {
 	gen_parameters* gp = state->input;
 	switch (key)
 	{
 		case 'l': gp->language = arg; break;
-		case 's': gp->sentence_length = atoi(arg); break;
+		case 's': gp->sentence_length = atoi(arg);
+		          if ((gp->sentence_length < 0) || (gp->sentence_length > 253))
+			          invalid_int_value("sentence length", gp->sentence_length);
+		          break;
 		case 'c': gp->corpus_size = atoi(arg); break;
+		          if (gp->corpus_size <= 0)
+			          invalid_int_value("corpus size", gp->corpus_size);
+		          break;
 		case 'd': gp->display_disjuncts = true; break;
+
 
 		case 'v':
 		{
@@ -67,6 +81,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 			parse_options_set_debug(gp->opts, arg); break;
 		case 2:
 			verbosity_level = atoi(arg);
+			if (verbosity_level < 0)
+				invalid_int_value("verbosity", verbosity_level);
 			parse_options_set_verbosity(gp->opts, verbosity_level); break;
 		case 3:
 			parse_options_set_test(gp->opts, arg); break;
@@ -120,13 +136,6 @@ int main (int argc, char* argv[])
 	printf("# Dictionary version %s\n", linkgrammar_get_dict_version(dict));
 
 	parse_options_set_linkage_limit(opts, parms.corpus_size);
-
-	if (parms.sentence_length < 0)
-	{
-		prt_error("Fatal error: Invalid sentence length \"%d\".\n",
-		          parms.sentence_length);
-		exit(-1);
-	}
 
 	if (parms.sentence_length > 0)
 	{

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -182,7 +182,6 @@ int main (int argc, char* argv[])
 		size_t nwords = linkage_get_num_words(linkage);
 		const char **words = linkage_get_words(linkage);
 
-		// printf("%d", i);
 		if (verbosity_level >= 5) printf("%d: ", i);
 		for (unsigned int w=0; w<nwords; w++)
 		{

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -5,6 +5,12 @@
  * February 2021
  */
 
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 #include <argp.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -28,6 +34,7 @@ typedef struct
 	int corpus_size;
 	bool display_disjuncts;
 	bool leave_subscripts;
+	bool unrepeatable_random;
 
 	Parse_Options opts;
 } gen_parameters;
@@ -40,6 +47,7 @@ static struct argp_option options[] =
 	{"version", 'v', 0, 0, "Print version and exit."},
 	{"disjuncts", 'd', 0, 0, "Display linkage disjuncts"},
 	{"leave-subscripts", '.', 0, 0, "Don't remove word subscripts."},
+	{"random", 'r', 0, 0, "Don't remove word subscripts."},
 	{0, 0, 0, 0, "Library options:", 1},
 	{"cost-max", '\4', "float"},
 	{"dialect", '\5', "dialect_list"},
@@ -73,6 +81,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 		          break;
 		case 'd': gp->display_disjuncts = true; break;
 		case '.': gp->leave_subscripts = true; break;
+		case 'r': gp->unrepeatable_random = true; break;
 
 
 		case 'v':
@@ -119,8 +128,17 @@ int main (int argc, char* argv[])
 	parms.corpus_size = 50;
 	parms.display_disjuncts = false;
 	parms.leave_subscripts = false;
+	parms.unrepeatable_random = false;
 	parms.opts = opts;
 	argp_parse(&argp, argc, argv, 0, 0, &parms);
+	if (!parms.unrepeatable_random)
+	{
+		srand(0);
+	}
+	else
+	{
+		srand(getpid());
+	}
 
 	printf("#\n# Corpus for language: \"%s\"\n", parms.language);
 	if (parms.sentence_length != 0)


### PR DESCRIPTION
Main changes:
- Rename variables per discussion.
- Implement category API.
- Move word selection to `link-generator'
- Set the linkage words of wild-card words to disjunct-strings.
- Set the category words of a sqlite3 dict to include `SUBSTRING_MARK`.

Note that fixed linkage words (resulted from fixed words in the sentence template) are currently always subscripted because they contain `SUBSCRIPT_DOT` that is not handled.

To see numbered linkages use arguments: `--verbosity=5 --debug link-generator.c`
To debug the random selection: --verbosity=5 --debug select_word`