### PR TITLE
Python bindings and tests fixes

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -583,7 +583,6 @@ class EErrorFacilityTestCase(unittest.TestCase):
 
     def test_50_set_orig_error_handler(self):
         # Set the error handler back to the default handler.
-        # The error message is now visible (but we cannot test that).
         self.__class__.handler["previous"] = LG_Error.set_handler(self.__class__.handler["default"])
         self.assertIsNone(self.__class__.handler["previous"])
         for _ in range(0, 1 + self.testleaks):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -671,7 +671,7 @@ class HEnglishLinkageTestCase(unittest.TestCase):
     # -- the one that is in the dict is not the grammatically appropriate word.
     #
     # Let's is NOT split into two! It's in the dict as one word, lower-case only.
-    def test_f_captilization(self):
+    def test_f_capitalization(self):
         self.assertEqual(list(self.parse_sent('Let\'s eat.')[0].words()),
              ['LEFT-WALL', 'let\'s', 'eat.v', '.', 'RIGHT-WALL'])
 
@@ -969,7 +969,7 @@ class JBDictCostReadingTestCase(unittest.TestCase):
         self.assertEqual(list(linkage.words())[4], 'white.a')
 
 
-# Currently, The dictionary creating function sets the generation mode if
+# Currently, the dictionary creating function sets the generation mode if
 # the "test" parse-option has "generate" in its value list. So it must be
 # set so before the call to Dictionary(). When the second argument of
 # Sentence is evaluated, it initializes the test parse-option to a null

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -170,7 +170,7 @@ class BParseOptionsTestCase(unittest.TestCase):
 
     def test_setting_verbosity_to_not_allow_value_raises_value_error(self):
         po = ParseOptions()
-        self.assertRaises(ValueError, setattr, po, "verbosity", 121)
+        self.assertRaises(ValueError, setattr, po, "verbosity", -1)
 
     def test_setting_verbosity_to_non_integer_raises_type_error(self):
         po = ParseOptions()

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -352,7 +352,7 @@ class DBasicParsingTestCase(unittest.TestCase):
     def test_that_parse_returns_empty_iterator_on_no_linkage_sat(self):
         """Parsing a bad sentence with no null-links shouldn't give any linkage (sat)"""
         self.po = ParseOptions(use_sat=True)
-        if self.po.use_sat != True:
+        if not self.po.use_sat:
             raise unittest.SkipTest("Library not configured with SAT parser")
         result = self.parse_sent("This this doesn't parse", self.po)
         linkage_exists = False
@@ -600,7 +600,7 @@ class FSATsolverTestCase(unittest.TestCase):
     def setUp(self):
         self.d, self.po = Dictionary(lang='en'), ParseOptions()
         self.po = ParseOptions(use_sat=True)
-        if self.po.use_sat != True:
+        if not self.po.use_sat:
             raise unittest.SkipTest("Library not configured with SAT parser")
 
     def test_SAT_getting_links(self):

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -46,7 +46,7 @@ if HAVE_SWIG
 # Swig builds these ....
 $(built_c_sources) $(built_py_sources): $(SWIG_INCLUDES)
 $(built_c_sources) $(built_py_sources): $(SWIG_SOURCES)
-	$(SWIG) -python -py3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
+	$(AM_V_GEN) $(SWIG) -python -py3 -module clinkgrammar -I$(top_srcdir)/link-grammar -o $@ $<
 else
 $(built_c_sources) $(built_py_sources):
 	touch $(built_c_sources) $(built_py_sources)

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -5,7 +5,10 @@
 #
 #
 SWIG_SOURCES = $(top_srcdir)/bindings/swig/link_grammar.i
-SWIG_INCLUDES = $(top_srcdir)/link-grammar/link-includes.h
+SWIG_INCLUDES =                                               \
+   $(top_srcdir)/link-grammar/link-includes.h                 \
+   $(top_srcdir)/link-grammar/dict-common/dict-defines.h
+
 built_c_sources = lg_python_wrap.cc
 built_py_sources = $(top_builddir)/bindings/python/clinkgrammar.py
 

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -68,6 +68,7 @@ _clinkgrammar_la_CPPFLAGS =       \
    $(SWIG_PYTHON_CPPFLAGS)        \
    $(PYTHON_CPPFLAGS)            \
    -I$(top_srcdir)                \
+   -I$(top_srcdir)/link-grammar   \
    -I$(top_builddir)
 
 # On Cygwin and MinGW, a DLL with version is named name-major.EXT with no

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -73,11 +73,6 @@ class ParseOptions(object):
             raise TypeError('Unknown parse option "{}".'.format(name))
         super(ParseOptions, self).__setattr__(name, value)
 
-    def __del__(self):
-        if hasattr(self, '_obj'):
-            clg.parse_options_delete(self._obj)
-            del self._obj
-
     @property
     def test(self):
         return clg.parse_options_get_test(self._obj)

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -94,14 +94,14 @@ class ParseOptions(object):
     @debug.setter
     def debug(self, value):
         if not isinstance(value, str):
-            raise TypeError("dialect must be set to a string")
+            raise TypeError("debug must be set to a string")
         return clg.parse_options_set_debug(self._obj, value)
 
     @property
     def dialect(self):
         return clg.parse_options_get_dialect(self._obj)
 
-    @debug.setter
+    @dialect.setter
     def dialect(self, value):
         if not isinstance(value, str):
             raise TypeError("dialect must be set to a string")

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -40,7 +40,7 @@ class ParseOptions(object):
                  spell_guess=False,
                  use_sat=False,
                  max_parse_time=-1,
-                 disjunct_cost=2.7,
+                 disjunct_cost=None,
                  repeatable_rand=True,
                  test='',
                  debug='',
@@ -59,7 +59,8 @@ class ParseOptions(object):
         self.spell_guess = spell_guess
         self.use_sat = use_sat
         self.max_parse_time = max_parse_time
-        self.disjunct_cost = disjunct_cost
+        if disjunct_cost is not None:
+            self.disjunct_cost = disjunct_cost
         self.repeatable_rand = repeatable_rand
         self.test = test
         self.debug = debug

--- a/bindings/python/linkgrammar.py
+++ b/bindings/python/linkgrammar.py
@@ -118,9 +118,9 @@ class ParseOptions(object):
     @verbosity.setter
     def verbosity(self, value):
         if not isinstance(value, int):
-            raise TypeError("verbosity must be set to an integer")
-        if value not in range(0,120):
-            raise ValueError("Verbosity levels can be any integer between 0 and 120 inclusive")
+            raise TypeError("verbosity must be set to a nonnegative integer")
+        if value < 0:
+            raise ValueError("verbosity must be set to a nonnegative integer")
         clg.parse_options_set_verbosity(self._obj, value)
 
     @property

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -12,6 +12,14 @@
 
 %}
 
+// The following C API calls don't need user callability.
+%ignore dictionary_create_default_lang;
+%ignore parse_options_memory_exhausted(Parse_Options opts); // Obsolete
+%ignore parse_options_resources_exhausted(Parse_Options opts);
+%ignore parse_options_set_max_memory(Parse_Options  opts, int mem); // No-Op
+%ignore parse_options_get_max_memory(Parse_Options opts);
+// End of ignored API calls.
+
 %nodefaultdtor lg_errinfo;
 
 #define link_public_api(x) x

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -7,8 +7,8 @@
 %module clinkgrammar
 %{
 
-#include "link-grammar/link-includes.h"
-#include "link-grammar/dict-common/dict-defines.h"
+#include "link-includes.h"
+#include "dict-common/dict-defines.h"
 
 %}
 
@@ -58,8 +58,8 @@ int prt_error(const char *, const char *);
 %ignore lg_error_set_handler_data;
 
 %immutable;                          /* Future-proof for const definitions. */
-%include ../link-grammar/link-includes.h
-%include ../link-grammar/dict-common/dict-defines.h
+%include link-includes.h
+%include dict-common/dict-defines.h
 %mutable;
 
 #ifdef SWIGPYTHON

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -21,27 +21,12 @@
 
 %newobject dictionary_get_data_dir;
 
-/**********************************************************************
-*
-* Functions that create and manipulate Linkages.
-* When a Linkage is requested, the user is given a
-* copy of all of the necessary information, and is responsible
-* for freeing up the storage when he/she is finished, using
-* the routines provided below.
-*
-***********************************************************************/
-
-/**********************************************************************
-*
-* These functions allocate strings to be returned, so need to be
-* newobject'd to avoid memory leaks
-*
-***********************************************************************/
-
+/* For functions returning (char *), free the returned result
+   after it gets converted to a Python object. */
 %define %free_returned_value(func)
 %newobject func;
 %typemap(newfree) char * { free##func($1); }
-%ignore free##func;
+%ignore free##func; /* They are not a part of the API here. */
 %enddef
 
 %free_returned_value(linkage_print_diagram);

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -38,41 +38,18 @@
 *
 ***********************************************************************/
 
-%newobject linkage_print_diagram;
-%typemap(newfree) char * {
-   linkage_free_diagram($1);
-}
-%rename("%s") linkage_print_diagram;
+%define %free_returned_value(func)
+%newobject func;
+%typemap(newfree) char * { free##func($1); }
+%ignore free##func;
+%enddef
 
-%newobject linkage_print_postscript;
-%typemap(newfree) char * {
-   linkage_free_postscript($1);
-}
-%rename("%s")  linkage_print_postscript;
-
-%newobject linkage_print_links_and_domains;
-%typemap(newfree) char * {
-   linkage_free_links_and_domains($1);
-}
-%rename("%s")  linkage_print_links_and_domains;
-
-%newobject linkage_print_constituent_tree;
-%typemap(newfree) char * {
-   linkage_free_constituent_tree_str($1);
-}
-%rename("%s")  linkage_print_constituent_tree;
-
-%newobject linkage_print_disjuncts;
-%typemap(newfree) char * {
-   linkage_free_disjuncts($1);
-}
-%rename("%s")  linkage_print_disjuncts;
-
-%newobject linkage_print_pp_msgs;
-%typemap(newfree) char * {
-   linkage_free_pp_msgs($1);
-}
-%rename("%s")  linkage_print_pp_msgs;
+%free_returned_value(linkage_print_diagram);
+%free_returned_value(linkage_print_postscript);
+%free_returned_value(linkage_print_links_and_domains);
+%free_returned_value(linkage_print_constituent_tree);
+%free_returned_value(linkage_print_disjuncts);
+%free_returned_value(linkage_print_pp_msgs);
 
 // Reset to default.
 %typemap(newfree) char * {

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -94,11 +94,6 @@ int prt_error(const char *, const char *);
  */
 %ignore lg_error_set_handler_data;
 
-// Set a default newfree typemap.
-%typemap(newfree) char * {
-   free($1);
-}
-
 %immutable;                          /* Future-proof for const definitions. */
 %include ../link-grammar/link-includes.h
 %include ../link-grammar/dict-common/dict-defines.h

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -68,6 +68,7 @@
 }
 %rename("%s")  linkage_print_disjuncts;
 
+%newobject linkage_print_pp_msgs;
 %typemap(newfree) char * {
    linkage_free_pp_msgs($1);
 }

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -41,6 +41,19 @@
    free($1);
 }
 
+%newobject parse_options_create;
+%delobject destroy_Parse_Options&;
+class Parse_Options {};
+%extend Parse_Options
+{
+   ~Parse_Options()
+   {
+      parse_options_delete(*$self);
+      delete($self);
+   }
+}
+%ignore Parse_Options;
+
 /* Error-handling facility calls. */
 %rename(_lg_error_formatmsg) lg_error_formatmsg;
 %newobject lg_error_formatmsg;


### PR DESCRIPTION
Bug fixes:
- linkgrammar.py: Fix `debug`/`dialect` copy-paste confusion
- linkgrammar.py: A better check for `verbosity` value
- link_grammar.i: Bug fix: `%newobject linkage_print_pp_msgs`
- python/Makefile.am: Update `#include` dependency from the previous PR (#1220)
- ParseOptions(): Allow `disjunct_cost` to be set from the dict
- ParseOptions(): Fix memory deallocation

Cleanup:
- link_grammar.i: Remove redundant setting of default `%newfree` for `(char *)`
- tests.py: Clean up `!= True` conditions
- linkgrammar.i: `#include` path cleanup
- tests.py: Fix typos
- `test_50_set_orig_error_handler`: Fix comment rot
- link_grammar.i: %ignore unneeded API functions

Enhancement:
- python/Makefile.am: Output a line for `swig` in quiet mode