### PR TITLE
Changes for dictionary duplicate word detection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.9.2 (XXX 2021)
  * Expanded English vocabulary
+ * Support dictionary "#define allow-duplicate-words true".
 
 Version 5.9.1 (28 April 2021)
  * Fix build break when SQLite3 is not installed. #1195

--- a/debug/README.md
+++ b/debug/README.md
@@ -56,9 +56,6 @@ messages of the lower ones.
 
 * 102: Print all disjuncts before and after pruning.
 
-* 103: Show unsubscripted dictionary words and subscripted ones which share
-       the same base word.
-
 * 104: Memory pool statistics.
 
 (These level descriptions appear also in the command-help file `command-help-en.txt`

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1428,8 +1428,7 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 		.operand_next = NULL,
 	};
 
-	/* Suppress reporting duplicate idioms unless requested. */
-	if (dup_idioms && !contains_underbar(newnode->string))
+	if (!contains_underbar(newnode->string) || dup_idioms)
 	{
 		dict_error2(dict, "Ignoring word which has been multiply defined:",
 		            newnode->string);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1408,19 +1408,32 @@ static Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
 
 /* ======================================================================== */
 /**
- * Notify about a duplicate word, unless it is an idiom definition.
+ * Notify about a duplicate word, unless allowed or it is an idiom definition.
  * Idioms are exempt because historically they couldn't be
  * differentiated using a subscript if duplicate definitions were
  * convenience (and also they were not inserted into the dictionary so
  * their duplicate check got neglected).
  *
+ * The following dictionary definition allows duplicate words:
+ * #define allow-duplicate-words true
  * An idiom duplicate check can be requested using the test "dup-idioms".
  */
 static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 {
 	static int dup_idioms = -1;
-	if (dup_idioms == -1) dup_idioms = (int)!!test_enabled("dup-idioms");
+	static int allow_duplicate_words = -1;
 
+	if (allow_duplicate_words == 1) return false;
+	if (allow_duplicate_words == -1)
+	{
+		const char *s = linkgrammar_get_dict_define(dict, "allow-duplicate-words");
+
+		allow_duplicate_words = ((s != NULL) && (0 == strcasecmp(s, "true")));
+		if (allow_duplicate_words) return false;
+		if (dup_idioms == -1) dup_idioms = !!test_enabled("dup-idioms");
+	}
+
+	/* FIXME: Make central. */
 	static Exp null_exp =
 	{
 		.type = AND_type,


### PR DESCRIPTION
1. Fix the bug introduced in PR #1203 (unintentional duplicate word check).
2. Allow duplicate words with `#define allow-duplicate-words true`.

Only the word `true` is recognized. Anything else is considered as `false`.