### PR TITLE
Generate - WIP6

### DIFF
--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -52,6 +52,15 @@ link_public_api(const Category *)
 link_public_api(const Category_cost *)
 	linkage_get_categories(const Linkage linkage, WordIdx w);
 
+link_public_api(Disjunct **)
+	sentence_unused_disjuncts(Sentence);
+
+link_public_api(char *)
+	disjunct_expression(Disjunct *);
+
+link_public_api(const Category_cost *)
+	disjunct_categories(Disjunct *);
+
 
 /* Return true if word can be found. */
 link_public_api(bool)

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -52,11 +52,11 @@ link_public_api(const Category *)
 link_public_api(const Category_cost *)
 	linkage_get_categories(const Linkage linkage, WordIdx w);
 
-link_public_api(Disjunct **)
+link_public_api(Disjunct **)              /* To be freed by the caller */
 	sentence_unused_disjuncts(Sentence);
 
 link_public_api(char *)
-	disjunct_expression(Disjunct *);
+	disjunct_expression(Disjunct *);       /* To be freed by the caller */
 
 link_public_api(const Category_cost *)
 	disjunct_categories(Disjunct *);

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -42,7 +42,7 @@ link_public_api(void)
 
 /**********************************************************************
  *
- * Category. Experimental and subject to changes.
+ * Generation mode. Experimental and subject to changes.
  *
  ***********************************************************************/
 
@@ -61,6 +61,7 @@ link_public_api(char *)
 link_public_api(const Category_cost *)
 	disjunct_categories(Disjunct *);
 
+/***********************************************************************/
 
 /* Return true if word can be found. */
 link_public_api(bool)

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -25,6 +25,8 @@ LINK_BEGIN_DECLS
  * the public API to the link-parser system.
  */
 
+typedef struct Disjunct_struct Disjunct;
+
 /**********************************************************************
  *
  * Lookup-list.


### PR DESCRIPTION
- Implement the API for finding unused disjuncts.
  Implement 3 API calls.
- link-generation.c: Implement --display-unused-disjuncts.
  Use the said API calls.

As mentioned in the discussion (https://github.com/opencog/link-grammar/discussions/1146#discussioncomment-555092) disjuncts on fixed words are not considered. This probably affects only the wall words (for long enough sentences). It can be fixed if desired (by adding code to handle that).

In a speed test of regular parses vs the `master` branch, there is a reduction of 1-3% (the speed is decreased with increased sentence length, so it is not a problem in reading the dict). I guess this may be due to changes that are not protected by `if (IS_GENERATION(dict))`. More checks are needed to find the exact problem.