### PR TITLE
Fix sentence generation (for file dict)

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -969,6 +969,20 @@ class JBDictCostReadingTestCase(unittest.TestCase):
         linkage = Sentence('Is the bed white?', self.d, self.po).parse().next()
         self.assertEqual(list(linkage.words())[4], 'white.a')
 
+
+class YGenerationTestCase(unittest.TestCase):
+    """
+    Generation mode tests.
+    """
+    @classmethod
+    def setUpClass(cls):
+        ParseOptions(test='generate')  # Must be set before Dictionary()
+
+    def test_getting_linkages_file_dict(self):
+        linkages = Sentence(r'\* ' * 5, Dictionary(lang='lt'), ParseOptions()).parse()
+        self.assertTrue(len(linkages) > 0, "No linkages")
+
+
 class ZENConstituentsCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -982,6 +982,9 @@ class YGenerationTestCase(unittest.TestCase):
         linkages = Sentence(r'\* ' * 5, Dictionary(lang='lt'), ParseOptions()).parse()
         self.assertTrue(len(linkages) > 0, "No linkages")
 
+    def test_getting_linkages_sql_dict(self):
+        linkages = Sentence(r'\* ' * 4, Dictionary(lang='demo-sql'), ParseOptions()).parse()
+        self.assertTrue(len(linkages) > 0, "No linkages")
 
 class ZENConstituentsCase(unittest.TestCase):
     @classmethod

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3151,8 +3151,8 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 #endif /* DEBUG */
 		if (dict->unknown_word_defined && dict->use_unknown_word)
 		{
-			bool is_wildcard = !IS_GENERATION(dict) &&
-				(NULL == strstr(s, WILDCARD_WORD));
+			bool is_wildcard = IS_GENERATION(dict) &&
+				(NULL != strstr(s, WILDCARD_WORD));
 
 			if (!IS_GENERATION(dict) || !is_wildcard)
 			{


### PR DESCRIPTION
Fix yet another logical conditions bug...

This time I added a test that sentence generation can get linkages.

---
EDIT:
~Generation from demo-sql still doesn't work, and I don't know why.
It didn't work when the `generate` branch got merged.
I'm still checking for the problem.~
There was actually no problem. It just cannot generate sentences in the default length (5). Using `-s 4` works.