### PR TITLE
Extend Python bindings

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -7,7 +7,9 @@
 SWIG_SOURCES = $(top_srcdir)/bindings/swig/link_grammar.i
 SWIG_INCLUDES =                                               \
    $(top_srcdir)/link-grammar/link-includes.h                 \
-   $(top_srcdir)/link-grammar/dict-common/dict-defines.h
+   $(top_srcdir)/link-grammar/dict-common/dict-defines.h      \
+   $(top_srcdir)/link-grammar/dict-common/dict-api.h          \
+   $(top_srcdir)/link-grammar/dict-common/dict-structures.h
 
 built_c_sources = lg_python_wrap.cc
 built_py_sources = $(top_builddir)/bindings/python/clinkgrammar.py

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -88,6 +88,12 @@ class Exp {};
    {
       free($self);
    }
+
+   %pythoncode
+   {
+      def __repr__(self):
+         return lg_exp_stringify(self)
+   }
 }
 %ignore Exp;
 

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -9,6 +9,8 @@
 
 #include "link-includes.h"
 #include "dict-common/dict-defines.h"
+#include "dict-common/dict-api.h"
+#include "dict-common/dict-structures.h"
 
 %}
 
@@ -23,6 +25,7 @@
 %nodefaultdtor lg_errinfo;
 
 #define link_public_api(x) x
+#define link_experimental_api(x) x
 #ifndef bool                         /* Prevent syntax errors if no bool. */
 #define bool int
 #endif /* bool */

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -79,6 +79,18 @@ class Parse_Options {};
 }
 %ignore Parse_Options;
 
+%newobject lg_exp_resolve;
+%delobject destroy_Exp;
+class Exp {};
+%extend Exp
+{
+   ~Exp()
+   {
+      free($self);
+   }
+}
+%ignore Exp;
+
 /* ===================== Dictionary lookup support ========================= */
 %newobject dictionary_lookup_list;
 %newobject dictionary_lookup_wild;

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -84,6 +84,8 @@ int prt_error(const char *, const char *);
 %immutable;                          /* Future-proof for const definitions. */
 %include link-includes.h
 %include dict-common/dict-defines.h
+%include dict-common/dict-api.h
+%include dict-common/dict-structures.h
 %mutable;
 
 #ifdef SWIGPYTHON

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -46,6 +46,20 @@
 %free_returned_value(linkage_print_constituent_tree);
 %free_returned_value(linkage_print_disjuncts);
 %free_returned_value(linkage_print_pp_msgs);
+// End of functions that need a special memory-freeing function.
+
+// These functions need free() for their returned value.
+%define %free_returned_value_by_free(func, ret_type)
+%newobject func;
+%typemap(newfree) ret_type { free($1); }
+%ignore free;
+%enddef
+
+%free_returned_value_by_free(dictionary_get_data_dir, char *);
+%free_returned_value_by_free(lg_exp_stringify, char *);
+%free_returned_value_by_free(sentence_unused_disjuncts, Disjunct **);
+%free_returned_value_by_free(disjunct_expression, char *);
+// End of functions that need free().
 
 // Reset to default.
 %typemap(newfree) char * {

--- a/link-grammar/api-types.h
+++ b/link-grammar/api-types.h
@@ -36,6 +36,7 @@ typedef struct Gword_struct Gword;
 typedef struct gword_set gword_set;
 typedef struct tracon_sharing_s Tracon_sharing;
 typedef struct Dialect_s Dialect;
+typedef struct Word_file_struct Word_file;
 
 /* Post-processing structures */
 typedef struct pp_knowledge_s pp_knowledge;

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -17,7 +17,9 @@
 #include "dict-structures.h"
 #include "link-includes.h"
 
+#ifndef SWIG
 LINK_BEGIN_DECLS
+#endif /* !SWIG */
 
 /**
  * Declaration of dictionary-related functions that link-grammar users
@@ -73,6 +75,7 @@ link_experimental_api(const Category_cost *)
 link_public_api(bool)
 	dictionary_word_is_known(const Dictionary dict, const char *word);
 
+#ifndef SWIG
 /* This was exported and used by mistake! */
 bool boolean_dictionary_lookup(const Dictionary dict, const char *word);
 
@@ -80,5 +83,6 @@ bool boolean_dictionary_lookup(const Dictionary dict, const char *word);
 Dict_node * insert_dict(Dictionary dict, Dict_node * n, Dict_node * newnode);
 
 LINK_END_DECLS
+#endif /* !SWIG */
 
 #endif /* _LG_DICT_API_H_ */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -16,7 +16,9 @@
 
 #include "link-includes.h"
 
+#ifndef SWIG
 LINK_BEGIN_DECLS
+#endif /* !SWIG */
 
 /* Forward decls */
 typedef struct Dict_node_struct Dict_node;
@@ -34,6 +36,7 @@ typedef enum
 	CONNECTOR_type
 } Exp_type;
 
+#ifndef SWIG
 static const int cost_max_dec_places = 3;
 static const double cost_epsilon = 1E-5;
 
@@ -74,6 +77,7 @@ struct Exp_struct
 	};
 	Exp *operand_next;     /* Next same-level operand. */
 };
+#endif /* !SWIG */
 
 /* List of words in a dictionary category. */
 typedef struct
@@ -91,8 +95,10 @@ typedef struct
 	float cost;          /* Corresponding disjunct cost. */
 } Category_cost;
 
+#ifndef SWIG
 bool cost_eq(double cost1, double cost2);
 const char *cost_stringify(double cost);
+#endif /* !SWIG */
 
 /* API to access the above structure. */
 static inline Exp_type lg_exp_get_type(const Exp* exp) { return exp->type; }
@@ -121,6 +127,8 @@ struct Dict_node_struct
 	Dict_node *left, *right;
 };
 
+#ifndef SWIG
 LINK_END_DECLS
+#endif /* !SWIG */
 
 #endif /* _LG_DICT_STRUCTURES_H_ */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -23,7 +23,6 @@ LINK_BEGIN_DECLS
 /* Forward decls */
 typedef struct Dict_node_struct Dict_node;
 typedef struct Exp_struct Exp;
-typedef struct Word_file_struct Word_file;
 typedef struct condesc_struct condesc_t;
 
 /**
@@ -122,7 +121,7 @@ link_public_api(char *)
 struct Dict_node_struct
 {
 	const char * string;  /* The word itself */
-	Word_file * file;     /* The file the word came from (NULL if dict file) */
+	const char * file;    /* The file the word came from (NULL if dict file) */
 	Exp       * exp;
 	Dict_node *left, *right;
 };

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1199,7 +1199,7 @@ static char *display_counts(const char *word, Dict_node *dn)
 
 		if (dn->file != NULL)
 		{
-			append_string(s, " <%s>", dn->file->file);
+			append_string(s, " <%s>", dn->file);
 		}
 		dyn_strcat(s, "\n\n");
 	}

--- a/link-grammar/dict-file/word-file.c
+++ b/link-grammar/dict-file/word-file.c
@@ -90,7 +90,7 @@ Dict_node * read_word_file(Dictionary dict, Dict_node * dn, char * filename)
 		dn_new->left = dn;
 		dn = dn_new;
 		dn->string = s;
-		dn->file = wf;
+		dn->file = wf->file;
 	}
 	fclose(fp);
 	return dn;


### PR DESCRIPTION
- Extend the Python bindings to include the whole C API.
- Add some trivial tests for `dictionary_lookup_list()` and `dictionary_lookup_wild()`.
- Free memory for `lg_exp_stringify()` (that now returns new memory - PR #1224).

Notes:
- There is no need to directly use `lg_exp_stringify()`: Instead use `str(expression)`.
- FIXME: Provide OO interface for `dictionary_lookup_*()` (`dict.lookup_*()` that returns an iterable object) and for some other API calls.
- FIXME: Add tests for the rest of the API functions.

The tests for `dictionary_lookup_*()` are very basic and can mainly detect if they are totally broken. For more fine-grain tests for these functions and additional ones, there is a need to use special test dictionaries.
