### PR TITLE
Remove optional detection of bare + subscripted word

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -1447,7 +1447,6 @@ its my.p your their.p our thy.p yisser.p yousser ye'r:
 
 % Possessive version of me
 % Cost on D, DD: avoids use as determiner on "Make me coffee"
-%suppress: DUP-BASE (for me.p)
 me.p:
   DP+
   or [{AL-} & {@L+} & (D+ or DD+)];
@@ -2426,7 +2425,6 @@ ninety-seventh.ord ninety-eighth.ord ninety-ninth.ord
 % - the strength was in the order of gerE > cotD > yfhP P2 > yfhP P1
 % also remember "-->"
 
-%suppress: DUP-BASE (for a.eq)
 A.eq B.eq C.eq D.eq E.eq F.eq G.eq H.eq I.eq J.eq K.eq L.eq M.eq
 N.eq O.eq P.eq Q.eq R.eq S.eq T.eq U.eq V.eq W.eq X.eq Y.eq Z.eq
 a.eq b.eq c.eq d.eq e.eq f.eq g.eq h.eq i.eq j.eq k.eq l.eq m.eq
@@ -12848,7 +12846,6 @@ maybe.r:
 % Argumentatives (children gain-saying).
 not.intj is_too is_not is_so unh_unh: Wa-;
 
-%suppress: DUP-BASE (for seriously.ij)
 % Openers to directives, commands (Xc+ & EI+ connection to infinitives)
 % or single-word interjections, exclamations.
 % These are semantically important, so they've got to parse!
@@ -12989,7 +12986,6 @@ necessarily no_longer: E+ or EBm-;
 ever: E+ or EBm- or EC+ or <adv-as> or <COMP-OPENER>;
 
 never.e always: ({EN-} & (E+ or EB-)) or <COMP-OPENER>;
-%suppress: DUP-BASE (for rarely.e)
 seldom rarely.e: ({EE-} & (E+ or EB-)) or <COMP-OPENER>;
 
 % MVa-: "He did just what you asked."
@@ -13041,7 +13037,6 @@ only:
   or (Rnx+ & <CLAUSE-E>)
   or (MVp+ & Wq- & Q+);
 
-%suppress: DUP-BASE (for rarely.i)
 never.i at_no_time not_once rarely.i since_when:
   {MVp+} & Wq- & Q+;
 
@@ -13292,7 +13287,6 @@ but.ij and.ij or.ij not.ij also.ij then.ij but_not and_not and_yet:
   [{Xd-} & (Xx- or Wc-) & {Xc+} & {EB+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>]1.1;
 
-%suppress: DUP-BASE (for ..y)
 % (NI- & WV- & W+): Optionally numbered, bulleted lists
 ..y *.j "•" ⁂ ❧ ☞ ◊ ※  "….j" ○  。 ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎:
   (Wd- & W+)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -1456,7 +1456,6 @@ its my.p your their.p our thy.p yisser.p yousser ye'r:
 
 % Possessive version of me
 % Cost on D, DD: avoids use as determiner on "Make me coffee"
-%suppress: DUP-BASE (for me.p)
 me.p:
   DP+
   or [{AL-} & {@L+} & (D+ or DD+)];
@@ -2435,7 +2434,6 @@ ninety-seventh.ord ninety-eighth.ord ninety-ninth.ord
 % - the strength was in the order of gerE > cotD > yfhP P2 > yfhP P1
 % also remember "-->"
 
-%suppress: DUP-BASE (for a.eq)
 A.eq B.eq C.eq D.eq E.eq F.eq G.eq H.eq I.eq J.eq K.eq L.eq M.eq
 N.eq O.eq P.eq Q.eq R.eq S.eq T.eq U.eq V.eq W.eq X.eq Y.eq Z.eq
 a.eq b.eq c.eq d.eq e.eq f.eq g.eq h.eq i.eq j.eq k.eq l.eq m.eq
@@ -10429,7 +10427,6 @@ maybe.r:
 % Argumentatives (children gain-saying).
 not.intj is_too is_not is_so unh_unh: Wa-;
 
-%suppress: DUP-BASE (for seriously.ij)
 % Openers to directives, commands (Xc+ & EI+ connection to infinitives)
 % or single-word interjections, exclamations.
 % These are semantically important, so they've got to parse!
@@ -10570,7 +10567,6 @@ necessarily no_longer: E+ or EBm-;
 ever: E+ or EBm- or EC+ or <adv-as> or <COMP-OPENER>;
 
 never.e always: ({EN-} & (E+ or EB-)) or <COMP-OPENER>;
-%suppress: DUP-BASE (for rarely.e)
 seldom rarely.e: ({EE-} & (E+ or EB-)) or <COMP-OPENER>;
 
 % MVa-: "He did just what you asked."
@@ -10622,7 +10618,6 @@ only:
   or (Rnx+ & <CLAUSE-E>)
   or (MVp+ & Wq- & Q+);
 
-%suppress: DUP-BASE (for rarely.i)
 never.i at_no_time not_once rarely.i since_when:
   {MVp+} & Wq- & Q+;
 
@@ -10875,7 +10870,6 @@ but.ij and.ij or.ij not.ij also.ij then.ij but_not and_not and_yet:
   [{Xd-} & (Xx- or Wc-) & {Xc+} & {EB+}
     & (Wdc+ or Qd+ or Ws+ or Wq+ or Ww+) & <WALL>]1.1;
 
-%suppress: DUP-BASE (for ..y)
 % (NI- & WV- & W+): Optionally numbered, bulleted lists
 ..y *.j "•" ⁂ ❧ ☞ ◊ ※  "….j" ○  。 ゜ ✿ ☆ ＊ ◕ ● ∇ □ ◇ ＠ ◎:
   (Wd- & W+)

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -41,16 +41,6 @@ static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
 #define SUBSCRIPT_MARK '\3'
 #define SUBSCRIPT_DOT '.'
 
-/* A dictionary directive to suppress dictionary check warnings.
- * For example:
- * %suppress: DUP-BARE SOME-OTHER ... optional comment
- * The chosen symbols for warning suppression should not overlap,
- * e.g. if there is a symbol DUP-BARE, there should no symbol "DUP".
- * Their effect is until the ending ';' of the following expression.
- */
-#define SUPPRESS "suppress: "
-#define DUP_BASE "DUP-BASE" /* Allow a base-word + subscripted-same-word. */
-
 static inline const char *subscript_mark_str(void)
 {
 	static const char sm[] = { SUBSCRIPT_MARK, '\0' };

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1408,6 +1408,41 @@ static Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
 
 /* ======================================================================== */
 /**
+ * Notify about a duplicate word, unless it is an idiom definition.
+ * Idioms are exempt because historically they couldn't be
+ * differentiated using a subscript if duplicate definitions were
+ * convenience (and also they were not inserted into the dictionary so
+ * their duplicate check got neglected).
+ *
+ * An idiom duplicate check can be requested using the test "dup-idioms".
+ */
+static bool dup_word_error(Dictionary dict, Dict_node *newnode)
+{
+	static int dup_idioms = -1;
+	if (dup_idioms == -1) dup_idioms = (int)!!test_enabled("dup-idioms");
+
+	static Exp null_exp =
+	{
+		.type = AND_type,
+		.operand_first = NULL,
+		.operand_next = NULL,
+	};
+
+	/* Suppress reporting duplicate idioms unless requested. */
+	if (dup_idioms && !contains_underbar(newnode->string))
+	{
+		dict_error2(dict, "Ignoring word which has been multiply defined:",
+		            newnode->string);
+		/* Too late to skip insertion - insert it with a null expression. */
+		newnode->exp = &null_exp;
+
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Insert the new node into the dictionary below node n.
  * "newnode" left and right fields are NULL, and its string is already
  * there.  If the string is already found in the dictionary, give an error
@@ -1421,27 +1456,10 @@ Dict_node *insert_dict(Dictionary dict, Dict_node *n, Dict_node *newnode)
 {
 	if (NULL == n) return newnode;
 
-	static Exp null_exp =
-	{
-		.type = AND_type,
-		.operand_first = NULL,
-		.operand_next = NULL,
-	};
 	int comp = dict_order_strict(newnode->string, n);
 
-	if (0 == comp &&
-	    /* Suppress reporting duplicate idioms until they are fixed. */
-	    (!contains_underbar(newnode->string) || test_enabled("dup-idioms")))
-	{
-		char t[80+MAX_TOKEN_LENGTH];
-		snprintf(t, sizeof(t),
-		         "Ignoring word \"%s\", which has been multiply defined:",
-		         newnode->string);
-		dict_error(dict, t);
-		/* Too late to skip insertion - insert it with a null expression. */
-		newnode->exp = &null_exp;
-		comp = -1;
-	}
+	if ((0 == comp) && dup_word_error(dict, newnode))
+	    comp = -1;
 
 	if (comp < 0)
 	{


### PR DESCRIPTION
There was once a documented rule that it is forbidden to have in the dict both a bare word and the same word subscripted. I am not sure why, but I think that in the old times there was no function to get a bare word in such a case (the code still has inefficiencies due to that, which I would like to fix next).

In any case, this check had a bug and some words didn't obey it. I once added an optional check (at verbosity 10 and 103) to list such words and a possibility to exempt selected words (the initial words that didn't obey this rule) from the list via a dictionary directive `%suppress DUP-BASE`.

It seems there is no reason now for this rule (I couldn't find its documentation, maybe it has been removed), as it doesn't seem harmful to have this word combination (BTW, for some reason it is a rare one).

So for the sake of clearing code bloating, this check is removed here.
On the same occasion, I cleaned up `insert_dict()` by moving the optional check for duplicate idioms to a separate function, and documented the historical reason for this check.
