### PR TITLE
link_grammar.i: Fix destroy_Parse_Options& for swig 3

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -67,7 +67,7 @@
 }
 
 %newobject parse_options_create;
-%delobject destroy_Parse_Options&;
+%delobject *destroy_Parse_Options;
 class Parse_Options {};
 %extend Parse_Options
 {


### PR DESCRIPTION
This fix tries to work around the problem of issue #1226.
It works fine in `swig` version 4 (no memory leaks).
@linas, as I don't have access just now to `swig` version 3, please validate that this indeed fixes the `swig` break.