### PR TITLE
Fix various How questions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Version 5.10.0 (XXX 2021)
    These last three changes introduce linkage incompatibilities.
  * Fix parsing with nulls when using an sqlite3 dictionary.
  * Fix regexes for NetBSD when using libc regexes. #1223
+ * English dict: fix many "how?" questions.
 
 Version 5.9.1 (28 April 2021)
  * Fix build break when SQLite3 is not installed. #1195

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2890,6 +2890,7 @@ do.v:
     (<b-minus> or O+ or [[@MV+ & O*n+]] or CX-) &
     <mv-coord> &
     (<verb-wall> or VJrpi-))
+  or ({@E-} & I*d- & <b-minus> & <verb-wall> & O+)
   or ({@E-} & I*d- & <verb-wall>);
 
 % Ss- & <verb-wall>: "so it does!"

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -1655,12 +1655,11 @@ half:
     or EZ+
     or [(({DD-} & {@Mp+ or (R+ & B+)}) or (AL+ & J+)) & <noun-main-x>]);
 
-% "How many years" -- prefer TQ+ over Dmc+
 % OFd+ & Dmc+: "I drank many of the beers"
 % Naked H-: "How many?"
 % H- & EC+: "How many more?"
 many:
-  (H- & (Dmc+ or ND+ or NIn+ or TQ+ or EC+ or [()]))
+  (H- & (Dmc+ or ND+ or NIn+ or EC+ or [()]))
   or (AM- & (Dmcy+ or Oy- or Jy-))
   or ({EE-} & (ND+ or NIn+))
   or ({DD-} & {EAx-} & Dmc+)
@@ -5217,7 +5216,7 @@ dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
 % I- & Bt- & WV-: "How many yars did it last?"
 % Negative cost to discourage bad linkage with last.a
-<vc-last>: {({[[@MV+]]} & OT+) or BT- or Bt-} & <mv-coord>;
+<vc-last>: {({[[@MV+]]} & OT+) or Bt-} & <mv-coord>;
 last.v wait.v: 
   ((<verb-pl,i> & (<vc-last>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-last>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -6783,7 +6782,7 @@ reeking.v smelling.v: <verb-pg> & <vc-smell>;
 % <vc-trans> plus particle and Vt
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({O+} & (OT+ or BT-) & {@MV+} & {<tot-verb> or <toi-verb>}) or
+  ({O+} & OT+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
   (OXii+ & Vtg+ & {@MV+} & TH+) or
   @MV+;
 take.v: 
@@ -10348,8 +10347,7 @@ fall.i spring.i winter.i summer.i:
 weeks.i days.i hours.i minutes.i seconds.i months.i years.i decades.i
 centuries.i semesters.i terms.i nights.i:
   ((ND- or (Jd- & Dmc-) or [[EN-]] or [()]) & (Yt+ or (OT- & {Mp+})))
-  or (ND- & Ye-)
-  or (TQ- & BT+);
+  or (ND- & Ye-);
 
 week.i day.i hour.i minute.i second.i month.i year.i decade.i century.i
 semester.i term.i night.u:
@@ -11478,7 +11476,7 @@ long.a:
   <ordinary-adj>
   or <adj-consn>
   or ((Ya- or Yt-) & (Pa- or Ma- or dMJra- or dMJla+))
-  or (H- & (BT+ or Yt+));
+  or (H- & Yt+);
 
 % Hmm does distant really belong here?
 % "The river is a mile wide here": Ya- & Pa- & MVp+

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10385,9 +10385,10 @@ every.i: {EN-} & Ye+ & <prep-main-t>;
 % cost on MVp-: "about five times".
 % cost on Qe-: prefer R & B in "how many times did you do it?"
 times.i x.i:
-  (ND- & (({Xc+ & {Xd-}} & dCOa+) or MVp- or EC+ or EZ+ or <advcl-verb> or [Qe+])) or
-  (((({ND-} & DG-) & {<subcl-verb>}) or (ND- & Ys+)) &
-    (({Xc+ & {Xd-}} & dCO+) or [MVp-]0.1 or (Xd- & Xc+ & MVx-)));
+  (ND- & (({Xc+ & {Xd-}} & dCOa+)
+       or MVp- or EC+ or EZ+ or <advcl-verb> or [Qe+]0.5))
+  or (((({ND-} & DG-) & {<subcl-verb>}) or (ND- & Ys+)) &
+       (({Xc+ & {Xd-}} & dCO+) or [MVp-]0.1 or (Xd- & Xc+ & MVx-)));
 
 time.i:
   {TT- or NR-} & DG- & {<subcl-verb>} &

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2527,7 +2527,7 @@ per "/.per": Us+ & Mp-;
 <verb-s>:    {@E-} & ((Ss- & {hPFt-} & <verb-wall>) or (RS- & Bs-) or Wg-);
 <verb-pl>:   {@E-} & ((Sp- & {hPFt-} & <verb-wall>) or (RS- & Bp-) or Wg-);
 <verb-sp>:   {@E-} & ((S- & {hPFt-} & <verb-wall>) or (RS- & B-) or Wg-);
-<verb-pp>:   {@E-} & PP- & {<verb-wall>};
+<verb-pp>:   {@E-} & PP- & (<verb-wall> or [()]);
 <verb-pg>:   {@E-} & (({[Sg-]-0.2} & Pg-) or Mg- or Wg-);
 <verb-sp,pp>: <verb-sp> or <verb-pp>;
 
@@ -2660,12 +2660,17 @@ per "/.per": Us+ & Mp-;
 
 % Relative clause, or question.
 % Qw- & <verb-wall>: "Where are they?" -- verb must connect to wall.
+%      ([<verb-wall>]-0.1 or ()): prefer wall to participle.
 % Qe-: "How many times did you do it?"
 % Qd-: "Does he drink?" -- Qd connects directly to wall.
 % {CO-} & Qd-: "By the way, does he drink?"
 % Iq-: "The big question is did he do it?"
 % Xd- & Iq-: "The big question is, did he do it?"
-<verb-rq>: Rw- or ({{Xd-} & Iq-} & (Qd- or Qp- or ((Qw- or Qe-) & <verb-wall>))) or [()];
+<verb-rq>:
+  Rw-
+  or ({{Xd-} & Iq-}
+      & (Qd- or Qp- or ((Qw- or Qe-) & ([<verb-wall>]-0.1 or ()))))
+  or [()];
 % Just like above, but no aux, should always be anded with I+.
 % The idea here is that the verb on the other end of the I+ will
 % connect to the wall.

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2890,7 +2890,7 @@ do.v:
     (<b-minus> or O+ or [[@MV+ & O*n+]] or CX-) &
     <mv-coord> &
     (<verb-wall> or VJrpi-))
-  or ({@E-} & I*d- & <b-minus> & <verb-wall> & O+)
+  or ({@E-} & I*d- & <b-minus> & O+)
   or ({@E-} & I*d- & <verb-wall>);
 
 % Ss- & <verb-wall>: "so it does!"

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -9866,14 +9866,14 @@ to.r:
   or ({@E-} & {NT-} & I+ &
     (<MX-PHRASE>
     or (SFsx+ & <S-CLAUSE>)
-    or [{Xd- & Xc+} & MVi-]
+    or [{Xd- & Xc+} & MVi-]0.9
     or [<OPENER>]
     or [[R-]] ))
   or ({NT-} & TO- & Xc+)
   or I*a+
   or ({JQ+} & ([J+] or Mgp+) & <prep-main-a>)
   or <locative>
-  or [MVp- & B-]
+  or [MVp- & B-]1.1
   or <null-prep-qu>;
 
 so_as_to: I+ & {Xd- & Xc+} & MVi-;

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -7937,7 +7937,7 @@ writing.g reading.g charging.g drawing.g:
 % mandatory: '*she sang me'
 % but then: 'she sang soprano'
 <vc-sing>:
-  ({(B- & {O+ or K+}) or
+  ({(<b-minus> & {O+ or K+}) or
     <vc-opt-ditrans> or
     (O+ & K+) or
     <of-coord> or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -4149,17 +4149,19 @@ overran.v-d mistook.v-d underwrote.v-d:
   ((<vc-trans>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 
+% I*d- & <b-minus> & O+: "how many more times did you hit her?"
 hit.v-d misread.v-d shed.v-d rid.v-d overcome.v-d
 overrun.v-d upset.v-d undercut.v-d:
   
   ((<verb-sp,pp> & (<vc-trans>)) or
   (<verb-and-sp-i-> & ([<vc-trans>]0.2 or ())) or
   ((<vc-trans>) & <verb-and-sp-i+>) or
-  <verb-and-sp-t>) or
-  (<verb-ico> & <vc-trans>) or
-  <verb-pv> or
-  <verb-adj> or
-  <verb-phrase-opener>;
+  <verb-and-sp-t>)
+  or (<verb-ico> & <vc-trans>)
+  or ({@E-} & I*d- & <b-minus> & O+)
+  or <verb-pv>
+  or <verb-adj>
+  or <verb-phrase-opener>;
 
 forsaken.v overridden.v overtaken.v rewritten.v undone.v
 beset.v mistaken.v underwritten.v:

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -1660,7 +1660,7 @@ half:
 % Naked H-: "How many?"
 % H- & EC+: "How many more?"
 many:
-  (H- & ([[Dmc+]] or ND+ or NIn+ or TQ+ or EC+ or [()]))
+  (H- & (Dmc+ or ND+ or NIn+ or TQ+ or EC+ or [()]))
   or (AM- & (Dmcy+ or Oy- or Jy-))
   or ({EE-} & (ND+ or NIn+))
   or ({DD-} & {EAx-} & Dmc+)
@@ -5215,13 +5215,15 @@ died.v-d:
   ((<vc-die>) & <verb-and-sp-i+>));
 dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
-<vc-last>: {({[[@MV+]]} & OT+) or BT- or (Bt- & WV-)} & <mv-coord>;
+% I- & Bt- & WV-: "How many yars did it last?"
+% Negative cost to discourage bad linkage with last.a
+<vc-last>: {({[[@MV+]]} & OT+) or BT- or Bt-} & <mv-coord>;
 last.v wait.v: 
   ((<verb-pl,i> & (<vc-last>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-last>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
   ({@E-} & hXd- & dWi- & (<vc-last>) & hXc+) or
   (<verb-and-pl-> & ((<vc-last>) or ())) or
-  (([<vc-last>]0.1 or [()]) & <verb-and-pl+>));
+  (([<vc-last>]0.1 or [()]) & <verb-and-pl+>)) or [I- & Bt- & WV-]-0.1;
 lasts.v waits.v: 
   ((<verb-s> & (<vc-last>)) or
   (<verb-and-s-> & ([<vc-last>] or ())) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -290,6 +290,9 @@
   ({[@M+]0.4 or Mp+} & dSJlp+) or ({[@M+]1.4 or [Mp+]} & dSJrp-) or
   ({[@M+]0.4 or Mp+} & dSJlu+) or ({[@M+]1.4 or [Mp+]} & dSJru-);
 
+% It might be a good idea to change these to be {Rw+ or Qe+} since
+% there are many how-questions that are relativized in this same way.
+%
 % Btm is used for time expressions.  It is used to constrain the verb
 % "last.v" which only makes sense for time.
 <rel-clause-x>: {Rw+} & B*m+;
@@ -10379,8 +10382,9 @@ ago:
 every.i: {EN-} & Ye+ & <prep-main-t>;
 
 % cost on MVp-: "about five times".
+% cost on Qe-: prefer R & B in "how many times did you do it?"
 times.i x.i:
-  (ND- & (({Xc+ & {Xd-}} & dCOa+) or MVp- or EC+ or EZ+ or <advcl-verb> or Qe+)) or
+  (ND- & (({Xc+ & {Xd-}} & dCOa+) or MVp- or EC+ or EZ+ or <advcl-verb> or [Qe+])) or
   (((({ND-} & DG-) & {<subcl-verb>}) or (ND- & Ys+)) &
     (({Xc+ & {Xd-}} & dCO+) or [MVp-]0.1 or (Xd- & Xc+ & MVx-)));
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10424,7 +10424,7 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
   ({NM+} & ((<noun-modifiers> &
       (({Dmc- or @M+} & {WN+ or TH+ or <embed-verb> or (R+ & Bp+)}  & {@MXp+} &
         (<noun-main-p> or
-        <rel-clause-p> or
+        % <rel-clause-p> or
         <rel-clause-t> or
         <noun-and-p>)) or
       Up- or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -6781,15 +6781,17 @@ reeking.v smelling.v: <verb-pg> & <vc-smell>;
 
 % <vc-trans> plus particle and Vt
 <vc-take>:
-  (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
-  (OXii+ & Vtg+ & {@MV+} & TH+) or
-  @MV+;
+  (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>)
+  or ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>})
+  or (OXii+ & Vtg+ & {@MV+} & TH+)
+  or @MV+;
+
+% If- & WV-: "How long did it take?"
 take.v: 
   ((<verb-s-pl,i> & (<vc-take>)) or
   (<verb-and-sp-i-> & ([<vc-take>]0.2 or ())) or
   ((<vc-take>) & <verb-and-sp-i+>) or
-  <verb-and-sp-t>);
+  <verb-and-sp-t>) or (If- & <verb-wall>);
 % conjoin: "He takes cookies and eats them."
 takes.v: 
   ((<verb-s-s> & (<vc-take>)) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2871,14 +2871,8 @@ per "/.per": Us+ & Mp-;
 % naked SIp+: "do you?"
 % Wi- & I*d+ & Xc+ & SI*i+: "please do tell, John"; comma is required!
 %
-% Things we'd like to have, but can't:
-% <b-minus> & O+: "what are the chances Sherlock could do it?"
-% Unfortunately, adding this breaks corpus-basic.batch:
-%    *how many more times did you do it
-%    *how many years did you do it
-% but, I dunno, both seem like valid sentences to me...
-% Hey, wait: using R & B here is wrong, should have Qe maybe?
-% Hang on, this is another zero-word:
+% I*d- & <b-minus> & O+: "How many years did you do it?"
+% Hang on, the above also enables a zero-word parse ...
 % "what are the chances [that] Sherlock could do it?"
 %
 do.v:

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -4486,10 +4486,14 @@ endeavouring.v condescending.v deigning.v: (<vc-deign> & <verb-pg,ge>) or
 
 % QI+ "it happened when?"
 <vc-happen>: {@MV+} & {<to-verb> or THi+ or QI+} & {VC+};
-happen.v occur.v: 
+
+% I*d- & <b-minus>: "how many more times will it happen"
+happen.v occur.v:
+   
   ((<verb-y-pl,i> & (<vc-happen>)) or
   (<verb-and-sp-i-> & ([<vc-happen>] or ())) or
-  ((<vc-happen>) & <verb-and-sp-i+>));
+  ((<vc-happen>) & <verb-and-sp-i+>))
+   or (I*d- & <b-minus>);
 happens.v occurs.v: 
   ((<verb-y-s> & (<vc-happen>)) or
   (<verb-and-s-> & ([<vc-happen>] or ())) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10743,6 +10743,7 @@ whether_or_not:
   or (<subcl-verb> & (({Xd- & Xc+} & MVs-) or ({Xc+ & {Xd-}} & dCO*s+)));
 
 % QI- & (): "I do not know how"
+% QI- & H+: "it happened how many times?"
 % EL+: "How else would you say that?"
 % (EAh+ or EEh+) & Wq-: "How big?" "How quickly?"
 %    Unfortunately, this is blocked by "S-V inversion required7"
@@ -10754,6 +10755,7 @@ how:
   or ({EW-} & Wh- & H+)
   or ({EW-} & <clause-q> & (({EL+} & Qw+) or AF+))
   or [QI-]0.5
+  or (QI- & H+)
   or ({EW-} & (QJ- or QJ+))
   or [dSJl+ or dSJr-]0.5
   or ((<subcl-verb> or <ton-verb>) & (QI- or BIq- or (SFsx+ & <S-CLAUSE>)));

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -5216,7 +5216,7 @@ dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
 % I- & Bt- & WV-: "How many yars did it last?"
 % Negative cost to discourage bad linkage with last.a
-<vc-last>: {({[[@MV+]]} & OT+) or Bt-} & <mv-coord>;
+<vc-last>: {({[[@MV+]]} & Ot+) or Bt-} & <mv-coord>;
 last.v wait.v: 
   ((<verb-pl,i> & (<vc-last>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-last>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -6782,7 +6782,7 @@ reeking.v smelling.v: <verb-pg> & <vc-smell>;
 % <vc-trans> plus particle and Vt
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({O+} & OT+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
+  ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
   (OXii+ & Vtg+ & {@MV+} & TH+) or
   @MV+;
 take.v: 
@@ -10346,27 +10346,27 @@ fall.i spring.i winter.i summer.i:
 % Jd- & Dmc-: "Millions of years ago..."
 weeks.i days.i hours.i minutes.i seconds.i months.i years.i decades.i
 centuries.i semesters.i terms.i nights.i:
-  ((ND- or (Jd- & Dmc-) or [[EN-]] or [()]) & (Yt+ or (OT- & {Mp+})))
+  ((ND- or (Jd- & Dmc-) or [[EN-]] or [()]) & (Yt+ or (Ot- & {Mp+})))
   or (ND- & Ye-);
 
 week.i day.i hour.i minute.i second.i month.i year.i decade.i century.i
 semester.i term.i night.u:
-  (NS- & (({NJ-} & {EN-} & (Yt+ or OT-)) or (EN- & J-)))
+  (NS- & (({NJ-} & {EN-} & (Yt+ or Ot-)) or (EN- & J-)))
   or (NSa- & [[Mp- or Ys-]])
   or ({NR- or TT-} & DG- & ((<subcl-verb> & (({Xc+ & {Xd-}} & dCO+) or MVp- or (Xd- & Xc+ & MVx-))) or Yt+));
 
-year_and_a_half: NSa- & {EN-} & (Yt+ or OT-);
+year_and_a_half: NSa- & {EN-} & (Yt+ or Ot-);
 moment.u:
-  (NS- & (({EN-} & (Yt+ or OT-)) or (EN- & J-)))
+  (NS- & (({EN-} & (Yt+ or Ot-)) or (EN- & J-)))
   or ({NR- or TT-} & DG- & ((<subcl-verb> & (({Xc+ & {Xd-}} & dCO+) or MVp- or (Xd- & Xc+ & MVx-))) or Yt+));
 
-a_while: J- or Yt+ or OT- or <adv-as>;
+a_while: J- or Yt+ or Ot- or <adv-as>;
 now.i then.i: JT- or FM-;
 now_on then_on there_on: FM-;
 from_now: Yt- & <prep-main-t>;
 
 a_long_time some_time a_few_moments moments.u:
-  Yt+ or OT-;
+  Yt+ or Ot-;
 
 % I can't figure out what the Js- would be for... ??
 % ago: Yt- & (<prep-main-e> or <advcl-verb> or Qe+ or JT- or Js-);
@@ -10498,7 +10498,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 /en/words/units.1.dot: {Xi+} & <units-suffix>;
 
 % Time unit abbreviations:
-<time-units>: <units-suffix> or ((ND- or NS-) & {NJ-} & OT-);
+<time-units>: <units-suffix> or ((ND- or NS-) & {NJ-} & Ot-);
 /en/words/units.4: <time-units>;
 /en/words/units.4.dot: {Xi+} & <time-units>;
 
@@ -12199,7 +12199,7 @@ longer.a-c:
     or MVb-
     or Qe+
     or <advcl-verb>
-    or OT-
+    or Ot-
     or FL-
   ))
   or (DG- & (TR+ or AF+ or <subcl-verb>) & {@MV+} & (ER- or (Wd- & Xc+ & ER+)));
@@ -12636,7 +12636,7 @@ voluntarily flatly purposely jointly universally thickly widely:
     or [[EA+]]);
 
 respectively: ({Xd- & Xc+} & <adv-as>) or ({Xd- & Xc+} & E+) or ({Xd- & Xc+} & EB-);
-long.e: E+ or ({EE- or EF+} & (({Xd- & Xc+} & <adv-as>) or OT- or FL- or Yt+));
+long.e: E+ or ({EE- or EF+} & (({Xd- & Xc+} & <adv-as>) or Ot- or FL- or Yt+));
 daily.e nightly.e weekly.e monthly.e yearly.e hourly.e
 partially: ({Xd- & Xc+} & <adv-as>) or E+ or EB-;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -290,9 +290,12 @@
   ({[@M+]0.4 or Mp+} & dSJlp+) or ({[@M+]1.4 or [Mp+]} & dSJrp-) or
   ({[@M+]0.4 or Mp+} & dSJlu+) or ({[@M+]1.4 or [Mp+]} & dSJru-);
 
+% Btm is used for time expressions.  It is used to constrain the verb
+% "last.v" which only makes sense for time.
 <rel-clause-x>: {Rw+} & B*m+;
 <rel-clause-s>: {Rw+} & Bsm+;
 <rel-clause-p>: {Rw+} & Bpm+;
+<rel-clause-t>: {Rw+} & Btm+;
 
 % TOf+ & IV+:  "there is going to be a meeting", "there appears to be a bug"
 % TOn+ & IV+:  "there are plots to hatch", "there is a bill to sign"
@@ -5212,7 +5215,7 @@ died.v-d:
   ((<vc-die>) & <verb-and-sp-i+>));
 dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
-<vc-last>: {({[[@MV+]]} & OT+) or BT-} & <mv-coord>;
+<vc-last>: {({[[@MV+]]} & OT+) or BT- or (Bt- & WV-)} & <mv-coord>;
 last.v wait.v: 
   ((<verb-pl,i> & (<vc-last>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-last>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -10419,6 +10422,7 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
       (({Dmc- or @M+} & {WN+ or TH+ or <embed-verb> or (R+ & Bp+)}  & {@MXp+} &
         (<noun-main-p> or
         <rel-clause-p> or
+        <rel-clause-t> or
         <noun-and-p>)) or
       Up- or
       (YP+ & {Dmc-}) or

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3933,13 +3933,15 @@ forsook.v-d overrode.v-d overtook.v-d rewrote.v-d undid.v-d
 overran.v-d mistook.v-d underwrote.v-d:
   VERB_SP_T(<vc-trans>);
 
+% I*d- & <b-minus> & O+: "how many more times did you hit her?"
 hit.v-d misread.v-d shed.v-d rid.v-d overcome.v-d
 overrun.v-d upset.v-d undercut.v-d:
-  VERB_SPPP_T(<vc-trans>) or
-  (<verb-ico> & <vc-trans>) or
-  <verb-pv> or
-  <verb-adj> or
-  <verb-phrase-opener>;
+  VERB_SPPP_T(<vc-trans>)
+  or (<verb-ico> & <vc-trans>)
+  or ({@E-} & I*d- & <b-minus> & O+)
+  or <verb-pv>
+  or <verb-adj>
+  or <verb-phrase-opener>;
 
 forsaken.v overridden.v overtaken.v rewritten.v undone.v
 beset.v mistaken.v underwritten.v:

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -4145,7 +4145,11 @@ endeavouring.v condescending.v deigning.v: (<vc-deign> & <verb-pg,ge>) or
 
 % QI+ "it happened when?"
 <vc-happen>: {@MV+} & {<to-verb> or THi+ or QI+} & {VC+};
-happen.v occur.v: VERB_Y_PLI(<vc-happen>);
+
+% I*d- & <b-minus>: "how many more times will it happen"
+happen.v occur.v:
+   VERB_Y_PLI(<vc-happen>)
+   or (I*d- & <b-minus>);
 happens.v occurs.v: VERB_Y_S(<vc-happen>);
 happened.v-d occured.v-d occurred.v-d: VERB_Y_SPPP(<vc-happen>);
 happening.v occuring.v occurring.v: (<vc-happen> & <verb-pg,ge>) or <verb-ge-d>;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -5426,11 +5426,13 @@ reeking.v smelling.v: <verb-pg> & <vc-smell>;
 
 % <vc-trans> plus particle and Vt
 <vc-take>:
-  (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
-  (OXii+ & Vtg+ & {@MV+} & TH+) or
-  @MV+;
-take.v: VERB_S_PLI(<vc-take>);
+  (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>)
+  or ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>})
+  or (OXii+ & Vtg+ & {@MV+} & TH+)
+  or @MV+;
+
+% If- & WV-: "How long did it take?"
+take.v: VERB_S_PLI(<vc-take>) or (If- & <verb-wall>);
 % conjoin: "He takes cookies and eats them."
 takes.v: VERB_S_S(<vc-take>);
 took.v-d: VERB_S_SP(<vc-take>);

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8000,7 +8000,7 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
   ({NM+} & ((<noun-modifiers> &
       (({Dmc- or @M+} & {WN+ or TH+ or <embed-verb> or (R+ & Bp+)}  & {@MXp+} &
         (<noun-main-p> or
-        <rel-clause-p> or
+        % <rel-clause-p> or
         <rel-clause-t> or
         <noun-and-p>)) or
       Up- or

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -7442,14 +7442,14 @@ to.r:
   or ({@E-} & {NT-} & I+ &
     (<MX-PHRASE>
     or (SFsx+ & <S-CLAUSE>)
-    or [{Xd- & Xc+} & MVi-]
+    or [{Xd- & Xc+} & MVi-]0.9
     or [<OPENER>]
     or [[R-]] ))
   or ({NT-} & TO- & Xc+)
   or I*a+
   or ({JQ+} & ([J+] or Mgp+) & <prep-main-a>)
   or <locative>
-  or [MVp- & B-]
+  or [MVp- & B-]1.1
   or <null-prep-qu>;
 
 so_as_to: I+ & {Xd- & Xc+} & MVi-;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8319,6 +8319,7 @@ whether_or_not:
   or (<subcl-verb> & (({Xd- & Xc+} & MVs-) or ({Xc+ & {Xd-}} & dCO*s+)));
 
 % QI- & (): "I do not know how"
+% QI- & H+: "it happened how many times?"
 % EL+: "How else would you say that?"
 % (EAh+ or EEh+) & Wq-: "How big?" "How quickly?"
 %    Unfortunately, this is blocked by "S-V inversion required7"
@@ -8330,6 +8331,7 @@ how:
   or ({EW-} & Wh- & H+)
   or ({EW-} & <clause-q> & (({EL+} & Qw+) or AF+))
   or [QI-]0.5
+  or (QI- & H+)
   or ({EW-} & (QJ- or QJ+))
   or [dSJl+ or dSJr-]0.5
   or ((<subcl-verb> or <ton-verb>) & (QI- or BIq- or (SFsx+ & <S-CLAUSE>)));

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -7961,9 +7961,10 @@ every.i: {EN-} & Ye+ & <prep-main-t>;
 % cost on MVp-: "about five times".
 % cost on Qe-: prefer R & B in "how many times did you do it?"
 times.i x.i:
-  (ND- & (({Xc+ & {Xd-}} & dCOa+) or MVp- or EC+ or EZ+ or <advcl-verb> or [Qe+])) or
-  (((({ND-} & DG-) & {<subcl-verb>}) or (ND- & Ys+)) &
-    (({Xc+ & {Xd-}} & dCO+) or [MVp-]0.1 or (Xd- & Xc+ & MVx-)));
+  (ND- & (({Xc+ & {Xd-}} & dCOa+)
+       or MVp- or EC+ or EZ+ or <advcl-verb> or [Qe+]0.5))
+  or (((({ND-} & DG-) & {<subcl-verb>}) or (ND- & Ys+)) &
+       (({Xc+ & {Xd-}} & dCO+) or [MVp-]0.1 or (Xd- & Xc+ & MVx-)));
 
 time.i:
   {TT- or NR-} & DG- & {<subcl-verb>} &

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -4528,7 +4528,7 @@ dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
 % I- & Bt- & WV-: "How many yars did it last?"
 % Negative cost to discourage bad linkage with last.a
-<vc-last>: {({[[@MV+]]} & OT+) or Bt-} & <mv-coord>;
+<vc-last>: {({[[@MV+]]} & Ot+) or Bt-} & <mv-coord>;
 last.v wait.v: VERB_PLI(<vc-last>) or [I- & Bt- & WV-]-0.1;
 lasts.v waits.v: VERB_S_I(<vc-last>);
 lasted.v-d waited.v-d: VERB_SPPP_I(<vc-last>);
@@ -5427,7 +5427,7 @@ reeking.v smelling.v: <verb-pg> & <vc-smell>;
 % <vc-trans> plus particle and Vt
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({O+} & OT+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
+  ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
   (OXii+ & Vtg+ & {@MV+} & TH+) or
   @MV+;
 take.v: VERB_S_PLI(<vc-take>);
@@ -7922,27 +7922,27 @@ fall.i spring.i winter.i summer.i:
 % Jd- & Dmc-: "Millions of years ago..."
 weeks.i days.i hours.i minutes.i seconds.i months.i years.i decades.i
 centuries.i semesters.i terms.i nights.i:
-  ((ND- or (Jd- & Dmc-) or [[EN-]] or [()]) & (Yt+ or (OT- & {Mp+})))
+  ((ND- or (Jd- & Dmc-) or [[EN-]] or [()]) & (Yt+ or (Ot- & {Mp+})))
   or (ND- & Ye-);
 
 week.i day.i hour.i minute.i second.i month.i year.i decade.i century.i
 semester.i term.i night.u:
-  (NS- & (({NJ-} & {EN-} & (Yt+ or OT-)) or (EN- & J-)))
+  (NS- & (({NJ-} & {EN-} & (Yt+ or Ot-)) or (EN- & J-)))
   or (NSa- & [[Mp- or Ys-]])
   or ({NR- or TT-} & DG- & ((<subcl-verb> & (({Xc+ & {Xd-}} & dCO+) or MVp- or (Xd- & Xc+ & MVx-))) or Yt+));
 
-year_and_a_half: NSa- & {EN-} & (Yt+ or OT-);
+year_and_a_half: NSa- & {EN-} & (Yt+ or Ot-);
 moment.u:
-  (NS- & (({EN-} & (Yt+ or OT-)) or (EN- & J-)))
+  (NS- & (({EN-} & (Yt+ or Ot-)) or (EN- & J-)))
   or ({NR- or TT-} & DG- & ((<subcl-verb> & (({Xc+ & {Xd-}} & dCO+) or MVp- or (Xd- & Xc+ & MVx-))) or Yt+));
 
-a_while: J- or Yt+ or OT- or <adv-as>;
+a_while: J- or Yt+ or Ot- or <adv-as>;
 now.i then.i: JT- or FM-;
 now_on then_on there_on: FM-;
 from_now: Yt- & <prep-main-t>;
 
 a_long_time some_time a_few_moments moments.u:
-  Yt+ or OT-;
+  Yt+ or Ot-;
 
 % I can't figure out what the Js- would be for... ??
 % ago: Yt- & (<prep-main-e> or <advcl-verb> or Qe+ or JT- or Js-);
@@ -8074,7 +8074,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 /en/words/units.1.dot: {Xi+} & <units-suffix>;
 
 % Time unit abbreviations:
-<time-units>: <units-suffix> or ((ND- or NS-) & {NJ-} & OT-);
+<time-units>: <units-suffix> or ((ND- or NS-) & {NJ-} & Ot-);
 /en/words/units.4: <time-units>;
 /en/words/units.4.dot: {Xi+} & <time-units>;
 
@@ -9775,7 +9775,7 @@ longer.a-c:
     or MVb-
     or Qe+
     or <advcl-verb>
-    or OT-
+    or Ot-
     or FL-
   ))
   or (DG- & (TR+ or AF+ or <subcl-verb>) & {@MV+} & (ER- or (Wd- & Xc+ & ER+)));
@@ -10212,7 +10212,7 @@ voluntarily flatly purposely jointly universally thickly widely:
     or [[EA+]]);
 
 respectively: ({Xd- & Xc+} & <adv-as>) or ({Xd- & Xc+} & E+) or ({Xd- & Xc+} & EB-);
-long.e: E+ or ({EE- or EF+} & (({Xd- & Xc+} & <adv-as>) or OT- or FL- or Yt+));
+long.e: E+ or ({EE- or EF+} & (({Xd- & Xc+} & <adv-as>) or Ot- or FL- or Yt+));
 daily.e nightly.e weekly.e monthly.e yearly.e hourly.e
 partially: ({Xd- & Xc+} & <adv-as>) or E+ or EB-;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2917,6 +2917,7 @@ do.v:
     (<b-minus> or O+ or [[@MV+ & O*n+]] or CX-) &
     <mv-coord> &
     (<verb-wall> or VJrpi-))
+  or ({@E-} & I*d- & <b-minus> & <verb-wall> & O+)
   or ({@E-} & I*d- & <verb-wall>);
 
 % Ss- & <verb-wall>: "so it does!"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -1664,12 +1664,11 @@ half:
     or EZ+
     or [(({DD-} & {@Mp+ or (R+ & B+)}) or (AL+ & J+)) & <noun-main-x>]);
 
-% "How many years" -- prefer TQ+ over Dmc+
 % OFd+ & Dmc+: "I drank many of the beers"
 % Naked H-: "How many?"
 % H- & EC+: "How many more?"
 many:
-  (H- & (Dmc+ or ND+ or NIn+ or TQ+ or EC+ or [()]))
+  (H- & (Dmc+ or ND+ or NIn+ or EC+ or [()]))
   or (AM- & (Dmcy+ or Oy- or Jy-))
   or ({EE-} & (ND+ or NIn+))
   or ({DD-} & {EAx-} & Dmc+)
@@ -4529,7 +4528,7 @@ dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
 % I- & Bt- & WV-: "How many yars did it last?"
 % Negative cost to discourage bad linkage with last.a
-<vc-last>: {({[[@MV+]]} & OT+) or BT- or Bt-} & <mv-coord>;
+<vc-last>: {({[[@MV+]]} & OT+) or Bt-} & <mv-coord>;
 last.v wait.v: VERB_PLI(<vc-last>) or [I- & Bt- & WV-]-0.1;
 lasts.v waits.v: VERB_S_I(<vc-last>);
 lasted.v-d waited.v-d: VERB_SPPP_I(<vc-last>);
@@ -5428,7 +5427,7 @@ reeking.v smelling.v: <verb-pg> & <vc-smell>;
 % <vc-trans> plus particle and Vt
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({O+} & (OT+ or BT-) & {@MV+} & {<tot-verb> or <toi-verb>}) or
+  ({O+} & OT+ & {@MV+} & {<tot-verb> or <toi-verb>}) or
   (OXii+ & Vtg+ & {@MV+} & TH+) or
   @MV+;
 take.v: VERB_S_PLI(<vc-take>);
@@ -7924,8 +7923,7 @@ fall.i spring.i winter.i summer.i:
 weeks.i days.i hours.i minutes.i seconds.i months.i years.i decades.i
 centuries.i semesters.i terms.i nights.i:
   ((ND- or (Jd- & Dmc-) or [[EN-]] or [()]) & (Yt+ or (OT- & {Mp+})))
-  or (ND- & Ye-)
-  or (TQ- & BT+);
+  or (ND- & Ye-);
 
 week.i day.i hour.i minute.i second.i month.i year.i decade.i century.i
 semester.i term.i night.u:
@@ -9054,7 +9052,7 @@ long.a:
   <ordinary-adj>
   or <adj-consn>
   or ((Ya- or Yt-) & (Pa- or Ma- or dMJra- or dMJla+))
-  or (H- & (BT+ or Yt+));
+  or (H- & Yt+);
 
 % Hmm does distant really belong here?
 % "The river is a mile wide here": Ya- & Pa- & MVp+

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -1669,7 +1669,7 @@ half:
 % Naked H-: "How many?"
 % H- & EC+: "How many more?"
 many:
-  (H- & ([[Dmc+]] or ND+ or NIn+ or TQ+ or EC+ or [()]))
+  (H- & (Dmc+ or ND+ or NIn+ or TQ+ or EC+ or [()]))
   or (AM- & (Dmcy+ or Oy- or Jy-))
   or ({EE-} & (ND+ or NIn+))
   or ({DD-} & {EAx-} & Dmc+)
@@ -4527,8 +4527,10 @@ dies.v: VERB_S_I(<vc-die>);
 died.v-d: VERB_SPPP_I(<vc-die>);
 dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
-<vc-last>: {({[[@MV+]]} & OT+) or BT- or (Bt- & WV-)} & <mv-coord>;
-last.v wait.v: VERB_PLI(<vc-last>);
+% I- & Bt- & WV-: "How many yars did it last?"
+% Negative cost to discourage bad linkage with last.a
+<vc-last>: {({[[@MV+]]} & OT+) or BT- or Bt-} & <mv-coord>;
+last.v wait.v: VERB_PLI(<vc-last>) or [I- & Bt- & WV-]-0.1;
 lasts.v waits.v: VERB_S_I(<vc-last>);
 lasted.v-d waited.v-d: VERB_SPPP_I(<vc-last>);
 lasting.v waiting.v: <verb-pg> & <vc-last>;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -299,6 +299,9 @@ changecom(`%')
   ({[@M+]0.4 or Mp+} & dSJlp+) or ({[@M+]1.4 or [Mp+]} & dSJrp-) or
   ({[@M+]0.4 or Mp+} & dSJlu+) or ({[@M+]1.4 or [Mp+]} & dSJru-);
 
+% It might be a good idea to change these to be {Rw+ or Qe+} since
+% there are many how-questions that are relativized in this same way.
+%
 % Btm is used for time expressions.  It is used to constrain the verb
 % "last.v" which only makes sense for time.
 <rel-clause-x>: {Rw+} & B*m+;
@@ -7955,8 +7958,9 @@ ago:
 every.i: {EN-} & Ye+ & <prep-main-t>;
 
 % cost on MVp-: "about five times".
+% cost on Qe-: prefer R & B in "how many times did you do it?"
 times.i x.i:
-  (ND- & (({Xc+ & {Xd-}} & dCOa+) or MVp- or EC+ or EZ+ or <advcl-verb> or Qe+)) or
+  (ND- & (({Xc+ & {Xd-}} & dCOa+) or MVp- or EC+ or EZ+ or <advcl-verb> or [Qe+])) or
   (((({ND-} & DG-) & {<subcl-verb>}) or (ND- & Ys+)) &
     (({Xc+ & {Xd-}} & dCO+) or [MVp-]0.1 or (Xd- & Xc+ & MVx-)));
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -299,9 +299,12 @@ changecom(`%')
   ({[@M+]0.4 or Mp+} & dSJlp+) or ({[@M+]1.4 or [Mp+]} & dSJrp-) or
   ({[@M+]0.4 or Mp+} & dSJlu+) or ({[@M+]1.4 or [Mp+]} & dSJru-);
 
+% Btm is used for time expressions.  It is used to constrain the verb
+% "last.v" which only makes sense for time.
 <rel-clause-x>: {Rw+} & B*m+;
 <rel-clause-s>: {Rw+} & Bsm+;
 <rel-clause-p>: {Rw+} & Bpm+;
+<rel-clause-t>: {Rw+} & Btm+;
 
 % TOf+ & IV+:  "there is going to be a meeting", "there appears to be a bug"
 % TOn+ & IV+:  "there are plots to hatch", "there is a bill to sign"
@@ -4524,7 +4527,7 @@ dies.v: VERB_S_I(<vc-die>);
 died.v-d: VERB_SPPP_I(<vc-die>);
 dying.v: (<vc-die> & <verb-pg,ge>) or <verb-ge-d>;
 
-<vc-last>: {({[[@MV+]]} & OT+) or BT-} & <mv-coord>;
+<vc-last>: {({[[@MV+]]} & OT+) or BT- or (Bt- & WV-)} & <mv-coord>;
 last.v wait.v: VERB_PLI(<vc-last>);
 lasts.v waits.v: VERB_S_I(<vc-last>);
 lasted.v-d waited.v-d: VERB_SPPP_I(<vc-last>);
@@ -7995,6 +7998,7 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
       (({Dmc- or @M+} & {WN+ or TH+ or <embed-verb> or (R+ & Bp+)}  & {@MXp+} &
         (<noun-main-p> or
         <rel-clause-p> or
+        <rel-clause-t> or
         <noun-and-p>)) or
       Up- or
       (YP+ & {Dmc-}) or

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2917,7 +2917,7 @@ do.v:
     (<b-minus> or O+ or [[@MV+ & O*n+]] or CX-) &
     <mv-coord> &
     (<verb-wall> or VJrpi-))
-  or ({@E-} & I*d- & <b-minus> & <verb-wall> & O+)
+  or ({@E-} & I*d- & <b-minus> & O+)
   or ({@E-} & I*d- & <verb-wall>);
 
 % Ss- & <verb-wall>: "so it does!"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2536,7 +2536,7 @@ per "/.per": Us+ & Mp-;
 <verb-s>:    {@E-} & ((Ss- & {hPFt-} & <verb-wall>) or (RS- & Bs-) or Wg-);
 <verb-pl>:   {@E-} & ((Sp- & {hPFt-} & <verb-wall>) or (RS- & Bp-) or Wg-);
 <verb-sp>:   {@E-} & ((S- & {hPFt-} & <verb-wall>) or (RS- & B-) or Wg-);
-<verb-pp>:   {@E-} & PP- & {<verb-wall>};
+<verb-pp>:   {@E-} & PP- & (<verb-wall> or [()]);
 <verb-pg>:   {@E-} & (({[Sg-]-0.2} & Pg-) or Mg- or Wg-);
 <verb-sp,pp>: <verb-sp> or <verb-pp>;
 
@@ -2669,12 +2669,17 @@ per "/.per": Us+ & Mp-;
 
 % Relative clause, or question.
 % Qw- & <verb-wall>: "Where are they?" -- verb must connect to wall.
+%      ([<verb-wall>]-0.1 or ()): prefer wall to participle.
 % Qe-: "How many times did you do it?"
 % Qd-: "Does he drink?" -- Qd connects directly to wall.
 % {CO-} & Qd-: "By the way, does he drink?"
 % Iq-: "The big question is did he do it?"
 % Xd- & Iq-: "The big question is, did he do it?"
-<verb-rq>: Rw- or ({{Xd-} & Iq-} & (Qd- or Qp- or ((Qw- or Qe-) & <verb-wall>))) or [()];
+<verb-rq>:
+  Rw-
+  or ({{Xd-} & Iq-}
+      & (Qd- or Qp- or ((Qw- or Qe-) & ([<verb-wall>]-0.1 or ()))))
+  or [()];
 % Just like above, but no aux, should always be anded with I+.
 % The idea here is that the verb on the other end of the I+ will
 % connect to the wall.

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -6105,7 +6105,7 @@ writing.g reading.g charging.g drawing.g:
 % mandatory: '*she sang me'
 % but then: 'she sang soprano'
 <vc-sing>:
-  ({(B- & {O+ or K+}) or
+  ({(<b-minus> & {O+ or K+}) or
     <vc-opt-ditrans> or
     (O+ & K+) or
     <of-coord> or

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2898,14 +2898,8 @@ define(`VERB_S_SPPP',`'VERB_x_T(``<verb-s-sp,pp>'',$1))
 % naked SIp+: "do you?"
 % Wi- & I*d+ & Xc+ & SI*i+: "please do tell, John"; comma is required!
 %
-% Things we'd like to have, but can't:
-% <b-minus> & O+: "what are the chances Sherlock could do it?"
-% Unfortunately, adding this breaks corpus-basic.batch:
-%    *how many more times did you do it
-%    *how many years did you do it
-% but, I dunno, both seem like valid sentences to me...
-% Hey, wait: using R & B here is wrong, should have Qe maybe?
-% Hang on, this is another zero-word:
+% I*d- & <b-minus> & O+: "How many years did you do it?"
+% Hang on, the above also enables a zero-word parse ...
 % "what are the chances [that] Sherlock could do it?"
 %
 do.v:

--- a/data/en/corpus-basic.batch
+++ b/data/en/corpus-basic.batch
@@ -377,10 +377,10 @@ I wonder how many more people he thinks will come
 How many times did you do it
 *How many times you did it
 I wonder how many times you did it
-*How many more stupid times did you do it
+How many more stupid times did you do it
 How many years ago did you do it
 *Many years ago did you do it
-*How many years did you do it
+How many years did you do it
 I wonder how many years ago you did it
 *How many years ago you did it
 I'll show you the house where I met your mother

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2355,6 +2355,9 @@ how many more times did you hit her
 how many more times will you hit her
 how many more times are you going to hit her
 
+how many more times did it happen?
+how many more times will it happen?
+
 Who?
 who else?
 who else not?

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2358,6 +2358,11 @@ how many more times are you going to hit her
 how many more times did it happen?
 how many more times will it happen?
 
+% Question inversion
+it happened when?
+it happened how many times?
+
+
 Who?
 who else?
 who else not?

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2346,6 +2346,9 @@ how many years did you do it?
 how many years did you abuse drugs?
 How long did you take?
 
+How many years ago did you do it
+How many years ago did you smoke pot?
+
 Who?
 who else?
 who else not?

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2351,7 +2351,9 @@ How many years ago did you smoke pot?
 
 How many more times did you do it
 how many more times did you sing to her
-
+how many more times did you hit her
+how many more times will you hit her
+how many more times are you going to hit her
 
 Who?
 who else?

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2341,6 +2341,11 @@ Many times!
 About five times!
 Almost five times!
 
+How many years did it last
+how many years did you do it?
+how many years did you abuse drugs?
+How long did you take?
+
 Who?
 who else?
 who else not?
@@ -6545,11 +6550,6 @@ I slipped on the ice as I ran home.
 
 % "as" as a colloquial form of "that"
 I don't know as I can answer your question.
-
-% --------------------------------------------------------------------
-% This should parse with the TQ/BT link (see OT page)
-% but that requires links crossing to head-word, so its screwed.
-How many years did it last
 
 % --------------------------------------------------------------------
 % assorted unclassified breakages, waiting for a fix:

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2349,6 +2349,10 @@ How long did you take?
 How many years ago did you do it
 How many years ago did you smoke pot?
 
+How many more times did you do it
+how many more times did you sing to her
+
+
 Who?
 who else?
 who else not?


### PR DESCRIPTION
Fix various how questions so that the work.

Remove the BT, OT and TQ link types -- they are un-needed and are now obsolete.