### PR TITLE
link-parser.c: Don't print "No complete linkages found" in batch mode

### DIFF
--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -969,9 +969,10 @@ open_error:
 			/* Now parse with null links */
 			if (!one_step_parse && num_linkages == 0)
 			{
-				if (verbosity > 0) fprintf(stdout, "No complete linkages found.\n");
 				if (!copts->batch_mode)
 				{
+					if (verbosity > 0)
+						fprintf(stdout, "No complete linkages found.\n");
 					if (copts->allow_null)
 					{
 						/* XXX should use expanded disjunct list here too */


### PR DESCRIPTION
See issue #1236.
This bug got introduced in the panic mode timeout fixes.