### PR TITLE
Generate - WIP5

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -182,6 +182,7 @@ struct Sentence_s
 	/* Generation mode - finding unused dictionary disjuncts.
 	 * This stuff is here and not in Dictionary because it depends on the
 	 * current dialect and cost. */
+	bool *disjunct_used;        /* Used dict disjuncts in memblock below. */
 	void *wildcard_word_dc_memblock;  /* Dictionary disjuncts & connectors. */
 	unsigned int wildcard_word_dc_memblock_sz;
 	unsigned int wildcard_word_num_disjuncts;

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -178,6 +178,13 @@ struct Sentence_s
 #ifdef USE_SAT_SOLVER
 	void *hook;                 /* Hook for the SAT solver */
 #endif /* USE_SAT_SOLVER */
+
+	/* Generation mode - finding unused dictionary disjuncts.
+	 * This stuff is here and not in Dictionary because it depends on the
+	 * current dialect and cost. */
+	void *wildcard_word_dc_memblock;  /* Dictionary disjuncts & connectors. */
+	unsigned int wildcard_word_dc_memblock_sz;
+	unsigned int wildcard_word_num_disjuncts;
 };
 
 #endif

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -542,6 +542,7 @@ void sentence_delete(Sentence sent)
 	post_process_free(sent->postprocessor);
 	post_process_free(sent->constituent_pp);
 	lg_exp_stringify(NULL);
+	free(sent->disjunct_used);
 
 	global_rand_state = sent->rand_state;
 	pool_delete(sent->Match_node_pool);

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -557,6 +557,13 @@ void sentence_delete(Sentence sent)
 		pool_reuse(sent->dict->Exp_pool);
 	}
 
+	if (NULL != sent->wildcard_word_dc_memblock)
+	{
+		free_categories_from_disjunct_array(sent->wildcard_word_dc_memblock,
+		                                    sent->wildcard_word_num_disjuncts);
+		free(sent->wildcard_word_dc_memblock);
+	}
+
 	free(sent);
 }
 

--- a/link-grammar/dict-common/dict-affix.h
+++ b/link-grammar/dict-common/dict-affix.h
@@ -81,9 +81,6 @@ typedef enum {
 #define INFIX_MARK(afdict) \
 	((NULL == afdict) ? '\0' : (AFCLASS(afdict, AFDICT_INFIXMARK)->string[0][0]))
 
-
 Afdict_class * afdict_find(Dictionary, const char *, bool);
-bool is_stem(const char *);
-bool is_macro(const char *); /* Not an affix but best include file to use */
 
 #endif /* _LG_DICT_AFFIX_H_ */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -17,7 +17,8 @@
 #include "dict-api.h"
 #include "dict-common.h"
 #include "dict-defines.h"
-#include "file-utils.h"
+#include "disjunct-utils.h"
+#include "file-utils.h"                // free_categories_from_disjunct_array
 #include "post-process/pp_knowledge.h" // Needed only for pp_close !!??
 #include "regex-morph.h"
 #include "string-set.h"
@@ -352,7 +353,6 @@ void dictionary_delete(Dictionary dict)
 	for (unsigned int i = 1; i <= dict->num_categories; i++)
 		free(dict->category[i].word);
 	free(dict->category);
-	free(dict->wildcard_word_dc_memblock);
 
 	free(dict);
 	object_open(NULL, NULL, NULL); /* Free the directory path cache */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -173,6 +173,7 @@ bool dictionary_word_is_known(const Dictionary dict, const char * word)
  */
 const Category *dictionary_get_categories(const Dictionary dict)
 {
+	if (dict->category == NULL) return NULL;
 	return dict->category + 1; /* First entry is not used */
 }
 

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -348,10 +348,11 @@ void dictionary_delete(Dictionary dict)
 	free_anysplit(dict);
 	free_dictionary(dict);
 
-	/* Free sentence generation categories and word lists. */
+	/* Free sentence generation stuff. */
 	for (unsigned int i = 1; i <= dict->num_categories; i++)
 		free(dict->category[i].word);
 	free(dict->category);
+	free(dict->wildcard_word_dc_memblock);
 
 	free(dict);
 	object_open(NULL, NULL, NULL); /* Free the directory path cache */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -65,9 +65,16 @@ bool is_macro(const char *w)
 
 bool is_wall(const char *s)
 {
-	if (0 == strcmp(s, LEFT_WALL_WORD)) return true;
-	if (0 == strcmp(s, RIGHT_WALL_WORD)) return true;
-
+	if (0 == strncmp(s, LEFT_WALL_WORD, sizeof(LEFT_WALL_WORD)-1))
+	{
+		if (s[sizeof(LEFT_WALL_WORD)-1] == '\0' ||
+			(s[sizeof(LEFT_WALL_WORD)-1] == SUBSCRIPT_MARK)) return true;
+	}
+	if (0 == strncmp(s, RIGHT_WALL_WORD, sizeof(RIGHT_WALL_WORD)-1))
+	{
+		if (s[sizeof(RIGHT_WALL_WORD)-1] == '\0' ||
+			(s[sizeof(RIGHT_WALL_WORD)-1] == SUBSCRIPT_MARK)) return true;
+	}
 	return false;
 }
 

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -63,6 +63,14 @@ bool is_macro(const char *w)
 	return false;
 }
 
+bool is_wall(const char *s)
+{
+	if (0 == strcmp(s, LEFT_WALL_WORD)) return true;
+	if (0 == strcmp(s, RIGHT_WALL_WORD)) return true;
+
+	return false;
+}
+
 /* ======================================================================== */
 
 Dictionary dictionary_create_default_lang(void)

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -358,3 +358,33 @@ void dictionary_delete(Dictionary dict)
 }
 
 /* ======================================================================== */
+
+/**
+ * Set sentence generation indications if requested.
+ * Since dictionary_create*() doesn't support options, use the "test"
+ * parse_option, which is in a global variable:
+ * If it contains "generate", enable generation mode.
+ * If an argument "walls" is also supplied ("generate:walls"), then
+ * set a wall generation indication.
+ *
+ * @param dict Set the indications in this dictionary.
+ * @return \c true if in generation mode, \c false otherwise.
+ */
+bool dictionary_generation_request(const Dictionary dict)
+{
+	const char *generation_mode = test_enabled("generate");
+	if (generation_mode != NULL)
+	{
+		const size_t initial_allocation = 256;
+		dict->num_categories_alloced = initial_allocation;
+		dict->category = malloc(sizeof(*dict->category) *initial_allocation);
+		dict->leave_subscripts = test_enabled("leave-subscripts");
+		dict->generate_walls =
+			feature_enabled(generation_mode, "walls", NULL) != NULL;
+		dict->spell_checker = NULL; /* Disable spell-checking. */
+
+		return true;
+	}
+
+	return false;
+}

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -378,7 +378,6 @@ bool dictionary_generation_request(const Dictionary dict)
 		const size_t initial_allocation = 256;
 		dict->num_categories_alloced = initial_allocation;
 		dict->category = malloc(sizeof(*dict->category) *initial_allocation);
-		dict->leave_subscripts = test_enabled("leave-subscripts");
 		dict->generate_walls =
 			feature_enabled(generation_mode, "walls", NULL) != NULL;
 		dict->spell_checker = NULL; /* Disable spell-checking. */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -159,7 +159,9 @@ struct Dictionary_s
 	char            token[MAX_TOKEN_LENGTH];
 };
 
+bool is_stem(const char *);
 bool is_wall(const char *);
+bool is_macro(const char *);
 
 /* The functions here are intended for use by the tokenizer, only,
  * and pretty much no one else. If you are not the tokenizer, you

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -143,6 +143,7 @@ struct Dictionary_s
 	unsigned int num_categories_alloced;
 	Category * category;      /* Word lists - indexed by category number */
 	bool leave_subscripts;    /* Leave generated-word subscripts */
+	bool generate_walls;      /* Generate walls too for wildcard words */
 
 	/* Private data elements that come in play only while the
 	 * dictionary is being read, and are not otherwise used.
@@ -157,6 +158,9 @@ struct Dictionary_s
 	char            current_idiom[IDIOM_LINK_SZ];
 	char            token[MAX_TOKEN_LENGTH];
 };
+
+bool is_wall(const char *);
+
 /* The functions here are intended for use by the tokenizer, only,
  * and pretty much no one else. If you are not the tokenizer, you
  * probably don't need these. */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -163,14 +163,14 @@ bool is_stem(const char *);
 bool is_wall(const char *);
 bool is_macro(const char *);
 
-/* The functions here are intended for use by the tokenizer, only,
- * and pretty much no one else. If you are not the tokenizer, you
- * probably don't need these. */
-
-bool dict_has_word(const Dictionary dict, const char *);
 Exp *Exp_create(Pool_desc *);
 Exp *Exp_create_dup(Pool_desc *, Exp *);
 Exp *make_unary_node(Pool_desc *, Exp *);
+
+/* The functions here are intended for use by the tokenizer, only,
+ * and pretty much no one else. If you are not the tokenizer, you
+ * probably don't need these. */
+bool dict_has_word(const Dictionary dict, const char *);
 void add_empty_word(Sentence, X_node *);
 
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -142,7 +142,6 @@ struct Dictionary_s
 	unsigned int num_categories;
 	unsigned int num_categories_alloced;
 	Category * category;      /* Word lists - indexed by category number */
-	bool leave_subscripts;    /* Leave generated-word subscripts */
 	bool generate_walls;      /* Generate walls too for wildcard words */
 
 	/* Private data elements that come in play only while the

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -167,6 +167,8 @@ Exp *Exp_create(Pool_desc *);
 Exp *Exp_create_dup(Pool_desc *, Exp *);
 Exp *make_unary_node(Pool_desc *, Exp *);
 
+bool dictionary_generation_request(const Dictionary);
+
 /* The functions here are intended for use by the tokenizer, only,
  * and pretty much no one else. If you are not the tokenizer, you
  * probably don't need these. */

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -635,7 +635,16 @@ static void dyn_print_disjunct_list(dyn_str *s, const Disjunct *dj,
 
 	for (;dj != NULL; dj=dj->next)
 	{
-		lg_strlcpy(word, dj->word_string, sizeof(word));
+		if (dj->is_category == 0)
+		{
+			lg_strlcpy(word, dj->word_string, sizeof(word));
+		}
+		else
+		{
+			int n = snprintf(word, sizeof(word), "%x", dj->category[0].num);
+			if (dj->num_categories > 1)
+				snprintf(word + n, sizeof(word) - n, " (%u)", dj->num_categories);
+		}
 		patch_subscript_mark(word);
 		dyn_str *l = dyn_str_new();
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -771,11 +771,6 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 	                              /*num_elements*/65536, sizeof(Connector),
 	                              /*zero_out*/true, /*align*/false, false);
 
-	/* copy_Exp() needs an Exp memory pool. */
-	Pool_desc *Exp_pool = pool_new(__func__, "Exp", /*num_elements*/256,
-	                               sizeof(Exp), /*zero_out*/false,
-	                               /*align*/false, /*exact*/false);
-
 	select_data criterion = { .regex = rn };
 	void *select = (rn == NULL) ? NULL : select_disjunct;
 
@@ -784,7 +779,7 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 	for (; dn != NULL; dn = dn->right)
 	{
 		/* Use copy_Exp() to assign dialect cost. */
-		Exp *e = copy_Exp(dn->exp, Exp_pool, opts);
+		Exp *e = copy_Exp(dn->exp, dummy_sent->Exp_pool, opts);
 		Disjunct *d = build_disjuncts_for_exp(dummy_sent, e, dn->string, NULL,
 		                                      max_cost, NULL);
 
@@ -802,7 +797,7 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 		dyn_print_disjunct_list(dyn_pdl, d, int_flags, select, &criterion);
 		char *dliststr = dyn_str_take(dyn_pdl);
 
-		pool_reuse(Exp_pool);
+		pool_reuse(dummy_sent->Exp_pool);
 		pool_reuse(dummy_sent->Disjunct_pool);
 		pool_reuse(dummy_sent->Connector_pool);
 
@@ -826,7 +821,6 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 				              criterion.num_selected == 1 ? "" : "s");
 		}
 	}
-	pool_delete(Exp_pool);
 	sentence_delete(dummy_sent);
 
 	return dyn_str_take(s);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -124,13 +124,16 @@ dictionary_six_str(const char * lang,
 
 	if (NULL != affix_name)
 	{
-		if (test_enabled("generate")) /* Sentence generation. */
+		const char *generation_mode = test_enabled("generate");
+		if (generation_mode != NULL) /* Sentence generation. */
 		{
 			const size_t initial_allocation = 256;
 			dict->num_categories_alloced = initial_allocation;
 			dict->category = malloc(sizeof(*dict->category) *initial_allocation);
 			dict->leave_subscripts = test_enabled("leave-subscripts");
 			dict->spell_checker = NULL; /* Disable spell-checking. */
+			dict->generate_walls =
+				feature_enabled(generation_mode, "walls", NULL) != NULL;
 		}
 		else
 		{

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -124,21 +124,9 @@ dictionary_six_str(const char * lang,
 
 	if (NULL != affix_name)
 	{
-		const char *generation_mode = test_enabled("generate");
-		if (generation_mode != NULL) /* Sentence generation. */
-		{
-			const size_t initial_allocation = 256;
-			dict->num_categories_alloced = initial_allocation;
-			dict->category = malloc(sizeof(*dict->category) *initial_allocation);
-			dict->leave_subscripts = test_enabled("leave-subscripts");
-			dict->spell_checker = NULL; /* Disable spell-checking. */
-			dict->generate_walls =
-				feature_enabled(generation_mode, "walls", NULL) != NULL;
-		}
-		else
-		{
+		if (!dictionary_generation_request(dict))
 			dict->spell_checker = spellcheck_create(dict->lang);
-		}
+
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */
 		if (verbosity_level(D_USER_BASIC) && (NULL == dict->spell_checker))

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1655,14 +1655,6 @@ static void add_define(Dictionary dict, const char *name, const char *value)
 	dict->define.value[id - 1] = string_set_add(value, dict->string_set);
 }
 
-static bool is_wall(const char *s)
-{
-	if (0 == strcmp(s, LEFT_WALL_WORD)) return true;
-	if (0 == strcmp(s, RIGHT_WALL_WORD)) return true;
-
-	return false;
-}
-
 static bool is_directive(const char *s)
 {
 	return
@@ -1682,7 +1674,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 	if (n == 1)
 	{
 		if (is_macro(dn->string)) return;
-		if (is_wall(dn->string)) return;
+		if (!dict->generate_walls && is_wall(dn->string)) return;
 		if (is_correction(dn->string)) return;
 		if (is_directive(dn->string)) return;
 	}
@@ -1703,7 +1695,7 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 	for (Dict_node *dnx = dn; dnx != NULL; dnx = dnx->left)
 	{
 		if (is_macro(dnx->string)) continue;
-		if (is_wall(dnx->string)) continue;
+		if (!dict->generate_walls && is_wall(dnx->string)) continue;
 		if (is_correction(dnx->string)) continue;
 		if (is_directive(dnx->string)) return;
 		dict->category[dict->num_categories].word[n] = dnx->string;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -413,8 +413,10 @@ static int classname_cb(void *user_data, int argc, char **argv, char **colName)
 	cbdata* bs = user_data;
 	Dictionary dict = bs->dict;
 
-	/* This assumes a class name of a wall is the same as the wall name. */
+	/* Assuming here that a class name of a wall is the same as the wall
+	 * name, and a class name of a macro is in macro format. */
 	if (!dict->generate_walls && is_wall(argv[0])) return 0;
+	if (is_macro(argv[0])) return 0;
 
 	/* Add a category. */
 	/* This is intentionally off-by-one, per design. */

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -638,14 +638,8 @@ Dictionary dictionary_create_from_db(const char *lang)
 		goto failure;
 
 	/* Initialize word categories, for text generation. */
-	const char *generation_mode = test_enabled("generate");
-	if (generation_mode != NULL)
-	{
-		dict->leave_subscripts = test_enabled("leave-subscripts");
-		dict->generate_walls =
-			feature_enabled(generation_mode, "walls", NULL) != NULL;
+	if (!dictionary_generation_request(dict))
 		add_categories(dict);
-	}
 
 	return dict;
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -45,16 +45,22 @@ void free_disjuncts(Disjunct *c)
 	}
 }
 
+void free_categories_from_disjunct_array(Disjunct *dbase,
+                                         unsigned int num_disjuncts)
+{
+	for (Disjunct *d = dbase; d < &dbase[num_disjuncts]; d++)
+	{
+		if (d->is_category != 0)
+			free(d->category);
+	}
+}
+
 void free_categories(Sentence sent)
 {
 	if (NULL != sent->dc_memblock)
 	{
-		for (Disjunct *d = sent->dc_memblock;
-		     d < &((Disjunct *)sent->dc_memblock)[sent->num_disjuncts]; d++)
-		{
-			if (d->is_category != 0)
-				free(d->category);
-		}
+		free_categories_from_disjunct_array(sent->dc_memblock,
+		                                    sent->num_disjuncts);
 	}
 	else
 	{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -725,6 +725,7 @@ static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 	newd->cost = d->cost;
 	newd->is_category = d->is_category;
 	newd->originating_gword = d->originating_gword;
+	newd->ordinal = d->ordinal;
 
 	if (NULL == ts->tracon_list)
 		 token = (uintptr_t)d->originating_gword;

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -59,7 +59,7 @@ struct Disjunct_struct
 	union
 	{
 		uint32_t dup_hash;        /* Duplicate elimination | before pruning */
-		uint32_t unused2;         /* Unused now | before and during parsing */
+		int32_t ordinal;          /* Generation mode | after d. elimination */
 	}; /* 4 bytes */
 
 	struct

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -75,6 +75,7 @@ struct Disjunct_struct
 void free_disjuncts(Disjunct *);
 void free_sentence_disjuncts(Sentence, bool);
 void free_categories(Sentence);
+void free_categories_from_disjunct_array(Disjunct *, unsigned int);
 unsigned int count_disjuncts(Disjunct *);
 Disjunct * catenate_disjuncts(Disjunct *, Disjunct *);
 Disjunct * eliminate_duplicate_disjuncts(Disjunct *, bool);

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -359,7 +359,7 @@ int prt_error(const char *fmt, ...)
  * enabled if it is found in the comma delimited list of features.
  * This list, if not empty, has a leading and a trailing commas.
  * Return NULL if not enabled, else ",". If the feature appears
- * as "feature:param", return a pointer to param.
+ * as "feature:param", return a pointer to the ":" before param.
  * @param    list Comma delimited list of features (start/end commas too).
  * @param    ... List of features to check.
  * @return   If not enabled - NULL; Else "," or the feature param if exists.

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -402,6 +402,23 @@ const char *feature_enabled(const char * list, ...)
 			va_end(given_features);
 			return strstr(list, buff) + len + 1;
 		}
+
+		if (list[0] == ':')
+		{
+			/* Check for a parameter in ":param1:param2," */
+			buff[0] = ':';
+			bool found = (NULL != strstr(list, buff));
+			if (!found)
+			{
+				buff[len+1] = ',';
+				found = (NULL != strstr(list, buff));
+			}
+			if (found)
+			{
+				va_end(given_features);
+				return strstr(list, buff) + strlen(buff) + 2;
+			}
+		}
 	}
 	va_end(given_features);
 

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -748,7 +748,6 @@ void compute_generated_words(Sentence sent, Linkage linkage)
 
 	linkage->word = malloc(linkage->num_words * sizeof(char *));
 
-	lgdebug(D_CGW, "Sentence %d\n", abs(linkage->lifo.index) - 1);
 	for (WordIdx i = 0; i < linkage->num_words; i++)
 	{
 		assert(cdjp[i] != NULL, "NULL disjunct in generated sentence");

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -836,3 +836,26 @@ void extract_links(extractor_t * pex, Linkage lkg)
 		list_links(lkg, pex->parse_set, index);
 	}
 }
+
+static void mark_used_disjunct(Parse_set *set, bool *disjunct_used)
+{
+	if (set == NULL || set->first == NULL) return;
+
+	for (Parse_choice *pc = set->first; pc != NULL; pc = pc->next)
+	{
+		if (pc->md->ordinal != -1)
+			disjunct_used[pc->md->ordinal] = true;
+	}
+}
+
+void mark_used_disjuncts(extractor_t *pex, bool *disjunct_used)
+{
+	assert(pex->x_table != NULL, "x_table==NULL");
+
+	for (unsigned int i = 0; i < pex->x_table_size; i++)
+	{
+		for (Pset_bucket *t = pex->x_table[i]; t != NULL; t = t->next)
+			mark_used_disjunct(&t->set, disjunct_used);
+	}
+
+}

--- a/link-grammar/parse/extract-links.h
+++ b/link-grammar/parse/extract-links.h
@@ -27,4 +27,6 @@ bool build_parse_set(extractor_t*, Sentence,
 
 void extract_links(extractor_t*, Linkage);
 
+void mark_used_disjuncts(extractor_t *, bool *);
+
 #endif /* _EXTRACT_LINKS_H */

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -23,6 +23,7 @@
 #include "string-set.h"
 #include "utilities.h"
 #include "tokenize/word-structures.h"   // Word_struct
+#include "tokenize/tokenize.h"          // word0_set
 #include "tokenize/tok-structures.h"    // gword_set
 
 #define D_PREP 5 // Debug level for this module.
@@ -122,6 +123,60 @@ static void build_sentence_disjuncts(Sentence sent, double cost_cutoff,
 	}
 }
 
+
+static void create_wildcard_word_disjunct_list(Sentence sent,
+                                               Parse_Options opts)
+{
+	if (opts->verbosity >= D_USER_TIMES)
+		prt_error("#### Creating a wild-card word disjunct list\n");
+
+	int spell_option = parse_options_get_spell_guess(opts);
+	parse_options_set_spell_guess(opts, 0);
+	Sentence wc_word_list = sentence_create(WILDCARD_WORD, sent->dict);
+	if (0 != sentence_split(wc_word_list, opts)) goto error;
+
+	/* The result sentence may already consist of a wild-card word only,
+	 * or may include walls. In the later case - discard the walls.
+	 * FIXME? Use build_word_expressions() instead. */
+	WordIdx w = 1; /* Check RIGHT-WALL here. */
+	if (0 == strcmp(wc_word_list->word[0].unsplit_word, LEFT_WALL_WORD))
+	{
+		Word tmp = wc_word_list->word[0];
+		wc_word_list->word[0] = wc_word_list->word[1];
+		wc_word_list->word[1] = tmp;
+		wc_word_list->word[1].x = NULL;  /* Don't generate disjuncts. */
+		w = 2;
+	}
+	if ((wc_word_list->length == w + 1) &&
+	    (0 == strcmp(wc_word_list->word[w].unsplit_word, RIGHT_WALL_WORD)))
+	{
+		wc_word_list->word[w].x = NULL;  /* Don't generate disjuncts. */
+	}
+
+	build_sentence_disjuncts(wc_word_list, opts->disjunct_cost, opts);
+
+	Word *word0 = &wc_word_list->word[0];
+	word0->d = eliminate_duplicate_disjuncts(word0->d, false);
+	word0->d = eliminate_duplicate_disjuncts(word0->d, true);
+
+	wc_word_list->min_len_encoding = 2; /* Don't share/encode. */
+	Tracon_sharing *t = pack_sentence_for_pruning(wc_word_list);
+
+	sent->wildcard_word_dc_memblock = t->memblock;
+	sent->wildcard_word_dc_memblock_sz = t->memblock_sz;
+	sent->wildcard_word_num_disjuncts = t->num_disjuncts;
+
+	if (opts->verbosity >= D_USER_TIMES)
+		print_time(opts, "Finished creating list: %u disjuncts", t->num_disjuncts);
+
+	t->memblock = NULL;
+	free_tracon_sharing(t);
+
+error:
+	parse_options_set_spell_guess(opts, spell_option);
+	sentence_delete(wc_word_list);
+}
+
 /**
  * Assumes that the sentence expression lists have been generated.
  */
@@ -137,6 +192,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 	print_time(opts, "Built disjuncts");
 
+	bool wildcard_word_found = false;
 	for (i=0; i<sent->length; i++)
 	{
 		sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d, false);
@@ -145,6 +201,16 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 		{
 			/* Also with different word_string. */
 			sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d, true);
+
+			unsigned int n = 1; /* 0 means no ordinal. */
+			for (Disjunct *d = sent->word[i].d; d != NULL; d = d->next)
+				d->ordinal = n++;
+
+			if (!wildcard_word_found)
+			{
+				wildcard_word_found = true;
+				create_wildcard_word_disjunct_list(sent, opts);
+			}
 		}
 #if 0
 		/* eliminate_duplicate_disjuncts() is now very efficient and doesn't

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -112,6 +112,7 @@ typedef enum
 } Guess_mark;
 
 #define MAX_SPLITS 10   /* See split_counter below */
+#define WILDCARD_WORD "\\*" /* All the dict words (generation mode) */
 
 struct Gword_struct
 {

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2717,7 +2717,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 	    !contains_digits(word, dict->lctype) &&
 	    !is_proper_name(word, dict->lctype) &&
 	    opts->use_spell_guess && dict->spell_checker &&
-	    !strstr(word, "\\*"))
+	    !strstr(word, WILDCARD_WORD))
 	{
 		bool spell_suggest = guess_misspelled_word(sent, unsplit_word, opts);
 		lgdebug(+D_SW, "Spell suggest=%d\n", spell_suggest);
@@ -3023,14 +3023,14 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w,
 	X_node * x, * y;
 	const Dictionary dict = sent->dict;
 
-	if (NULL != strstr(w->subword, "\\*"))
+	if (NULL != strstr(w->subword, WILDCARD_WORD))
 	{
 		char *t = alloca(strlen(w->subword) + 8); /* + room for multibyte copy */
 		const char *backslash = strchr(w->subword, '\\');
 
 		strcpy(t, w->subword);
 		strcpy(t+(backslash - w->subword), backslash+1);
-		if (0 == strcmp(w->subword, "\\*"))
+		if (0 == strcmp(w->subword, WILDCARD_WORD))
 			dn_head = dictionary_all_categories(dict);
 		else
 			dn_head = dictionary_lookup_wild(dict, t);
@@ -3065,7 +3065,7 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w,
 		x->word = w;
 		dn = dn->right;
 	}
-	if (0 != strcmp(w->subword, "\\*"))
+	if (0 != strcmp(w->subword, WILDCARD_WORD))
 		free_lookup_list (dict, dn_head);
 	else
 		free(dn_head);
@@ -3128,7 +3128,7 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 #endif /* DEBUG */
 		if (dict->unknown_word_defined && dict->use_unknown_word)
 		{
-			if (NULL == strstr(s, "\\*"))
+			if (NULL == strstr(s, WILDCARD_WORD))
 			{
 
 				we = build_word_expressions(sent, w, UNKNOWN_WORD, opts);

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -10,6 +10,10 @@
 #define SUBSCRIPT_DOT '.'
 #define MAX_WORD 180
 
+/**
+ * Patch a subscript to SUBSCRIPT_DOT, or remove it iff
+ * \p leave_subscript is false.
+ */
 static const char *cond_subscript(const char *ow, bool leave_subscript)
 {
 	const char *sm = strchr(ow, SUBSCRIPT_MARK);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -77,7 +77,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 	{
 		case 'l': gp->language = arg; break;
 		case 's': gp->sentence_length = atoi(arg);
-		          if ((gp->sentence_length < 0) || (gp->sentence_length > 253))
+		          if ((gp->sentence_length < 0) ||
+		              (gp->sentence_length > MAX_SENTENCE))
 			          invalid_int_value("sentence length", gp->sentence_length);
 		          break;
 		case 'c': gp->corpus_size = atoll(arg);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -22,7 +22,8 @@
 
 #include "generator-utilities.h"
 
-#define WILDCARDWORD "\\*"
+#define MAX_SENTENCE 254
+#define WILDCARD_WORD "\\*"
 
 static int verbosity_level; // TODO/FIXME: Avoid using exposed library static variable.
 
@@ -186,7 +187,7 @@ int main (int argc, char* argv[])
 		char *stmp = malloc(4 * parms.sentence_length + 1);
 		stmp[0] = '\0';
 		for (int i = 0; i < parms.sentence_length; i++)
-			strcat(stmp, WILDCARDWORD " ");
+			strcat(stmp, WILDCARD_WORD " ");
 
 		sent = sentence_create(stmp, dict);
 		free(stmp);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -37,6 +37,7 @@ typedef struct
 	bool leave_subscripts;
 	bool unrepeatable_random;
 	bool explode;
+	bool walls;
 
 	Parse_Options opts;
 } gen_parameters;
@@ -51,6 +52,7 @@ static struct argp_option options[] =
 	{"disjuncts", 'd', 0, 0, "Display linkage disjuncts."},
 	{"leave-subscripts", '.', 0, 0, "Don't remove word subscripts."},
 	{"random", 'r', 0, 0, "Use unrepeatable random numbers."},
+	{"no-walls", 'w'+128, 0, 0, "Don't use walls in wildcard words."},
 	{0, 0, 0, 0, "Library options:", 1},
 	{"cost-max", 4, "float"},
 	{"dialect", 5, "dialect_list"},
@@ -86,7 +88,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 		case 'd': gp->display_disjuncts = true; break;
 		case '.': gp->leave_subscripts = true; break;
 		case 'r': gp->unrepeatable_random = true; break;
-
+		case 'w'+128: gp->walls = false; break;
 
 		case 'v':
 		{
@@ -134,6 +136,7 @@ int main (int argc, char* argv[])
 	parms.display_disjuncts = false;
 	parms.leave_subscripts = false;
 	parms.unrepeatable_random = false;
+	parms.walls = true;
 	parms.opts = opts;
 	argp_parse(&argp, argc, argv, 0, 0, &parms);
 	if (!parms.unrepeatable_random)
@@ -154,7 +157,8 @@ int main (int argc, char* argv[])
 	// parse-option to "generate".
 	const char *old_test = parse_options_get_test(opts);
 	char tbuf[256];
-	snprintf(tbuf, sizeof(tbuf), "generate,%s", old_test);
+	snprintf(tbuf, sizeof(tbuf), "generate%s,%s",
+	         parms.walls ? ":walls" : "", old_test);
 	parse_options_set_test(opts, tbuf);
 
 	dict = dictionary_create_lang(parms.language);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -166,6 +166,12 @@ int main (int argc, char* argv[])
 	printf("# Dictionary version %s\n", linkgrammar_get_dict_version(dict));
 
 	const Category* catlist = dictionary_get_categories(dict);
+	const Category* category = dictionary_get_categories(dict);
+	if (catlist == NULL)
+	{
+		prt_error("Fatal error: dictionary_get_categories() failed\n");
+		exit(-1);
+	}
 	unsigned int num_categories = 0;
 	for (const Category* c = catlist; c->num_words != 0; c++)
 		num_categories++;


### PR DESCRIPTION
PR #1175 clashed with my changes for printing disjunct costs, so I removed them (they are not important anyway, see my comment https://github.com/opencog/link-grammar/discussions/1146#discussioncomment-537636.

Main changes here:
- Generation mode: Implement --no-walls
- sqlite3 DB: Don't include macros in the Category array
- Generation mode: Implement finding unused disjuncts

There is still no API to get the unused disjunct info, since I'm waiting for input on my proposal at https://github.com/opencog/link-grammar/discussions/1146#discussioncomment-549964, which I repeat here for convenience:
``` c
typedef struct Disjunct_struct * Disjunct; // Opaque pointer
Disjunct * linkage_dictionary_unused_disjuncts(const Linkage);
const char * disjunct_expression(Disjunct *);
const int * disjunct_categories(Disjunct *); // NULL terminated array
```
Using the categories array returned by `disjunct_categories()`  it is possible to find the list of words (this seems more useful than directly providing the list of words).

