### PR TITLE
Fix issue #1249

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1255,6 +1255,12 @@ class ZXDictDialectTestCase(unittest.TestCase):
 
 #############################################################################
 
+# Note on the linkage order of next(linkage):
+# tests.py uses add_eqcost_linkage_order(), which sorts linkages with
+# identical metrics according to their diagram character values. Thus the
+# order of linkages with the identical metrics doesn't depend on their
+# linkage order of the LG library, which may vary across releases.
+
 def linkage_testfile(self, lgdict, popt, desc=''):
     """
     Reads sentences and their corresponding
@@ -1346,6 +1352,12 @@ def linkage_testfile(self, lgdict, popt, desc=''):
         # It ends with an empty line
         elif line[0] == 'P':
             if line[1] == '\n' and len(wordpos) > 1:
+                # Spell guesses may vary between spell packages. We assume
+                # here that those that we test here always exist (and thus know
+                # their relative order) and skip the rest.
+                if '~' in wordpos or '&' in wordpos:
+                    while getwordpos(linkage) != wordpos:
+                        linkage = next(linkages, None)
                 self.assertEqual(getwordpos(linkage), wordpos, "at {}:{}".format(testfile, lineno))
                 wordpos = None
             else:

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -826,7 +826,7 @@ class IWordPositionTestCase(unittest.TestCase):
         linkage_testfile(self, self.d_en, ParseOptions(), 'pos')
 
     def test_en_spell_word_positions(self):
-        po = ParseOptions(spell_guess=1)
+        po = ParseOptions(spell_guess=99)
         if po.spell_guess == 0:
             raise unittest.SkipTest("Library is not configured with spell guess")
         linkage_testfile(self, self.d_en, po, 'pos-spell')


### PR DESCRIPTION
There were 3 problems:
1. `guess_mispelled_word()` (in `tokenize.c`) wrongly assumes the run-on word are always provided first.
When this is not the case, it can miss the run-on fix that we test.
Fix that by always using all the run-on guesses (if `use_spell_guess>0`) and only then `use_spell_guess` single-word guesses.
2. The test asks only for a single guess.
3. Fix that by asking allowing a big number of guesses (that is never reached).
3. There can be linkages with other guesses (that we cannot know in advance) before the linkage we need for our tests.
Fix that by skipping until we find the guess we check for.\\

The comments in `linkage_testfile()` explain why this (I hope) should work.