### PR TITLE
Change idiom construction conventions

### DIFF
--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -78,8 +78,9 @@ static const char * build_idiom_word_name(Dictionary dict, const char * s)
 
 	size_t n = lg_strlcpy(buff, s, sizeof(buff));
 	buff[n] = SUBSCRIPT_MARK;
-	buff[n + 1] = 'I';
-	buff[n + 2] = '\0';
+	buff[n + 1] = '_';
+	buff[n + 2] = 'I';
+	buff[n + 3] = '\0';
 
 	return string_set_add(buff, dict->string_set);
 }
@@ -146,9 +147,9 @@ static const char * generate_id_connector(Dictionary dict)
 	/* i is now the number of characters of current_name to skip */
 	t = buff;
 
-	/* All idiom connector names start with the two letters "ID" */
+	/* All idiom connector names start with the two characters "_D" */
+	*t++ = '_';
 	*t++ = 'I';
-	*t++ = 'D';
 	for (; i < IDIOM_LINK_SZ; i++)
 	{
 		*t++ = dict->current_idiom[i];
@@ -314,6 +315,6 @@ bool is_idiom_word(const char * s)
 	const char *sm = strchr(s, SUBSCRIPT_MARK);
 
 	if (NULL == sm) return false;
-	if ((sm[1] == 'I') && (sm[2] == '\0')) return true;
+	if ((sm[1] == '_') && (sm[2] == 'I') && (sm[3] == '\0')) return true;
 	return false;
 }

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -100,8 +100,8 @@
   used.
 
   The dictionary writer is not allowed to use connectors that begin in
-  "ID".  This is reserved for the connectors automatically
-  generated for idioms.
+  "_".  This is reserved for connectors that are automatically
+  generated (currently only for idioms).
 
   Dictionary words may be followed by a dot (period, "."), and a "subscript"
   identifying the word type. The subscript may be one or more letters or
@@ -109,6 +109,9 @@
   (mostly?) subscripts consisting of a single letter, and these serve mostly
   to identify the part-of-speech. In general, subscripts can also be used
   to distinguish different word senses.
+
+  Subscripts that start with "_" are reserved for words that are
+  automatically generated (currently only for idioms).
 */
 
 static bool link_advance(Dictionary dict);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1578,10 +1578,11 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	dn_second_half = dn->left;
 	dn->left = dn->right = NULL;
 
-	if (is_idiom_word(dn->string))
+	const char *sm = strchr(dn->string, SUBSCRIPT_MARK);
+	if ((NULL != sm) && ('_' == sm[1]))
 	{
 		prt_error("Warning: Word \"%s\" found near line %d of \"%s\".\n"
-		        "\tWords ending \".I\" are reserved for idioms.\n"
+		        "\tWords ending \"._\" are reserved for internal use.\n"
 		        "\tThis word will be ignored.\n",
 		        dn->string, dict->line_number, dict->name);
 		free(dn);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -400,11 +400,6 @@ static bool check_connector(Dictionary dict, const char * s)
 		           "(an initial \"_\" is reserved for internal use).");
 		return false;
 	}
-	/* Note that IDx when x is a subscript is allowed (to allow e.g. ID4id+). */
-	if ((*s == 'I') && (*(s+1) == 'D') && isupper((unsigned char)*(s+2))) {
-		dict_error(dict, "Connectors beginning with \"ID\" are forbidden.");
-		return false;
-	}
 
 	/* The first uppercase has been validated above. */
 	do { s++; } while (is_connector_name_char(*s));


### PR DESCRIPTION
Use `_IX` for idiom links.
Use `_I` for idiom subscripts.
Remove the reservation of `IDX` connectors and `.In`s subscripts.
Reserve subscripts that start with `_` (connectors that start with `_` are already reserved, PR #1201).

---
Comments:
1. The new connector names for idioms may be incompatible for people who pedantically analyze link and connector names in the results.
2. There is a need to change the library documentation in the places it mentions the `ID` and `.I` reservation, and instead add the initial `_` reservation.

A reference for the "Idioms" issue: #1200.

A ChangeLog suggestion:
```
 * Support underbars in connector names (the first position is reserved).
 * Connector names starting with "ID" are not reserved now.
 * ".I" subscripts are not reserved now; "._" subscripts are now reserved.
```


