### PR TITLE
Fix memory issues in `!word//`

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1299,7 +1299,7 @@ class ZZdict_display_word_expr(unittest.TestCase):
 
        out = clg.dict_display_word_expr(self.d._obj, 'a//', self.po._obj)
        self.assertIn('Token "a" disjuncts:', out)
-       self.assertIn('=  <> Ds**x+', out)
+       #self.assertRegex(out, r'a: \[\d+] \d+\.\d+\s*=  <> Ds\*\*x\+')
        self.assertIn(' a.eq ', out)
 
     def test_disjunct_macros(self):
@@ -1309,6 +1309,10 @@ class ZZdict_display_word_expr(unittest.TestCase):
        out = clg.dict_display_word_expr(self.d._obj, 'test//m', self.po._obj)
        self.assertIn('Token "test" disjuncts:', out)
        self.assertIn('<b-minus>: B*w- &', out)
+
+    def test_low_level_exp(self):
+       out = clg.dict_display_word_expr(self.d._obj, 'a/l', self.po._obj)
+       self.assertRegex(out, r'e=0[xX][0-9a-fA-F]+: CONNECTOR Ds\*\*x\+ cost=0.000')
 
 
 #############################################################################

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1249,9 +1249,67 @@ class ZRULangTestCase(unittest.TestCase):
              'облачк.=', '=а.ndnpi',
              '.', 'RIGHT-WALL'])
 
+
 class ZXDictDialectTestCase(unittest.TestCase):
     def test_dialect(self):
         linkage_testfile(self, Dictionary(lang='en'), ParseOptions(dialect='headline'), 'dialect')
+
+
+# Test for some catastrophic failures in displaying word expressions.
+# FIXME: This is a very small subset of the tests that are needed to
+# cover the correctness of dict_display_word_expr().
+class ZZdict_display_word_expr(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+       cls.d, cls.po = Dictionary(), ParseOptions()
+
+    @classmethod
+    def tearDownClass(cls):
+       del cls.d, cls.po
+
+    def test_nonexistent_word(self):
+       out = clg.dict_display_word_expr(self.d._obj, 'xxxdummy', self.po._obj)
+       self.assertIsNone(out)
+
+    def test_unsubscripted_word(self):
+       out = clg.dict_display_word_expr(self.d._obj, 'test', self.po._obj)
+       self.assertIsNotNone(out, 'Word "test" not found')
+       self.assertIn(' test.n ', out)
+
+    def test_subscripted_word(self):
+       out = clg.dict_display_word_expr(self.d._obj, 'test.v', self.po._obj)
+       self.assertIsNotNone(out, 'Word "test.v" not found')
+       self.assertIn(' test.v ', out)
+       self.assertNotIn(' test.n ', out)
+
+    def test_wildcard(self):
+       ltdict = Dictionary('lt')
+       out = clg.dict_display_word_expr(ltdict._obj, '*', self.po._obj)
+       # The output contains at least this number of non-empty lines.
+       self.assertTrue(len(list(out.splitlines())) > 1800)
+
+    def test_macros(self):
+       out = clg.dict_display_word_expr(self.d._obj, 'test/m', self.po._obj)
+       self.assertIn('<common-const-noun>:', out)
+       self.assertIn('<verb-pl,i>', out)
+
+    def test_disjuncts(self):
+       # dict_display_word_expr doesn't trigger reading the default cost_max.
+       self.po.disjunct_cost = clg.linkgrammar_get_dict_max_disjunct_cost(self.d._obj)
+
+       out = clg.dict_display_word_expr(self.d._obj, 'a//', self.po._obj)
+       self.assertIn('Token "a" disjuncts:', out)
+       self.assertIn('=  <> Ds**x+', out)
+       self.assertIn(' a.eq ', out)
+
+    def test_disjunct_macros(self):
+       self.po.disjunct_cost = clg.linkgrammar_get_dict_max_disjunct_cost(self.d._obj)
+       # Here we use the word "test" that has many disjuncts, in a try to
+       # trigger memory handling bugs, if exist.
+       out = clg.dict_display_word_expr(self.d._obj, 'test//m', self.po._obj)
+       self.assertIn('Token "test" disjuncts:', out)
+       self.assertIn('<b-minus>: B*w- &', out)
+
 
 #############################################################################
 

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -59,6 +59,8 @@
 %free_returned_value_by_free(lg_exp_stringify, char *);
 %free_returned_value_by_free(sentence_unused_disjuncts, Disjunct **);
 %free_returned_value_by_free(disjunct_expression, char *);
+%free_returned_value_by_free(dict_display_word_expr, char *);
+%free_returned_value_by_free(dict_display_word_info, char *);
 // End of functions that need free().
 
 // Reset to default.

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -639,6 +639,8 @@ static void dyn_print_disjunct_list(dyn_str *s, const Disjunct *dj,
 {
 	int djn = 0;
 	char word[MAX_WORD + 32];
+	int max_ccnt = 0;
+	int *exp_pos = NULL;
 	bool print_disjunct_address = test_enabled("disjunct-address");
 
 	for (;dj != NULL; dj=dj->next)
@@ -667,6 +669,7 @@ static void dyn_print_disjunct_list(dyn_str *s, const Disjunct *dj,
 		dyn_print_connector_list(l, dj->right, /*dir*/1, flags);
 
 		char *ls = dyn_str_take(l);
+
 		if ((NULL == select) || select(ls, criterion))
 		{
 			dyn_strcat(s, ls);
@@ -674,14 +677,19 @@ static void dyn_print_disjunct_list(dyn_str *s, const Disjunct *dj,
 
 			if ((criterion != NULL) && (criterion->exp != NULL))
 			{
-				int ccnt = 1;
+				int ccnt = 1; /* 1 for exp_pos -1 terminator. */
 				for (Connector *c = dj->left; c != NULL; c = c->next)
 					ccnt++;
 				for (Connector *c = dj->right; c != NULL; c = c->next)
 					ccnt++;
 
-				int *exp_pos = alloca(ccnt * sizeof(int));
+				if (ccnt > max_ccnt)
+				{
+					max_ccnt = (ccnt == 0) ? 32 : ccnt;
+					exp_pos = alloca(max_ccnt * sizeof(int));
+				}
 				int *i = exp_pos;
+
 				for (Connector *c = dj->left; c != NULL; c = c->next)
 					*i++ = c->exp_pos;
 				for (Connector *c = dj->right; c != NULL; c = c->next)

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -352,6 +352,7 @@ const char *exp_stringify(const Exp *n)
 	static TLS char *s;
 
 	free(s);
+	s = NULL;
 	if (n == NULL) return ("(null)");
 	s = lg_exp_stringify_with_tags(NULL, n, false);
 	return s;


### PR DESCRIPTION
Fix a "double free" problem, and also problems that are reported by ASAN/LSAN.
The repeated `alloca()` problem was "detected" by LSAN in a strange way - due to a stack overflow caused by the added LSAN stack overhead (and not by a direct detection).

I added some trivial tests for some `!word/` commands. They only check the results in a minimal way, but can still detect total failures, crashes, or memory leaks.
