### PR TITLE
SQLite-related test suite fixes

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1093,21 +1093,28 @@ class XExp_resolving_test(unittest.TestCase):
 
 # Currently, the dictionary creating function sets the generation mode if
 # the "test" parse-option has "generate" in its value list. So it must be
-# set so before the call to Dictionary(). When the second argument of
-# Sentence is evaluated, it initializes the test parse-option to a null
-# string.
+# set so before the call to Dictionary(). tearDownClass() takes care to
+# get out of generation mode.
 class YGenerationTestCase(unittest.TestCase):
     """
     Generation mode tests.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.po = ParseOptions(test='generate')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.po = ParseOptions() # Reset the "test" parse option
+        del cls.po
+
     def test_getting_linkages_file_dict(self):
-        ParseOptions(test='generate')
-        linkages = Sentence((clg.WILDCARD_WORD + ' ') * 5, Dictionary(lang='lt'), ParseOptions()).parse()
+        linkages = Sentence((clg.WILDCARD_WORD + ' ') * 5, Dictionary(lang='lt'), self.po).parse()
         self.assertTrue(len(linkages) > 0, "No linkages")
 
     def test_getting_linkages_sql_dict(self):
-        ParseOptions(test='generate')
-        linkages = Sentence((clg.WILDCARD_WORD + ' ') * 4, Dictionary(lang='demo-sql'), ParseOptions()).parse()
+        linkages = Sentence((clg.WILDCARD_WORD + ' ') * 4, Dictionary(lang='demo-sql'), self.po).parse()
         self.assertTrue(len(linkages) > 0, "No linkages")
 
 

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -111,7 +111,11 @@ Dictionary dictionary_create_lang(const char * lang)
 	/* If an sql database exists, try to read that. */
 	if (check_db(lang))
 	{
+#if HAVE_SQLITE3
 		dictionary = dictionary_create_from_db(lang);
+#else
+		return NULL;
+#endif /* HAVE_SQLITE3 */
 	}
 
 	/* Fallback to a plain-text dictionary */

--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -441,6 +441,19 @@ FILE *linkgrammar_open_data_file(const char *filename)
 
 /* ======================================================== */
 
+bool check_db(const char *lang)
+{
+	char *dbname = join_path (lang, "dict.db");
+	bool retval = file_exists(dbname);
+	free(dbname);
+#if !HAVE_SQLITE3
+	if (retval)
+		prt_error("Error: Could not open dictionary \"%s\" "
+		          "(not configured with SQLite support)\n", dbname);
+#endif /* !HAVE_SQLITE3 */
+	return retval;
+}
+
 /**
  * Check to see if a file exists.
  */

--- a/link-grammar/dict-common/file-utils.h
+++ b/link-grammar/dict-common/file-utils.h
@@ -23,6 +23,7 @@ void * object_open(const char *filename,
                    void * (*opencb)(const char *, const void *),
                    const void * user_data);
 
+bool check_db(const char *lang);
 bool file_exists(const char * dict_name);
 char * get_file_contents(const char *filename);
 char *find_last_dir_separator(char *path);

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -527,14 +527,6 @@ static void add_categories(Dictionary dict)
 /* ========================================================= */
 /* Dictionary creation, setup, open procedures */
 
-bool check_db(const char *lang)
-{
-	char *dbname = join_path (lang, "dict.db");
-	bool retval = file_exists(dbname);
-	free(dbname);
-	return retval;
-}
-
 static void* db_open(const char * fullname, const void * user_data)
 {
 	int fd;

--- a/link-grammar/dict-sql/read-sql.h
+++ b/link-grammar/dict-sql/read-sql.h
@@ -17,12 +17,7 @@
 #include "link-includes.h"
 
 #ifdef HAVE_SQLITE3
-bool check_db(const char *lang);
 Dictionary dictionary_create_from_db(const char *lang);
-#else
-
-static inline bool check_db(const char *lang) { return false; }
-static inline Dictionary dictionary_create_from_db(const char *lang) { return NULL; }
 #endif /* HAVE_SQLITE3 */
 
 #endif /* READ_SQL_H */


### PR DESCRIPTION
1.. Fix a nasty bug in `YGenerationTestCase` that happens if there is no SQLite support. Generation mode is not terminated then and the next test is done in generation mode and fails.
2. When there is no SQLite support SQL dict just cannot be opened as if they don't exist.  Make the error message clearer.
3. The MSVC build definitions don't support for now using an SQLite library. This causes the test suite to fail. Fix that by skipping tests involving an SQL dict if the library is compiled by MSVC and is not configured with SQLite.

(BTW, I didn't forget the other bugs, just had not much time recently to work on them.)