### PR TITLE
Idiom dictionary loading speedup

### DIFF
--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -116,7 +116,11 @@ static long max_postfix_found(Dict_node * d)
 static const char * build_idiom_word_name(Dictionary dict, const char * s)
 {
 	char buff[2*MAX_WORD];
-	snprintf(buff, sizeof(buff), "%s%cI%ld", s, SUBSCRIPT_MARK, count);
+
+	size_t n = lg_strlcpy(buff, s, sizeof(buff));
+	buff[n] = SUBSCRIPT_MARK;
+	buff[n + 1] = 'I';
+	buff[n + 2] = '\0';
 
 	return string_set_add(buff, dict->string_set);
 }

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -67,47 +67,6 @@ static bool is_idiom_string(const char * s)
 }
 
 /**
- * Return true if the string s is a sequence of digits.
- */
-static bool is_number(const char *s)
-{
-	while(*s != '\0') {
-		if (!isdigit(*s)) return false;
-		s++;
-	}
-	return true;
-}
-
-/**
- * If the string contains a SUBSCIPT_MARK, and ends in ".Ix" where
- * x is a number, return x.  Return -1 if not of this form.
- */
-static long numberfy(const char * s)
-{
-	s = strrchr(s, SUBSCRIPT_MARK);
-	if (NULL == s) return -1;
-	if (*++s != 'I') return -1;
-	if (!is_number(++s)) return -1;
-	return atol(s);
-}
-
-/**
- * Look for words that end in ".Ix" where x is a number.
- * Return the largest x found.
- */
-static long max_postfix_found(Dict_node * d)
-{
-	long i, j;
-	i = 0;
-	while(d != NULL) {
-		j = numberfy(d->string);
-		if (j > i) i = j;
-		d = d->right;
-	}
-	return i;
-}
-
-/**
  * build_idiom_word_name() -- return idiomized name of given string.
  *
  * Allocates string space and returns a pointer to it.

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -161,11 +161,10 @@ static const char * generate_id_connector(Dictionary dict)
  * Takes as input a pointer to a Dict_node.
  * The string of this Dict_node is an idiom string.
  * This string is torn apart, and its components are inserted into the
- * dictionary as special idiom words (ending in .I*, where * is a number).
+ * dictionary as special idiom words (ending in .I).
  * The expression of this Dict_node (its node field) has already been
  * read and constructed.  This will be used to construct the special idiom
  * expressions.
- * The given dict node is freed.  The string is also freed.
  */
 void insert_idiom(Dictionary dict, Dict_node * dn)
 {

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -640,7 +640,7 @@ static bool subscr_match(const char *s, const Dict_node * dn)
  */
 static Dict_node *
 rdictionary_lookup(Dict_node * restrict llist,
-                   const Dict_node * restrict dn,
+                   Dict_node * restrict dn,
                    const char * restrict s,
                    bool match_idiom,
                    int (*dict_order)(const char *, const Dict_node *))
@@ -662,6 +662,7 @@ rdictionary_lookup(Dict_node * restrict llist,
 		dn_new = dict_node_new();
 		*dn_new = *dn;
 		dn_new->right = llist;
+		dn_new->left = dn; /* Currently only used for inserting idioms */
 		llist = dn_new;
 	}
 	if (m <= 0)
@@ -1572,7 +1573,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	if (is_idiom_word(dn->string))
 	{
 		prt_error("Warning: Word \"%s\" found near line %d of \"%s\".\n"
-		        "\tWords ending \".Ix\" (x a number) are reserved for idioms.\n"
+		        "\tWords ending \".I\" are reserved for idioms.\n"
 		        "\tThis word will be ignored.\n",
 		        dn->string, dict->line_number, dict->name);
 		free(dn);


### PR DESCRIPTION
Use a better algo for inserting idioms into the dictionary.
The original algo inserted each word of an idiom with a numbered subscript and did hard work to find the number to use (by fetching all the previous such words and iterating them).

Instead, insert the idiom word into the dictionary (as `word.I`) only for the first time it is encountered. On subsequent identical idiom words that are encountered,  just OR their expression with the existing dictionary expression for that same idiom words.

When tested with `entities.b` (see issue #1192), the speedup is ~280x.  The memory saving is much more modest but still significant.

There are some more things to discuss on idioms., to be done here or in a new issue.
