### PR TITLE
`count.c`: Fix `lrcnt` table leak

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -205,8 +205,10 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
  * sent->length as a hint for the initial table size. Usually, this
  * saves on dynamic table growth, which is costly.
  * */
-static void init_table(count_context_t *ctxt, Sentence sent)
+static void init_table(count_context_t *ctxt)
 {
+	Sentence sent = ctxt->sent;
+
 	if (ctxt->table) free_table(ctxt);
 
 	/* A piecewise exponential function determines the size of the
@@ -286,9 +288,10 @@ static void free_table_lrcnt(count_context_t *ctxt)
 	}
 }
 
-static void init_table_lrcnt(count_context_t *ctxt, Sentence sent)
+static void init_table_lrcnt(count_context_t *ctxt)
 {
 	if (ctxt->is_short) return;
+	Sentence sent = ctxt->sent;
 
 	for (unsigned int dir = 0; dir < 2; dir++)
 	{
@@ -1334,7 +1337,7 @@ count_context_t * alloc_count_context(Sentence sent, Tracon_sharing *ts)
 	for (unsigned int dir = 0; dir < 2; dir++)
 		ctxt->table_lrcnt_size[dir] = ts->next_id[!dir] + 1;
 
-	init_table_lrcnt(ctxt, sent);
+	init_table_lrcnt(ctxt);
 
 	/* consecutive blocks of this many words are considered as
 	 * one null link. */
@@ -1352,7 +1355,7 @@ count_context_t * alloc_count_context(Sentence sent, Tracon_sharing *ts)
 			         /*zero_out*/false, /*align*/false, /*exact*/false);
 	}
 
-	init_table(ctxt, sent);
+	init_table(ctxt);
 	return ctxt;
 }
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1313,8 +1313,6 @@ int do_parse(Sentence sent, fast_matcher_t *mchxt, count_context_t *ctxt,
 	ctxt->checktimer = 0;
 	ctxt->islands_ok = opts->islands_ok;
 	ctxt->mchxt = mchxt;
-	ctxt->is_short =
-		(sent->length <= min_len_word_vector) && !IS_GENERATION(ctxt->sent->dict);
 
 	hist = do_count(ctxt, -1, sent->length, NULL, NULL, sent->null_count+1);
 
@@ -1329,6 +1327,8 @@ count_context_t * alloc_count_context(Sentence sent, Tracon_sharing *ts)
 	memset(ctxt, 0, sizeof(count_context_t));
 
 	ctxt->sent = sent;
+	ctxt->is_short =
+		(sent->length <= min_len_word_vector) && !IS_GENERATION(ctxt->sent->dict);
 
 	/* next_id keeps the last tracon_id used, so we need +1 for array size.  */
 	for (unsigned int dir = 0; dir < 2; dir++)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -113,12 +113,6 @@ struct count_context_s
 #define MAX_TABLE_SIZE(s) (s / 10) /* Low load factor, for speed */
 #define MAX_LOG2_TABLE_SIZE ((sizeof(size_t)==4) ? 25 : 34)
 
-static void free_table(count_context_t *ctxt)
-{
-	ctxt->table = NULL;
-	ctxt->table_size = 0;
-}
-
 #if HAVE_THREADS_H
 /* Each thread will get it's own version of the `kept_table`.
  * If the program creates zillions of threads, then there will
@@ -208,8 +202,6 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 static void init_table(count_context_t *ctxt)
 {
 	Sentence sent = ctxt->sent;
-
-	if (ctxt->table) free_table(ctxt);
 
 	/* A piecewise exponential function determines the size of the
 	 * hash table. Probably should make use of the actual number of
@@ -1367,7 +1359,6 @@ void free_count_context(count_context_t *ctxt, Sentence sent)
 	           "disjunct %"PRIu64", null_count %"PRIu64"\n",
 	            ctxt->count_cost[0], ctxt->count_cost[1], ctxt->count_cost[2]);)
 
-	free_table(ctxt);
 	free_table_lrcnt(ctxt);
 	free(ctxt);
 }


### PR DESCRIPTION
I introduced a bug in PR #1212, in which only freeing the `lrcnt` table gets skipped for short sentences.
However, the allocation is still done because it checks `ctxt->short` which gets set only afterward.
Fix it by setting  `ctxt->short` earlier. Some additional small speedup results.

Note that on the `fixes` corpus benchmark, all the functions together in `count.c` take ~1% of the total CPU (with an additional ~0.5% for `fast-match.c`) so currently even large improvements in these source files have a negligible effect on the total speedup for relatively short sentences. (For comparison, postprocessing takes ~25% and it is easy to improve its speed.)