### PR TITLE
Fix compilation break if here is no `threads.h`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,9 @@ test "$ac_cv_tls" != "none" && lg_tls=yes
 AX_PTHREAD
 CFLAGS="${CFLAGS} ${PTHREAD_CFLAGS}"
 
+dnl Check if we can use C11 threads functions
+AC_CHECK_HEADERS_ONCE([threads.h])
+
 dnl Check for specific OSs
 # ====================================================================
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -12,7 +12,9 @@
 /*************************************************************************/
 
 #include <limits.h>
+#if HAVE_THREADS_H
 #include <threads.h>
+#endif /* HAVE_THREADS_H */
 
 #include "link-includes.h"
 #include "api-structures.h"
@@ -116,7 +118,7 @@ static void free_table(count_context_t *ctxt)
 	ctxt->table_size = 0;
 }
 
-#if HAVE_PTHREAD
+#if HAVE_THREADS_H
 /* Each thread will geit it's own version of the `kept_table`.
  * If the program creates zillions of threads, then there will
  * be a mem-leak if this table is not released when each thread
@@ -139,7 +141,7 @@ static void make_key(void)
 {
 	tss_create(&key, free_tls_table);
 }
-#endif /* HAVE_PTHREAD */
+#endif /* HAVE_THREADS_H */
 
 /**
  * Allocate memory for the connector-pair table and initialize table-size
@@ -156,14 +158,14 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 	static TLS Table_connector **kept_table = NULL;
 	static TLS unsigned int log2_kept_table_size = 0;
 
-#if HAVE_PTHREAD
+#if HAVE_THREADS_H
 	// Install a thread-exit handler, to free kept_table on thread-exit.
 	static once_flag flag = ONCE_FLAG_INIT;
 	call_once(&flag, make_key);
 
 	if (NULL == kept_table)
 		tss_set(key, &kept_table);
-#endif /* HAVE_PTHREAD */
+#endif /* HAVE_THREADS_H */
 
 	if (shift == 0)
 		shift = ctxt->log2_table_size + 1; /* Double the table size */

--- a/link-grammar/tokenize/spellcheck-aspell.c
+++ b/link-grammar/tokenize/spellcheck-aspell.c
@@ -16,7 +16,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <aspell.h>
+#if HAVE_PTHREAD
 #include <pthread.h>
+#else
+#define pthread_mutex_lock(x)
+#define pthread_mutex_ulock(x)
+#endif /* HAVE_PTHREAD */
 
 #include "link-includes.h"
 #include "spellcheck.h"
@@ -119,7 +124,9 @@ bool spellcheck_test(void * chk, const char * word)
 
 // Despite having a thread-compatible API, it appears that apsell
 // is not actually thread-safe. Bummer.
+#if HAVE_PTHREAD
 static pthread_mutex_t aspell_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif /* HAVE_PTHREAD */
 
 int spellcheck_suggest(void * chk, char ***sug, const char * word)
 {

--- a/link-grammar/tokenize/spellcheck-hun.c
+++ b/link-grammar/tokenize/spellcheck-hun.c
@@ -12,12 +12,6 @@
 
 #ifdef HAVE_HUNSPELL
 
-#ifdef __MINGW32__
-#define LGPTHREAD(x) x
-#else
-#define LGPTHREAD(x)
-#endif // __MINGW32__
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>

--- a/link-grammar/tokenize/spellcheck-hun.c
+++ b/link-grammar/tokenize/spellcheck-hun.c
@@ -12,14 +12,18 @@
 
 #ifdef HAVE_HUNSPELL
 
+#if HAVE_PTHREAD && __MINGW32__
+#define HUN_THREAD_PROTECT
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
+#if HUN_THREAD_PROTECT
 #include <pthread.h>
-#ifdef __MINGW32__
-#define LGPTHREAD(x) x
 #else
-#define LGPTHREAD(x)
-#endif // __MINGW32__
+#define pthread_mutex_lock(x)
+#define pthread_mutex_unlock(x)
+#endif /* HUN_THREAD_PROTECT */
 
 #include "link-includes.h"
 #include "error.h"
@@ -67,7 +71,9 @@ void * spellcheck_create(const char * lang)
 	static char hunspell_aff_file[FPATHLEN];
 	static char hunspell_dic_file[FPATHLEN];
 
+#if HUN_THREAD_PROTECT
 	static pthread_mutex_t findpath_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif /* HUN_THREAD_PROTECT */
 
 	pthread_mutex_lock(&findpath_lock);
 
@@ -149,7 +155,9 @@ bool spellcheck_test(void * chk, const char * word)
 	return (bool) Hunspell_spell((Hunhandle *)chk, word);
 }
 
-LGPTHREAD(static pthread_mutex_t hunspell_lock = PTHREAD_MUTEX_INITIALIZER;)
+#if HUN_THREAD_PROTECT
+static pthread_mutex_t hunspell_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif /* HUN_THREAD_PROTECT */
 
 int spellcheck_suggest(void * chk, char ***sug, const char * word)
 {
@@ -159,9 +167,9 @@ int spellcheck_suggest(void * chk, char ***sug, const char * word)
 		return 0;
 	}
 
-	LGPTHREAD(pthread_mutex_lock(&hunspell_lock);)
+	pthread_mutex_lock(&hunspell_lock);
 	int rc = Hunspell_suggest((Hunhandle *)chk, sug, word);
-	LGPTHREAD(pthread_mutex_unlock(&hunspell_lock);)
+	pthread_mutex_unlock(&hunspell_lock);
 	return rc;
 }
 


### PR DESCRIPTION
- Fix a compilation problem on macOS (and systems that don't provide it).
- Fix a compilation problem if there is no pthreads support (like on Emscripten).

Comments:
1. I also found the reason sqlite3 is "not found" on macOS (it just doesn't have a `pkgconf ` definition). I will send a PR.
2. For Emscripten, I plan to change `configure.ac` to not check for pthread / `threads.h`. Now that all of the thread code is protected by `#ifdef`, I hope it would be fine.