### PR TITLE
Use $PTHREAD_CFLAGS) on the relevant source file compilation and the library linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,8 +111,6 @@ AX_TLS(,:)
 test "$ac_cv_tls" != "none" && lg_tls=yes
 
 AX_PTHREAD
-CFLAGS="${CFLAGS} ${PTHREAD_CFLAGS}"
-LIBS="${LIBS} ${PTHREAD_LIBS}"
 
 dnl Check if we can use C11 threads functions
 AC_CHECK_HEADERS_ONCE([threads.h])

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -34,7 +34,7 @@ DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir_realpath)\
 
 # $(top_builddir) to pick up autogened link-grammar/link-features.h
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir)
-AM_CFLAGS = $(WARN_CFLAGS) $(HUNSPELL_CFLAGS) $(REGEX_CFLAGS) $(SQLITE3_CFLAGS)
+AM_CFLAGS = $(WARN_CFLAGS) $(HUNSPELL_CFLAGS) $(REGEX_CFLAGS) $(SQLITE3_CFLAGS) $(PTHREAD_CFLAGS)
 
 post-process/pp_lexer.lo: AM_CPPFLAGS += -I$(top_srcdir)/link-grammar/post-process
 MAINTAINERCLEANFILES = $(top_srcdir)/link-grammar/post-process/pp_lexer.c
@@ -43,7 +43,7 @@ lib_LTLIBRARIES = liblink-grammar.la
 
 liblink_grammar_la_LDFLAGS = -version-info @VERSION_INFO@ \
 	-export-dynamic -no-undefined \
-	$(LINK_CFLAGS)
+	$(PTHREAD_CFLAGS)
 
 liblink_grammar_la_LIBADD  =  ${REGEX_LIBS}
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,9 +16,9 @@ check_PROGRAMS = dict-reopen multi-dict multi-thread mem-leak
 
 if HAVE_JAVA
 check_PROGRAMS += multi-java
-AM_CPPFLAGS += $(JAVA_CPPFLAGS)
+AM_CPPFLAGS += $(JAVA_CPPFLAGS) $(PTHREAD_CFLAGS)
 multi_java_SOURCES = multi-java.cc
-multi_java_LDADD = -L$(top_builddir)/bindings/java-jni/ -llink-grammar-java -lpthread $(LDADD)
+multi_java_LDADD = -L$(top_builddir)/bindings/java-jni/ -llink-grammar-java $(LDADD)
 endif
 
 TESTS = $(check_PROGRAMS)
@@ -32,8 +32,8 @@ mem_leak_SOURCES = mem-leak.cc
 
 LDADD = -L$(top_builddir)/link-grammar/ -llink-grammar
 
-multi_dict_LDADD = -lpthread $(LDADD)
-multi_thread_LDADD = -lpthread $(LDADD)
+multi_dict_LDADD = $(LDADD)
+multi_thread_LDADD = $(LDADD)
 
 if WITH_SAT_SOLVER
 if LIBMINISAT_BUNDLED


### PR DESCRIPTION
Regarding issue #1195, these are my proposed changes.

They don't set the global CFLAGS, but instead, use $(PTHREAD_CFLAGS) on the `tests` sources that use pthread, on all the library sources, and on the library linking.

I validated it by inspecting `make V=1` and ensuring that `-pthread` appears on these source file compilation and the library linking. It doesn't appear in the `link-parser` sources compilation and the python wrapper compilation (because it is not set in the global `CFLAGS` as I removed this line from `configure`).

Please test.