### PR TITLE
Make `dict-defines.h` a public API

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -981,12 +981,12 @@ class YGenerationTestCase(unittest.TestCase):
     """
     def test_getting_linkages_file_dict(self):
         ParseOptions(test='generate')
-        linkages = Sentence(r'\* ' * 5, Dictionary(lang='lt'), ParseOptions()).parse()
+        linkages = Sentence((clg.WILDCARD_WORD + ' ') * 5, Dictionary(lang='lt'), ParseOptions()).parse()
         self.assertTrue(len(linkages) > 0, "No linkages")
 
     def test_getting_linkages_sql_dict(self):
         ParseOptions(test='generate')
-        linkages = Sentence(r'\* ' * 4, Dictionary(lang='demo-sql'), ParseOptions()).parse()
+        linkages = Sentence((clg.WILDCARD_WORD + ' ') * 4, Dictionary(lang='demo-sql'), ParseOptions()).parse()
         self.assertTrue(len(linkages) > 0, "No linkages")
 
 

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -8,6 +8,7 @@
 %{
 
 #include "link-grammar/link-includes.h"
+#include "link-grammar/dict-common/dict-defines.h"
 
 %}
 
@@ -100,6 +101,7 @@ int prt_error(const char *, const char *);
 
 %immutable;                          /* Future-proof for const definitions. */
 %include ../link-grammar/link-includes.h
+%include ../link-grammar/dict-common/dict-defines.h
 %mutable;
 
 #ifdef SWIGPYTHON

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -7,7 +7,7 @@
 %module clinkgrammar
 %{
 
-#include <link-grammar/link-includes.h>
+#include "link-grammar/link-includes.h"
 
 %}
 

--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -196,6 +196,7 @@ liblink_grammar_include_HEADERS =   \
 	link-features.h                  \
 	link-includes.h                  \
 	dict-common/dict-api.h           \
+	dict-common/dict-defines.h           \
 	dict-common/dict-structures.h
 
 uninstall-hook:

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -16,6 +16,7 @@
 
 #include "api-types.h"                  // pp_knowledge
 #include "connectors.h"                 // ConTable
+#include "dict-defines.h"
 #include "dict-structures.h"
 #include "memory-pool.h"                // Pool_desc
 #include "utilities.h"                  // locale_t
@@ -24,6 +25,15 @@
 #define UNLIMITED_CONNECTORS_WORD ("UNLIMITED-CONNECTORS")
 #define LIMITED_CONNECTORS_WORD ("LENGTH-LIMIT-")
 #define IS_GENERATION(dict) (dict->category != NULL)
+
+/* If the maximum disjunct cost is yet uninitialized, the value defined in the
+ * dictionary (or if not defined then DEFAULT_MAX_DISJUNCT_COST) is used. */
+static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
+static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
+/* We need some of these as literal strings. */
+#define LG_DISJUNCT_COST                        "max-disjunct-cost"
+#define LG_DICTIONARY_VERSION_NUMBER            "dictionary-version-number"
+#define LG_DICTIONARY_LOCALE                    "dictionary-locale"
 
 /* Forward decls */
 typedef struct Afdict_class_struct Afdict_class;
@@ -174,4 +184,9 @@ bool dictionary_generation_request(const Dictionary);
 bool dict_has_word(const Dictionary dict, const char *);
 void add_empty_word(Sentence, X_node *);
 
+static inline const char *subscript_mark_str(void)
+{
+	static const char sm[] = { SUBSCRIPT_MARK, '\0' };
+	return sm;
+}
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -20,9 +20,8 @@
 
 #define UNKNOWN_WORD "<UNKNOWN-WORD>"
 
-/*      Some size definitions.  Reduce these for small machines */
-/* MAX_WORD is large, because Unicode entries can use a lot of space */
-#define MAX_WORD 180          /* maximum number of bytes in a word */
+/* MAX_WORD is large, because Unicode entries can use a lot of space. */
+#define MAX_WORD 180              /* Maximum number of bytes in a word. */
 
 /* Word subscripts come after the subscript mark (ASCII ETX)
  * In the dictionary, a dot is used; but that dot interferes with dots

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -19,6 +19,9 @@
 #define RIGHT_WALL_WORD  "RIGHT-WALL"
 #define UNKNOWN_WORD     "<UNKNOWN-WORD>"
 
+/* The following is for using in generation-mode sentence template. */
+#define WILDCARD_WORD    "\\*"    /* Any dictionary word. */
+
 /* MAX_WORD is large, because Unicode entries can use a lot of space. */
 #define MAX_WORD 180              /* Maximum number of bytes in a word. */
 

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -20,15 +20,6 @@
 
 #define UNKNOWN_WORD "<UNKNOWN-WORD>"
 
-/* If the maximum disjunct cost is yet uninitialized, the value defined in the
- * dictionary (or if not defined then DEFAULT_MAX_DISJUNCT_COST) is used. */
-static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
-static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
-/* We need some of these as literal strings. */
-#define LG_DISJUNCT_COST                        "max-disjunct-cost"
-#define LG_DICTIONARY_VERSION_NUMBER            "dictionary-version-number"
-#define LG_DICTIONARY_LOCALE                    "dictionary-locale"
-
 /*      Some size definitions.  Reduce these for small machines */
 /* MAX_WORD is large, because Unicode entries can use a lot of space */
 #define MAX_WORD 180          /* maximum number of bytes in a word */
@@ -40,10 +31,4 @@ static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
  */
 #define SUBSCRIPT_MARK '\3'
 #define SUBSCRIPT_DOT '.'
-
-static inline const char *subscript_mark_str(void)
-{
-	static const char sm[] = { SUBSCRIPT_MARK, '\0' };
-	return sm;
-}
 #endif

--- a/link-grammar/dict-common/dict-defines.h
+++ b/link-grammar/dict-common/dict-defines.h
@@ -15,10 +15,9 @@
 #define _DICT_DEFINES_H_
 
 /* The following define the names of the special strings in the dictionary. */
-#define LEFT_WALL_WORD   ("LEFT-WALL")
-#define RIGHT_WALL_WORD  ("RIGHT-WALL")
-
-#define UNKNOWN_WORD "<UNKNOWN-WORD>"
+#define LEFT_WALL_WORD   "LEFT-WALL"
+#define RIGHT_WALL_WORD  "RIGHT-WALL"
+#define UNKNOWN_WORD     "<UNKNOWN-WORD>"
 
 /* MAX_WORD is large, because Unicode entries can use a lot of space. */
 #define MAX_WORD 180              /* Maximum number of bytes in a word. */
@@ -28,6 +27,6 @@
  * in the input stream, and so we convert dictionary dots into the
  * subscript mark, which we don't expect to see in user input.
  */
-#define SUBSCRIPT_MARK '\3'
-#define SUBSCRIPT_DOT '.'
-#endif
+#define SUBSCRIPT_MARK   '\3'
+#define SUBSCRIPT_DOT    '.'
+#endif /* _DICT_DEFINES_H_ */

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -15,7 +15,7 @@
 #include <string.h>
 
 #include "api-structures.h"
-#include "dict-common/dict-common.h"     // For Dictionary_s
+#include "dict-common/dict-common.h"    // Dictionary_s
 #include "dict-common/dict-defines.h"   // RIGHT_WALL_WORD, MAX_WORD
 #include "error.h"
 #include "linkage/linkage.h"

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -15,9 +15,8 @@
 #include <string.h>
 
 #include "api-structures.h"
-#include "dict-common/dict-defines.h"    // For RIGHT_WALL_WORD
 #include "dict-common/dict-common.h"     // For Dictionary_s
-#include "dict-common/dict-defines.h"    // For MAX_WORD
+#include "dict-common/dict-defines.h"   // RIGHT_WALL_WORD, MAX_WORD
 #include "error.h"
 #include "linkage/linkage.h"
 #include "post-process/post-process.h"

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -112,7 +112,6 @@ typedef enum
 } Guess_mark;
 
 #define MAX_SPLITS 10   /* See split_counter below */
-#define WILDCARD_WORD "\\*" /* All the dict words (generation mode) */
 
 struct Gword_struct
 {

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -26,7 +26,7 @@ link_generator_SOURCES = link-generator.c \
                          generator-utilities.h \
                          generator-utilities.c
 
-link_generator_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/link-grammar
+link_generator_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/link-grammar -I$(top_srcdir)/link-grammar/dict-common
 link_generator_CFLAGS = $(WARN_CFLAGS)
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -7,12 +7,9 @@
 #endif /* _MSC_VER */
 
 #include <dict-api.h>
+#include <dict-defines.h>
 
 #include "generator-utilities.h"
-
-#define SUBSCRIPT_MARK '\3'
-#define SUBSCRIPT_DOT '.'
-#define MAX_WORD 180
 
 /**
  * Patch a subscript to SUBSCRIPT_DOT, or remove it iff

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -6,7 +6,7 @@
 #define LINK_GRAMMAR_DLL_EXPORT 0
 #endif /* _MSC_VER */
 
-#include "link-grammar/dict-common/dict-api.h"
+#include <dict-api.h>
 
 #include "generator-utilities.h"
 

--- a/link-parser/generator-utilities.h
+++ b/link-parser/generator-utilities.h
@@ -1,4 +1,4 @@
-#include "link-grammar/dict-common/dict-api.h"
+#include <dict-api.h>
 
 void dump_categories(const Dictionary, const Category *);
 size_t print_sentences(const Category*,

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -24,11 +24,11 @@
 
 #include <link-includes.h>
 #include <dict-api.h>
+#include <dict-defines.h>               // WILDCARD_WORD
 
 #include "generator-utilities.h"
 
 #define MAX_SENTENCE 254
-#define WILDCARD_WORD "\\*"
 
 int verbosity_level;
 

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -22,8 +22,8 @@
 #define LINK_GRAMMAR_DLL_EXPORT 0
 #endif /* _MSC_VER */
 
-#include "link-grammar/link-includes.h"
-#include "link-grammar/dict-common/dict-api.h"
+#include <link-includes.h>
+#include <dict-api.h>
 
 #include "generator-utilities.h"
 


### PR DESCRIPTION
See issue #1217.

`dict-defines.h`:
- Move internal definitions to `dict-common.h`.
- Move `WILDCARD_WORD` from `tok-structures.h`.
- Perform cleanups.
- Add it to the public include files.
- Use it in `link-generator` and remove the private library-constants definitions.
- Add it to the SWIG interface (Fix #include style and use WILDCARD_WORD in `tests.py` instead of a hard-coded string.

On the same occasion:
- In the `link-generator` sources, use `#include <...>` instead of `#include "..."`.
  (I don't know why I previously encountered a problem in that.)
- In `constituents.h`, remove a duplicate `#include` of `dict-defines.h`.

(I have not exposed `MAX_SENTENCE` for now.)