### PR TITLE
Cleanup++

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -27,7 +27,7 @@ from linkgrammar import (Sentence, Linkage, ParseOptions, Link, Dictionary,
 
 print(clg.linkgrammar_get_configuration())
 NO_SQLITE_ERROR = ''
-# USE_SQLITE is currently not use in the MSVC build.
+# USE_SQLITE is currently not used in the MSVC build.
 if re.search(r'_MSC_FULL_VER', clg.linkgrammar_get_configuration()) and \
    not re.search(r'USE_SQLITE', clg.linkgrammar_get_configuration()):
     NO_SQLITE_ERROR = 'Library is not configures with SQLite support'

--- a/configure.ac
+++ b/configure.ac
@@ -134,7 +134,7 @@ if test "$emscripten" != yes; then
 fi
 
 dnl If the visibility __attribute__  is supported, define HAVE_VISIBILITY
-dnl and a variable a CFLAG_VISIBILITY, to be added to CFLAGS/CXXFLAGS.
+dnl and a variable CFLAG_VISIBILITY, to be added to CFLAGS/CXXFLAGS.
 LG_C_ATTRIBUTE_VISIBILITY
 
 dnl Check for specific OSs

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -6666,6 +6666,13 @@ This is a TEST
 % The example for defect 28 from issue #50.
 The remarks--made off the cuff--were wrong.
 
+% Issue 404: Words that are classified by a regex (like "acheive") are
+% currently not spell-corrected.
+!spell=1
+He tried but failed to acheive his goal.
+*Therefo, I declare I love Computer Science.
+!spell=0
+
 % The very long sentences that take forever to  parse are now in the
 % file 4.0.fix-long.batch
 % --------------------------------------------------------------------

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -6009,7 +6009,7 @@ They had no sooner arrived but they turned around and left.
 % conjoined verbs
 He tried and failed.
 He tried but failed.
-He tried but failed to acheive his goal.
+He tried but failed to achieve his goal.
 
 Oscar Peterson played piano and wrote music.
 

--- a/link-grammar/README.md
+++ b/link-grammar/README.md
@@ -162,7 +162,7 @@ The result of the experiment was ultimately negative: early results
 showed that the default parser is a bit faster for short sentences
 and that the SAT solver can be faster for long sentences. Subsequent
 enhancements to the original algorithm shows that it wins in all
-situtations.  Basically, the SAT solver cannot make effective use
+situations.  Basically, the SAT solver cannot make effective use
 of the planarity constraints that the default parser leverages to
 discard impossible parses.
 
@@ -190,7 +190,7 @@ One can force the bundled version to always be used by saying:
 ./configure --enable-sat-solver=bundled
 ```
 
-Other problems with the SAT sover include:
+Other problems with the SAT solver include:
 - Disjunct cost: Cost of null expressions is disregarded. Thus, it
   still cannot rank sentences by cost, which is the most basic parse
   ranking that we've got... In order not to show incorrect costs, the

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -798,7 +798,7 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 		                                      max_cost, NULL);
 
 		unsigned int dnum0 = count_disjuncts(d);
-		d = eliminate_duplicate_disjuncts(d, NULL);
+		d = eliminate_duplicate_disjuncts(d, false);
 		unsigned int dnum1 = count_disjuncts(d);
 
 		if ((flags != NULL) && (strchr(flags, 'm') != NULL))

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1553,7 +1553,7 @@ static bool mprefix_split(Sentence sent, Gword *unsplit_word, const char *word)
  * -- if its the first word of a sentence
  * -- if its the first word following a colon, a period, a question mark,
  *    or any bullet (For example:  VII. Ancient Rome)
- * -- if its the first word following an elipsis
+ * -- if its the first word following an ellipsis
  * -- if its the first word of a quote
  *
  * XXX FIXME: These rules are rather English-centric.  Someone should

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -264,7 +264,7 @@ void dump_categories(Dictionary dict, const Category *catlist)
 	printf(TAB"\"categories\": [\n");
 	for (unsigned int n = 0; catlist[n].num_words != 0; n++)
 	{
-		printf(TAB"\{\n");
+		printf(TAB"{\n");
 		if (catlist[n].name[0] != '\0')
 			printf(TAB TAB"\"name\": %s,\n", catlist[n].name);
 		printf(TAB TAB"\"category_num\": %u,\n", n + 1);


### PR DESCRIPTION
This PR contains typo fixes.
However, while checking for typos (this time using the `codespell` command), I found the following sentence in the `corpus-fixes` batch that is not getting parsed:
`He tried but failed to acheive his goal.`
From its context, I guess this is not an intended typo. So I fixed it.
But since it demonstrates a problem in the current tokenization algo (issue #404) I also added two examples to `corpus-fixes`.
I added a FIXME in the commit because I think I know how to fix it with negligible overhead (no reparsing).
