### PR TITLE
`lg_exp_stringify()` fixes

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -541,7 +541,7 @@ void sentence_delete(Sentence sent)
 	free_linkages(sent);
 	post_process_free(sent->postprocessor);
 	post_process_free(sent->constituent_pp);
-	lg_exp_stringify(NULL);
+	exp_stringify(NULL);
 	free(sent->disjunct_used);
 
 	global_rand_state = sent->rand_state;

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -105,7 +105,7 @@ static inline const Exp* lg_exp_operand_next(const Exp* exp)
                                             { return exp->operand_next; }
 link_public_api(const char *)
 	lg_exp_get_string(const Exp*);
-link_public_api(const char *)
+link_public_api(char *)
 	lg_exp_stringify(const Exp *); /* To be freed by the caller. */
 
 /**

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -99,12 +99,14 @@ static inline Exp_type lg_exp_get_type(const Exp* exp) { return exp->type; }
 static inline char lg_exp_get_dir(const Exp* exp) { return exp->dir; }
 static inline bool lg_exp_get_multi(const Exp* exp) { return exp->multi; }
 static inline double lg_exp_get_cost(const Exp* exp) { return exp->cost; }
-static inline Exp* lg_exp_operand_first(Exp* exp) { return exp->operand_first; }
-static inline Exp* lg_exp_operand_next(Exp* exp) { return exp->operand_next; }
+static inline const Exp* lg_exp_operand_first(const Exp* exp)
+                                             { return exp->operand_first; }
+static inline const Exp* lg_exp_operand_next(const Exp* exp)
+                                            { return exp->operand_next; }
 link_public_api(const char *)
 	lg_exp_get_string(const Exp*);
 link_public_api(const char *)
-	lg_exp_stringify(const Exp *); /* Result is in static variable. */
+	lg_exp_stringify(const Exp *); /* To be freed by the caller. */
 
 /**
  * The dictionary is stored as a binary tree comprised of the following

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -157,7 +157,7 @@ static bool exp_compare(Exp *e1, Exp *e2)
 static int exp_contains(Exp * super, Exp * sub)
 {
 #if 0 /* DEBUG */
-	if (super) printf("SUP: %s\n", lg_exp_stringify(super));
+	if (super) printf("SUP: %s\n", exp_stringify(super));
 #endif
 
 	if (sub==NULL || super==NULL)
@@ -319,8 +319,8 @@ static bool dn_word_contains(Dictionary dict,
 	m_exp = m_dn->exp;
 
 #if 0 /* DEBUG */
-	printf("\nWORD: %s\n", lg_exp_stringify(w_dn->exp));
-	printf("\nMACR: %s\n", lg_exp_stringify(m_exp));
+	printf("\nWORD: %s\n", exp_stringify(w_dn->exp));
+	printf("\nMACR: %s\n", exp_stringify(m_exp));
 #endif
 
 	for (;w_dn != NULL; w_dn = w_dn->right)

--- a/link-grammar/dict-common/dict-utils.h
+++ b/link-grammar/dict-common/dict-utils.h
@@ -26,6 +26,7 @@ int  size_of_expression(Exp *);
 Exp * copy_Exp(Exp *, Pool_desc *, Parse_Options);
 bool is_exp_like_empty_word(Dictionary dict, Exp *);
 void prt_exp_all(dyn_str *,Exp *, int, Dictionary);
+const char *exp_stringify(const Exp *n);
 #ifdef DEBUG
 void prt_exp(Exp *, int);
 void prt_exp_mem(Exp *);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -68,6 +68,7 @@ static void print_expression_tag_start(Dictionary dict, dyn_str *e, const Exp *n
                                  int *indent)
 {
 	if (n->type == CONNECTOR_type) return;
+	if (NULL == dict) return;
 
 	switch (n->tag_type)
 	{
@@ -95,7 +96,6 @@ static void print_expression_tag_end(Dictionary dict, dyn_str *e, const Exp *n,
                                  int *indent)
 {
 	if (n->type == CONNECTOR_type) return;
-
 	if (NULL == dict) return;
 
 	switch (n->tag_type)

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -338,7 +338,7 @@ static char *lg_exp_stringify_with_tags(Dictionary dict, const Exp *n,
 /**
  * Stringify the given expression, ignoring tags.
  */
-const char *lg_exp_stringify(const Exp *n)
+char *lg_exp_stringify(const Exp *n)
 {
 	return lg_exp_stringify_with_tags(NULL, n, false);
 }
@@ -350,8 +350,8 @@ const char *exp_stringify(const Exp *n)
 	static TLS char *s;
 
 	free(s);
-	if (n == NULL) return ("null");
-	s = strdup(lg_exp_stringify(n));
+	if (n == NULL) return ("(null)");
+	s = strdup(lg_exp_stringify_with_tags(NULL, n, false));
 	return s;
 }
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -323,23 +323,16 @@ static void print_connector_macros(cmacro_context *cmc, const Exp *n)
 		print_expression_tag_end(cmc->dict, cmc->e, n, &cmc->indent);
 }
 
-static const char *lg_exp_stringify_with_tags(Dictionary dict, const Exp *n,
-                                              bool show_macros)
+static char *lg_exp_stringify_with_tags(Dictionary dict, const Exp *n,
+                                        bool show_macros)
 {
-	static TLS char *e_str;
-	int indent = show_macros ? 0 : -1;
+	if (n == NULL) return strdup("(null)");
 
-	if (e_str != NULL) free(e_str);
-	if (n == NULL)
-	{
-		e_str = NULL;
-		return "(null)";
-	}
+	int indent = show_macros ? 0 : -1;
 
 	dyn_str *e = dyn_str_new();
 	print_expression_parens(dict, e, n, false, &indent);
-	e_str = dyn_str_take(e);
-	return e_str;
+	return dyn_str_take(e);
 }
 
 /**
@@ -348,6 +341,18 @@ static const char *lg_exp_stringify_with_tags(Dictionary dict, const Exp *n,
 const char *lg_exp_stringify(const Exp *n)
 {
 	return lg_exp_stringify_with_tags(NULL, n, false);
+}
+
+/* For usage convenience when assigning to a temporary variable + free() is
+ * cumbersome. Care should be taken due to the static memory of the result. */
+const char *exp_stringify(const Exp *n)
+{
+	static TLS char *s;
+
+	free(s);
+	if (n == NULL) return ("null");
+	s = strdup(lg_exp_stringify(n));
+	return s;
 }
 
 #ifdef DEBUG

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1887,7 +1887,7 @@ static void rprint_dictionary_data(Dict_node * n)
 {
 	if (n == NULL) return;
 	rprint_dictionary_data(n->left);
-	printf("%s: %s\n", n->string, lg_exp_stringify(n->exp));
+	printf("%s: %s\n", n->string, exp_stringify(n->exp));
 	rprint_dictionary_data(n->right);
 }
 

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -262,7 +262,7 @@ db_lookup_exp(Dictionary dict, const char *s, cbdata* bs)
 	if (es != s) free(es);
 
 	lgdebug(D_SQL+1, "Found expression for class %s: %s\n",
-	        s, lg_exp_stringify(bs->exp));
+	        s, exp_stringify(bs->exp));
 }
 
 
@@ -356,7 +356,7 @@ static Dict_node * db_lookup_list(Dictionary dict, const char *s)
 		if (bs.dn)
 		{
 			printf("Found expression for word %s: %s\n",
-	        s, lg_exp_stringify(bs.dn->exp));
+	        s, exp_stringify(bs.dn->exp));
 		}
 		else
 		{
@@ -383,7 +383,7 @@ static Dict_node * db_lookup_wild(Dictionary dict, const char *s)
 		if (bs.dn)
 		{
 			printf("Found expression for glob %s: %s\n",
-			       s, lg_exp_stringify(bs.dn->exp));
+			       s, exp_stringify(bs.dn->exp));
 		}
 		else
 		{


### PR DESCRIPTION
Bug fix:
- `print_expression_tag_start()`: Fix printing extra `[` when not printing tags
- 
API change:
- `lg_exp_stringify()`: Return a new memory
- `lg_exp_operand_*()`: Use const for parameter and result

The API changes are according to my proposals in issue #1222. I didn't implement a special `free()`.

`clinkgrammar.lg_exp_stringify()` now leaks memory in Python. This is to be fixed in the next PR (needs a rebase on `master` after applying this PR).

Force-pushed:
-  Change `lg_exp_stringify()` to return `char *` instead of `const char *`, as usual for functions that don't own the resulting memory.
- Change  `exp_stringify()` (the function for internal use, that uses TLS memory for its result) to call an internal function that `lg_exp_stringify()` calls (instead of calling `lg_exp_stringify()`, which has an external linkage).