### PR TITLE
Branch `generate` cleanup

### DIFF
--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -25,8 +25,9 @@ link_parser_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la
 link_parser_LDADD += $(LIBEDIT_LIBS)
 
 link_generator_SOURCES = link-generator.c \
-								 generator-utilities.h \
-								 generator-utilities.c
+                         generator-utilities.h \
+                         generator-utilities.c
+
 link_generator_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/link-grammar
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -2,8 +2,6 @@
 # Automake file for building the command line application `link-parser`.
 #
 
-DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir)\"
-
 # $(top_builddir) to pick up autogened link-grammar/link-features.h
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
 AM_CFLAGS = $(WARN_CFLAGS) $(HUNSPELL_CFLAGS) $(LIBEDIT_CFLAGS)

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -30,9 +30,6 @@ link_generator_SOURCES = link-generator.c \
 link_generator_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/link-grammar
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la
-if HAVE_SQLITE
-link_generator_LDADD += $(SQLITE3_LIBS)
-endif
 
 
 # Installation checks, to be manually done after "make install".

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -2,11 +2,6 @@
 # Automake file for building the command line application `link-parser`.
 #
 
-# $(top_builddir) to pick up autogened link-grammar/link-features.h
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
-AM_CFLAGS = $(WARN_CFLAGS) $(HUNSPELL_CFLAGS) $(LIBEDIT_CFLAGS)
-
-# -----------------------------------------------------------
 # Directives to build the link-parser command-line application
 bin_PROGRAMS=link-parser link-generator
 
@@ -18,18 +13,20 @@ link_parser_SOURCES = link-parser.c \
                       command-line.h \
                       lg_readline.h
 
+# -I$(top_builddir) to pick up autogened link-grammar/link-features.h
+link_parser_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
+link_parser_CFLAGS = $(WARN_CFLAGS) $(HUNSPELL_CFLAGS) $(LIBEDIT_CFLAGS)
 link_parser_LDFLAGS = $(LINK_CFLAGS)
-link_parser_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la
-link_parser_LDADD += $(LIBEDIT_LIBS)
+link_parser_LDADD = $(LIBEDIT_LIBS) $(top_builddir)/link-grammar/liblink-grammar.la
 
 link_generator_SOURCES = link-generator.c \
                          generator-utilities.h \
                          generator-utilities.c
 
-link_generator_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/link-grammar
+link_generator_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/link-grammar
+link_generator_CFLAGS = $(WARN_CFLAGS)
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la
-
 
 # Installation checks, to be manually done after "make install".
 # link-parser checks:

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -93,7 +93,7 @@ static void sent_odom(const Category* catlist,
 	}
 }
 
-void count_choices(void* data)
+static void count_choices(void* data)
 {
 	size_t* count = data;
 	(*count) ++;
@@ -107,7 +107,7 @@ typedef struct {
 	size_t nprinted;
 } sent_data;
 
-void print_word_choices(void* data)
+static void print_word_choices(void* data)
 {
 	sent_data* sd = data;
 

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -196,7 +196,7 @@ static const char *select_random_word(const Category *catlist,
 	unsigned int catnum = cc[catidx].num - 1;
 	if (verbosity_level >= 5)
 	{
-		printf("Word %zu: r=%08x category %d/%u \"%u\";", w, r,
+		printf("Word %zu: r=%08x category %u/%u \"%u\";", w, r,
 		       catidx, dj_num_cats, catnum);
 	}
 	unsigned int num_words = catlist[catnum].num_words;
@@ -207,7 +207,7 @@ static const char *select_random_word(const Category *catlist,
 	const char *word = catlist[catnum].word[dict_word_idx];
 	if (verbosity_level >= 5)
 	{
-		printf(" r=%08x word %d/%u \"%s\"\n",
+		printf(" r=%08x word %u/%u \"%s\"\n",
 		       r, dict_word_idx, num_words, word);
 	}
 

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -238,9 +238,6 @@ size_t print_sentences(const Category* catlist,
 		                     subscript, max_samples);
 	}
 
-	/* Otherwise, just select one word at random */
-	const char* selected_words[nwords];
-
 	for(WordIdx w = 0; w < nwords; w++)
 	{
 		const Category_cost* cc = linkage_get_categories(linkage, w);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -179,7 +179,6 @@ int main (int argc, char* argv[])
 	printf("# Dictionary version %s\n", linkgrammar_get_dict_version(dict));
 
 	const Category* catlist = dictionary_get_categories(dict);
-	const Category* category = dictionary_get_categories(dict);
 	if (catlist == NULL)
 	{
 		prt_error("Fatal error: dictionary_get_categories() failed\n");


### PR DESCRIPTION
- Fix compilation break due to merge problem (issue #1185).
- Fix warnings due to unused variables.
- Fix warnings due to missing `static`.
-  Fix `print()` format.
- Clean up `link-parser/Makefile.am`.
