### PR TITLE
`generate` branch build-break + misc. fixes  

### DIFF
--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -52,19 +52,19 @@ link_public_api(bool)
  *
  ***********************************************************************/
 
-link_public_api(const Category *)
+link_experimental_api(const Category *)
 	dictionary_get_categories(const Dictionary dict);
 
-link_public_api(const Category_cost *)
+link_experimental_api(const Category_cost *)
 	linkage_get_categories(const Linkage linkage, WordIdx w);
 
-link_public_api(Disjunct **)              /* To be freed by the caller */
+link_experimental_api(Disjunct **)              /* To be freed by the caller */
 	sentence_unused_disjuncts(Sentence);
 
-link_public_api(char *)
+link_experimental_api(char *)
 	disjunct_expression(Disjunct *);       /* To be freed by the caller */
 
-link_public_api(const Category_cost *)
+link_experimental_api(const Category_cost *)
 	disjunct_categories(Disjunct *);
 
 /***********************************************************************/

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -36,7 +36,6 @@ static Linkage linkage_array_new(int num_to_alloc)
 	return lkgs;
 }
 
-
 static void find_unused_disjuncts(extractor_t *pex, Linkage linkage)
 {
 	Sentence sent = linkage->sent;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3130,7 +3130,6 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 		{
 			if (NULL == strstr(s, WILDCARD_WORD))
 			{
-
 				we = build_word_expressions(sent, w, UNKNOWN_WORD, opts);
 				assert(we, UNKNOWN_WORD " supposed to be defined in the dictionary!");
 				w->status |= WS_UNKNOWN;

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -1,8 +1,8 @@
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "link-grammar/dict-common/dict-api.h"
-#include "link-grammar/error.h"
 
 #include "generator-utilities.h"
 
@@ -30,7 +30,7 @@ static void print_sent(size_t nwords, const char** words,
 {
 	for(WordIdx w = 0; w < nwords; w++)
 	{
-		assert(NULL != words[w], "Failed to select word!");
+		assert(NULL != words[w] /* Failed to select word! */);
 		printf("%s", cond_subscript(words[w], subscript));
 		if (w < nwords-1) printf(" ");
 	}
@@ -139,7 +139,7 @@ static size_t print_several(const Category* catlist,
 		{
 			/* Count the number of categories for this disjunct */
 			while (cc[dj_num_cats].num != 0) dj_num_cats++;
-			assert(dj_num_cats != 0, "Bad disjunct!");
+			assert(dj_num_cats != 0 /* Bad disjunct! */);
 
 			cclen[w] = dj_num_cats;
 		}
@@ -182,7 +182,7 @@ static const char *select_random_word(const Category *catlist,
 	while (cc[dj_num_cats].num != 0)
 	   dj_num_cats++;
 
-	assert(dj_num_cats != 0, "Bad disjunct!");
+	assert(dj_num_cats != 0 /* Bad disjunct! */);
 
 	/* Select a category on this disjunct. */
 	unsigned int r = (unsigned int)rand();

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -190,16 +190,22 @@ static const char *select_random_word(const Category *catlist,
 
 	/* Subtract 1 because Category 0 is undefined. */
 	unsigned int catnum = cc[catidx].num - 1;
-	lgdebug(5, "Word %zu: r=%08x category %d/%u \"%u\";", w, r,
-	        catidx, dj_num_cats, catnum);
+	if (verbosity_level >= 5)
+	{
+		printf("Word %zu: r=%08x category %d/%u \"%u\";", w, r,
+		       catidx, dj_num_cats, catnum);
+	}
 	unsigned int num_words = catlist[catnum].num_words;
 
 	/* Select a dictionary word from the selected disjunct category. */
 	r = (unsigned int)rand();
 	unsigned int dict_word_idx = r % num_words;
 	const char *word = catlist[catnum].word[dict_word_idx];
-	lgdebug(5, " r=%08x word %d/%u \"%s\"\n",
-	        r, dict_word_idx, num_words, word);
+	if (verbosity_level >= 5)
+	{
+		printf(" r=%08x word %d/%u \"%s\"\n",
+		       r, dict_word_idx, num_words, word);
+	}
 
 	return word;
 }

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -2,6 +2,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#define LINK_GRAMMAR_DLL_EXPORT 0
+#endif /* _MSC_VER */
+
 #include "link-grammar/dict-common/dict-api.h"
 
 #include "generator-utilities.h"

--- a/link-parser/generator-utilities.h
+++ b/link-parser/generator-utilities.h
@@ -4,3 +4,6 @@ void dump_categories(const Dictionary, const Category *);
 size_t print_sentences(const Category*,
                        Linkage, size_t nwords, const char** words,
                        bool subscript, double max_samples);
+
+
+extern int verbosity_level;

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -260,7 +260,7 @@ int main (int argc, char* argv[])
 	}
 
 	int linkages_valid = sentence_num_valid_linkages(sent);
-	assert(linkages_valid == num_linkages, "unexpected linkages!");
+	assert(linkages_valid == num_linkages /* "unexpected linkages! */);
 
 	// How many sentences to print per linkage.
 	// Print more than one only if explode flag set.

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -12,20 +12,20 @@
 #endif
 
 #include <argp.h>
+#include <assert.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "link-grammar/link-includes.h"
 #include "link-grammar/dict-common/dict-api.h"
-#include "link-grammar/error.h"
 
 #include "generator-utilities.h"
 
 #define MAX_SENTENCE 254
 #define WILDCARD_WORD "\\*"
 
-static int verbosity_level; // TODO/FIXME: Avoid using exposed library static variable.
+int verbosity_level;
 
 /* Argument parsing for the generator */
 typedef struct

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -17,6 +17,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#define LINK_GRAMMAR_DLL_EXPORT 0
+#endif /* _MSC_VER */
+
 #include "link-grammar/link-includes.h"
 #include "link-grammar/dict-common/dict-api.h"
 


### PR DESCRIPTION
Main changes:
- Fix build-break due to the recent change.

Also:
- dict-api.h: Use link_experimental_api for the generation API
  See issue #1179.
- Remove extra blank lines.
- Fix build-break with MSVC.