### PR TITLE
Dict lookup cleanup and speedup

### DIFF
--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -970,9 +970,10 @@ static Exp * make_connector(Dictionary dict)
 		if (dn == NULL)
 		{
 			file_free_lookup(dn_head);
-			dict_error(dict, "Perhaps missing + or - in a connector.\n"
+			dict_error2(dict, "Perhaps missing + or - in a connector.\n"
 			                 "Or perhaps you forgot the subscript on a word.\n"
-			                 "Or perhaps a word is used before it is defined.");
+			                 "Or perhaps the word is used before it is defined:",
+			                 dict->token);
 			return NULL;
 		}
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -544,6 +544,13 @@ static inline int dict_order_wild(const char * s, const Dict_node * dn)
 }
 #undef D_DOW
 
+static inline Dict_node * dict_node_new(void)
+{
+	return (Dict_node*) malloc(sizeof(Dict_node));
+}
+
+/* ======================================================================== */
+#if 0
 /**
  * dict_match --  return true if strings match, else false.
  * A "bare" string (one without a subscript) will match any corresponding
@@ -561,13 +568,6 @@ static bool dict_match(const char * s, const char * t)
 	if ((*s == SUBSCRIPT_MARK) && (*t == 0)) return true;
 
 	return false;
-}
-
-/* ======================================================================== */
-
-static inline Dict_node * dict_node_new(void)
-{
-	return (Dict_node*) malloc(sizeof(Dict_node));
 }
 
 /**
@@ -606,6 +606,7 @@ static Dict_node * prune_lookup_list(Dict_node * restrict llist, const char * re
 	}
 	return llist;
 }
+#endif
 
 /* ======================================================================== */
 static bool subscr_match(const char *s, const Dict_node * dn)
@@ -675,10 +676,7 @@ rdictionary_lookup(Dict_node * restrict llist,
  */
 Dict_node * file_lookup_list(const Dictionary dict, const char *s)
 {
-	Dict_node * llist =
-		rdictionary_lookup(NULL, dict->root, s, true, dict_order_bare);
-	llist = prune_lookup_list(llist, s);
-	return llist;
+	return rdictionary_lookup(NULL, dict->root, s, true, dict_order_bare);
 }
 
 bool file_boolean_lookup(Dictionary dict, const char *s)
@@ -750,10 +748,7 @@ Dict_node * file_lookup_wild(Dictionary dict, const char *s)
  */
 static Dict_node * abridged_lookup_list(const Dictionary dict, const char *s)
 {
-	Dict_node *llist;
-	llist = rdictionary_lookup(NULL, dict->root, s, false, dict_order_bare);
-	llist = prune_lookup_list(llist, s);
-	return llist;
+	return rdictionary_lookup(NULL, dict->root, s, false, dict_order_bare);
 }
 
 #if 0
@@ -773,10 +768,7 @@ static Dict_node * abridged_lookup_list(const Dictionary dict, const char *s)
  */
 static Dict_node * strict_lookup_list(const Dictionary dict, const char *s)
 {
-	Dict_node *llist;
-	llist = rdictionary_lookup(NULL, dict->root, s, false, dict_order_strict);
-	llist = prune_lookup_list(llist, s);
-	return llist;
+	return rdictionary_lookup(NULL, dict->root, s, false, dict_order_strict);
 }
 #endif
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -635,7 +635,6 @@ rdictionary_lookup(Dict_node * restrict llist,
                    bool match_idiom,
                    int (*dict_order)(const char *, const Dict_node *))
 {
-	/* see comment in dictionary_lookup below */
 	int m;
 	Dict_node * dn_new;
 	if (dn == NULL) return llist;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -722,7 +722,7 @@ Dict_node * file_lookup_wild(Dictionary dict, const char *s)
 	char * ws = strrchr(s, WILD_TYPE);     /* A SUBSCRIPT_DOT can only appear
                                              after a wild-card */
 	Dict_node * result;
-	char * stmp = strdup(s);
+	char * stmp = strdupa(s);
 
 	/* It is not a SUBSCRIPT_DOT if it is at the end or before the wild-card.
 	 * E.g: "Dr.", "i.*", "." */
@@ -730,7 +730,6 @@ Dict_node * file_lookup_wild(Dictionary dict, const char *s)
 		stmp[ds-s] = SUBSCRIPT_MARK;
 
 	result = rdictionary_lookup(NULL, dict->root, stmp, true, dict_order_wild);
-	free(stmp);
 	return result;
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -480,7 +480,7 @@ static inline int dict_order_strict(const char *s, const Dict_node * dn)
 {
 	const char * t = dn->string;
 	while (*s != '\0' && *s == *t) {s++; t++;}
-	return ((*s == SUBSCRIPT_MARK)?(1):(*s))  -  ((*t == SUBSCRIPT_MARK)?(1):(*t));
+	return (*s - *t);
 }
 
 /**

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -479,7 +479,7 @@ NO_SAN_DICT
 static inline int dict_order_strict(const char *s, const Dict_node * dn)
 {
 	const char * t = dn->string;
-	while (*s != '\0' && *s == *t) {s++; t++;}
+	while ((*s == *t) && (*s != '\0')) { s++; t++; }
 	return (*s - *t);
 }
 
@@ -502,7 +502,7 @@ NO_SAN_DICT
 static inline int dict_order_bare(const char *s, const Dict_node * dn)
 {
 	const char * t = dn->string;
-	while (*s != '\0' && *s == *t) {s++; t++;}
+	while ((*s == *t) && (*s != '\0')) { s++; t++; }
 	return (*s)  -  ((*t == SUBSCRIPT_MARK)?(0):(*t));
 }
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -612,10 +612,13 @@ static Dict_node * prune_lookup_list(Dict_node * restrict llist, const char * re
 static bool subscr_match(const char *s, const Dict_node * dn)
 {
 	const char * s_sub = strrchr(s, SUBSCRIPT_MARK);
-	const char * t_sub;
+	const char * t_sub = strrchr(dn->string, SUBSCRIPT_MARK);
 
-	if (NULL == s_sub) return true;
-	t_sub = strrchr(dn->string, SUBSCRIPT_MARK);
+	if (NULL == s_sub)
+	{
+		if (NULL == t_sub) return true;
+		return !is_idiom_word(t_sub);
+	}
 	if (NULL == t_sub) return false;
 	if (0 == strcmp(s_sub, t_sub)) return true;
 
@@ -714,7 +717,6 @@ void free_insert_list(Dict_node *ilist)
  */
 Dict_node * file_lookup_wild(Dictionary dict, const char *s)
 {
-	bool lookup_idioms = test_enabled("lookup-idioms");
 	char * ds = strrchr(s, SUBSCRIPT_DOT); /* Only the rightmost dot is a
 	                                          candidate for SUBSCRIPT_DOT */
 	char * ws = strrchr(s, WILD_TYPE);     /* A SUBSCRIPT_DOT can only appear
@@ -727,8 +729,7 @@ Dict_node * file_lookup_wild(Dictionary dict, const char *s)
 	if ((NULL != ds) && ('\0' != ds[1]) && ((NULL == ws) || (ds > ws)))
 		stmp[ds-s] = SUBSCRIPT_MARK;
 
-	result =
-	 rdictionary_lookup(NULL, dict->root, stmp, lookup_idioms, dict_order_wild);
+	result = rdictionary_lookup(NULL, dict->root, stmp, true, dict_order_wild);
 	free(stmp);
 	return result;
 }

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -554,7 +554,7 @@ static inline int dict_order_wild(const char * s, const Dict_node * dn)
  */
 static bool dict_match(const char * s, const char * t)
 {
-	while ((*s != '\0') && (*s == *t)) { s++; t++; }
+	while ((*s == *t) && (*s != '\0')) { s++; t++; }
 
 	if (*s == *t) return true; /* both are '\0' */
 	if ((*s == 0) && (*t == SUBSCRIPT_MARK)) return true;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -534,7 +534,7 @@ static inline int dict_order_wild(const char * s, const Dict_node * dn)
 	const char * t = dn->string;
 
 	lgdebug(+D_DOW, "search-word='%s' dict-word='%s'\n", s, t);
-	while((*s != '\0') && (*s != SUBSCRIPT_MARK) && (*s == *t)) {s++; t++;}
+	while((*s == *t) && (*s != SUBSCRIPT_MARK) && (*s != '\0')) { s++; t++; }
 
 	if (*s == WILD_TYPE) return 0;
 


### PR DESCRIPTION
(See issue #1205.)

- Simplify and clean up.
- Make faster.

The dict lookup time for tokenization is now significantly faster. However, it is a negligible part of the total parsing time.
As a result, the speedup for `en/corpus-basic.batch` is only about 1%, and for the other corpus batches, it is unnoticeable.



