### PR TITLE
Correct support for question inversion

### DIFF
--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3866,11 +3866,11 @@ rising.v falling.v:
 % QN+: "you bike how many miles?"
 % O+ & QN+: "you saw it when?"
 <vc-fill>:
-  ((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
+  (((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
     or ({O+ or <b-minus>} & {K+})
-    or ({O+} & {K+} & QN+)
     or [[@MV+ & O*n+]]
-  ) & <mv-coord>;
+  ) & <mv-coord>)
+  or ({O+} & {K+} & QN+);
 
 /en/words/words.v.6.1:
   
@@ -4332,12 +4332,12 @@ buttering.g:
 % K+ & Pa+: "it washed up, unbroken"
 % QN+: "you kicked how many balls?"
 <vc-kick>:
-  ((K+ & {[[@MV+]]} & O*n+)
-  or ((O+ or <b-minus>) & {K+})
-  or (<b-minus> & O+ & {K+})
-  or ({K+} & QN+)
-  or ({K+} & {Xc+} & Pa+)
-  or [[@MV+ & O*n+]]) & <mv-coord>;
+  (((K+ & {[[@MV+]]} & O*n+)
+    or ((O+ or <b-minus>) & {K+})
+    or (<b-minus> & O+ & {K+})
+    or ({K+} & {Xc+} & Pa+)
+    or [[@MV+ & O*n+]]) & <mv-coord>)
+  or ({K+} & QN+);
 
 /en/words/words.v.8.1: 
   ((<verb-pl,i> & (<vc-kick>)) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3876,11 +3876,12 @@ rising.v falling.v:
 
 % <verb-si>: "Above him hung a lamp"
 %  However, not every verb listed would be used like that.
+% QN+: "you biked how many miles?"
 /en/words/words.v.6.3:
   
-  ((<verb-sp,pp> & (<vc-fill>)) or
-  (<verb-and-sp-i-> & ([<vc-fill>]0.2 or ())) or
-  ((<vc-fill>) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-fill> or QN+)) or
+  (<verb-and-sp-i-> & ([<vc-fill> or QN+]0.2 or ())) or
+  ((<vc-fill> or QN+) & <verb-and-sp-i+>) or
   <verb-and-sp-t>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or
@@ -3898,6 +3899,7 @@ split.v-d spread.v-d fit.v-d shut.v-d cast.v-d:
   or <verb-adj>
   or ({K+} & <verb-phrase-opener>);
 
+% QN+: "you ate how many cookies?"
 ate.v-d bit.v-d blew.v-d broke.v-d drank.v-d
 flew.v-d froze.v-d hid.v-d stole.v-d
 rang.v-d rode.v-d sprang.v-d stalked.v-d woke.v-d
@@ -3910,9 +3912,9 @@ deep-froze.v-d forbad.v-d deep-freezed.v-d retook.v-d interwove.v-d
 bespoke.v-d underwent.v-d slew.v-d overdrew.v-d overcame.v-d
 outwore.v-d foreknew.v-d wove.v-d trod.v-d outwent.v-d:
   
-  ((<verb-sp,pp> & (<vc-fill>)) or
-  (<verb-and-sp-i-> & ([<vc-fill>]0.2 or ())) or
-  ((<vc-fill>) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-fill> or QN+)) or
+  (<verb-and-sp-i-> & ([<vc-fill> or QN+]0.2 or ())) or
+  ((<vc-fill> or QN+) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 
 bitten.v blown.v broken.v drunk.v
@@ -4356,11 +4358,12 @@ forgone.v curretted.v forsworn.v oversewn.v over-eaten.v
 % this, the other half clearly should not. I'm too lazy to sort it out,
 % right now.
 % Pa+: "it washed up unbroken"
+% QN+: "you kicked how many balls?"
 /en/words/words.v.8.3:
   
-  ((<verb-sp,pp> & (<vc-kick>)) or
-  (<verb-and-sp-i-> & ([<vc-kick>]0.2 or ())) or
-  ((<vc-kick>) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-kick> or QN+)) or
+  (<verb-and-sp-i-> & ([<vc-kick> or QN+]0.2 or ())) or
+  ((<vc-kick> or QN+) & <verb-and-sp-i+>) or
   <verb-and-sp-t>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3667,9 +3667,10 @@ coming.v:
 % --------------------------------------------------------------
 % optionally transitive verbs
 % abdicate.v abide.v abort.v accelerate.v acclimate.v acclimatize.v
+% O+ & QN+: "he anchors the bolts how?"
 <vc-tr,intr>:
   ({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>)
-  or QN+;
+  or ({O+} & QN+);
 
 /en/words/words.v.2.1: 
   ((<verb-pl,i> & (<vc-tr,intr>)) or
@@ -3888,7 +3889,6 @@ rising.v falling.v:
 
 % <verb-si>: "Above him hung a lamp"
 %  However, not every verb listed would be used like that.
-% QN+: "you biked how many miles?"
 /en/words/words.v.6.3:
   
   ((<verb-sp,pp> & (<vc-fill>)) or
@@ -3998,15 +3998,15 @@ and.v-fill:
 %   "What are the chances she will really DRIVE him crazy?"
 % ({@E-} & B- & O+ & K+):
 %   "What are the chances she will DRIVE him up to the farm?"
-% QN+: you run how many miles?
-%
+% QN+: "you run how many miles?"
+% QN+ & MV+: "you ran to her, when?"
 <vc-run>:
   ((K+ & {[[@MV+]]} & O*n+)
     or Pa+
     or ({O+ or <b-minus>} & {K+})
     or ((O+ or <b-minus>) & ({@MV+} & Pa**j+))
     or ({@E-} & <b-minus> & O+ & {Pa**j+ or K+})
-    or ({K+} & QN+)
+    or ({O+} & {K+} & {@MV+} & {Xc+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 
@@ -4503,8 +4503,9 @@ endeavoured.v-d condescended.v-d deigned.v-d:
 endeavouring.v condescending.v deigning.v: (<vc-deign> & <verb-pg,ge>) or
 <verb-ge-d>;
 
-% QN+ "it happened when?"
-<vc-happen>: {@MV+} & {<to-verb> or THi+ or QN+} & {VC+};
+% QN+: "it happened when?"
+% MV+ & QN+: "That happened to her, when?"
+<vc-happen>: {@MV+} & {<to-verb> or THi+ or ({Xc+} & QN+)} & {VC+};
 
 % I*d- & <b-minus>: "how many more times will it happen"
 happen.v occur.v:
@@ -4678,9 +4679,9 @@ seeming.v: (<vc-seem> & <verb-x-pg,ge>) or <verb-ge-d>;
 % "I do not care where you put it"
 % "I wonder when he will come"
 <QI+pref>: [QI+]-0.05;
-<QN+pref>: [QN+]-0.05;
+<QN+pref>: [QN+]-0.10;
 
-<vc-care>: {@MV+} & {<to-verb> or <QI+pref>};
+<vc-care>: {@MV+} & {<to-verb> or <QI+pref> or <QN+pref>};
 care.v: 
   ((<verb-pl,i> & (<vc-care>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-care>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -4970,7 +4971,8 @@ wondering.v inquiring.v: (<vc-wonder> & <verb-pg,ge>) or <verb-ge-d>;
 % B-: "which way did it go?"
 % QN+: "you will go when?"
 <vc-go>:
-  {K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus> or QN+} & <mv-coord>;
+  ({K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus>} & <mv-coord>)
+  or QN+;
 go.v: 
   ((<verb-pl,i> & (<vc-go>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-go>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -5533,6 +5535,7 @@ deciding.g resolving.g: (<vc-decide> & <verb-ge>) or <verb-ge-d>;
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & (<QN+pref> or TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or Pg+));
 
+
 remember.v forget.v: 
   ((<verb-pl,i> & (<vc-forget>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-forget>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -5565,11 +5568,12 @@ forgotten.v:
 remembering.g forgetting.g: (<vc-forget> & <verb-ge>) or <verb-ge-d>;
 remembering.v forgetting.v: <verb-pg> & <vc-forget>;
 
-% OF+ & QN+: "you learned of this when?
 <vc-learn>:
-  {<vc-trans>} or
-  ({@MV+} & (TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or
-      <QN+pref> or (OF+ & {{Xc+} & QN+} & <mv-coord>)));
+  {<vc-trans>}
+  or ({@MV+} & (TH+ or <to-verb> or <embed-verb> or RSe+ or Zs-
+     or <of-coord>))
+  or QN+;
+
 learn.v: 
   ((<verb-pl,i> & (<vc-learn>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-learn>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -5590,12 +5594,13 @@ learning.g: (<vc-learn> & <verb-ge>) or <verb-ge-d>;
 learning.v: <verb-pg> & <vc-learn>;
 
 % TO+ & Xc+: allows null-infinitive: "I did not propose to"
+% O+ & MV+ & QN+: "You proposed to her when?"
 <vc-propose>:
   <vc-trans>
   or (<mv-coord> & <null-verb>)
-  or ({@MV+} & (<to-verb> or
-    TH+ or <embed-verb> or RSe+ or QN+ or
-    Z- or Pg+ or TS+ or (SI*j+ & I*j+)));
+  or ({@MV+} & (<to-verb>
+    or TH+ or <embed-verb> or RSe+ or QN+
+    or Z- or Pg+ or TS+ or (SI*j+ & I*j+)));
 propose.v: 
   ((<verb-pl,i> & (<vc-propose>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-propose>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -5625,7 +5630,7 @@ proposing.v: <verb-pg> & <vc-propose>;
 % <vc-trans> & QN+: "You demand this why?"
 % O+ & <of-coord>: "You demanded this of him why?"
 <vc-demand>:
-  (<vc-trans> & {{Xc+} & QN+})
+  (<vc-trans>)
   or ({O+} & <of-coord>)
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & ((<to-verb> or TH+ or Z- or TS+ or ((SI*j+ or SFI**j+) & I*j+))));
@@ -7271,10 +7276,11 @@ refusing.v: <verb-pg> & <vc-refuse>;
 % TO+ & Xc+: allows null-infinitive: "Because I want to."
 % intransitive: "Try it if you want"
 % QN+: "you want which one?"
+% O+ & QN+: "you want it when?"
 <vc-want>:
   (<mv-coord> & ({<to-verb>} or <null-verb>))
   or ((O+ or <b-minus> or OX+) & <mv-coord> & {<too-verb> or Pv+ or Pa**j+})
-  or QN+
+  or ({O+} & QN+)
   or [[@MV+ & O*n+]]
   or [[CX- & <mv-coord>]];
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2503,7 +2503,7 @@ per "/.per": Us+ & Mp-;
 <mv-coord>: {@MV+} & {VC+};
 
 % <of-coord>: "You were informed of this when?"
-<of-coord>: OF+ & {{Xc+} & QI+} & <mv-coord>;
+<of-coord>: OF+ & {{Xc+} & QN+} & <mv-coord>;
 
 % When we are done, remove the option costly NULL below.
 <WALL>: hWV+ or [[()]];
@@ -2855,12 +2855,12 @@ per "/.per": Us+ & Mp-;
 % AUXILIARY VERBS
 
 % O+ & <verb-wall>: "did" is not an auxiliary, and so needs the wall.
-% O+ & QI+: "you did that when?"
-% QI+: "you did what?"
+% O+ & QN+: "you did that when?"
+% QN+: "you did what?"
 <vc-do>:
   ((<b-minus>
-    or (O+ & {@MV+} & <verb-wall> & {{Xc+} & QI+})
-    or ({@MV+} & <verb-wall> & QI+)
+    or (O+ & {@MV+} & <verb-wall> & {{Xc+} & QN+})
+    or ({@MV+} & <verb-wall> & QN+)
     or [[@MV+ & O*n+]]
     or Vd+
     or ({N+} & (CX- or [[()]]))) & <mv-coord>)
@@ -3622,7 +3622,7 @@ listening.v:
 
 % I*g: "Come walk with me".
 <vc-come>:
-  ({(K+ & {Pa+}) or Pv+ or [[Pg+]] or I*g+ or <b-minus> or QI+} & <mv-coord>)
+  ({(K+ & {Pa+}) or Pv+ or [[Pg+]] or I*g+ or <b-minus> or QN+} & <mv-coord>)
   or ({@MV+} & Pa+);
 come.v:
   
@@ -4484,8 +4484,8 @@ endeavoured.v-d condescended.v-d deigned.v-d:
 endeavouring.v condescending.v deigning.v: (<vc-deign> & <verb-pg,ge>) or
 <verb-ge-d>;
 
-% QI+ "it happened when?"
-<vc-happen>: {@MV+} & {<to-verb> or THi+ or QI+} & {VC+};
+% QN+ "it happened when?"
+<vc-happen>: {@MV+} & {<to-verb> or THi+ or QN+} & {VC+};
 
 % I*d- & <b-minus>: "how many more times will it happen"
 happen.v occur.v:
@@ -4659,6 +4659,7 @@ seeming.v: (<vc-seem> & <verb-x-pg,ge>) or <verb-ge-d>;
 % "I do not care where you put it"
 % "I wonder when he will come"
 <QI+pref>: [QI+]-0.05;
+<QN+pref>: [QN+]-0.05;
 
 <vc-care>: {@MV+} & {<to-verb> or <QI+pref>};
 care.v: 
@@ -4948,9 +4949,9 @@ wondering.v inquiring.v: (<vc-wonder> & <verb-pg,ge>) or <verb-ge-d>;
 % go.w: {E-} & (Wi- or S-) & I+;
 
 % B-: "which way did it go?"
-% QI+: "you will go when?"
+% QN+: "you will go when?"
 <vc-go>:
-  {K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus> or QI+} & <mv-coord>;
+  {K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus> or QN+} & <mv-coord>;
 go.v: 
   ((<verb-pl,i> & (<vc-go>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-go>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -5478,10 +5479,10 @@ planned.v-d confessed.v-d:
 planning.g confessing.g: (<vc-plan> & <verb-ge>) or <verb-ge-d>;
 planning.v confessing.v: <verb-pg> & <vc-plan>;
 
-% <vc-trans> & QI+: "you decided that when?"
+% <vc-trans> & QN+: "you decided that when?"
 <vc-decide>:
-  (<vc-trans> & {{Xc+} & QI+}) or
-  ({@MV+} & {TH+ or {<QI+pref>} or
+  (<vc-trans> & {{Xc+} & QN+}) or
+  ({@MV+} & {TH+ or {<QN+pref>} or
     <to-verb> or <embed-verb> or RSe+ or Zs-});
 
 decide.v resolve.v: 
@@ -5511,7 +5512,7 @@ deciding.g resolving.g: (<vc-decide> & <verb-ge>) or <verb-ge-d>;
 <vc-forget>:
   {<vc-trans>}
   or (<mv-coord> & <null-verb>)
-  or ({@MV+} & (<QI+pref> or TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or Pg+));
+  or ({@MV+} & (<QN+pref> or TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or Pg+));
 
 remember.v forget.v: 
   ((<verb-pl,i> & (<vc-forget>)) or
@@ -5545,11 +5546,11 @@ forgotten.v:
 remembering.g forgetting.g: (<vc-forget> & <verb-ge>) or <verb-ge-d>;
 remembering.v forgetting.v: <verb-pg> & <vc-forget>;
 
-% OF+ & QI+: "you learned of this when?
+% OF+ & QN+: "you learned of this when?
 <vc-learn>:
   {<vc-trans>} or
   ({@MV+} & (TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or
-      <QI+pref> or (OF+ & {{Xc+} & QI+} & <mv-coord>)));
+      <QN+pref> or (OF+ & {{Xc+} & QN+} & <mv-coord>)));
 learn.v: 
   ((<verb-pl,i> & (<vc-learn>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-learn>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -5574,7 +5575,7 @@ learning.v: <verb-pg> & <vc-learn>;
   <vc-trans>
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & (<to-verb> or
-    TH+ or <embed-verb> or RSe+ or QI+ or
+    TH+ or <embed-verb> or RSe+ or QN+ or
     Z- or Pg+ or TS+ or (SI*j+ & I*j+)));
 propose.v: 
   ((<verb-pl,i> & (<vc-propose>)) or
@@ -5588,12 +5589,12 @@ proposes.v:
   ((<vc-propose>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 
-% <vc-propose> & QI+: "You proposed this to her when?"
+% <vc-propose> & QN+: "You proposed this to her when?"
 proposed.v-d:
   
-  ((<verb-sp,pp> & (<vc-propose> & {{Xc+} & QI+})) or
-  (<verb-and-sp-i-> & ([<vc-propose> & {{Xc+} & QI+}]0.2 or ())) or
-  ((<vc-propose> & {{Xc+} & QI+}) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-propose> & {{Xc+} & QN+})) or
+  (<verb-and-sp-i-> & ([<vc-propose> & {{Xc+} & QN+}]0.2 or ())) or
+  ((<vc-propose> & {{Xc+} & QN+}) & <verb-and-sp-i+>) or
   <verb-and-sp-t>)
   or (<verb-s-pv> & {THi+ or TSi+ or Z-})
   or <verb-adj>
@@ -5602,10 +5603,10 @@ proposing.g: (<vc-propose> & <verb-ge>) or <verb-ge-d>;
 proposing.v: <verb-pg> & <vc-propose>;
 
 % TO+ & Xc+: allows null-infinitive: "I did not demand to"
-% <vc-trans> & QI+: "You demand this why?"
+% <vc-trans> & QN+: "You demand this why?"
 % O+ & <of-coord>: "You demanded this of him why?"
 <vc-demand>:
-  (<vc-trans> & {{Xc+} & QI+})
+  (<vc-trans> & {{Xc+} & QN+})
   or ({O+} & <of-coord>)
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & ((<to-verb> or TH+ or Z- or TS+ or ((SI*j+ or SFI**j+) & I*j+))));
@@ -5762,12 +5763,12 @@ continuing.g: (<vc-begin> & <verb-ge>) or <verb-ge-d> or <verb-adj>;
 beginning.v continuing.v ceasing.v: <verb-pg> & <vc-begin>;
 
 % <vc-trans> with particle
-% <vc-trans> & QI+: "you started this when?"
+% <vc-trans> & QN+: "you started this when?"
 <vc-start>:
-  ((({O+ or <b-minus>} & {K+ or QI+}) or
+  ((({O+ or <b-minus>} & {K+ or QN+}) or
     (K+ & {[[@MV+]]} & O*n+) or
     [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({@MV+} & ((<to-verb> & {{Xc+} & QI+}) or Pg+));
+  ({@MV+} & ((<to-verb> & {{Xc+} & QN+}) or Pg+));
 
 start.v stop.v try.v: 
   ((<verb-pl,i> & (<vc-start>)) or
@@ -6181,10 +6182,10 @@ figuring.g: (<vc-figure> & <verb-ge>) or <verb-ge-d>;
 figuring.v: <verb-pg> & <vc-figure>;
 
 % (QI+ & {MV+}): "I did not say why until recently"
-% <vc-trans> & QI+: "you said this to her where?"
+% <vc-trans> & QN+: "you said this to her where?"
 %    "you indicate this why?"
 <vc-predict>:
-  (<vc-trans> & {{Xc+} & QI+})
+  (<vc-trans> & {{Xc+} & QN+})
   or ({@MV+} & (<embed-verb> or TH+ or RSe+ or Zs- or VC+))
   or ({@MV+} & (<QI+pref> & {MV+}));
 
@@ -6333,8 +6334,8 @@ known.v well-known.v:
 knowing.g: (<vc-know> & <verb-ge>) or <verb-ge-d>;
 knowing.v: <verb-pg> & <vc-know>;
 
-% <vc-trans> & QI+: "You requested these favors why?"
-<vc-request>: (<vc-trans> & {{Xc+} & QI+}) or
+% <vc-trans> & QN+: "You requested these favors why?"
+<vc-request>: (<vc-trans> & {{Xc+} & QN+}) or
   ({@MV+} & (TH+ or <embed-verb> or RSe+ or Zs- or TS+ or ((SI*j+ or SFI**j+) & I*j+)));
 request.v: 
   ((<verb-pl,i> & (<vc-request>)) or
@@ -6409,8 +6410,8 @@ minded.v-d:
 minding.g: (<vc-mind> & <verb-ge>) or <verb-ge-d>;
 minding.v: <verb-pg> & <vc-mind>;
 
-% <verb-pv> & QI+: "Anesthesiology is studied where?"
-<vc-study>: {<vc-trans>} or ({@MV+} & <QI+pref>);
+% <verb-pv> & QN+: "Anesthesiology is studied where?"
+<vc-study>: {<vc-trans>} or ({@MV+} & <QN+pref>);
 study.v: 
   ((<verb-pl,i> & (<vc-study>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-study>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
@@ -6428,14 +6429,14 @@ studied.v-d:
   (<verb-and-sp-i-> & ([<vc-study>]0.2 or ())) or
   ((<vc-study>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>) or
-  (<verb-pv> & {QI+}) or
+  (<verb-pv> & {QN+}) or
   <verb-adj> or
   <verb-phrase-opener>;
 studying.g: (<vc-study> & <verb-ge>) or <verb-ge-d>;
 studying.v: <verb-pg> & <vc-study>;
 
 % QI+ link: "I will discuss which vitamins I take"
-% <verb-pv> & QI+: "It was discussed where?"
+% <verb-pv> & QN+: "It was discussed where?"
 <vc-discuss>: <vc-trans> or ({@MV+} & (Pg+ or QI+));
 discuss.v: 
   ((<verb-pl,i> & (<vc-discuss>)) or
@@ -6454,7 +6455,7 @@ discussed.v-d:
   (<verb-and-sp-i-> & ([<vc-discuss>]0.2 or ())) or
   ((<vc-discuss>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>)
-  or (<verb-pv> & {QI+})
+  or (<verb-pv> & {QN+})
   or <verb-adj>
   or <verb-phrase-opener>;
 discussing.g: (<vc-discuss> & <verb-ge>) or <verb-ge-d>;
@@ -6485,7 +6486,7 @@ necessitated.v-d justified.v-d risked.v-d avoided.v-d involved.v-d favored.v-d:
   (<verb-and-sp-i-> & ([<vc-oppose>]0.2 or ())) or
   ((<vc-oppose>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>) or
-  (<verb-pv> & {QI+}) or
+  (<verb-pv> & {QN+}) or
   <verb-adj> or
   <verb-phrase-opener>;
 
@@ -6519,7 +6520,7 @@ finished.v-d practiced.v-d resisted.v-d quitted.v-d:
   (<verb-and-sp-i-> & ([<vc-finish> or ({Xc+} & Pa+)]0.2 or ())) or
   ((<vc-finish> or ({Xc+} & Pa+)) & <verb-and-sp-i+>) or
   <verb-and-sp-t>)
-  or (<verb-pv> & {QI+})
+  or (<verb-pv> & {QN+})
   or <verb-adj>
   or <verb-phrase-opener>;
 quit.v-d:
@@ -6582,7 +6583,7 @@ turning.g: (<vc-turn> & <verb-ge>) or <verb-ge-d>;
 % <vc-trans> plus TI
 <vc-become>:
   ((O+ or <b-minus> or TI+ or [[@MV+ & (O*n+ or TI+)]] or Pv+) & <mv-coord>)
-   or ({@MV+} & (AF- or Pa+) & {QI+});
+   or ({@MV+} & (AF- or Pa+) & {QN+});
 become.v: 
   ((<verb-s-pl,i> & (<vc-become>)) or
   (<verb-and-sp-i-> & ([<vc-become>]0.2 or ())) or
@@ -6635,13 +6636,13 @@ remaining.v: <verb-pg> & <vc-remain>;
     or (K+ & {[[@MV+]]} & O*n+)
     or [[@MV+ & O*n+]]) & <mv-coord>);
 
-% <verb-i> & QI+: "The crime rate began to grow when?"
+% <verb-i> & QN+: "The crime rate began to grow when?"
 grow.v: 
   ((<verb-pl,i> & (<vc-grow>)) or
   ({@E-} & {([Sp-] or (Xd- & EI-))} & dWi- & (<vc-grow>) & Xc+ & SI*i+ & {Xc+} & {@MV+}) or
   ({@E-} & hXd- & dWi- & (<vc-grow>) & hXc+) or
   (<verb-and-pl-> & ((<vc-grow>) or ())) or
-  (([<vc-grow>]0.1 or [()]) & <verb-and-pl+>)) or <verb-sip> or (<verb-i> & QI+);
+  (([<vc-grow>]0.1 or [()]) & <verb-and-pl+>)) or <verb-sip> or (<verb-i> & QN+);
 grows.v: 
   ((<verb-s> & (<vc-grow>)) or
   (<verb-and-sp-i-> & ([<vc-grow>]0.2 or ())) or
@@ -6826,10 +6827,10 @@ for_granted: Vtg-;
 % VERBS TAKING [OBJ] + [OTHER COMPLEMENT]
 % basically, all these are <vc-trans> plus mess
 % I think the WR- here is dead and not used. See other WR- below
-% O+ & QI+: "You put it where?"
+% O+ & QN+: "You put it where?"
 <vc-put>:
   ((K+ & {[[@MV+]]} & O*n+) or
-  ((O+ or <b-minus>) & (K+ or Pp+ or WR- or QI+)) or
+  ((O+ or <b-minus>) & (K+ or Pp+ or WR- or QN+)) or
   (Vp+ & (Zs- or MVa+))) & <mv-coord>;
 
 
@@ -8043,7 +8044,7 @@ promising.v: <verb-pg> & <vc-promise>;
 
 % ditransitive
 <vc-show>:
-  ({O+ or <b-minus>} & ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or B-))) or
+  ({O+ or <b-minus>} & ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or B-))) or
   ((
     <vc-opt-ditrans> or
     (O+ & K+) or
@@ -8075,14 +8076,14 @@ shown.v:
   <verb-manner> or
   (<verb-s-pv-b> &
     (({O+ or K+ or B- or [[@MV+ & O*n+]]} & <mv-coord>) or
-    ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs-)))) or
-  ({O+ or K+ or [[@MV+ & O*n+]] or ({@MV+} & (QI+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
+    ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs-)))) or
+  ({O+ or K+ or [[@MV+ & O*n+]] or ({@MV+} & (QN+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
 showing.g: (<vc-show> & <verb-ge>) or <verb-ge-d>;
 showing.v: <verb-pg> & <vc-show>;
 
 % ditransitive
 <vc-teach>:
-  ((O+ or <b-minus>) & ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
+  ((O+ or <b-minus>) & ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
   or ({
     <vc-opt-ditrans>
     or (B- & {[[@MV+]]} & O*n+)
@@ -8099,7 +8100,7 @@ teaches.v:
   (<verb-and-sp-i-> & ([<vc-teach>]0.2 or ())) or
   ((<vc-teach>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
-% (<verb-sp,pp> & @MV+ & QI+): "You taught there when?"
+% (<verb-sp,pp> & @MV+ & QN+): "You taught there when?"
 taught.v-d:
   
   ((<verb-sp,pp> & (<vc-teach>)) or
@@ -8108,9 +8109,9 @@ taught.v-d:
   <verb-and-sp-t>) or
   (<verb-pv-b> &
     (({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>) or
-    ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
-  (<verb-sp,pp> & @MV+ & QI+) or
-  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QI+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
+    ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
+  (<verb-sp,pp> & @MV+ & QN+) or
+  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QN+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
 teaching.g: (<vc-teach> & <verb-ge>) or <verb-ge-d>;
 teaching.v: <verb-pg> & <vc-teach>;
 
@@ -8416,7 +8417,7 @@ convincing.v persuading.v: <verb-pg> & <vc-convince>;
 % K+ is for "tell him off"
 % bare MVp+ for "Today, we will tell about ..."
 % OF+ for "They have told of the soldiers' fear"
-% (QI+ & {MV+}): "I did not tell why until recently"
+% (QN+ & {MV+}): "I did not tell why until recently"
 % <embed-verb>: "He told me that Fred is dead."
 % {O+} & <embed-verb>: "He told me Fred is dead."
 % O+ & OF+: "tell me of that ingenious hero"
@@ -10560,6 +10561,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 who:
   (R- & (({MVp+ or MVx+} & RS+) or <porcl-verb>))
   or [QI-]
+  or QN-
   or dSJl+ or dSJr-
   or Jw-
   or ({EL+} & ((S**w+ & {Bsw+}) or (R+ & B*w+)) & {EW-} & (Ws- or Wq- or QI*d- or BIqd-))
@@ -10587,7 +10589,7 @@ what:
     & (<noun-main2-s-no-punc> or (Ss*t+ & <CLAUSE>) or SIs*t-))
   or (D+ & JQ-)
   or Jw-
-  or [QI-]0.5
+  or [QN-]0.5
   or dSJl+ or dSJr-;
 
 % [QI-]: "I do not know which"
@@ -10598,6 +10600,7 @@ which:
   or (JQ- & D+)
   or ({MVp+ or MVx+} & (S**w+ or B*w+) & ((Xc+ or <costly-null>) & Xd- & MX*r-))
   or [QI-]
+  or QN-
   or (R+ & B*w+ & (QJ+ or QJ-))
   or Jw-;
 
@@ -10693,6 +10696,7 @@ when:
   or ((<ton-verb> or <subcl-verb>) & (BIq- or QI- or (SFsx+ & <S-CLAUSE>)))
   or (Mv- & <subcl-verb>)
   or [QI-]0.5
+  or QN-
   or [dSJl+ or dSJr-]0.5
   or [dMJl+]0.5
   or ({JT-} & dMJr- & Qw+)
@@ -10755,7 +10759,7 @@ how:
   or ({EW-} & Wh- & H+)
   or ({EW-} & <clause-q> & (({EL+} & Qw+) or AF+))
   or [QI-]0.5
-  or (QI- & H+)
+  or (QN- & {H+})
   or ({EW-} & (QJ- or QJ+))
   or [dSJl+ or dSJr-]0.5
   or ((<subcl-verb> or <ton-verb>) & (QI- or BIq- or (SFsx+ & <S-CLAUSE>)));

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3992,6 +3992,7 @@ and.v-fill:
 %   "What are the chances she will really DRIVE him crazy?"
 % ({@E-} & B- & O+ & K+):
 %   "What are the chances she will DRIVE him up to the farm?"
+% QN+: you run how many miles?
 %
 <vc-run>:
   ((K+ & {[[@MV+]]} & O*n+)
@@ -3999,6 +4000,7 @@ and.v-fill:
     or ({O+ or <b-minus>} & {K+})
     or ((O+ or <b-minus>) & ({@MV+} & Pa**j+))
     or ({@E-} & <b-minus> & O+ & {Pa**j+ or K+})
+    or ({K+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3470,7 +3470,8 @@ mean.eq avg.eq avg..eq average.eq sum.eq difference.eq total.eq:
 
 % -----------------------------------------------------------
 % common intransitive verbs
-<vc-intrans>: <mv-coord>;
+% QN+: "you arrived how?"
+<vc-intrans>: <mv-coord> or QN+;
 
 % XXX Hmmm. There is a fair number of verbs in here that are "weakly"
 % transitive, i.e. are transitive in various rare usages:

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10582,7 +10582,7 @@ what:
       or Ss*w+
       or Sp*w+
       or (R+ & (Bsw+ or BW+)))
-    & {hCO-} & {EW-} & (Wb- or Wq- or Ws- or QI*d- or BIqd- or QJ+ or QJ-))
+    & {hCO-} & {EW-} & (Wb- or Wq- or Ws- or QI*d- or QN- or BIqd- or QJ+ or QJ-))
   or ({EL+} & Ww-)
   or (Wn- & O+)
   or ((Ss*d+ or (R+ & (Bsd+ or BW+)))

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -1701,6 +1701,7 @@ all_this: (<noun-rel-s> & <noun-main-s>) or <noun-and-s>;
 
 all_those all_these: [[<noun-rel-p> & <noun-main-p>]] or <noun-and-p>;
 
+% Ds*w-: "you want which one?"
 % ({Ds-} & Wa-): "That one."
 one:
   NA+ or
@@ -1711,6 +1712,7 @@ one:
     (YS+ or
     (<noun-rel-s> & (<noun-main-s> or <rel-clause-s>)) or
     <noun-and-s>))))
+  or Ds*w-
   or NIm+
   or NSn+
   or (NA- & ND+)
@@ -3664,7 +3666,9 @@ coming.v:
 % --------------------------------------------------------------
 % optionally transitive verbs
 % abdicate.v abide.v abort.v accelerate.v acclimate.v acclimatize.v
-<vc-tr,intr>: {O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>;
+<vc-tr,intr>:
+  ({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>)
+  or QN+;
 
 /en/words/words.v.2.1: 
   ((<verb-pl,i> & (<vc-tr,intr>)) or
@@ -7262,11 +7266,13 @@ refusing.v: <verb-pg> & <vc-refuse>;
 % Pa**j+: predicative adjective -- "I want it green", "I want it very shiny."
 % TO+ & Xc+: allows null-infinitive: "Because I want to."
 % intransitive: "Try it if you want"
+% QN+: "you want which one?"
 <vc-want>:
-  (<mv-coord> & ({<to-verb>} or <null-verb>)) or
-  ((O+ or <b-minus> or OX+) & <mv-coord> & {<too-verb> or Pv+ or Pa**j+}) or
-  ([[@MV+ & O*n+]]) or
-  [[CX- & <mv-coord>]];
+  (<mv-coord> & ({<to-verb>} or <null-verb>))
+  or ((O+ or <b-minus> or OX+) & <mv-coord> & {<too-verb> or Pv+ or Pa**j+})
+  or QN+
+  or [[@MV+ & O*n+]]
+  or [[CX- & <mv-coord>]];
 
 want.v:
   
@@ -10612,13 +10618,14 @@ what:
 
 % [QI-]: "I do not know which"
 % (R+ & B*w+ & (QJ+ or QJ-)): "... which to pick and which to leave behind."
+% QN- & D+: "you ate which one?"
 which:
   ((Jr- or R-) & (({MVp+ or MVx+} & RS+) or <porcl-verb>))
   or ((D**w+ or ({OF+} & (S**w+ or (R+ & B*w+)))) & {EW-} & (Wq- or Ws- or QI*d- or BIqd-))
   or (JQ- & D+)
   or ({MVp+ or MVx+} & (S**w+ or B*w+) & ((Xc+ or <costly-null>) & Xd- & MX*r-))
   or [QI-]
-  or QN-
+  or (QN- & {D+})
   or (R+ & B*w+ & (QJ+ or QJ-))
   or Jw-;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3885,9 +3885,9 @@ rising.v falling.v:
 % QN+: "you biked how many miles?"
 /en/words/words.v.6.3:
   
-  ((<verb-sp,pp> & (<vc-fill> or QN+)) or
-  (<verb-and-sp-i-> & ([<vc-fill> or QN+]0.2 or ())) or
-  ((<vc-fill> or QN+) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-fill>)) or
+  (<verb-and-sp-i-> & ([<vc-fill>]0.2 or ())) or
+  ((<vc-fill>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or
@@ -4322,10 +4322,12 @@ buttering.g:
 %    what are the chances she will TRACK him down to the farm?
 % Pa+: "he cut out after fifth period"
 % K+ & Pa+: "it washed up, unbroken"
+% QN+: "you kicked how many balls?"
 <vc-kick>:
   ((K+ & {[[@MV+]]} & O*n+)
   or ((O+ or <b-minus>) & {K+})
   or (<b-minus> & O+ & {K+})
+  or ({K+} & QN+)
   or ({K+} & {Xc+} & Pa+)
   or [[@MV+ & O*n+]]) & <mv-coord>;
 
@@ -4364,12 +4366,11 @@ forgone.v curretted.v forsworn.v oversewn.v over-eaten.v
 % this, the other half clearly should not. I'm too lazy to sort it out,
 % right now.
 % Pa+: "it washed up unbroken"
-% QN+: "you kicked how many balls?"
 /en/words/words.v.8.3:
   
-  ((<verb-sp,pp> & (<vc-kick> or QN+)) or
-  (<verb-and-sp-i-> & ([<vc-kick> or QN+]0.2 or ())) or
-  ((<vc-kick> or QN+) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-kick>)) or
+  (<verb-and-sp-i-> & ([<vc-kick>]0.2 or ())) or
+  ((<vc-kick>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3863,10 +3863,11 @@ rising.v falling.v:
 % [A+]0.5: He was xxx'ed there  should have xxx as verb not adjective.
 %
 % QN+: "you bike how many miles?"
+% O+ & QN+: "you saw it when?"
 <vc-fill>:
   ((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
     or ({O+ or <b-minus>} & {K+})
-    or ({K+} & QN+)
+    or ({O+} & {K+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 
@@ -6807,10 +6808,12 @@ reeking.g smelling.g: (<vc-smell> & <verb-ge>) or <verb-ge-d>;
 reeking.v smelling.v: <verb-pg> & <vc-smell>;
 
 % <vc-trans> plus particle and Vt
+% QN+: "you took which one?"
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>)
   or ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>})
   or (OXii+ & Vtg+ & {@MV+} & TH+)
+  or QN+
   or @MV+;
 
 % If- & WV-: "How long did it take?"

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10589,7 +10589,8 @@ what:
     & (<noun-main2-s-no-punc> or (Ss*t+ & <CLAUSE>) or SIs*t-))
   or (D+ & JQ-)
   or Jw-
-  or [QN-]0.5
+  or [QI-]0.5
+  or QN-
   or dSJl+ or dSJr-;
 
 % [QI-]: "I do not know which"

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -2585,7 +2585,10 @@ per "/.per": Us+ & Mp-;
 <verb-why>:  Qa- & <verb-wall>;
 
 % Sj- & I*j-: subject of bare infinitive: "you should hear him talk!"
-<verb-ico>:  {@E-} & ((I- & (<verb-wall> or VJrpi- or [()])) or
+% <verb-wall> or [()]0.5: This is used with <b-minus> which already
+%                         has a <verb-wall> in it (maybe) so we don't
+%                         need a second one. So don't be harsh.
+<verb-ico>:  {@E-} & ((I- & (<verb-wall> or VJrpi- or [()]0.5)) or
                       (Sj- & I*j-) or
                       <verb-why> or
                       ({(Xd- & (EI- or S**i-)) or [{Xd-} & hCO-]} & Wi- & {NM+}) or
@@ -10457,6 +10460,7 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
   ((ND- or [()] or [[EN-]]) & (Yd+ or Ya+ or EC+ or [[MVp-]] or OD-))
   or ((ND- or [()]) & Jp-)
   or (ND- & A- & D- & Jp-)
+  or (ND- & Rw+ & Bpm+) % <rel-clause-p>
   or (ND- & (NIfu+ or NItu- or EQt+ or EQt-));
 
 % AU is abbreviation for "astronomical units"

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -8083,7 +8083,7 @@ showing.v: <verb-pg> & <vc-show>;
 
 % ditransitive
 <vc-teach>:
-  ((O+ or <b-minus>) & ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
+  ((O+ or <b-minus>) & ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
   or ({
     <vc-opt-ditrans>
     or (B- & {[[@MV+]]} & O*n+)
@@ -8109,9 +8109,9 @@ taught.v-d:
   <verb-and-sp-t>) or
   (<verb-pv-b> &
     (({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>) or
-    ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
+    ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
   (<verb-sp,pp> & @MV+ & QN+) or
-  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QN+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
+  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QI+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
 teaching.g: (<vc-teach> & <verb-ge>) or <verb-ge-d>;
 teaching.v: <verb-pg> & <vc-teach>;
 

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -3857,9 +3857,11 @@ rising.v falling.v:
 %
 % [A+]0.5: He was xxx'ed there  should have xxx as verb not adjective.
 %
+% QN+: "you bike how many miles?"
 <vc-fill>:
   ((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
     or ({O+ or <b-minus>} & {K+})
+    or ({K+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 
@@ -3902,7 +3904,6 @@ split.v-d spread.v-d fit.v-d shut.v-d cast.v-d:
   or <verb-adj>
   or ({K+} & <verb-phrase-opener>);
 
-% QN+: "you ate how many cookies?"
 ate.v-d bit.v-d blew.v-d broke.v-d drank.v-d
 flew.v-d froze.v-d hid.v-d stole.v-d
 rang.v-d rode.v-d sprang.v-d stalked.v-d woke.v-d
@@ -3915,9 +3916,9 @@ deep-froze.v-d forbad.v-d deep-freezed.v-d retook.v-d interwove.v-d
 bespoke.v-d underwent.v-d slew.v-d overdrew.v-d overcame.v-d
 outwore.v-d foreknew.v-d wove.v-d trod.v-d outwent.v-d:
   
-  ((<verb-sp,pp> & (<vc-fill> or QN+)) or
-  (<verb-and-sp-i-> & ([<vc-fill> or QN+]0.2 or ())) or
-  ((<vc-fill> or QN+) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-fill>)) or
+  (<verb-and-sp-i-> & ([<vc-fill>]0.2 or ())) or
+  ((<vc-fill>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>);
 
 bitten.v blown.v broken.v drunk.v
@@ -4089,6 +4090,7 @@ running.g beating.g catching.g driving.g striking.g:
 <vc-trans>:
   (O+
    or <b-minus>
+   or QN+
    or [[@MV+ & O*n+]]
    or ({@E-} & <b-minus> & (Os+ or Op+))
   ) & <mv-coord>;

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -522,6 +522,7 @@ Hallowe'en:
     ([[AN+]]
     or ({NM+ or ({{Dmc-} & Jd-} & Dmc-)} &
       <noun-rel-p> & (<noun-main-p> or <rel-clause-p>))
+    or ND-
     or ({NM+ or Dmc-} & <noun-and-p>)
     or dSJrp-
     or (YP+ & {Dmc-})
@@ -4087,10 +4088,11 @@ running.g beating.g catching.g driving.g striking.g:
 % The (Os+ or Op+) is used to block:
 %    *This is the man we love him
 %    *I still remember the room I kissed him
+% O+ & QN+: "you hit the shot how many times?"
 <vc-trans>:
   (O+
    or <b-minus>
-   or QN+
+   or ({O+} & QN+)
    or [[@MV+ & O*n+]]
    or ({@E-} & <b-minus> & (Os+ or Op+))
   ) & <mv-coord>;
@@ -4162,13 +4164,12 @@ overran.v-d mistook.v-d underwrote.v-d:
   <verb-and-sp-t>);
 
 % I*d- & <b-minus> & O+: "how many more times did you hit her?"
-% O+ & QN+: "you hit her how many times?"
 hit.v-d misread.v-d shed.v-d rid.v-d overcome.v-d
 overrun.v-d upset.v-d undercut.v-d:
   
-  ((<verb-sp,pp> & (<vc-trans> or (O+ & QN+))) or
-  (<verb-and-sp-i-> & ([<vc-trans> or (O+ & QN+)]0.2 or ())) or
-  ((<vc-trans> or (O+ & QN+)) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-trans>)) or
+  (<verb-and-sp-i-> & ([<vc-trans>]0.2 or ())) or
+  ((<vc-trans>) & <verb-and-sp-i+>) or
   <verb-and-sp-t>)
   or (<verb-ico> & <vc-trans>)
   or ({@E-} & I*d- & <b-minus> & O+)

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -4155,12 +4155,13 @@ overran.v-d mistook.v-d underwrote.v-d:
   <verb-and-sp-t>);
 
 % I*d- & <b-minus> & O+: "how many more times did you hit her?"
+% O+ & QN+: "you hit her how many times?"
 hit.v-d misread.v-d shed.v-d rid.v-d overcome.v-d
 overrun.v-d upset.v-d undercut.v-d:
   
-  ((<verb-sp,pp> & (<vc-trans>)) or
-  (<verb-and-sp-i-> & ([<vc-trans>]0.2 or ())) or
-  ((<vc-trans>) & <verb-and-sp-i+>) or
+  ((<verb-sp,pp> & (<vc-trans> or (O+ & QN+))) or
+  (<verb-and-sp-i-> & ([<vc-trans> or (O+ & QN+)]0.2 or ())) or
+  ((<vc-trans> or (O+ & QN+)) & <verb-and-sp-i+>) or
   <verb-and-sp-t>)
   or (<verb-ico> & <vc-trans>)
   or ({@E-} & I*d- & <b-minus> & O+)

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10715,6 +10715,7 @@ why:
     ({hCO-} & {EW-} & (Ww- or Wq-) & {Qw+ or N+})
     or (Wv- & Qa+)
     or (QI- & (<subcl-verb> or <ton-verb> or [()]0.5))
+    or QN-
     or (<subcl-verb> & ((SFsx+ & <S-CLAUSE>) or WY- or BIq- or QJ+ or QJ-))
     or dCOa+
     or [dSJl+ or dSJr-]0.5
@@ -10731,6 +10732,7 @@ where:
     & (
       ({hCO-} & {EW-} & Wq- & ((Rw+ & WR+) or (R+ & Bsw+) or Qw+))
       or [QI-]0.5
+      or QN-
       or [dSJl+ or dSJr-]0.5
       or ({EW-} & (QJ- or QJ+))
       or (<subcl-verb> & Bsw+ & QI-)

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -4098,12 +4098,12 @@ running.g beating.g catching.g driving.g striking.g:
 %    *I still remember the room I kissed him
 % O+ & QN+: "you hit the shot how many times?"
 <vc-trans>:
-  (O+
+  ((O+
    or <b-minus>
-   or ({O+} & QN+)
    or [[@MV+ & O*n+]]
    or ({@E-} & <b-minus> & (Os+ or Op+))
-  ) & <mv-coord>;
+  ) & <mv-coord>)
+  or ({O+} & QN+);
 
 /en/words/words.v.4.1 : 
   ((<verb-pl,i> & (<vc-trans>)) or

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -10456,11 +10456,14 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
 % create a bunch of parses that are wrong & interfere with the below.
 % Jp-: "we walked for three kilometers"
 % ND- & A- & D- & Jp-: "we walked for a further three kilometers"
+% ND- & Rw+ & Bpm+: "how many miles did you bike?"
+% ND-: "you biked how many miles?"
 <units-funky-plural>:
   ((ND- or [()] or [[EN-]]) & (Yd+ or Ya+ or EC+ or [[MVp-]] or OD-))
   or ((ND- or [()]) & Jp-)
   or (ND- & A- & D- & Jp-)
   or (ND- & Rw+ & Bpm+) % <rel-clause-p>
+  or ND-
   or (ND- & (NIfu+ or NItu- or EQt+ or EQt-));
 
 % AU is abbreviation for "astronomical units"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3834,6 +3834,7 @@ and.v-fill:
 %   "What are the chances she will really DRIVE him crazy?"
 % ({@E-} & B- & O+ & K+):
 %   "What are the chances she will DRIVE him up to the farm?"
+% QN+: you run how many miles?
 %
 <vc-run>:
   ((K+ & {[[@MV+]]} & O*n+)
@@ -3841,6 +3842,7 @@ and.v-fill:
     or ({O+ or <b-minus>} & {K+})
     or ((O+ or <b-minus>) & ({@MV+} & Pa**j+))
     or ({@E-} & <b-minus> & O+ & {Pa**j+ or K+})
+    or ({K+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -1710,6 +1710,7 @@ all_this: (<noun-rel-s> & <noun-main-s>) or <noun-and-s>;
 
 all_those all_these: [[<noun-rel-p> & <noun-main-p>]] or <noun-and-p>;
 
+% Ds*w-: "you want which one?"
 % ({Ds-} & Wa-): "That one."
 one:
   NA+ or
@@ -1720,6 +1721,7 @@ one:
     (YS+ or
     (<noun-rel-s> & (<noun-main-s> or <rel-clause-s>)) or
     <noun-and-s>))))
+  or Ds*w-
   or NIm+
   or NSn+
   or (NA- & ND+)
@@ -3611,7 +3613,9 @@ coming.v:
 % --------------------------------------------------------------
 % optionally transitive verbs
 % abdicate.v abide.v abort.v accelerate.v acclimate.v acclimatize.v
-<vc-tr,intr>: {O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>;
+<vc-tr,intr>:
+  ({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>)
+  or QN+;
 
 /en/words/words.v.2.1: VERB_PLI(`<vc-tr,intr>');
 /en/words/words.v.2.2: VERB_S_T(`<vc-tr,intr>');
@@ -5717,11 +5721,13 @@ refusing.v: <verb-pg> & <vc-refuse>;
 % Pa**j+: predicative adjective -- "I want it green", "I want it very shiny."
 % TO+ & Xc+: allows null-infinitive: "Because I want to."
 % intransitive: "Try it if you want"
+% QN+: "you want which one?"
 <vc-want>:
-  (<mv-coord> & ({<to-verb>} or <null-verb>)) or
-  ((O+ or <b-minus> or OX+) & <mv-coord> & {<too-verb> or Pv+ or Pa**j+}) or
-  ([[@MV+ & O*n+]]) or
-  [[CX- & <mv-coord>]];
+  (<mv-coord> & ({<to-verb>} or <null-verb>))
+  or ((O+ or <b-minus> or OX+) & <mv-coord> & {<too-verb> or Pv+ or Pa**j+})
+  or QN+
+  or [[@MV+ & O*n+]]
+  or [[CX- & <mv-coord>]];
 
 want.v:
   VERB_PLI(<vc-want>);
@@ -8188,13 +8194,14 @@ what:
 
 % [QI-]: "I do not know which"
 % (R+ & B*w+ & (QJ+ or QJ-)): "... which to pick and which to leave behind."
+% QN- & D+: "you ate which one?"
 which:
   ((Jr- or R-) & (({MVp+ or MVx+} & RS+) or <porcl-verb>))
   or ((D**w+ or ({OF+} & (S**w+ or (R+ & B*w+)))) & {EW-} & (Wq- or Ws- or QI*d- or BIqd-))
   or (JQ- & D+)
   or ({MVp+ or MVx+} & (S**w+ or B*w+) & ((Xc+ or <costly-null>) & Xd- & MX*r-))
   or [QI-]
-  or QN-
+  or (QN- & {D+})
   or (R+ & B*w+ & (QJ+ or QJ-))
   or Jw-;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2512,7 +2512,7 @@ per "/.per": Us+ & Mp-;
 <mv-coord>: {@MV+} & {VC+};
 
 % <of-coord>: "You were informed of this when?"
-<of-coord>: OF+ & {{Xc+} & QI+} & <mv-coord>;
+<of-coord>: OF+ & {{Xc+} & QN+} & <mv-coord>;
 
 % When we are done, remove the option costly NULL below.
 <WALL>: hWV+ or [[()]];
@@ -2882,12 +2882,12 @@ define(`VERB_S_SPPP',`'VERB_x_T(``<verb-s-sp,pp>'',$1))
 % AUXILIARY VERBS
 
 % O+ & <verb-wall>: "did" is not an auxiliary, and so needs the wall.
-% O+ & QI+: "you did that when?"
-% QI+: "you did what?"
+% O+ & QN+: "you did that when?"
+% QN+: "you did what?"
 <vc-do>:
   ((<b-minus>
-    or (O+ & {@MV+} & <verb-wall> & {{Xc+} & QI+})
-    or ({@MV+} & <verb-wall> & QI+)
+    or (O+ & {@MV+} & <verb-wall> & {{Xc+} & QN+})
+    or ({@MV+} & <verb-wall> & QN+)
     or [[@MV+ & O*n+]]
     or Vd+
     or ({N+} & (CX- or [[()]]))) & <mv-coord>)
@@ -3587,7 +3587,7 @@ listening.v:
 
 % I*g: "Come walk with me".
 <vc-come>:
-  ({(K+ & {Pa+}) or Pv+ or [[Pg+]] or I*g+ or <b-minus> or QI+} & <mv-coord>)
+  ({(K+ & {Pa+}) or Pv+ or [[Pg+]] or I*g+ or <b-minus> or QN+} & <mv-coord>)
   or ({@MV+} & Pa+);
 come.v:
   VERB_PLI(<vc-come>)
@@ -4143,8 +4143,8 @@ endeavoured.v-d condescended.v-d deigned.v-d: VERB_SPPP_I(<vc-deign>);
 endeavouring.v condescending.v deigning.v: (<vc-deign> & <verb-pg,ge>) or
 <verb-ge-d>;
 
-% QI+ "it happened when?"
-<vc-happen>: {@MV+} & {<to-verb> or THi+ or QI+} & {VC+};
+% QN+ "it happened when?"
+<vc-happen>: {@MV+} & {<to-verb> or THi+ or QN+} & {VC+};
 
 % I*d- & <b-minus>: "how many more times will it happen"
 happen.v occur.v:
@@ -4254,6 +4254,7 @@ seeming.v: (<vc-seem> & <verb-x-pg,ge>) or <verb-ge-d>;
 % "I do not care where you put it"
 % "I wonder when he will come"
 <QI+pref>: [QI+]-0.05;
+<QN+pref>: [QN+]-0.05;
 
 <vc-care>: {@MV+} & {<to-verb> or <QI+pref>};
 care.v: VERB_PLI(<vc-care>);
@@ -4399,9 +4400,9 @@ wondering.v inquiring.v: (<vc-wonder> & <verb-pg,ge>) or <verb-ge-d>;
 % go.w: {E-} & (Wi- or S-) & I+;
 
 % B-: "which way did it go?"
-% QI+: "you will go when?"
+% QN+: "you will go when?"
 <vc-go>:
-  {K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus> or QI+} & <mv-coord>;
+  {K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus> or QN+} & <mv-coord>;
 go.v: VERB_PLI(<vc-go>);
 
 % SFs-: "There goes the cutest guy ever!", needs O*t to survive PP.
@@ -4682,10 +4683,10 @@ planned.v-d confessed.v-d:
 planning.g confessing.g: (<vc-plan> & <verb-ge>) or <verb-ge-d>;
 planning.v confessing.v: <verb-pg> & <vc-plan>;
 
-% <vc-trans> & QI+: "you decided that when?"
+% <vc-trans> & QN+: "you decided that when?"
 <vc-decide>:
-  (<vc-trans> & {{Xc+} & QI+}) or
-  ({@MV+} & {TH+ or {<QI+pref>} or
+  (<vc-trans> & {{Xc+} & QN+}) or
+  ({@MV+} & {TH+ or {<QN+pref>} or
     <to-verb> or <embed-verb> or RSe+ or Zs-});
 
 decide.v resolve.v: VERB_PLI(<vc-decide>);
@@ -4702,7 +4703,7 @@ deciding.g resolving.g: (<vc-decide> & <verb-ge>) or <verb-ge-d>;
 <vc-forget>:
   {<vc-trans>}
   or (<mv-coord> & <null-verb>)
-  or ({@MV+} & (<QI+pref> or TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or Pg+));
+  or ({@MV+} & (<QN+pref> or TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or Pg+));
 
 remember.v forget.v: VERB_PLI(<vc-forget>);
 remembers.v forgets.v: VERB_S_T(<vc-forget>);
@@ -4716,11 +4717,11 @@ forgotten.v:
 remembering.g forgetting.g: (<vc-forget> & <verb-ge>) or <verb-ge-d>;
 remembering.v forgetting.v: <verb-pg> & <vc-forget>;
 
-% OF+ & QI+: "you learned of this when?
+% OF+ & QN+: "you learned of this when?
 <vc-learn>:
   {<vc-trans>} or
   ({@MV+} & (TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or
-      <QI+pref> or (OF+ & {{Xc+} & QI+} & <mv-coord>)));
+      <QN+pref> or (OF+ & {{Xc+} & QN+} & <mv-coord>)));
 learn.v: VERB_PLI(<vc-learn>);
 learns.v: VERB_S_T(<vc-learn>);
 learned.v-d: VERB_SPPP_T(<vc-learn>) or (<verb-pv> & {THi+}) or <verb-phrase-opener>;
@@ -4732,14 +4733,14 @@ learning.v: <verb-pg> & <vc-learn>;
   <vc-trans>
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & (<to-verb> or
-    TH+ or <embed-verb> or RSe+ or QI+ or
+    TH+ or <embed-verb> or RSe+ or QN+ or
     Z- or Pg+ or TS+ or (SI*j+ & I*j+)));
 propose.v: VERB_PLI(<vc-propose>);
 proposes.v: VERB_S_T(<vc-propose>);
 
-% <vc-propose> & QI+: "You proposed this to her when?"
+% <vc-propose> & QN+: "You proposed this to her when?"
 proposed.v-d:
-  VERB_SPPP_T(<vc-propose> & {{Xc+} & QI+})
+  VERB_SPPP_T(<vc-propose> & {{Xc+} & QN+})
   or (<verb-s-pv> & {THi+ or TSi+ or Z-})
   or <verb-adj>
   or <verb-phrase-opener>;
@@ -4747,10 +4748,10 @@ proposing.g: (<vc-propose> & <verb-ge>) or <verb-ge-d>;
 proposing.v: <verb-pg> & <vc-propose>;
 
 % TO+ & Xc+: allows null-infinitive: "I did not demand to"
-% <vc-trans> & QI+: "You demand this why?"
+% <vc-trans> & QN+: "You demand this why?"
 % O+ & <of-coord>: "You demanded this of him why?"
 <vc-demand>:
-  (<vc-trans> & {{Xc+} & QI+})
+  (<vc-trans> & {{Xc+} & QN+})
   or ({O+} & <of-coord>)
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & ((<to-verb> or TH+ or Z- or TS+ or ((SI*j+ or SFI**j+) & I*j+))));
@@ -4833,12 +4834,12 @@ continuing.g: (<vc-begin> & <verb-ge>) or <verb-ge-d> or <verb-adj>;
 beginning.v continuing.v ceasing.v: <verb-pg> & <vc-begin>;
 
 % <vc-trans> with particle
-% <vc-trans> & QI+: "you started this when?"
+% <vc-trans> & QN+: "you started this when?"
 <vc-start>:
-  ((({O+ or <b-minus>} & {K+ or QI+}) or
+  ((({O+ or <b-minus>} & {K+ or QN+}) or
     (K+ & {[[@MV+]]} & O*n+) or
     [[@MV+ & O*n+]]) & <mv-coord>) or
-  ({@MV+} & ((<to-verb> & {{Xc+} & QI+}) or Pg+));
+  ({@MV+} & ((<to-verb> & {{Xc+} & QN+}) or Pg+));
 
 start.v stop.v try.v: VERB_PLI(<vc-start>);
 starts.v stops.v tries.v: VERB_S_T(<vc-start>);
@@ -5098,10 +5099,10 @@ figuring.g: (<vc-figure> & <verb-ge>) or <verb-ge-d>;
 figuring.v: <verb-pg> & <vc-figure>;
 
 % (QI+ & {MV+}): "I did not say why until recently"
-% <vc-trans> & QI+: "you said this to her where?"
+% <vc-trans> & QN+: "you said this to her where?"
 %    "you indicate this why?"
 <vc-predict>:
-  (<vc-trans> & {{Xc+} & QI+})
+  (<vc-trans> & {{Xc+} & QN+})
   or ({@MV+} & (<embed-verb> or TH+ or RSe+ or Zs- or VC+))
   or ({@MV+} & (<QI+pref> & {MV+}));
 
@@ -5200,8 +5201,8 @@ known.v well-known.v:
 knowing.g: (<vc-know> & <verb-ge>) or <verb-ge-d>;
 knowing.v: <verb-pg> & <vc-know>;
 
-% <vc-trans> & QI+: "You requested these favors why?"
-<vc-request>: (<vc-trans> & {{Xc+} & QI+}) or
+% <vc-trans> & QN+: "You requested these favors why?"
+<vc-request>: (<vc-trans> & {{Xc+} & QN+}) or
   ({@MV+} & (TH+ or <embed-verb> or RSe+ or Zs- or TS+ or ((SI*j+ or SFI**j+) & I*j+)));
 request.v: VERB_PLI(<vc-request>);
 requests.v: VERB_S_T(<vc-request>);
@@ -5237,26 +5238,26 @@ minded.v-d: VERB_SPPP_T(<vc-mind>) or <verb-pv> or <verb-phrase-opener>;
 minding.g: (<vc-mind> & <verb-ge>) or <verb-ge-d>;
 minding.v: <verb-pg> & <vc-mind>;
 
-% <verb-pv> & QI+: "Anesthesiology is studied where?"
-<vc-study>: {<vc-trans>} or ({@MV+} & <QI+pref>);
+% <verb-pv> & QN+: "Anesthesiology is studied where?"
+<vc-study>: {<vc-trans>} or ({@MV+} & <QN+pref>);
 study.v: VERB_PLI(<vc-study>);
 studies.v: VERB_S_T(<vc-study>);
 studied.v-d:
   VERB_SPPP_T(<vc-study>) or
-  (<verb-pv> & {QI+}) or
+  (<verb-pv> & {QN+}) or
   <verb-adj> or
   <verb-phrase-opener>;
 studying.g: (<vc-study> & <verb-ge>) or <verb-ge-d>;
 studying.v: <verb-pg> & <vc-study>;
 
 % QI+ link: "I will discuss which vitamins I take"
-% <verb-pv> & QI+: "It was discussed where?"
+% <verb-pv> & QN+: "It was discussed where?"
 <vc-discuss>: <vc-trans> or ({@MV+} & (Pg+ or QI+));
 discuss.v: VERB_PLI(<vc-discuss>);
 discusses.v: VERB_S_T(<vc-discuss>);
 discussed.v-d:
   VERB_SPPP_T(<vc-discuss>)
-  or (<verb-pv> & {QI+})
+  or (<verb-pv> & {QN+})
   or <verb-adj>
   or <verb-phrase-opener>;
 discussing.g: (<vc-discuss> & <verb-ge>) or <verb-ge-d>;
@@ -5274,7 +5275,7 @@ justifies.v risks.v avoids.v involves.v favors.v:
 opposed.v-d enjoyed.v-d advocated.v-d contemplated.v-d entailed.v-d
 necessitated.v-d justified.v-d risked.v-d avoided.v-d involved.v-d favored.v-d:
   VERB_SPPP_T(<vc-oppose>) or
-  (<verb-pv> & {QI+}) or
+  (<verb-pv> & {QN+}) or
   <verb-adj> or
   <verb-phrase-opener>;
 
@@ -5295,7 +5296,7 @@ finishes.v practices.v resists.v quits.v: VERB_S_T(<vc-finish>);
 % <verb-pv>: "I want it finished"
 finished.v-d practiced.v-d resisted.v-d quitted.v-d:
   VERB_SPPP_T(<vc-finish> or ({Xc+} & Pa+))
-  or (<verb-pv> & {QI+})
+  or (<verb-pv> & {QN+})
   or <verb-adj>
   or <verb-phrase-opener>;
 quit.v-d:
@@ -5336,7 +5337,7 @@ turning.g: (<vc-turn> & <verb-ge>) or <verb-ge-d>;
 % <vc-trans> plus TI
 <vc-become>:
   ((O+ or <b-minus> or TI+ or [[@MV+ & (O*n+ or TI+)]] or Pv+) & <mv-coord>)
-   or ({@MV+} & (AF- or Pa+) & {QI+});
+   or ({@MV+} & (AF- or Pa+) & {QN+});
 become.v: VERB_S_PLI(<vc-become>) or (<verb-s-pp> & <vc-become>) or <verb-pv>;
 becomes.v: VERB_S_S(<vc-become>);
 became.v-d: VERB_S_SP(<vc-become>);
@@ -5364,8 +5365,8 @@ remaining.v: <verb-pg> & <vc-remain>;
     or (K+ & {[[@MV+]]} & O*n+)
     or [[@MV+ & O*n+]]) & <mv-coord>);
 
-% <verb-i> & QI+: "The crime rate began to grow when?"
-grow.v: VERB_PLI(<vc-grow>) or <verb-sip> or (<verb-i> & QI+);
+% <verb-i> & QN+: "The crime rate began to grow when?"
+grow.v: VERB_PLI(<vc-grow>) or <verb-sip> or (<verb-i> & QN+);
 grows.v: VERB_S_T(<vc-grow>) or <verb-si>;
 grew.v-d: VERB_SP_T(<vc-grow>) or <verb-si>;
 grown.v:
@@ -5459,10 +5460,10 @@ for_granted: Vtg-;
 % VERBS TAKING [OBJ] + [OTHER COMPLEMENT]
 % basically, all these are <vc-trans> plus mess
 % I think the WR- here is dead and not used. See other WR- below
-% O+ & QI+: "You put it where?"
+% O+ & QN+: "You put it where?"
 <vc-put>:
   ((K+ & {[[@MV+]]} & O*n+) or
-  ((O+ or <b-minus>) & (K+ or Pp+ or WR- or QI+)) or
+  ((O+ or <b-minus>) & (K+ or Pp+ or WR- or QN+)) or
   (Vp+ & (Zs- or MVa+))) & <mv-coord>;
 
 
@@ -6168,7 +6169,7 @@ promising.v: <verb-pg> & <vc-promise>;
 
 % ditransitive
 <vc-show>:
-  ({O+ or <b-minus>} & ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or B-))) or
+  ({O+ or <b-minus>} & ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or B-))) or
   ((
     <vc-opt-ditrans> or
     (O+ & K+) or
@@ -6184,14 +6185,14 @@ shown.v:
   <verb-manner> or
   (<verb-s-pv-b> &
     (({O+ or K+ or B- or [[@MV+ & O*n+]]} & <mv-coord>) or
-    ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs-)))) or
-  ({O+ or K+ or [[@MV+ & O*n+]] or ({@MV+} & (QI+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
+    ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs-)))) or
+  ({O+ or K+ or [[@MV+ & O*n+]] or ({@MV+} & (QN+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
 showing.g: (<vc-show> & <verb-ge>) or <verb-ge-d>;
 showing.v: <verb-pg> & <vc-show>;
 
 % ditransitive
 <vc-teach>:
-  ((O+ or <b-minus>) & ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
+  ((O+ or <b-minus>) & ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
   or ({
     <vc-opt-ditrans>
     or (B- & {[[@MV+]]} & O*n+)
@@ -6199,14 +6200,14 @@ showing.v: <verb-pg> & <vc-show>;
 
 teach.v: VERB_PLI(<vc-teach>);
 teaches.v: VERB_S_T(<vc-teach>);
-% (<verb-sp,pp> & @MV+ & QI+): "You taught there when?"
+% (<verb-sp,pp> & @MV+ & QN+): "You taught there when?"
 taught.v-d:
   VERB_SPPP_T(<vc-teach>) or
   (<verb-pv-b> &
     (({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>) or
-    ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
-  (<verb-sp,pp> & @MV+ & QI+) or
-  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QI+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
+    ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
+  (<verb-sp,pp> & @MV+ & QN+) or
+  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QN+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
 teaching.g: (<vc-teach> & <verb-ge>) or <verb-ge-d>;
 teaching.v: <verb-pg> & <vc-teach>;
 
@@ -6397,7 +6398,7 @@ convincing.v persuading.v: <verb-pg> & <vc-convince>;
 % K+ is for "tell him off"
 % bare MVp+ for "Today, we will tell about ..."
 % OF+ for "They have told of the soldiers' fear"
-% (QI+ & {MV+}): "I did not tell why until recently"
+% (QN+ & {MV+}): "I did not tell why until recently"
 % <embed-verb>: "He told me that Fred is dead."
 % {O+} & <embed-verb>: "He told me Fred is dead."
 % O+ & OF+: "tell me of that ingenious hero"
@@ -8136,6 +8137,7 @@ tenfold a_hundredfold a_thousandfold: {EN-} & (MVp- or Em+ or EC+ or [Pa-] or A+
 who:
   (R- & (({MVp+ or MVx+} & RS+) or <porcl-verb>))
   or [QI-]
+  or QN-
   or dSJl+ or dSJr-
   or Jw-
   or ({EL+} & ((S**w+ & {Bsw+}) or (R+ & B*w+)) & {EW-} & (Ws- or Wq- or QI*d- or BIqd-))
@@ -8163,7 +8165,7 @@ what:
     & (<noun-main2-s-no-punc> or (Ss*t+ & <CLAUSE>) or SIs*t-))
   or (D+ & JQ-)
   or Jw-
-  or [QI-]0.5
+  or [QN-]0.5
   or dSJl+ or dSJr-;
 
 % [QI-]: "I do not know which"
@@ -8174,6 +8176,7 @@ which:
   or (JQ- & D+)
   or ({MVp+ or MVx+} & (S**w+ or B*w+) & ((Xc+ or <costly-null>) & Xd- & MX*r-))
   or [QI-]
+  or QN-
   or (R+ & B*w+ & (QJ+ or QJ-))
   or Jw-;
 
@@ -8269,6 +8272,7 @@ when:
   or ((<ton-verb> or <subcl-verb>) & (BIq- or QI- or (SFsx+ & <S-CLAUSE>)))
   or (Mv- & <subcl-verb>)
   or [QI-]0.5
+  or QN-
   or [dSJl+ or dSJr-]0.5
   or [dMJl+]0.5
   or ({JT-} & dMJr- & Qw+)
@@ -8331,7 +8335,7 @@ how:
   or ({EW-} & Wh- & H+)
   or ({EW-} & <clause-q> & (({EL+} & Qw+) or AF+))
   or [QI-]0.5
-  or (QI- & H+)
+  or (QN- & {H+})
   or ({EW-} & (QJ- or QJ+))
   or [dSJl+ or dSJr-]0.5
   or ((<subcl-verb> or <ton-verb>) & (QI- or BIq- or (SFsx+ & <S-CLAUSE>)));

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -531,6 +531,7 @@ Hallowe'en:
     ([[AN+]]
     or ({NM+ or ({{Dmc-} & Jd-} & Dmc-)} &
       <noun-rel-p> & (<noun-main-p> or <rel-clause-p>))
+    or ND-
     or ({NM+ or Dmc-} & <noun-and-p>)
     or dSJrp-
     or (YP+ & {Dmc-})
@@ -3901,10 +3902,11 @@ running.g beating.g catching.g driving.g striking.g:
 % The (Os+ or Op+) is used to block:
 %    *This is the man we love him
 %    *I still remember the room I kissed him
+% O+ & QN+: "you hit the shot how many times?"
 <vc-trans>:
   (O+
    or <b-minus>
-   or QN+
+   or ({O+} & QN+)
    or [[@MV+ & O*n+]]
    or ({@E-} & <b-minus> & (Os+ or Op+))
   ) & <mv-coord>;
@@ -3946,10 +3948,9 @@ overran.v-d mistook.v-d underwrote.v-d:
   VERB_SP_T(<vc-trans>);
 
 % I*d- & <b-minus> & O+: "how many more times did you hit her?"
-% O+ & QN+: "you hit her how many times?"
 hit.v-d misread.v-d shed.v-d rid.v-d overcome.v-d
 overrun.v-d upset.v-d undercut.v-d:
-  VERB_SPPP_T(<vc-trans> or (O+ & QN+))
+  VERB_SPPP_T(<vc-trans>)
   or (<verb-ico> & <vc-trans>)
   or ({@E-} & I*d- & <b-minus> & O+)
   or <verb-pv>

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3742,11 +3742,11 @@ rising.v falling.v:
 % QN+: "you bike how many miles?"
 % O+ & QN+: "you saw it when?"
 <vc-fill>:
-  ((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
+  (((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
     or ({O+ or <b-minus>} & {K+})
-    or ({O+} & {K+} & QN+)
     or [[@MV+ & O*n+]]
-  ) & <mv-coord>;
+  ) & <mv-coord>)
+  or ({O+} & {K+} & QN+);
 
 /en/words/words.v.6.1:
   VERB_PLI(<vc-fill>);
@@ -4063,12 +4063,12 @@ buttering.g:
 % K+ & Pa+: "it washed up, unbroken"
 % QN+: "you kicked how many balls?"
 <vc-kick>:
-  ((K+ & {[[@MV+]]} & O*n+)
-  or ((O+ or <b-minus>) & {K+})
-  or (<b-minus> & O+ & {K+})
-  or ({K+} & QN+)
-  or ({K+} & {Xc+} & Pa+)
-  or [[@MV+ & O*n+]]) & <mv-coord>;
+  (((K+ & {[[@MV+]]} & O*n+)
+    or ((O+ or <b-minus>) & {K+})
+    or (<b-minus> & O+ & {K+})
+    or ({K+} & {Xc+} & Pa+)
+    or [[@MV+ & O*n+]]) & <mv-coord>)
+  or ({K+} & QN+);
 
 /en/words/words.v.8.1: VERB_PLI(<vc-kick>);
 /en/words/words.v.8.2: VERB_S_T(<vc-kick>);

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3912,12 +3912,12 @@ running.g beating.g catching.g driving.g striking.g:
 %    *I still remember the room I kissed him
 % O+ & QN+: "you hit the shot how many times?"
 <vc-trans>:
-  (O+
+  ((O+
    or <b-minus>
-   or ({O+} & QN+)
    or [[@MV+ & O*n+]]
    or ({@E-} & <b-minus> & (Os+ or Op+))
-  ) & <mv-coord>;
+  ) & <mv-coord>)
+  or ({O+} & QN+);
 
 /en/words/words.v.4.1 : VERB_PLI(<vc-trans>);
 /en/words/words-medical.v.4.1: VERB_PLI(<vc-trans>);

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8158,7 +8158,7 @@ what:
       or Ss*w+
       or Sp*w+
       or (R+ & (Bsw+ or BW+)))
-    & {hCO-} & {EW-} & (Wb- or Wq- or Ws- or QI*d- or BIqd- or QJ+ or QJ-))
+    & {hCO-} & {EW-} & (Wb- or Wq- or Ws- or QI*d- or QN- or BIqd- or QJ+ or QJ-))
   or ({EL+} & Ww-)
   or (Wn- & O+)
   or ((Ss*d+ or (R+ & (Bsd+ or BW+)))

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3614,9 +3614,10 @@ coming.v:
 % --------------------------------------------------------------
 % optionally transitive verbs
 % abdicate.v abide.v abort.v accelerate.v acclimate.v acclimatize.v
+% O+ & QN+: "he anchors the bolts how?"
 <vc-tr,intr>:
   ({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>)
-  or QN+;
+  or ({O+} & QN+);
 
 /en/words/words.v.2.1: VERB_PLI(`<vc-tr,intr>');
 /en/words/words.v.2.2: VERB_S_T(`<vc-tr,intr>');
@@ -3755,7 +3756,6 @@ rising.v falling.v:
 
 % <verb-si>: "Above him hung a lamp"
 %  However, not every verb listed would be used like that.
-% QN+: "you biked how many miles?"
 /en/words/words.v.6.3:
   VERB_SPPP_T(<vc-fill>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
@@ -3840,15 +3840,15 @@ and.v-fill:
 %   "What are the chances she will really DRIVE him crazy?"
 % ({@E-} & B- & O+ & K+):
 %   "What are the chances she will DRIVE him up to the farm?"
-% QN+: you run how many miles?
-%
+% QN+: "you run how many miles?"
+% QN+ & MV+: "you ran to her, when?"
 <vc-run>:
   ((K+ & {[[@MV+]]} & O*n+)
     or Pa+
     or ({O+ or <b-minus>} & {K+})
     or ((O+ or <b-minus>) & ({@MV+} & Pa**j+))
     or ({@E-} & <b-minus> & O+ & {Pa**j+ or K+})
-    or ({K+} & QN+)
+    or ({O+} & {K+} & {@MV+} & {Xc+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 
@@ -4162,8 +4162,9 @@ endeavoured.v-d condescended.v-d deigned.v-d: VERB_SPPP_I(<vc-deign>);
 endeavouring.v condescending.v deigning.v: (<vc-deign> & <verb-pg,ge>) or
 <verb-ge-d>;
 
-% QN+ "it happened when?"
-<vc-happen>: {@MV+} & {<to-verb> or THi+ or QN+} & {VC+};
+% QN+: "it happened when?"
+% MV+ & QN+: "That happened to her, when?"
+<vc-happen>: {@MV+} & {<to-verb> or THi+ or ({Xc+} & QN+)} & {VC+};
 
 % I*d- & <b-minus>: "how many more times will it happen"
 happen.v occur.v:
@@ -4273,9 +4274,9 @@ seeming.v: (<vc-seem> & <verb-x-pg,ge>) or <verb-ge-d>;
 % "I do not care where you put it"
 % "I wonder when he will come"
 <QI+pref>: [QI+]-0.05;
-<QN+pref>: [QN+]-0.05;
+<QN+pref>: [QN+]-0.10;
 
-<vc-care>: {@MV+} & {<to-verb> or <QI+pref>};
+<vc-care>: {@MV+} & {<to-verb> or <QI+pref> or <QN+pref>};
 care.v: VERB_PLI(<vc-care>);
 cares.v: VERB_S_I(<vc-care>);
 cared.v-d: VERB_SPPP_I(<vc-care>);
@@ -4421,7 +4422,8 @@ wondering.v inquiring.v: (<vc-wonder> & <verb-pg,ge>) or <verb-ge-d>;
 % B-: "which way did it go?"
 % QN+: "you will go when?"
 <vc-go>:
-  {K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus> or QN+} & <mv-coord>;
+  ({K+ or [[{Xc+} & Pa+]] or [Pg+] or I*g+ or <b-minus>} & <mv-coord>)
+  or QN+;
 go.v: VERB_PLI(<vc-go>);
 
 % SFs-: "There goes the cutest guy ever!", needs O*t to survive PP.
@@ -4724,6 +4726,7 @@ deciding.g resolving.g: (<vc-decide> & <verb-ge>) or <verb-ge-d>;
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & (<QN+pref> or TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or Pg+));
 
+
 remember.v forget.v: VERB_PLI(<vc-forget>);
 remembers.v forgets.v: VERB_S_T(<vc-forget>);
 remembered.v-d: VERB_SPPP_T(<vc-forget>) or <verb-pv> or <verb-phrase-opener>;
@@ -4736,11 +4739,13 @@ forgotten.v:
 remembering.g forgetting.g: (<vc-forget> & <verb-ge>) or <verb-ge-d>;
 remembering.v forgetting.v: <verb-pg> & <vc-forget>;
 
-% OF+ & QN+: "you learned of this when?
+% OF+ & QN+: "you learned of this when?"
 <vc-learn>:
-  {<vc-trans>} or
-  ({@MV+} & (TH+ or <to-verb> or <embed-verb> or RSe+ or Zs- or
-      <QN+pref> or (OF+ & {{Xc+} & QN+} & <mv-coord>)));
+  {<vc-trans>}
+  or ({@MV+} & (TH+ or <to-verb> or <embed-verb> or RSe+ or Zs-
+     or <of-coord>))
+  or QN+;
+
 learn.v: VERB_PLI(<vc-learn>);
 learns.v: VERB_S_T(<vc-learn>);
 learned.v-d: VERB_SPPP_T(<vc-learn>) or (<verb-pv> & {THi+}) or <verb-phrase-opener>;
@@ -4748,12 +4753,13 @@ learning.g: (<vc-learn> & <verb-ge>) or <verb-ge-d>;
 learning.v: <verb-pg> & <vc-learn>;
 
 % TO+ & Xc+: allows null-infinitive: "I did not propose to"
+% O+ & MV+ & QN+: "You proposed to her when?"
 <vc-propose>:
   <vc-trans>
   or (<mv-coord> & <null-verb>)
-  or ({@MV+} & (<to-verb> or
-    TH+ or <embed-verb> or RSe+ or QN+ or
-    Z- or Pg+ or TS+ or (SI*j+ & I*j+)));
+  or ({@MV+} & (<to-verb>
+    or TH+ or <embed-verb> or RSe+ or QN+
+    or Z- or Pg+ or TS+ or (SI*j+ & I*j+)));
 propose.v: VERB_PLI(<vc-propose>);
 proposes.v: VERB_S_T(<vc-propose>);
 
@@ -4770,7 +4776,7 @@ proposing.v: <verb-pg> & <vc-propose>;
 % <vc-trans> & QN+: "You demand this why?"
 % O+ & <of-coord>: "You demanded this of him why?"
 <vc-demand>:
-  (<vc-trans> & {{Xc+} & QN+})
+  (<vc-trans>)
   or ({O+} & <of-coord>)
   or (<mv-coord> & <null-verb>)
   or ({@MV+} & ((<to-verb> or TH+ or Z- or TS+ or ((SI*j+ or SFI**j+) & I*j+))));
@@ -5726,10 +5732,11 @@ refusing.v: <verb-pg> & <vc-refuse>;
 % TO+ & Xc+: allows null-infinitive: "Because I want to."
 % intransitive: "Try it if you want"
 % QN+: "you want which one?"
+% O+ & QN+: "you want it when?"
 <vc-want>:
   (<mv-coord> & ({<to-verb>} or <null-verb>))
   or ((O+ or <b-minus> or OX+) & <mv-coord> & {<too-verb> or Pv+ or Pa**j+})
-  or QN+
+  or ({O+} & QN+)
   or [[@MV+ & O*n+]]
   or [[CX- & <mv-coord>]];
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3743,8 +3743,9 @@ rising.v falling.v:
 
 % <verb-si>: "Above him hung a lamp"
 %  However, not every verb listed would be used like that.
+% QN+: "you biked how many miles?"
 /en/words/words.v.6.3:
-  VERB_SPPP_T(<vc-fill>) or
+  VERB_SPPP_T(<vc-fill> or QN+) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or
   <verb-si> or
@@ -3757,6 +3758,7 @@ split.v-d spread.v-d fit.v-d shut.v-d cast.v-d:
   or <verb-adj>
   or ({K+} & <verb-phrase-opener>);
 
+% QN+: "you ate how many cookies?"
 ate.v-d bit.v-d blew.v-d broke.v-d drank.v-d
 flew.v-d froze.v-d hid.v-d stole.v-d
 rang.v-d rode.v-d sprang.v-d stalked.v-d woke.v-d
@@ -3768,7 +3770,7 @@ befell.v-d outrode.v-d betrode.v-d outdid.v-d ridded.v-d
 deep-froze.v-d forbad.v-d deep-freezed.v-d retook.v-d interwove.v-d
 bespoke.v-d underwent.v-d slew.v-d overdrew.v-d overcame.v-d
 outwore.v-d foreknew.v-d wove.v-d trod.v-d outwent.v-d:
-  VERB_SPPP_T(<vc-fill>);
+  VERB_SPPP_T(<vc-fill> or QN+);
 
 bitten.v blown.v broken.v drunk.v
 eaten.v flown.v frozen.v hidden.v ridden.v rung.v
@@ -4071,8 +4073,9 @@ forgone.v curretted.v forsworn.v oversewn.v over-eaten.v
 % this, the other half clearly should not. I'm too lazy to sort it out,
 % right now.
 % Pa+: "it washed up unbroken"
+% QN+: "you kicked how many balls?"
 /en/words/words.v.8.3:
-  VERB_SPPP_T(<vc-kick>) or
+  VERB_SPPP_T(<vc-kick> or QN+) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or
   ({K+} & <verb-phrase-opener>);

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3739,10 +3739,11 @@ rising.v falling.v:
 % [A+]0.5: He was xxx'ed there  should have xxx as verb not adjective.
 %
 % QN+: "you bike how many miles?"
+% O+ & QN+: "you saw it when?"
 <vc-fill>:
   ((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
     or ({O+ or <b-minus>} & {K+})
-    or ({K+} & QN+)
+    or ({O+} & {K+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 
@@ -5452,10 +5453,12 @@ reeking.g smelling.g: (<vc-smell> & <verb-ge>) or <verb-ge-d>;
 reeking.v smelling.v: <verb-pg> & <vc-smell>;
 
 % <vc-trans> plus particle and Vt
+% QN+: "you took which one?"
 <vc-take>:
   (((K+ & {[[@MV+]]} & O*n+) or ((O+ or <b-minus>) & {K+ or Vt+}) or [[@MV+ & O*n+]]) & <mv-coord>)
   or ({O+} & Ot+ & {@MV+} & {<tot-verb> or <toi-verb>})
   or (OXii+ & Vtg+ & {@MV+} & TH+)
+  or QN+
   or @MV+;
 
 % If- & WV-: "How long did it take?"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3751,7 +3751,7 @@ rising.v falling.v:
 %  However, not every verb listed would be used like that.
 % QN+: "you biked how many miles?"
 /en/words/words.v.6.3:
-  VERB_SPPP_T(<vc-fill> or QN+) or
+  VERB_SPPP_T(<vc-fill>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or
   <verb-si> or
@@ -4053,10 +4053,12 @@ buttering.g:
 %    what are the chances she will TRACK him down to the farm?
 % Pa+: "he cut out after fifth period"
 % K+ & Pa+: "it washed up, unbroken"
+% QN+: "you kicked how many balls?"
 <vc-kick>:
   ((K+ & {[[@MV+]]} & O*n+)
   or ((O+ or <b-minus>) & {K+})
   or (<b-minus> & O+ & {K+})
+  or ({K+} & QN+)
   or ({K+} & {Xc+} & Pa+)
   or [[@MV+ & O*n+]]) & <mv-coord>;
 
@@ -4079,9 +4081,8 @@ forgone.v curretted.v forsworn.v oversewn.v over-eaten.v
 % this, the other half clearly should not. I'm too lazy to sort it out,
 % right now.
 % Pa+: "it washed up unbroken"
-% QN+: "you kicked how many balls?"
 /en/words/words.v.8.3:
-  VERB_SPPP_T(<vc-kick> or QN+) or
+  VERB_SPPP_T(<vc-kick>) or
   (<verb-pv-b> & {K+} & <mv-coord>) or
   <verb-adj> or
   ({K+} & <verb-phrase-opener>);

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3485,7 +3485,8 @@ mean.eq avg.eq avg..eq average.eq sum.eq difference.eq total.eq:
 
 % -----------------------------------------------------------
 % common intransitive verbs
-<vc-intrans>: <mv-coord>;
+% QN+: "you arrived how?"
+<vc-intrans>: <mv-coord> or QN+;
 
 % XXX Hmmm. There is a fair number of verbs in here that are "weakly"
 % transitive, i.e. are transitive in various rare usages:

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3733,9 +3733,11 @@ rising.v falling.v:
 %
 % [A+]0.5: He was xxx'ed there  should have xxx as verb not adjective.
 %
+% QN+: "you bike how many miles?"
 <vc-fill>:
   ((K+ & {[[@MV+]]} & (O*n+ or ({Xc+} & (Pa+ or Pv+))))
     or ({O+ or <b-minus>} & {K+})
+    or ({K+} & QN+)
     or [[@MV+ & O*n+]]
   ) & <mv-coord>;
 
@@ -3761,7 +3763,6 @@ split.v-d spread.v-d fit.v-d shut.v-d cast.v-d:
   or <verb-adj>
   or ({K+} & <verb-phrase-opener>);
 
-% QN+: "you ate how many cookies?"
 ate.v-d bit.v-d blew.v-d broke.v-d drank.v-d
 flew.v-d froze.v-d hid.v-d stole.v-d
 rang.v-d rode.v-d sprang.v-d stalked.v-d woke.v-d
@@ -3773,7 +3774,7 @@ befell.v-d outrode.v-d betrode.v-d outdid.v-d ridded.v-d
 deep-froze.v-d forbad.v-d deep-freezed.v-d retook.v-d interwove.v-d
 bespoke.v-d underwent.v-d slew.v-d overdrew.v-d overcame.v-d
 outwore.v-d foreknew.v-d wove.v-d trod.v-d outwent.v-d:
-  VERB_SPPP_T(<vc-fill> or QN+);
+  VERB_SPPP_T(<vc-fill>);
 
 bitten.v blown.v broken.v drunk.v
 eaten.v flown.v frozen.v hidden.v ridden.v rung.v
@@ -3903,6 +3904,7 @@ running.g beating.g catching.g driving.g striking.g:
 <vc-trans>:
   (O+
    or <b-minus>
+   or QN+
    or [[@MV+ & O*n+]]
    or ({@E-} & <b-minus> & (Os+ or Op+))
   ) & <mv-coord>;

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -3939,9 +3939,10 @@ overran.v-d mistook.v-d underwrote.v-d:
   VERB_SP_T(<vc-trans>);
 
 % I*d- & <b-minus> & O+: "how many more times did you hit her?"
+% O+ & QN+: "you hit her how many times?"
 hit.v-d misread.v-d shed.v-d rid.v-d overcome.v-d
 overrun.v-d upset.v-d undercut.v-d:
-  VERB_SPPP_T(<vc-trans>)
+  VERB_SPPP_T(<vc-trans> or (O+ & QN+))
   or (<verb-ico> & <vc-trans>)
   or ({@E-} & I*d- & <b-minus> & O+)
   or <verb-pv>

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8291,6 +8291,7 @@ why:
     ({hCO-} & {EW-} & (Ww- or Wq-) & {Qw+ or N+})
     or (Wv- & Qa+)
     or (QI- & (<subcl-verb> or <ton-verb> or [()]0.5))
+    or QN-
     or (<subcl-verb> & ((SFsx+ & <S-CLAUSE>) or WY- or BIq- or QJ+ or QJ-))
     or dCOa+
     or [dSJl+ or dSJr-]0.5
@@ -8307,6 +8308,7 @@ where:
     & (
       ({hCO-} & {EW-} & Wq- & ((Rw+ & WR+) or (R+ & Bsw+) or Qw+))
       or [QI-]0.5
+      or QN-
       or [dSJl+ or dSJr-]0.5
       or ({EW-} & (QJ- or QJ+))
       or (<subcl-verb> & Bsw+ & QI-)

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -6192,7 +6192,7 @@ showing.v: <verb-pg> & <vc-show>;
 
 % ditransitive
 <vc-teach>:
-  ((O+ or <b-minus>) & ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
+  ((O+ or <b-minus>) & ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or B- or <too-verb>)))
   or ({
     <vc-opt-ditrans>
     or (B- & {[[@MV+]]} & O*n+)
@@ -6205,9 +6205,9 @@ taught.v-d:
   VERB_SPPP_T(<vc-teach>) or
   (<verb-pv-b> &
     (({O+ or <b-minus> or [[@MV+ & O*n+]]} & <mv-coord>) or
-    ({@MV+} & (QN+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
+    ({@MV+} & (QI+ or <embed-verb> or TH+ or RSe+ or Zs- or <to-verb>)))) or
   (<verb-sp,pp> & @MV+ & QN+) or
-  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QN+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
+  ({O+ or [[@MV+ & O*n+]] or ({@MV+} & (QI+ or <embed-verb> or TH+))} & <verb-phrase-opener>);
 teaching.g: (<vc-teach> & <verb-ge>) or <verb-ge-d>;
 teaching.v: <verb-pg> & <vc-teach>;
 

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8032,11 +8032,14 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
 % create a bunch of parses that are wrong & interfere with the below.
 % Jp-: "we walked for three kilometers"
 % ND- & A- & D- & Jp-: "we walked for a further three kilometers"
+% ND- & Rw+ & Bpm+: "how many miles did you bike?"
+% ND-: "you biked how many miles?"
 <units-funky-plural>:
   ((ND- or [()] or [[EN-]]) & (Yd+ or Ya+ or EC+ or [[MVp-]] or OD-))
   or ((ND- or [()]) & Jp-)
   or (ND- & A- & D- & Jp-)
   or (ND- & Rw+ & Bpm+) % <rel-clause-p>
+  or ND-
   or (ND- & (NIfu+ or NItu- or EQt+ or EQt-));
 
 % AU is abbreviation for "astronomical units"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -8165,7 +8165,8 @@ what:
     & (<noun-main2-s-no-punc> or (Ss*t+ & <CLAUSE>) or SIs*t-))
   or (D+ & JQ-)
   or Jw-
-  or [QN-]0.5
+  or [QI-]0.5
+  or QN-
   or dSJl+ or dSJr-;
 
 % [QI-]: "I do not know which"

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -2594,7 +2594,10 @@ per "/.per": Us+ & Mp-;
 <verb-why>:  Qa- & <verb-wall>;
 
 % Sj- & I*j-: subject of bare infinitive: "you should hear him talk!"
-<verb-ico>:  {@E-} & ((I- & (<verb-wall> or VJrpi- or [()])) or
+% <verb-wall> or [()]0.5: This is used with <b-minus> which already
+%                         has a <verb-wall> in it (maybe) so we don't
+%                         need a second one. So don't be harsh.
+<verb-ico>:  {@E-} & ((I- & (<verb-wall> or VJrpi- or [()]0.5)) or
                       (Sj- & I*j-) or
                       <verb-why> or
                       ({(Xd- & (EI- or S**i-)) or [{Xd-} & hCO-]} & Wi- & {NM+}) or
@@ -8033,6 +8036,7 @@ periods.n months.n nights.n seconds.n decades.n centuries.n:
   ((ND- or [()] or [[EN-]]) & (Yd+ or Ya+ or EC+ or [[MVp-]] or OD-))
   or ((ND- or [()]) & Jp-)
   or (ND- & A- & D- & Jp-)
+  or (ND- & Rw+ & Bpm+) % <rel-clause-p>
   or (ND- & (NIfu+ or NItu- or EQt+ or EQt-));
 
 % AU is abbreviation for "astronomical units"

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2458,7 +2458,9 @@ how many miles did you bike
 how many kilometers did you bike
 how many calories did you burn?
 you biked how many miles?
-
+you banged out how many?
+you banged out how many miles?
+you benched how many pounds?
 
 
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2463,6 +2463,8 @@ you banged out how many miles?
 you benched how many pounds?
 you hit the shot how many times?
 you kick how many goals?
+he runs how many miles?
+the machine ran out how many inches?
 
 
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2453,6 +2453,12 @@ You will go when?
 it happened when?
 it happened how many times?
 you hit her how many times?
+you ate how many cookies?
+how many miles did you bike
+how many kilometers did you bike
+how many calories did you burn?
+
+
 
 % Statements of the same form.
 I am not certain where

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2468,7 +2468,10 @@ the machine ran out how many inches?
 
 you ate which one?
 you swallowed which one?
+you took which one?
 you want which one?
+
+you saw it when?
 
 
 % Statements of the same form.

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2461,6 +2461,8 @@ you biked how many miles?
 you banged out how many?
 you banged out how many miles?
 you benched how many pounds?
+you hit the shot how many times?
+you kick how many goals?
 
 
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2450,6 +2450,8 @@ You helped her when?
 You will come when?
 You will go when?
 
+you did what with it?
+
 it happened when?
 it happened how many times?
 you hit her how many times?
@@ -2465,13 +2467,18 @@ you hit the shot how many times?
 you kick how many goals?
 he runs how many miles?
 the machine ran out how many inches?
+you ran to her, when?
+That happened to her, when?
 
 you ate which one?
 you swallowed which one?
 you took which one?
 you want which one?
-
+you want it when?
 you saw it when?
+
+he anchors the bolts how?
+he cares for you how?
 
 you arrived how?
 we travel when?

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2473,6 +2473,9 @@ you want which one?
 
 you saw it when?
 
+you arrived how?
+we travel when?
+he is travelling when?
 
 % Statements of the same form.
 I am not certain where

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2457,6 +2457,8 @@ you ate how many cookies?
 how many miles did you bike
 how many kilometers did you bike
 how many calories did you burn?
+you biked how many miles?
+
 
 
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2477,6 +2477,9 @@ you arrived how?
 we travel when?
 he is travelling when?
 
+You finally flipped out why?
+You finally flipped out, why?
+
 % Statements of the same form.
 I am not certain where
 

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2466,6 +2466,9 @@ you kick how many goals?
 he runs how many miles?
 the machine ran out how many inches?
 
+you ate which one?
+you swallowed which one?
+you want which one?
 
 
 % Statements of the same form.

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2358,10 +2358,6 @@ how many more times are you going to hit her
 how many more times did it happen?
 how many more times will it happen?
 
-% Question inversion
-it happened when?
-it happened how many times?
-
 
 Who?
 who else?
@@ -2453,6 +2449,9 @@ You helped her when?
 
 You will come when?
 You will go when?
+
+it happened when?
+it happened how many times?
 
 % Statements of the same form.
 I am not certain where

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -2452,6 +2452,7 @@ You will go when?
 
 it happened when?
 it happened how many times?
+you hit her how many times?
 
 % Statements of the same form.
 I am not certain where


### PR DESCRIPTION
Split the QI link into a QI and a QN link. QI is for indirect questions, QN is for question inversion.