### PR TITLE
Windows build break fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.10.3 (XXX 2021)
  * Remove `node.js/package-lock.json` from tarball distribution. #1251
+ * Fix Windows MSVC build break. #1253
 
 Version 5.10.2 (16 Sept 2021)
  * Fix python install path.

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -504,6 +504,11 @@ table_lookup(count_context_t *ctxt, int lw, int rw,
 	return NULL;
 }
 
+extern  count_t *
+table_lookup(count_context_t *, int, int,
+             const Connector *, const Connector *,
+             unsigned int, size_t *);
+
 /**
  * Generate a word skip vector.
  * This implements an idea similar to the Boyer-Moore algo for searches.

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -99,7 +99,7 @@ void *alloca (size_t);
 #define strcasecmp _stricmp
 #endif
 #ifndef strncasecmp
-#define strncasecmp(a,b,s) strnicmp((a),(b),(s))
+#define strncasecmp _strnicmp
 #endif
 
 #undef rand_r  /* Avoid (a bad) definition on MinGW */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -278,8 +278,8 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 #define GNUC_NORETURN
 #define NO_SAN_DICT
 
-#define likely(x)
-#define unlikely(x)
+#define likely(x) x
+#define unlikely(x) x
 #endif
 
 

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -95,9 +95,13 @@ void *alloca (size_t);
 #include <mbctype.h>
 
 /* Compatibility definitions. */
+#ifndef strcasecmp
+#define strcasecmp _stricmp
+#endif
 #ifndef strncasecmp
 #define strncasecmp(a,b,s) strnicmp((a),(b),(s))
 #endif
+
 #undef rand_r  /* Avoid (a bad) definition on MinGW */
 int rand_r(unsigned int *);
 #ifndef __MINGW32__

--- a/msvc/Python3.vcxproj
+++ b/msvc/Python3.vcxproj
@@ -24,22 +24,22 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">&lt;nul set/p x="Invoking "&amp; where.exe swig.exe
 echo on
 cd $(IntDir)
-swig.exe -python -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
+swig.exe -c++ -python -py3 -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
 %40echo off</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">&lt;nul set/p x="Invoking "&amp; where.exe swig.exe
 echo on
 cd $(IntDir)
-swig.exe -python -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
+swig.exe -c++ -python -py3 -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
 %40echo off</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">&lt;nul set/p x="Invoking "&amp; where.exe swig.exe
 echo on
 cd $(IntDir)
-swig.exe -python -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
+swig.exe -c++ -python -py3 -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
 %40echo off</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">&lt;nul set/p x="Invoking "&amp; where.exe swig.exe
 echo on
 cd $(IntDir)
-swig.exe -python -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
+swig.exe -c++ -python -py3 -outdir $(OutDir) -module clinkgrammar -I..\..\..\link-grammar -o lg_python_wrap.cpp "%(FullPath)"
 %40echo off</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Generating Python3 wrapper ^&amp; interface</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\lg_python_wrap.cpp;$(OutDir)\clinkgrammar.py</Outputs>

--- a/msvc/make-check.py
+++ b/msvc/make-check.py
@@ -80,7 +80,9 @@ def get_prop(prop, default=NODEFAULT):
 #---
 #print('Running by:', sys.executable)
 
-rundir = os.path.dirname(sys.argv[0])
+rundir = os.path.dirname(sys.argv[0]) or '.'
+if rundir == '':
+    rundir = '.'
 local_prop_file = rundir + '\\' + local_prop_file
 read_props(local_prop_file)
 
@@ -116,7 +118,7 @@ if pyscript != '':
 
 args = ''
 if len(sys.argv) >= 2:
-    args = ' '.join(sys.argv[1:])
+    args = ' '.join(sys.argv[2:])
 
 path = os.environ["PATH"]
 dllpath = get_prop('LG_DLLPATH')


### PR DESCRIPTION
Some recent modifications cause an MS-Windows build break.
(Such breaks could be avoided by adding an MSVC CI test.)

Still need fixing:
1. Subscript marks are not converted to dots in the linkages that use the next dictionary opened after generating mode is used.  This happens only in the MSVC build and I suspect a UB (detected by ZDELangTestCase).
2. 3 tests that use the SQL dict fail on the MSVC build since it is not linked with `sqlite`. I will arrange for skipping them on MSVC builds.
3. Update `msvc/README.ms`.

I am also working on adding an option to use  C++ regex. This will eliminate the painful step of installing a regex library on Windows.