### PR TITLE
SAT crash and doc fix

### DIFF
--- a/bindings/python-examples/parses-demo-sql.txt
+++ b/bindings/python-examples/parses-demo-sql.txt
@@ -19,6 +19,9 @@ OLEFT-WALL this.p is.v another test.n
 O
 
 -max_null_count=1
+% A hack: The SAT parser cannot parse with nulls yet,
+% so change back to classic parser.
+-use_sat=False
 IThis is a a test
 O
 O    +------WV------+----Osm----+

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -808,9 +808,10 @@ class GSQLDictTestCase(unittest.TestCase):
 
     def test_getting_links_sat(self):
         sat_po = ParseOptions(use_sat=True)
-        if sat_po.use_sat != True:
+        if not sat_po.use_sat:
             raise unittest.SkipTest("Library not configured with SAT parser")
         linkage_testfile(self, self.d, sat_po)
+
 
 class IWordPositionTestCase(unittest.TestCase):
     @classmethod

--- a/link-grammar/README.md
+++ b/link-grammar/README.md
@@ -173,6 +173,25 @@ slower, it is a **LOT** slower than the default parser. It is:
 * More than 100x slower on `corpus-fix-long.batch`.
 * 21x slower on Jane Austen's *Pride and Prejudice*.
 
+The SAT solver speed can be significantly increased by these changes:
+- Improve the XOR encoding. It has been tested, yielding a ~2x speedup for
+  long sentences.
+- Use connector sharing. This change alone has sped up the classic parser
+  on batch parsing of `data/en/corpus-fix-long.batch` by 15x, but has less
+  speedup potential for the SAT solver because it doesn't use connectors
+  when it solves the SAT equations.
+- Use the `power_prune()` function of the classic parser instead of its own
+  `power_prune()`. This needs a tricky addition to delete connectors in the
+  word expressions according the discarded disjuncts. It has been
+  tested.
+- Use "tracons". See `disjunct-utils.c` for what they are.
+- Use memory pools.
+- Improve and add hashing.
+- Improve the postprocessing efficiency. For short sentences (also in
+  the classic parser) this has a potential for maybe 10% speedup.
+  However, for getting several parsings for long sentences a huge speedup
+  is expected.
+
 The code can still be built by saying
 ```
 configure --enable-sat-solver
@@ -190,12 +209,6 @@ One can force the bundled version to always be used by saying:
 ./configure --enable-sat-solver=bundled
 ```
 
-Other problems with the SAT solver include:
-- Disjunct cost: Cost of null expressions is disregarded. Thus, it
-  still cannot rank sentences by cost, which is the most basic parse
-  ranking that we've got... In order not to show incorrect costs, the
-  DIS= field in the status message is always 0.
-- Connector order shown by the `!disjunct` link-parser command.
-  Currently it is just a "random" order.
-- Cannot parse with null links.
-- No panic timeout.
+Other problems with the SAT sover include:
+- Cannot parse with null links (can be fixed but it is not trivial).
+- No panic timeout (trivial to fix).

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -314,7 +314,8 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			ndis->num_categories = 1;
 			ndis->category[0].num = strtol(string, NULL, 16);
 			ndis->category[1].num = 0; /* API array terminator */
-			assert((ndis->category[0].num > 0) && (ndis->category[0].num < 64*1024),
+			assert(sat_solver || ((ndis->category[0].num > 0) &&
+			       (ndis->category[0].num < 64*1024)),
 			       "Insane category %u", ndis->category[0].num);
 			ndis->category[0].cost = cl->cost;
 		}

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -293,9 +293,14 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			*loc = n;         /* update the connector list */
 		}
 
+		bool sat_solver = false;
+#if USE_SAT_SOLVER
+		sat_solver = opts->use_sat_solver;
+#endif /* USE_SAT_SOLVER */
+
 		/* XXX add_category() starts category strings by ' '.
 		 * FIXME Replace it by a better indication. */
-		if (!IS_GENERATION(sent->dict) || (' ' != string[0]))
+		if (sat_solver || (!IS_GENERATION(sent->dict) || (' ' != string[0])))
 		{
 			ndis->word_string = string;
 			ndis->cost = cl->cost;


### PR DESCRIPTION
- Fix a crash caused by the generation code.
- Update the current status of the SAT-parser and how it can be sped up.

BTW, I found another bug in the SAT-parser but I still don't know how to fix it:
```
"On second thought," he said, "this is what I'm going to do".
+++++ error 89
```
```
The only thing that has prevented a collapse of the dollar so far is that it is the currency reserve of the world.
+++++ error 130
```
With `-short=16` these sentences get parsed, but not with `-short=20`.