### PR TITLE
sqlite3 dict: Fix unintended generation mode by default

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Version 5.9.2 (XXX 2021)
  * Expanded English vocabulary
  * Support dictionary "#define allow-duplicate-words true".
+ * Fix parsing with nulls when using an sqlite3 dictionary.
 
 Version 5.9.1 (28 April 2021)
  * Fix build break when SQLite3 is not installed. #1195

--- a/bindings/python-examples/parses-demo-sql.txt
+++ b/bindings/python-examples/parses-demo-sql.txt
@@ -17,3 +17,12 @@ O    +---Wd---+-Ss*b+     +---Ds--+
 O    |        |     |     |       |
 OLEFT-WALL this.p is.v another test.n
 O
+
+-max_null_count=1
+IThis is a a test
+O
+O    +------WV------+----Osm----+
+O    +---Wd---+-Ss*b+      +-Ds-+
+O    |        |     |      |    |
+OLEFT-WALL this.p is.v [a] a test.n
+O

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -370,9 +370,6 @@ bool dictionary_generation_request(const Dictionary dict)
 	const char *generation_mode = test_enabled("generate");
 	if (generation_mode != NULL)
 	{
-		const size_t initial_allocation = 256;
-		dict->num_categories_alloced = initial_allocation;
-		dict->category = malloc(sizeof(*dict->category) *initial_allocation);
 		dict->generate_walls =
 			feature_enabled(generation_mode, "walls", NULL) != NULL;
 		dict->spell_checker = NULL; /* Disable spell-checking. */

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -126,8 +126,16 @@ dictionary_six_str(const char * lang,
 
 	if (NULL != affix_name)
 	{
-		if (!dictionary_generation_request(dict))
+		if (dictionary_generation_request(dict))
+		{
+			const size_t initial_allocation = 256;
+			dict->num_categories_alloced = initial_allocation;
+			dict->category = malloc(sizeof(*dict->category) * initial_allocation);
+		}
+		else
+		{
 			dict->spell_checker = spellcheck_create(dict->lang);
+		}
 
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 		/* FIXME: Move to spellcheck-*.c */

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -637,7 +637,7 @@ Dictionary dictionary_create_from_db(const char *lang)
 		goto failure;
 
 	/* Initialize word categories, for text generation. */
-	if (!dictionary_generation_request(dict))
+	if (dictionary_generation_request(dict))
 		add_categories(dict);
 
 	return dict;


### PR DESCRIPTION
This bug makes it impossible to parse with nulls when using an SQLite dict (because I checked the inverse condition).
It exists in 5.9.1. Also, in 5.9.1 generation mode using a sqlite3 dict gets a segfault.
However,  I think there is no need to hurry to issue a new version due to the rarity of sqlite3 dict usage.
Before issuing a new version, I would like to apply two speedup fixes, add the expression resolving API call, and make a code/comment cleanup.

In any case, after 5.9.1 got issued, one of my fixes broke generation mode. It will be fixed in the next PR (after I find out the problem...). 


