### PR TITLE
Code cleanup

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -68,7 +68,7 @@ _clinkgrammar_la_SOURCES = $(built_c_sources) $(SWIG_SOURCES)
 # $(top_builddir) to pick up autogen'ed link-grammar/link-features.h
 _clinkgrammar_la_CPPFLAGS =       \
    $(SWIG_PYTHON_CPPFLAGS)        \
-   $(PYTHON_CPPFLAGS)            \
+   $(PYTHON_CPPFLAGS)             \
    -I$(top_srcdir)                \
    -I$(top_srcdir)/link-grammar   \
    -I$(top_builddir)

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -91,7 +91,9 @@ struct Parse_Options_s
 	short use_spell_guess; /* Up to this many spell-guesses per unknown word 7 */
 
 	/* Choice of the parser to use */
+#if USE_SAT_SOLVER
 	bool use_sat_solver;   /* Use the Boolean SAT based parser */
+#endif
 
 	/* Options governing the parser internals operation */
 	double disjunct_cost;  /* Max disjunct cost to allow */

--- a/link-grammar/api-types.h
+++ b/link-grammar/api-types.h
@@ -37,12 +37,11 @@ typedef struct gword_set gword_set;
 typedef struct tracon_sharing_s Tracon_sharing;
 typedef struct Dialect_s Dialect;
 typedef struct Word_file_struct Word_file;
+typedef struct Wordgraph_pathpos_s Wordgraph_pathpos;
 
 /* Post-processing structures */
 typedef struct pp_knowledge_s pp_knowledge;
 typedef struct pp_linkset_s pp_linkset;
 typedef struct PP_domains_s PP_domains;
-
-typedef struct Wordgraph_pathpos_s Wordgraph_pathpos;
 
 #endif

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -94,7 +94,9 @@ Parse_Options parse_options_create(void)
 	po->min_null_count = 0;
 	po->max_null_count = 0;
 	po->islands_ok = false;
+#if USE_SAT_SOLVER
 	po->use_sat_solver = false;
+#endif
 	po->linkage_limit = 100;
 #if defined HAVE_HUNSPELL || defined HAVE_ASPELL
 	po->use_spell_guess = 7;
@@ -269,7 +271,11 @@ void parse_options_set_use_sat_parser(Parse_Options opts, bool dummy) {
 }
 
 bool parse_options_get_use_sat_parser(Parse_Options opts) {
+#if USE_SAT_SOLVER
 	return opts->use_sat_solver;
+#else
+	return false;
+#endif
 }
 
 void parse_options_set_linkage_limit(Parse_Options opts, int dummy)
@@ -631,11 +637,13 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 
 	if (IS_GENERATION(sent->dict))
 	{
+#if USE_SAT_SOLVER
 		if (opts->use_sat_solver)
 		{
 			prt_error("Error: Cannot use the SAT parser in generation mode\n");
 			return -3;
 		}
+#endif
 		if (opts->max_null_count > 0)
 		{
 			prt_error("Error: Cannot parse with nulls in generation mode\n");
@@ -692,11 +700,13 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 	 */
 	expression_prune(sent, opts);
 	print_time(opts, "Finished expression pruning");
+#if USE_SAT_SOLVER
 	if (opts->use_sat_solver)
 	{
 		sat_parse(sent, opts);
 	}
 	else
+#endif
 	{
 		classic_parse(sent, opts);
 	}

--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -82,12 +82,14 @@ Connector * connector_new(Pool_desc *connector_pool, const condesc_t *desc,
 {
 	Connector *c;
 
+#if USE_SAT_SOLVER
 	if (NULL == connector_pool) /* For the SAT-parser, until fixed. */
 	{
 		c = malloc(sizeof(Connector));
 		memset(c, 0, sizeof(Connector));
 	}
 	else
+#endif
 		c = pool_alloc(connector_pool); /* Memory-pool has zero_out attribute.*/
 
 	c->desc = desc;

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -44,10 +44,6 @@ link_public_api(Dict_node *)
 link_public_api(void)
 	free_lookup_list(const Dictionary, Dict_node *);
 
-/* Return true if word can be found. */
-link_public_api(bool)
-	dictionary_word_is_known(const Dictionary, const char *);
-
 /**********************************************************************
  *
  * Generation mode. Experimental and subject to changes.

--- a/link-grammar/dict-common/dict-api.h
+++ b/link-grammar/dict-common/dict-api.h
@@ -56,7 +56,7 @@ link_experimental_api(const Category *)
 link_experimental_api(const Category_cost *)
 	linkage_get_categories(const Linkage linkage, WordIdx w);
 
-link_experimental_api(Disjunct **)              /* To be freed by the caller */
+link_experimental_api(Disjunct **)        /* To be freed by the caller */
 	sentence_unused_disjuncts(Sentence);
 
 link_experimental_api(char *)

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -338,7 +338,6 @@ void dictionary_delete(Dictionary dict)
 	string_id_delete(dict->define.set);
 	free(dict->define.name);
 	free(dict->define.value);
-	free((void *)dict->suppress_warning);
 	free_regexs(dict->regex_root);
 	free_anysplit(dict);
 	free_dictionary(dict);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -160,7 +160,6 @@ struct Dictionary_s
 	const char    * input;
 	const char    * pin;
 	bool            recursive_error;
-	const char    * suppress_warning;
 	bool            is_special;
 	int             already_got_it; /* For char, but needs to hold EOF */
 	int             line_number;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -1852,12 +1852,6 @@ static bool read_entry(Dictionary dict)
 
 	dict->insert_entry(dict, dn, i);
 
-	if (dict->suppress_warning)
-	{
-		free((void *)dict->suppress_warning);
-		dict->suppress_warning = NULL;
-	}
-
 	/* pass the ; */
 	if (!link_advance(dict))
 	{

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -240,9 +240,13 @@ void remove_empty_words(Linkage lkg)
 			continue;
 		}
 
+#if USE_SAT_SOLVER
 		Disjunct *cdtmp = cdj[j];
+#endif
 		cdj[j] = cdj[i];
+#if USE_SAT_SOLVER
 		cdj[i] = cdtmp; /* The SAT parser frees chosen_disjuncts elements. */
+#endif
 		remap[i] = j;
 		j++;
 		wgp++;
@@ -718,9 +722,13 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 			linkage->word[j] = chosen_words[i];
 			//chosen_words[i] = cwtmp;
 
+#if USE_SAT_SOLVER
 			Disjunct *cdtmp = cdj[j];
+#endif
 			cdj[j] = cdj[i];
+#if USE_SAT_SOLVER
 			cdj[i] = cdtmp; /* The SAT parser frees chosen_disjuncts elements. */
+#endif
 
 			remap[i] = j;
 			j++;
@@ -778,12 +786,14 @@ Linkage linkage_create(LinkageIdx k, Sentence sent, Parse_Options opts)
 {
 	Linkage linkage;
 
+#if USE_SAT_SOLVER
 	if (opts->use_sat_solver)
 	{
 		linkage = sat_create_linkage(k, sent, opts);
 		if (!linkage) return NULL;
 	}
 	else
+#endif
 	{
 		/* Cannot create a Linkage for a discarded linkage. */
 		if (sent->num_linkages_post_processed <= k) return NULL;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -267,11 +267,13 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 		if (NULL == cl->c) continue; /* no connectors */
 		if (cl->maxcost > cost_cutoff) continue;
 
+#if USE_SAT_SOLVER
 		if (NULL == sent) /* For the SAT-parser, until fixed. */
 		{
 			ndis = xalloc(sizeof(Disjunct));
 		}
 		else
+#endif
 		{
 			ndis = pool_alloc(sent->Disjunct_pool);
 			connector_pool = sent->Connector_pool;

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -157,11 +157,11 @@ struct Gword_struct
 	Gword *alternative_id;       /* Alternative start - a unique identifier of
 	                                the alternative to which the word belongs. */
 	const char *regex_name;      /* Subword matches this regex.
-                                   FIXME? Extend for multiple regexes. */
+	                                FIXME? Extend for multiple regexes. */
 
 	/* Only used by wordgraph_flatten() */
 	const Gword **hier_position; /* Unsplit_word/alternative_id pointer list, up
-                                   to the original sentence word. */
+	                                to the original sentence word. */
 	size_t hier_depth;           /* Number of pointer pairs in hier_position */
 
 	/* XXX Experimental. Only used after the linkage (by compute_chosen_words())

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -36,7 +36,9 @@ static struct
 	int batch_mode;
 	int panic_mode;
 	int allow_null;
+#if USE_SAT_SOLVER
 	int use_sat_solver;
+#endif
 	int echo_on;
 	Cost_Model_type cost_model;
 	double max_cost;
@@ -1007,8 +1009,9 @@ static void put_opts_in_local_vars(Command_Options* copts)
 	local.short_length = parse_options_get_short_length(opts);
 	local.cost_model = parse_options_get_cost_model_type(opts);
 	local.max_cost = parse_options_get_disjunct_cost(opts);
+#if USE_SAT_SOLVER
 	local.use_sat_solver = parse_options_get_use_sat_parser(opts);
-
+#endif
 	local.screen_width = (int)copts->screen_width;
 	local.echo_on = copts->echo_on;
 	local.batch_mode = copts->batch_mode;
@@ -1046,7 +1049,7 @@ void put_local_vars_in_opts(Command_Options* copts)
 	parse_options_set_short_length(opts, local.short_length);
 	parse_options_set_cost_model_type(opts, local.cost_model);
 	parse_options_set_disjunct_cost(opts, local.max_cost);
-#ifdef USE_SAT_SOLVER
+#if USE_SAT_SOLVER
 	parse_options_set_use_sat_parser(opts, local.use_sat_solver);
 #endif
 	parse_options_set_display_morphology(opts, local.display_morphology);

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -410,7 +410,7 @@ void initialize_screen_width(Command_Options *copts)
 {
 #ifdef SIGWINCH
 #if HAVE_SIGACTION
-	struct sigaction winch_act = { 0 };
+	struct sigaction winch_act = { { 0 } };
 	winch_act.sa_handler = get_screen_width;
 	sigemptyset(&winch_act.sa_mask);
 	winch_act.sa_flags = 0;


### PR DESCRIPTION
- Add conditional compilation for SAT parser code.
This removes unnecessary checks and assignments when not configuring with the SAT parser.
- Remove the defunct `suppress_warning` checks.
- `parser-utilities.c`: Avoid`-Wmissing-braces` warning
- Cosmetical changes.