### PR TITLE
Support >1G entries in Table_connector 

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -285,11 +285,11 @@ static inline uint32_t string_hash(const char *s)
 /**
  * Hash function for the classic parser linkage memoization.
  */
-static inline unsigned int pair_hash(int lw, int rw,
-                                     int l_id, const int r_id,
-                                     unsigned int null_count)
+static inline size_t pair_hash(int lw, int rw,
+                               int l_id, const int r_id,
+                               unsigned int null_count)
 {
-	unsigned int i;
+	size_t i;
 
 #if 0
 	/* hash function. Based on some tests, this seems to be

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -96,7 +96,6 @@ struct count_context_s
 	bool    islands_ok;
 	bool    exhausted;
 	uint8_t num_growth;       /* Number of table growths, for debug */
-	bool    keep_table;
 	bool    is_short;
 	unsigned int checktimer;  /* Avoid excess system calls */
 	unsigned int table_size;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -110,7 +110,7 @@ struct count_context_s
 	COUNT_COST(uint64_t count_cost[3];)
 };
 #define MAX_TABLE_SIZE(s) (s / 10) /* Low load factor, for speed */
-#define MAX_LOG2_TABLE_SIZE 34     /* 16G entries */
+#define MAX_LOG2_TABLE_SIZE ((sizeof(size_t)==4) ? 25 : 34)
 
 static void free_table(count_context_t *ctxt)
 {

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -14,16 +14,16 @@
 #define _COUNT_H
 
 #include "fast-match.h"                 // fast_matcher_t
-#include "histogram.h"                  // Count_bin
+#include "histogram.h"                  // linkage count definitions
 
 typedef struct count_context_s count_context_t;
 
-Count_bin* table_lookup(count_context_t *, int, int,
+count_t *table_lookup(count_context_t *, int, int,
                         const Connector *, const Connector *,
                         unsigned int, size_t *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 bool no_count(count_context_t *, int, Connector *, unsigned int, unsigned int);
 
-count_context_t* alloc_count_context(Sentence, Tracon_sharing*);
+count_context_t *alloc_count_context(Sentence, Tracon_sharing*);
 void free_count_context(count_context_t*, Sentence);
 #endif /* _COUNT_H */

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -20,7 +20,7 @@ typedef struct count_context_s count_context_t;
 
 Count_bin* table_lookup(count_context_t *, int, int,
                         const Connector *, const Connector *,
-                        unsigned int, unsigned int *);
+                        unsigned int, size_t *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 bool no_count(count_context_t *, int, Connector *, unsigned int, unsigned int);
 

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -52,10 +52,10 @@ struct Parse_set_struct
 	unsigned int   null_count; /* number of island words */
 	int            l_id, r_id; /* tracons on words lw, rw */
 
-	s64 count;      /* The number of ways to parse. */
+	count_t count;      /* The number of ways to parse. */
 #ifdef RECOUNT
-	s64 recount;  /* Exactly the same as above, but counted at a later stage. */
-	s64 cut_count;  /* Count only low-cost parses, i.e. below the cost cutoff */
+	count_t recount;  /* Exactly the same as above, but counted at a later stage. */
+	count_t cut_count;  /* Count only low-cost parses, i.e. below the cost cutoff */
 	//double cost_cutoff;
 #undef RECOUNT
 #define RECOUNT(X) X
@@ -350,7 +350,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 {
 	int start_word, end_word, w;
 	Pset_bucket *xt;
-	Count_bin * count;
+	count_t *count;
 
 	assert(null_count < 0x7fff, "mk_parse_set() called with null_count < 0.");
 
@@ -624,7 +624,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 static bool set_node_overflowed(Parse_set *set)
 {
 	Parse_choice *pc;
-	s64 n = 0;
+	w_count_t n = 0;
 	if (set == NULL || set->first == NULL) return false;
 
 	for (pc = set->first; pc != NULL; pc = pc->next)
@@ -763,7 +763,7 @@ static void issue_links_for_choice(Linkage lkg, Parse_choice *pc)
 static void list_links(Linkage lkg, const Parse_set * set, int index)
 {
 	Parse_choice *pc;
-	int n; /* No overflow here - see extract_links() and process_linkages() */
+	count_t n; /* No overflow - see extract_links() and process_linkages() */
 
 	if (set == NULL || set->first == NULL) return;
 	for (pc = set->first; pc != NULL; pc = pc->next) {

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -48,11 +48,11 @@ struct Parse_choice_struct
  * tracons l_id and r_id on words lw and rw, correspondingly. */
 struct Parse_set_struct
 {
-	short          lw, rw; /* left and right word index */
+	short          lw, rw;     /* left and right word index */
 	unsigned int   null_count; /* number of island words */
 	int            l_id, r_id; /* tracons on words lw, rw */
 
-	count_t count;      /* The number of ways to parse. */
+	count_t count;             /* The number of ways to parse. */
 #ifdef RECOUNT
 	count_t recount;  /* Exactly the same as above, but counted at a later stage. */
 	count_t cut_count;  /* Count only low-cost parses, i.e. below the cost cutoff */
@@ -77,7 +77,7 @@ struct extractor_s
 {
 	unsigned int   x_table_size;
 	unsigned int   log2_x_table_size; /* Not used */
-	Pset_bucket ** x_table;  /* Hash table */
+	Pset_bucket ** x_table;           /* Hash table */
 	Parse_set *    parse_set;
 	Word           *words;
 	Pool_desc *    Pset_bucket_pool;

--- a/link-grammar/parse/histogram.c
+++ b/link-grammar/parse/histogram.c
@@ -154,7 +154,7 @@ void hist_muladdv(Count_bin* acc, const Count_bin* a, double cost, const Count_b
 double hist_cost_cutoff(Count_bin* hist, int count)
 {
 	int i;
-	s64 cnt = 0;
+	w_count_t cnt = 0;
 
 	for (i=0; i<NUM_BINS; i++)
 	{
@@ -165,10 +165,10 @@ double hist_cost_cutoff(Count_bin* hist, int count)
 	return 1.0e38;
 }
 
-s64 hist_cut_total(Count_bin* hist, int min_total)
+w_count_t hist_cut_total(Count_bin* hist, int min_total)
 {
 	int i;
-	s64 cnt = 0;
+	w_count_t cnt = 0;
 
 	for (i=0; i<NUM_BINS; i++)
 	{


### PR DESCRIPTION
Because `table_size` got enlarged to 64 bit, the table element size got increased.
The following commit reduces it to its original size:
`Table_connector: Reduce memory for the count field`

Set the maximum table size to 2^34 (16G).

With null_count=0, I think the bigger table size with the bundled batches is 2^30.
With null_count>0 it can be much larger than 2^30 (but I have no idea by how much).

This patch needs also to be applied to the `generate` branch by merging master into it (there is one easy conflict).

---
The problem with big table sizes (say over 2^24, the original limit), is that getting into page swapping more than negates the benefit of a bigger table. It is better to have a table load of 90% (or even more) than swapping.
I once proposed to use the `memory` parse option for a kind of soft memory limit. If not 0, the table size would not be enlarged over some minimal size if the program takes more memory than the `memory` option indicates. This can be easily implemented for systems that have `procfs` (Linux and *BSD). On systems w/o `procfs` it can just limit the table size - maybe
this can even be the implementations for all the systems - i.e. that `memory` would only control `Table_connector` size, since it is the main memory consumer and it can be adjusted.