### PR TITLE
Fix histogram compilation break due to the 32-bit linkage-count change

### DIFF
--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -14,12 +14,12 @@
 #define _COUNT_H
 
 #include "fast-match.h"                 // fast_matcher_t
-#include "histogram.h"                  // linkage count definitions
+#include "histogram.h"                  // Count_bin
 #include "connectors.h"                 // Connector
 
 typedef struct count_context_s count_context_t;
 
-count_t *table_lookup(count_context_t *, int, int,
+Count_bin *table_lookup(count_context_t *, int, int,
                         const Connector *, const Connector *,
                         unsigned int, size_t *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -352,7 +352,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 {
 	int start_word, end_word, w;
 	Pset_bucket *xt;
-	count_t *count;
+	Count_bin *count;
 
 	if (!valid_nearest_words(le, re, lw, rw)) return NULL;
 

--- a/link-grammar/parse/histogram.c
+++ b/link-grammar/parse/histogram.c
@@ -12,7 +12,7 @@
 #include <math.h>
 #include "histogram.h"
 
-#ifdef PERFORM_COUNT_HISTOGRAMMING
+#if PERFORM_COUNT_HISTOGRAMMING
 /* A histogram distribution of the parse counts. */
 
 Count_bin hist_zero(void)

--- a/link-grammar/parse/histogram.h
+++ b/link-grammar/parse/histogram.h
@@ -17,17 +17,17 @@
 
 #define PARSE_NUM_OVERFLOW (1<<24)  // We always assume sizeof(int)>=4
 
+typedef int32_t count_t;
 typedef int64_t w_count_t;          // For overflow detection
 
 /*
  * Count Histogramming is currently not required for anything, and the
  * code runs about 6% faster when it is disabled.
- *
-#define PERFORM_COUNT_HISTOGRAMMING 1
  */
-#ifdef PERFORM_COUNT_HISTOGRAMMING
+#define PERFORM_COUNT_HISTOGRAMMING 0
 
-typedef int64_t count_t;
+#if PERFORM_COUNT_HISTOGRAMMING
+
 #define COUNT_FMT PRId64
 
 /**
@@ -42,36 +42,37 @@ typedef int64_t count_t;
  *     total == sum_i bin[i] + overrun
  */
 #define NUM_BINS 12
-struct count_t_s
+typedef struct
 {
 	short base;
-	count_t total;
-	count_t bin[NUM_BINS];
-	count_t overrun;
-};
+	w_count_t total;
+	w_count_t bin[NUM_BINS];
+	w_count_t overrun;
+} Count_bin;
 
-typedef struct count_t_s count_t;
+typedef Count_bin w_Count_bin;
 
-count_t hist_zero(void);
-count_t hist_one(void);
+Count_bin hist_zero(void);
+Count_bin hist_one(void);
 
-void hist_accum(count_t* sum, double, const count_t*);
-void hist_accumv(count_t* sum, double, const count_t);
-void hist_prod(count_t* prod, const count_t*, const count_t*);
-void hist_muladd(count_t* prod, const count_t*, double, const count_t*);
-void hist_muladdv(count_t* prod, const count_t*, double, const count_t);
+void hist_accum(Count_bin* sum, double, const Count_bin*);
+void hist_accumv(Count_bin* sum, double, const Count_bin);
+void hist_prod(Count_bin* prod, const Count_bin*, const Count_bin*);
+void hist_muladd(Count_bin* prod, const Count_bin*, double, const Count_bin*);
+void hist_muladdv(Count_bin* prod, const Count_bin*, double, const Count_bin);
 
-static inline count_t hist_total(count_t* tot) { return tot->total; }
-count_t hist_cut_total(count_t* tot, int min_total);
+static inline w_count_t hist_total(Count_bin* tot) { return tot->total; }
+w_count_t hist_cut_total(Count_bin* tot, count_t min_total);
 
-double hist_cost_cutoff(count_t*, int count);
+double hist_cost_cutoff(Count_bin*, count_t count);
 
 #else
 
 typedef int32_t count_t;
 #define COUNT_FMT PRId32
 
-typedef count_t count_t;
+typedef count_t Count_bin;
+typedef w_count_t w_Count_bin;
 
 static inline count_t hist_zero(void) { return 0; }
 static inline count_t hist_one(void) { return 1; }
@@ -84,7 +85,7 @@ static inline count_t hist_one(void) { return 1; }
 #define hist_total(tot) (*tot)
 
 #define hist_cut_total(tot, min_total) (*tot)
-static inline double hist_cost_cutoff(count_t* tot, int count) { return 1.0e38; }
+static inline double hist_cost_cutoff(count_t* tot, count_t count) { return 1.0e38; }
 
 #endif /* PERFORM_COUNT_HISTOGRAMMING */
 


### PR DESCRIPTION
BTW
- For the histogram counter, I used a 64-bit int instead of a 32-bit one, as it seems there is no need to improve the performance of the histogram code by a few percent.
- A comment in `histogram.h` says "the code runs about 6% faster when it is disabled".
However, at the time it was written it was not feasible to test it on a long sentence batch.
It turns out that now the impact on short sentences is 1%-3%, but for `fix-long` it is ~40% and for `pandp-union` it is ~25%.
I guess this is due to cache misses on the big cache memory that is needed for parsing long sentences. (I'm now working on reducing the needed parsing cache.)