### PR TITLE
generate - last minute fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -832,7 +832,7 @@ fi
 # ===================================================================
 # argp is needed for link-generate.
 
-AC_CHECK_HEADER([argp.h], [AC_SEARCH_LIBS([argp_parse], [argp])], [no_argp=1])
+AC_CHECK_HEADER([argp.h], [AC_SEARCH_LIBS([argp_parse], [argp],, [no_argp=1])], [no_argp=1])
 
 if test -n "$no_argp"; then
 	AC_MSG_WARN([No argp library found - "link-generator" will not get built.])

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -355,15 +355,15 @@ void dictionary_delete(Dictionary dict)
 /* ======================================================================== */
 
 /**
- * Set sentence generation indications if requested.
- * Since dictionary_create*() doesn't support options, use the "test"
- * parse_option, which is in a global variable:
+ * Initialize generation mode, if requested.
+ * Since the dictionary_create*() functions don't support Parse_Options as
+ * an argument, use the "test" parse-option, which is in a global variable:
  * If it contains "generate", enable generation mode.
  * If an argument "walls" is also supplied ("generate:walls"), then
  * set a wall generation indication.
  *
- * @param dict Set the indications in this dictionary.
- * @return \c true if in generation mode, \c false otherwise.
+ * @param dict Set the generation mode in this dictionary.
+ * @return \c true if generation mode has been set, \c false otherwise.
  */
 bool dictionary_generation_request(const Dictionary dict)
 {

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -51,7 +51,7 @@ typedef enum { Exptag_none=0, Exptag_dialect, Exptag_macro } Exptag_type;
 struct Exp_struct
 {
 	Exp_type type:8;      /* One of three types: AND, OR, or connector. */
-	unsigned int category:24; /* Index into the category field of Dictionary. */
+	unsigned int unused:24;
 	union
 	{
 		struct /* For non-terminals. */

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1670,7 +1670,6 @@ static bool is_correction(const char *s)
 
 static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 {
-	e->category = 0;
 	if (n == 1)
 	{
 		if (is_macro(dn->string)) return;
@@ -1714,7 +1713,6 @@ static void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 		snprintf(category_string, sizeof(category_string), " %x",
 		         dict->num_categories);
 		string_set_add(category_string, dict->string_set);
-		e->category = dict->num_categories;
 		dict->category[dict->num_categories].exp = e;
 		dict->category[dict->num_categories].num_words = n;
 		dict->category[dict->num_categories].name = "";

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -489,7 +489,6 @@ static void add_categories(Dictionary dict)
 		sqlite3_exec(db, qry->str, exp_cb, &bs, NULL);
 		dyn_str_delete(qry);
 
-		bs.exp->category = i;
 		dict->category[i].exp = bs.exp;
 
 		/* ------------------ */


### PR DESCRIPTION
- `configure.a: Fix searching for argp`
Missing `argp.h` was not detected, it detected only missing library `argp` support.
- generation mode: Exp_struct: Remove field "category"
initially thought this field would be useful.
- dictionary_generation_request(): Fix function comment
This fixes a comment rot.
