### PR TITLE
do_count() speedup

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -826,6 +826,11 @@ static count_t do_count(
 	w_count_t total = hist_zero();
 	int start_word, end_word, w;
 
+	/* This check is not necessary for correctness. It typically saves
+	 * significant CPU and Table_connector memory because in many cases a
+	 * linkage is not possible due to nearest_word restrictions. */
+	if (!valid_nearest_words(le, re, lw, rw)) return hist_zero();
+
 	if (is_panic(ctxt)) return hist_zero();
 
 	/* TODO: static_assert() that null_count is an unsigned int. */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -725,6 +725,14 @@ static count_t pseudocount(count_context_t * ctxt,
                            int lw, int rw, Connector *le, Connector *re,
                            unsigned int null_count)
 {
+	/* This check is not necessary for correctness, but it saves CPU time.
+	 * If a cross link would result, immediatly return 0. Note that there is
+	 * no need to check here if the nearest_word fields are in the range
+	 * [lw, rw] due to the way start_word/end_word are computed, and due to
+	 * nearest_word checks in form_match_list(). */
+	if ((le != NULL) && (re != NULL) && (le->nearest_word > re->nearest_word))
+		return hist_zero();
+
 	count_t *count = table_lookup(ctxt, lw, rw, le, re, null_count, NULL);
 	if (NULL == count) return count_unknown;
 	return *count;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -347,7 +347,7 @@ static void table_stat(count_context_t *ctxt)
 		{
 			assert(t->hash != 0, "Invalid hash value: 0");
 			assert((hist_total(&t->count)>=0)&&(hist_total(&t->count) <= INT_MAX),
-			       "Invalid count %lld", hist_total(&t->count));
+			       "Invalid count %"COUNT_FMT, hist_total(&t->count));
 			assert(t->l_id < (int)ctxt->sent->length ||
 			       ((t->l_id >= 255)&&(t->l_id < (int)ctxt->table_lrcnt_size[0])),
 			       "invalid l_id %d", t->l_id);
@@ -393,7 +393,7 @@ static void table_stat(count_context_t *ctxt)
 		for (unsigned int nc = 0; nc < ARRAY_SIZE(null_count); nc++)
 		{
 			if (0 != null_count[nc])
-				printf("%u: %d\n", nc, null_count[nc]);
+				printf("%u: %zu\n", nc, null_count[nc]);
 		}
 	}
 
@@ -410,8 +410,8 @@ static void table_stat(count_context_t *ctxt)
 				{
 					if (t->null_count != nc) continue;
 
-					printf("[%u]%n", i, &n);
-					printf("%*d %5d c=%lld\n",  15-n, t->l_id, t->r_id, t->count);
+					printf("[%zu]%n", i, &n);
+					printf("%*d %5d c=%"COUNT_FMT"\n",  15-n, t->l_id, t->r_id, t->count);
 				}
 			}
 		}

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -15,6 +15,7 @@
 
 #include "fast-match.h"                 // fast_matcher_t
 #include "histogram.h"                  // linkage count definitions
+#include "connectors.h"                 // Connector
 
 typedef struct count_context_s count_context_t;
 
@@ -26,4 +27,22 @@ bool no_count(count_context_t *, int, Connector *, unsigned int, unsigned int);
 
 count_context_t *alloc_count_context(Sentence, Tracon_sharing*);
 void free_count_context(count_context_t*, Sentence);
+
+/**
+ * Are the nearest_word of the end connectors in the range [lw, rw] and
+ * also don't need a link cross?
+ */
+static inline bool valid_nearest_words(const Connector *le, const Connector *re,
+                                       int lw, int rw)
+{
+	if (le != NULL)
+	{
+		if ((re != NULL) && (le->nearest_word > re->nearest_word)) return false;
+		if (le->nearest_word > rw) return false;
+	}
+	if ((re != NULL) && (re->nearest_word < lw)) return false;
+
+	return true;
+}
+
 #endif /* _COUNT_H */

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -35,12 +35,18 @@ void free_count_context(count_context_t*, Sentence);
 static inline bool valid_nearest_words(const Connector *le, const Connector *re,
                                        int lw, int rw)
 {
-	if (le != NULL)
+	int r_limit;
+
+	if (re != NULL)
 	{
-		if ((re != NULL) && (le->nearest_word > re->nearest_word)) return false;
-		if (le->nearest_word > rw) return false;
+		if (re->nearest_word < lw) return false;
+		r_limit = re->nearest_word;
 	}
-	if ((re != NULL) && (re->nearest_word < lw)) return false;
+	else
+	{
+		r_limit = rw;
+	}
+	if ((le != NULL) && (le->nearest_word > r_limit)) return false;
 
 	return true;
 }

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -37,16 +37,16 @@ static inline bool valid_nearest_words(const Connector *le, const Connector *re,
 {
 	int r_limit;
 
-	if (re != NULL)
+	if (likely(re != NULL))
 	{
-		if (re->nearest_word < lw) return false;
+		if (unlikely(re->nearest_word < lw)) return false;
 		r_limit = re->nearest_word;
 	}
 	else
 	{
 		r_limit = rw;
 	}
-	if ((le != NULL) && (le->nearest_word > r_limit)) return false;
+	if (likely(le != NULL) && unlikely(le->nearest_word > r_limit)) return false;
 
 	return true;
 }

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -354,6 +354,8 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 	Pset_bucket *xt;
 	count_t *count;
 
+	if (!valid_nearest_words(le, re, lw, rw)) return NULL;
+
 	assert(null_count < 0x7fff, "Called with null_count < 0.");
 
 	count = table_lookup(ctxt, lw, rw, le, re, null_count, NULL);


### PR DESCRIPTION
- Check at the start of  `do_count()` before anything else if the end connector's `next_word` values prevent a linkage. It saves costly table lookups.
- Implement a similar idea in `pseudocount()`. Also, see the comment there.
- Fix a problem in the table debug code due to the recent 32-bit linkage count change. The histogram code compilation that got broken by the 32-bit linkage count change is to be fixed in the next PR.

This patch saves 3%-4% on long sentences, and also (surprisingly maybe), on the `pandp-union` batch.