### PR TITLE
Make `_` valid in connector names 

### DIFF
--- a/data/vn/4.0.dict
+++ b/data/vn/4.0.dict
@@ -12,10 +12,11 @@
 % DT = danh từ = noun
 % TVT=trước động từ=preceeding verb
 
-% Due clashes with the conventions of the library, the following
-% link characters are replaced:
+% Due to clashes with the conventions of the library, the following
+% connector characters are replaced:
+% 2_ is replaced by 2u.
 % _ is replaced by U.
-% Đ is replaced by V
+% Đ is replaced by V.
 
 % Danh từ
 bàn ghế giường áo quần sách quyển_sách báo nhà cửa

--- a/data/vn/4.0.dict
+++ b/data/vn/4.0.dict
@@ -12,11 +12,11 @@
 % DT = danh từ = noun
 % TVT=trước động từ=preceeding verb
 
-% Due to clashes with the conventions of the library, the following
-% connector characters are replaced:
-% 2_ is replaced by 2u.
-% _ is replaced by U.
-% Đ is replaced by V.
+% Due clashes with the conventions of the library, the following
+% link characters are replaced:
+% 2_ is replaced by 2u
+% _ is replaced by U
+% Đ is replaced by V
 
 % Danh từ
 bàn ghế giường áo quần sách quyển_sách báo nhà cửa
@@ -80,14 +80,14 @@ cái chiếc tấm bộ con : TDT3+;
 
 % Trước danh từ 2
 những các mỗi mọi : TDT2+;
-% từng : TDT2+ or TVT2U1+ or TTT2U1+ or TST2U1+;
+% từng : TDT2+ or TVT2u1+ or TTT2u1+ or TST2u1+;
 
 % Trước danh từ 1
 toàn_thể tất_thảy tất_cả toàn_bộ bất_kỳ : TDT1+;
 
 % Số từ
 một hai ba 22 200 40 3 vài phần_lớn 9 5 :
-  (({TST2U1- or TST2U2-} & {{TST4-} & TST3-}
+  (({TST2u1- or TST2u2-} & {{TST4-} & TST3-}
       & {TST4-}) & {TST-}) & {DTUVT-} & STUDT+;
 
 khoảng chừng : TST+;
@@ -105,7 +105,7 @@ từ bởi cùng khỏi : GTUDT+ & (TTUGT- or VTUGT- or ({PH+} & CL+));
 
 ra vào theo sang :
   (GTUDT+ & (TTUGT- or VTUGT- or ({PH+} & CL+)))
-  or (((({TVT1-} & {TVT2U1-} & {{TVT4-} & TVT3-} & {TVT4-})
+  or (((({TVT1-} & {TVT2u1-} & {{TVT4-} & TVT3-} & {TVT4-})
       or {TTUVT-} or ({TTUVT-} & TVT5-))
     & {DTUVT- or VTUVT- or THIUVT- or LTUVT-}
     & {VTUXONG+} & {VTUDT+} & {VTUTT+}
@@ -121,7 +121,7 @@ này : GTUDT- or SDT6-;
 
 % Từ "là"
 là :
-  (({TVT1-} & {TVT2U1-} & {TVT3-} & {TVT4-})
+  (({TVT1-} & {TVT2u1-} & {TVT3-} & {TVT4-})
     or TVT5- or TTUVT-)
   & {DTULA- or THIUVT-} & {LAUDT+ or VTUTT+};
 
@@ -131,7 +131,7 @@ mơ.w đi_làm ngủ đi_ngủ ăn_nói đồng_ý trò_chuyện
 nấu_ăn gắng đứng_dậy hành_xử giao_kèo ở_lại tiến_hóa
 sinh_sản vật_lộn tắt_thở rơi_xuống thụ_phấn phát_quang :
 % [v]
-  ((({TVT1-} & {TVT2U1-} & {{TVT4-} & TVT3-} & {TVT4-})
+  ((({TVT1-} & {TVT2u1-} & {{TVT4-} & TVT3-} & {TVT4-})
       or TTUVT- or ({TTUVT-} & TVT5-))
     & {DTUVT- or VTUVT- or THIUVT- or LTUVT-}
     & {VTUXONG+} & {VTUTT+} & {VTUGT+} & {VTULT+}
@@ -147,7 +147,7 @@ nhìn_thấy chống_cự lấy chụp xếp thuộc săn_đuổi
 giúp sản_xuất phát_ra sử_dụng đưa sinh_hạ tìm_ra
 điều_trị đối_phó truyền tạo hy_vọng :
 % [v]
-  ((({TVT1-} & {TVT2U1-} & {TVT3-} & {TVT4-})
+  ((({TVT1-} & {TVT2u1-} & {TVT3-} & {TVT4-})
       or TTUVT-
       or ({TTUVT-} & TVT5-))
    & {DTUVT- or VTUVT- or THIUVT- or LTUVT- or BI-}
@@ -158,7 +158,7 @@ giúp sản_xuất phát_ra sử_dụng đưa sinh_hạ tìm_ra
 nói biết hỏi.v xác_nhận bác_bỏ bảo cho_rằng khẳng_định
 cho_biết trả lời.v :
 % [v]
-  ((({TVT1-} & {TVT2U1-} & {{TVT4-} & TVT3-} & {TVT4-})
+  ((({TVT1-} & {TVT2u1-} & {{TVT4-} & TVT3-} & {TVT4-})
       or TTUVT-
       or ({TTUVT-} & TVT5-)) & {DTUVT- or VTUVT- or THIUVT- or LTUVT-}
   & {VTUXONG+} & {VTUTT+} & {VTUGT+}
@@ -170,7 +170,7 @@ cho_biết trả lời.v :
 ra_lệnh bắt bắt_buộc ép nài_ép hỏi.w đòi_hỏi cấm cho_phép
 yêu_cầu đề_nghị kêu_gọi quyết_định cân_nhắc cảm_thấy :
 % [v]
-  ((({TVT1-} & {TVT2U1-} & {{TVT4-} & TVT3-} & {TVT4-})
+  ((({TVT1-} & {TVT2u1-} & {{TVT4-} & TVT3-} & {TVT4-})
      or TTUVT-
      or ({TTUVT-} & TVT5-)) & {DTUVT- or THIUVT- or LTUVT-}
    & {VTUXONG+} & {CL+} & {VTULT+ or VTUSS+}
@@ -179,7 +179,7 @@ yêu_cầu đề_nghị kêu_gọi quyết_định cân_nhắc cảm_thấy :
 % Động từ tình thái
 phải dám nỡ nên.v có_thể không_thể định :
 % [v]
-  (({TVT1-} & {TVT2U1- or TVT2U2-} & {{TVT4-} & TVT3-} & {TVT4-})
+  (({TVT1-} & {TVT2u1- or TVT2u2-} & {{TVT4-} & TVT3-} & {TVT4-})
       or TTUVT-
       or ({TTUVT-} & TVT5-)) & {DTUVT- or THIUVT- or LTUVT-}
     & VTUVT+ & {VTULT+ or VTUSS+} & {THT- or THS+}
@@ -188,7 +188,7 @@ phải dám nỡ nên.v có_thể không_thể định :
 muốn cần thích sợ mong mong_chờ tiếc hối_tiếc
 lo_lắng nhớ mơ.v ước quên kiên_nhẫn giận :
 % [v]
-  ((({TVT1-} & {TVT2U1- or TVT2U2-} & {{TVT4-} & TVT3-} & {TVT4-})
+  ((({TVT1-} & {TVT2u1- or TVT2u2-} & {{TVT4-} & TVT3-} & {TVT4-})
       or TTUVT-
       or ({TTUVT-} & TVT5-)) & {DTUVT- or THIUVT- or LTUVT-}
     & {VTUDT+ or VTUVT+ or VTUTT+} & {SVT+} & {THT- or THS+}
@@ -197,7 +197,7 @@ lo_lắng nhớ mơ.v ước quên kiên_nhẫn giận :
 % Động từ chỉ sự bắt đầu, tiếp diễn
 bắt_đầu tiếp_tục thôi dừng kết_thúc :
 % [v]
-  ((({TVT1-} & {TVT2U1-} & {{TVT4-} & TVT3-} & {TVT4-})
+  ((({TVT1-} & {TVT2u1-} & {{TVT4-} & TVT3-} & {TVT4-})
       or TTUVT-
       or ({TTUVT-} & TVT5-)) & {DTUVT- or VTUVT- or THIUVT- or LTUVT-}
   & {VTUXONG+} & {VTUDT+ or @VTUVT+} & {VTUTT+}
@@ -208,10 +208,10 @@ bắt_đầu tiếp_tục thôi dừng kết_thúc :
 thường hay luôn : TVT1+ or TTT1+ or TST1+;
 
 % Trước động từ 2.1 và tính từ 2.1
-không chẳng chưa chưa_từng : TVT2U1+ or TTT2U1+ or TST2U1+;
+không chẳng chưa chưa_từng : TVT2u1+ or TTT2u1+ or TST2u1+;
 
 % Trước động từ 2.2 và tính từ 2.2
-rất hơi khá chỉ : TVT2U2+ or TTT2U2+ or TST2U2+;
+rất hơi khá chỉ : TVT2u2+ or TTT2u2+ or TST2u2+;
 
 % Trước động từ 3 và tính từ 3
 đã đang sẽ vừa mới sắp sắp_sửa : TVT3+ or TTT3+ or TST3+;
@@ -223,9 +223,9 @@ cũng vẫn còn cứ : TVT4+ or TTT4+ or TST4+;
 đừng chớ : TVT5+ or TTT5+;
 
 % Từ "bị", "được"
-bị : (({TVT1-} & {TVT2U1- or TVT2U2-} & {TVT3-} & {TVT4-}) or TVT5-) & {DTUVT- or SDT5- or THIUVT- or LTUVT- or VTUVT-} & BI+ & {VTULT+} & ({THT-} or {THS+} or ({EV+} & {CL-} & {CO-}));
+bị : (({TVT1-} & {TVT2u1- or TVT2u2-} & {TVT3-} & {TVT4-}) or TVT5-) & {DTUVT- or SDT5- or THIUVT- or LTUVT- or VTUVT-} & BI+ & {VTULT+} & ({THT-} or {THS+} or ({EV+} & {CL-} & {CO-}));
 
-được : ((({TVT1-} & {TVT2U1- or TVT2U2-} & {TVT3-} & {TVT4-}) or TVT5-) & {DTUVT- or SDT5- or THIUVT- or LTUVT- or VTUVT-} & BI+ & {VTULT+} & ({THT-} or {THS+} or ({EV+} & {CL-} & {CO-}))) or VTUXONG-;
+được : ((({TVT1-} & {TVT2u1- or TVT2u2-} & {TVT3-} & {TVT4-}) or TVT5-) & {DTUVT- or SDT5- or THIUVT- or LTUVT- or VTUVT-} & BI+ & {VTULT+} & ({THT-} or {THS+} or ({EV+} & {CL-} & {CO-}))) or VTUXONG-;
 
 % Tính từ
 tốt đẹp xấu sạch bẩn đỏ xanh vàng đen trắng
@@ -236,10 +236,10 @@ hạnh_phúc gần cuối_cùng chuyên_nghiệp lập_tức gay_gắt
 riêng muộn đắt chăm thấp tuyệt_vời rõ_ràng chính_thức
 hoàn_toàn có_thật chung đơn_tính quan_trọng có_ích
 hiện_đại hiệu_quả lùn :
-(({TTT1-} & {TTT2U1- or TTT2U2-} & {{TTT4-} & TTT3-} & {TTT4-}) or TTT5- or TTUTT-) & {TTUTT+} & {DTUTT- or SDT2- or TT- or VTUTT- or THIUTT- or BI-} & {TTUVT+ or TTUGT+ or TTULT+} & {STT+ or TTUSS+} & {THT- or THS+} & {EV+} & {CL-} & {CO-};
+(({TTT1-} & {TTT2u1- or TTT2u2-} & {{TTT4-} & TTT3-} & {TTT4-}) or TTT5- or TTUTT-) & {TTUTT+} & {DTUTT- or SDT2- or TT- or VTUTT- or THIUTT- or BI-} & {TTUVT+ or TTUGT+ or TTULT+} & {STT+ or TTUSS+} & {THT- or THS+} & {EV+} & {CL-} & {CO-};
 
 nhiều ít tân :
-(({TTT1-} & {TTT2U1- or TTT2U2-} & {{TTT4-} & TTT3-} & {TTT4-}) or TTT5- or TTUTT-) & (({TTUTT+} & {DTUTT- or SDT2- or VTUTT- or THIUTT- or BI-} & {TTUVT+ or TTUGT+} & {STT+ or TTUSS+} & {THT- or THS+} & ({EV+} & {CL-} & {CO-})) or STUDT-);
+(({TTT1-} & {TTT2u1- or TTT2u2-} & {{TTT4-} & TTT3-} & {TTT4-}) or TTT5- or TTUTT-) & (({TTUTT+} & {DTUTT- or SDT2- or VTUTT- or THIUTT- or BI-} & {TTUVT+ or TTUGT+} & {STT+ or TTUSS+} & {THT- or THS+} & ({EV+} & {CL-} & {CO-})) or STUDT-);
 
 % Sau tính từ
 lắm quá : STT- or SVT-;

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -303,7 +303,8 @@ static void calculate_connector_info(condesc_t * c)
 	}
 
 	c->uc_start = (uint8_t)(s - c->string);
-	while (isupper(*++s)) {} /* Skip the uppercase part. */
+	/* Skip the uppercase part. */
+	do { s++; } while (is_connector_name_char(*s));
 	c->uc_length = (uint8_t)(s - c->string - c->uc_start);
 
 	connector_encode_lc(s, c);
@@ -321,7 +322,7 @@ static uint32_t connector_str_hash(const char *s)
 #ifdef USE_DJB2
 	/* djb2 hash. */
 	uint32_t i = 5381;
-	while (isupper(*s)) /* Connector tables cannot contain UTF8. */
+	while (is_connector_name_char(*s))
 	{
 		i = ((i << 5) + i) + *s;
 		s++;
@@ -333,7 +334,7 @@ static uint32_t connector_str_hash(const char *s)
 #ifdef USE_JENKINS
 	/* Jenkins one-at-a-time hash. */
 	uint32_t i = 0;
-	while (isupper(*s)) /* Connector tables cannot contain UTF8. */
+	while (is_connector_name_char(*s))
 	{
 		i += *s;
 		i += (i<<10);
@@ -349,7 +350,7 @@ static uint32_t connector_str_hash(const char *s)
 	/* sdbm hash. */
 	uint32_t i = 0;
 	c->uc_start = s - c->string;
-	while (isupper(*s))
+	while (is_connector_name_char(*s))
 	{
 		i = *s + (i << 6) + (i << 16) - i;
 		s++;

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -290,11 +290,15 @@ static void calculate_connector_info(condesc_t * c)
 	const char *s;
 
 	s = c->string;
-	if (islower(*s)) s++; /* Ignore head-dependent indicator. */
-	if ((c->string[0] == 'h') || (c->string[0] == 'd'))
-		c->flags |= CD_HEAD_DEPENDENT;
-	if (c->string[0] == 'h')
-		c->flags |= CD_HEAD;
+	if (islower(*s))
+	{
+		dassert((c->string[0] == 'h') || (c->string[0] == 'd'),
+	        "\'%c\': Bad head/dependent character", c->string[0]);
+
+		if ((*s == 'h') || (*s == 'd')) c->flags |= CD_HEAD_DEPENDENT;
+		if (*s == 'h') c->flags |= CD_HEAD;
+		s++; /* Ignore head-dependent indicator. */
+	}
 
 	c->uc_start = (uint8_t)(s - c->string);
 	while (isupper(*++s)) {} /* Skip the uppercase part. */

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -284,6 +284,8 @@ static void connector_encode_lc(const char *lc_string, condesc_t *desc)
  * Calculate fixed connector information that only depend on its string.
  * This information is used to speed up the parsing stage. It is
  * calculated during the directory creation and doesn't change afterward.
+ *
+ * Note: check_connector() has already validated the connector string.
  */
 static void calculate_connector_info(condesc_t * c)
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -53,7 +53,7 @@ typedef uint32_t connector_hash_t;
 static inline bool is_connector_name_char(unsigned char c)
 {
 	if (isupper(c)) return true;
-	if (c == '_') return true;
+	if (unlikely(c == '_')) return true;
 
 	return false;
 }
@@ -61,8 +61,8 @@ static inline bool is_connector_name_char(unsigned char c)
 static inline bool is_connector_subscript_char(unsigned char c)
 {
 	if (islower(c)) return true;
-	if (isdigit(c)) return true;
-	if (c == '*') return true;
+	if (unlikely(isdigit(c))) return true;
+	if (unlikely(c == '*')) return true;
 
 	return false;
 }

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -48,6 +48,25 @@ typedef uint32_t connector_hash_t;
 #define CD_HEAD              (1<<1) /* 0: dependent; 1: head; */
 #define CD_PERMANENT         (1<<2) /* For SQL dict: Do not clear (future). */
 
+/* Validate connector string characters.
+ * Note that only ASCII characters are allowed. */
+static inline bool is_connector_name_char(unsigned char c)
+{
+	if (isupper(c)) return true;
+	if (c == '_') return true;
+
+	return false;
+}
+
+static inline bool is_connector_subscript_char(unsigned char c)
+{
+	if (isalnum(c)) return true;
+	if (c == '*') return true;
+
+	return false;
+}
+/* End of connector string character validation. */
+
 /* The size of the following struct on a 64-bit machine is 32 bytes.
  * It should be kept at this size. If needed, head_dependent, uc_length
  * and uc_start can be eliminate or moved out. Also, there not enough

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -60,7 +60,8 @@ static inline bool is_connector_name_char(unsigned char c)
 
 static inline bool is_connector_subscript_char(unsigned char c)
 {
-	if (isalnum(c)) return true;
+	if (islower(c)) return true;
+	if (isdigit(c)) return true;
 	if (c == '*') return true;
 
 	return false;

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -114,6 +114,8 @@ dictionary_six_str(const char * lang,
 	dict = (Dictionary) malloc(sizeof(struct Dictionary_s));
 	memset(dict, 0, sizeof(struct Dictionary_s));
 
+	dict->line_number = 1;
+
 	/* Language and file-name stuff */
 	dict->string_set = string_set_create();
 	t = find_last_dir_separator((char *)lang);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -237,7 +237,7 @@ static bool get_character(Dictionary dict, int quote_mode, utf8char uc)
 			uc[i] = c;
 			i++;
 		}
-		dict_error(dict, "UTF8 char is too long");
+		dict_error(dict, "UTF8 char is too long.");
 		return false;
 	}
 	uc[0] = 0x0;
@@ -308,7 +308,7 @@ static bool link_advance(Dictionary dict)
 	for (;;)
 	{
 		if (i > MAX_TOKEN_LENGTH-3) {
-			dict_error(dict, "Token too long");
+			dict_error(dict, "Token too long.");
 			return false;
 		}
 		if (quote_mode) {
@@ -321,12 +321,12 @@ static bool link_advance(Dictionary dict)
 				return true;
 			}
 			if (lg_isspace(c[0])) {
-				dict_error(dict, "White space inside of token");
+				dict_error(dict, "White space inside of token.");
 				return false;
 			}
 			if (c[0] == '\0')
 			{
-				dict_error(dict, "EOF while reading quoted token");
+				dict_error(dict, "EOF while reading quoted token.");
 				return false;
 			}
 
@@ -412,7 +412,7 @@ static bool check_connector(Dictionary dict, const char * s)
 	}
 	/* Note that IDx when x is a subscript is allowed (to allow e.g. ID4id+). */
 	if ((*s == 'I') && (*(s+1) == 'D') && isupper((unsigned char)*(s+2))) {
-		dict_error(dict, "Connectors beginning with \"ID\" are forbidden");
+		dict_error(dict, "Connectors beginning with \"ID\" are forbidden.");
 		return false;
 	}
 
@@ -1303,7 +1303,7 @@ static Exp *make_expression(Dictionary dict)
 		{
 			if (e_head->type != op)
 			{
-				dict_error(dict, "\"and\" and \"or\" at the same level in an expression");
+				dict_error(dict, "\"and\" and \"or\" at the same level in an expression.");
 				return NULL;
 			}
 		}

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "api-structures.h"             // Sentence_s (add_empty_word)
+#include "connectors.h"
 #include "dict-common/dialect.h"
 #include "dict-common/dict-affix.h"     // is_stem
 #include "dict-common/dict-common.h"

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -399,7 +399,9 @@ static bool check_connector(Dictionary dict, const char * s)
 	if (*s == '@') s++;
 	if (('h' == *s) || ('d' == *s)) s++;
 	if (!isupper((unsigned char)*s)) {
-		dict_error(dict, "Connectors must start with uppercase after an optional h or d.");
+		dict_error2(dict, "Invalid character in connector "
+		            "(connectors must start with an uppercase letter "
+		            "after an optional \"h\" or \"d\"):", (char[]){*s, '\0'});
 		return false;
 	}
 	/* Note that IDx when x is a subscript is allowed (to allow e.g. ID4id+). */

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -152,7 +152,7 @@ static void dict_error2(Dictionary dict, const char * s, const char *s2)
 	if (s2)
 	{
 		prt_error("Error: While parsing dictionary \"%s\":\n"
-		          "%s %s\n\t Line %d, next tokens: %s\n",
+		          "%s \"%s\"\n\t Line %d, next tokens: %s\n",
 		          dict->name, s, s2, dict->line_number, tokens);
 	}
 	else

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -398,10 +398,16 @@ static bool check_connector(Dictionary dict, const char * s)
 	}
 	if (*s == '@') s++;
 	if (('h' == *s) || ('d' == *s)) s++;
-	if (!isupper((unsigned char)*s)) {
+	if (!is_connector_name_char(*s)) {
 		dict_error2(dict, "Invalid character in connector "
 		            "(connectors must start with an uppercase letter "
 		            "after an optional \"h\" or \"d\"):", (char[]){*s, '\0'});
+		return false;
+	}
+	if (*s == '_')
+	{
+		dict_error(dict, "Invalid character in connector "
+		           "(an initial \"_\" is reserved for internal use).");
 		return false;
 	}
 	/* Note that IDx when x is a subscript is allowed (to allow e.g. ID4id+). */
@@ -410,24 +416,14 @@ static bool check_connector(Dictionary dict, const char * s)
 		return false;
 	}
 
-	bool connector_base = true;
-	s++; /* The first uppercase has been validated above. */
-	while (*(s+1)) {
-		if ((!isalnum((unsigned char)*s)) && (*s != WILD_TYPE)) {
-			dict_error(dict, "All letters of a connector must be ASCII alpha-numeric.");
+	/* The first uppercase has been validated above. */
+	do { s++; } while (is_connector_name_char(*s));
+	while (s[1]) {
+		if (!is_connector_subscript_char(*s) && (*s != WILD_TYPE)) {
+			dict_error2(dict, "Invalid character in connector subscript "
+			            "(only lowercase letters, digits, and \"*\" are allowed):",
+			            (char[]){*s, '\0'});
 			return false;
-		}
-		if (isupper((unsigned char)*s))
-		{
-			if (!connector_base)
-			{
-				dict_error(dict, "Connector subscript contains uppercase.");
-				return false;
-			}
-		}
-		else
-		{
-			connector_base = false;
 		}
 		s++;
 	}

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -69,7 +69,8 @@ const char *intersect_strings(String_set *sset, const Connector *c1,
 	const char *s2 =  &connector_string(c1)[d1->uc_start];
 	do
 	{
-		assert(isupper(*s1) == isupper(*s2), "Invalid uppercase part!");
+		assert(is_connector_name_char(*s1) == is_connector_name_char(*s2),
+		       "Invalid uppercase part!");
 		assert(*s1 == *s2 || *s1 == '*' || *s2 == '*', "Invalid intersection!");
 	}
 	while ((*s1++ != '0') && (*s2++ != 0));

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -1308,8 +1308,8 @@ static void cms_table_delete(multiset_table *mt)
 static unsigned int cms_hash(const char *s)
 {
 	unsigned int i = 5381;
-	if (islower((int) *s)) s++; /* skip head-dependent indicator */
-	while (isupper((int) *s))
+	if (islower((unsigned int)*s)) s++; /* skip head-dependent indicator */
+	while (is_connector_name_char(*s))
 	{
 		i = ((i << 5) + i) + *s;
 		s++;
@@ -1347,13 +1347,13 @@ static void reset_last_criterion(multiset_table *cmt, const char *ctiterion)
 static bool can_form_link(const char *s, const char *t, const char *e)
 {
 	if (islower(*t)) t++; /* Skip head-dependent indicator */
-	while (isupper(*s))
+	while (is_connector_name_char(*s))
 	{
 		if (*s != *t) return false;
 		s++;
 		t++;
 	}
-	if (isupper(*t)) return false;
+	if (is_connector_name_char(*t)) return false;
 	while (*t != '\0')
 	{
 		if (*s == '\0') return true;
@@ -1492,7 +1492,7 @@ static bool all_connectors_exist(multiset_table *cmt, const char *pp_link)
 	ppdebug("check PP-link=%s\n", pp_link);
 
 	const char *s;
-	for (s = pp_link; isupper(*s); s++) {}
+	for (s = pp_link; is_connector_name_char(*s); s++) {}
 
 	/* The first iteration of the next loop handles the special case
 	 * which occurs if there were 0 subscripts. */

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -77,7 +77,7 @@ struct CNode_s
  */
 static bool uppercompare(const char * s, const char * t)
 {
-	while (isupper(*s) || isupper(*t))
+	while (is_connector_name_char(*s) || is_connector_name_char(*t))
 	{
 		if (*s++ != *t++) return false;
 	}

--- a/link-grammar/post-process/post-process.c
+++ b/link-grammar/post-process/post-process.c
@@ -19,6 +19,7 @@
 #include "post-process.h"
 
 #include "api-structures.h"
+#include "connectors.h"
 #include "error.h"
 #include "linkage/linkage.h"
 #include "linkage/score.h"
@@ -53,13 +54,13 @@ bool post_process_match(const char *s, const char *t)
 {
 	if (NULL == t) return false;
 	if (islower(*t)) t++; /* Skip head-dependent indicator */
-	while (isupper(*s))
+	while (is_connector_name_char(*s))
 	{
 		if (*s != *t) return false;
 		s++;
 		t++;
 	}
-	if (isupper(*t)) return false;
+	if (is_connector_name_char(*t)) return false;
 	while (*t != '\0')
 	{
 		if (*s == '\0') return true;

--- a/link-grammar/post-process/pp_linkset.c
+++ b/link-grammar/post-process/pp_linkset.c
@@ -20,6 +20,7 @@ to the caller to ensure that the pointers always point to something useful.
 
 #include <memory.h>
 
+#include "connectors.h"
 #include "post-process.h"
 #include "pp_linkset.h"
 #include "error.h"
@@ -50,7 +51,7 @@ static unsigned int compute_hash(pp_linkset *ls, const char *str)
 	hashval = LINKSET_SEED_VALUE;
 	i = 0;
 	if (islower((int)str[0])) i++; /* skip head-dependent indicator */
-	for (; isupper((int)str[i]); i++)
+	for (; is_connector_name_char(str[i]); i++)
 		hashval = str[i] + 31*hashval;
 	hashval %= ls->hash_table_size;
 	return hashval;

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -266,12 +266,20 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 #define NO_SAN_DICT
 #endif
 
+#ifndef DONT_EXPECT
+#define likely(x)      __builtin_expect(!!(x), 1)
+#define unlikely(x)    __builtin_expect(!!(x), 0)
+#endif
+
 #else
 #define UNREACHABLE(x)
 #define GNUC_MALLOC
 #define GNUC_UNUSED
 #define GNUC_NORETURN
 #define NO_SAN_DICT
+
+#define likely(x)
+#define unlikely(x)
 #endif
 
 


### PR DESCRIPTION
Add underbar as a valid character in the connector uppercase part. See issue #1200.

It turns out it is not possible to restore the original underbars in `vn` dictionary. This is because its author used a Java implementation of the link-grammar library in which underbars and numbers belong to the connector name (a.k.a the uppercase part). BTW, I wondered why this dict has only 5 sentence examples and none of them can be fully parsed. I will write on that in a separate issue.

Main fixes here:
- Accept also '_' in the connector uppercase part
- connectors.h: Add functions to check for valid connector string
-  data/vn/4.0.dict: Fix connector strings with mixed digits & uppercase
   (An old patch that validates connector subscripts made them invalid but the problem in this file was neglected.)
- Fix line numbers in the main dictionary file
  (I noticed it again in the error on invalid connectors so I fixed it at last.)
- Improve dict error messages.

---
I would like now to fix the idiom connector-name/subscript conventions to include an initial underbar:
- `_Ixxxx` for idionm links.
- `_I` for idiom subscripts.

Edit: Force-pushed to correct a bad inclusion of a test `en/4.0.dict`.