### PR TITLE
Implement `lg_exp_resolve()`

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -97,6 +97,11 @@ class Exp {};
 }
 %ignore Exp;
 
+/* lg_exp_resolve() 2-arguments support. */
+%feature("compactdefaultargs") lg_exp_resolve;
+Exp *lg_exp_resolve(Dictionary dict, const Exp *e, Parse_Options opts = NULL);
+
+
 /* ===================== Dictionary lookup support ========================= */
 %newobject dictionary_lookup_list;
 %newobject dictionary_lookup_wild;

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -112,6 +112,8 @@ link_public_api(const char *)
 	lg_exp_get_string(const Exp*);
 link_public_api(char *)
 	lg_exp_stringify(const Exp *); /* To be freed by the caller. */
+link_experimental_api(Exp *)
+	lg_exp_resolve(Dictionary, const Exp *, Parse_Options);
 
 /**
  * The dictionary is stored as a binary tree comprised of the following


### PR DESCRIPTION
See issue #1172.

Implement `Exp *lg_exp_resolve(Dictionary, const Exp *, Parse_Options)`. The result is to be freed by the caller using `free()`
(a special free function could be added too if desired).
It is marked as experimental.

If the Parse_Options argument is NULL, no resolving is done, and the result is just a copy. This copy can be resolved using this function if needed.

---

An expression that is already resolved should not be resolved again as the result be incorrect. If needed, an enhancement can be implemented to produce an error in such a case (returning `NULL` to indicate the error). My current idea is to add an additional Exptag_type to denote a resolved dialect component tag. I.e. instead of:
https://github.com/opencog/link-grammar/blob/186530c1f4d97da19a7b49a80cdc3632c019343a/link-grammar/dict-common/dict-structures.h#L43
use:
``` c
	typedef enum { Exptag_none=0, Exptag_dialect, Exptag_dialect_resolved, Exptag_macro } Exptag_type;
```