### PR TITLE
Port link-generator to MS Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Version 5.10.3 (XXX 2021)
  * Fix memory leak in the "!" link-parser command. #1256
  * Add C++ regex support. It is now the default for MSVC builds. #1258
  * Fix spell-guess for run-on words. #1249
+ * Port link-generator to MS-Windows. #1269
 
 Version 5.10.2 (16 Sept 2021)
  * Fix python install path.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Tools that may need installation before you can build link-grammar:
 `autoconf`<br>
 `libtool`<br>
 `autoconf-archive`<br>
-`pkg-config`<br>
+`pkg-config` (may be named `pkgconf` or `pkgconfig`)<br>
 `pip3` (for the Python bindings)<br>
 
 Optional:<br>
@@ -470,8 +470,7 @@ It adds some verification debug code and functions that can
 pretty-print several data structures.
 
 A feature that may be useful for debugging is the word-graph
-display.  Use the `configure` option `--enable-wordgraph-display` to enable
-it. For more details on this feature, see
+display.  It is enabled by default. For more details on this feature, see
 [Word-graph display](link-grammar/tokenize/README.md#word-graph-display).
 
 
@@ -532,23 +531,7 @@ Windows systems from Vista on.
 The Cygwin way currently produces the best result, as it supports line editing
 with command completion and history and also supports word-graph displaying on
 X-windows. (MinGW currently doesn't  have `libedit`, and the MSVC port
-currently doesn't support command completion and history, spelling and
-X-Windows word-graph display.)
-
-Link-grammar requires a working version of POSIX-standard regex
-libraries.  Since these are not provided by Microsoft, a copy must
-be obtained elsewhere.  One popular choice is
-[TRE](http://gnuwin32.sourceforge.net/packages/tre.htm).
-
-Another popular choice is PCRE, 'Perl-Compatible Regular Expressions',
-available at: http://www.pcre.org/ .<br>
-For building on Windows: https://github.com/rivy/PCRE .<br>
-Another popular choice is
-[PCRE, 'Perl-Compatible Regular Expressions'](http://www.pcre.org/).<br>
-Older 32-bit binaries are at:
-http://gnuwin32.sourceforge.net/packages/regex.htm .<br>
-See also:
-http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/regex.README .
+currently doesn't support command completion and history, and also spelling.
 
 ### BUILDING on Windows (Cygwin)
 The easiest way to have link-grammar working on MS Windows is to
@@ -599,7 +582,7 @@ directory in that order, directly or under a directory names `data`:
    command, which may be a script).
 
 If link-parser cannot find the desired dictionary, use verbosity
-level 3 to debug the problem; for example:
+level 4 to debug the problem; for example:
 ```
 link-parser ru -verbosity=4
 ```

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -24,7 +24,9 @@ link_parser_LDADD = $(LIBEDIT_LIBS) $(top_builddir)/link-grammar/liblink-grammar
 
 link_generator_SOURCES = link-generator.c \
                          generator-utilities.h \
-                         generator-utilities.c
+                         generator-utilities.c \
+                         parser-utilities.h \
+                         parser-utilities.c
 
 link_generator_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/link-grammar -I$(top_srcdir)/link-grammar/dict-common
 link_generator_CFLAGS = $(WARN_CFLAGS)

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -28,7 +28,7 @@ link_generator_SOURCES = link-generator.c \
                          parser-utilities.h \
                          parser-utilities.c
 
-link_generator_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/link-grammar -I$(top_srcdir)/link-grammar/dict-common
+link_generator_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/link-grammar -I$(top_srcdir)/link-grammar/dict-common -UHAVE_EDITLINE
 link_generator_CFLAGS = $(WARN_CFLAGS)
 link_generator_LDFLAGS = $(LINK_CFLAGS)
 link_generator_LDADD = $(top_builddir)/link-grammar/liblink-grammar.la

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -445,7 +445,7 @@ void display_1line_help(const Switch *sp, bool is_completion)
 	}
 
 	int n; /* actual varname and optional varvalue print length */
-	printf("%s%s%s%n", sp->string, display_eq ? "=" : " ", value, &n);
+	n = printf("%s%s%s", sp->string, display_eq ? "=" : " ", value);
 	if (is_completion) printf("%*s", MAX(0, vnw - n), "");
 	printf("%*s- %s\n", vtw, value_type[sp->param_type], sp->description+undoc);
 }
@@ -642,8 +642,7 @@ void setup_panic_parse_options(Command_Options *copts, int sentence_length)
 
 	if (local.verbosity > 1)
 	{
-		int n = 0;
-		fprintf(stdout, "Panic mode setup: %n", &n); /* Remember alignment. */
+		int n = fprintf(stdout, "Panic mode setup: "); /* Remember alignment. */
 		fprintf(stdout,
 		        "!cost-max=%.2f !limit=%d !timeout=%d " "!spell=%d !short=%d\n"
 		        "%*s(all_short=%d min_null_count=%d max_null_count=%d)\n",

--- a/link-parser/generator-utilities.c
+++ b/link-parser/generator-utilities.c
@@ -124,9 +124,9 @@ static size_t print_several(const Category* catlist,
                             Linkage linkage, size_t nwords, const char** words,
                             bool subscript, double fraction)
 {
-	const Category_cost* cclist[nwords];
-	unsigned int cclen[nwords];
-	const char* selected_words[nwords];
+	const Category_cost* cclist[MAX_SENTENCE];
+	unsigned int cclen[MAX_SENTENCE];
+	const char* selected_words[MAX_SENTENCE];
 
 	for(WordIdx w = 0; w < nwords; w++)
 	{

--- a/link-parser/generator-utilities.h
+++ b/link-parser/generator-utilities.h
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define LINK_GRAMMAR_DLL_EXPORT 0
+#endif /* _MSC_VER */
+
 #include <dict-api.h>
 
 void dump_categories(const Dictionary, const Category *);

--- a/link-parser/generator-utilities.h
+++ b/link-parser/generator-utilities.h
@@ -7,3 +7,5 @@ size_t print_sentences(const Category*,
 
 
 extern int verbosity_level;
+
+#define MAX_SENTENCE 254

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -434,8 +434,8 @@ char *lg_readline(const char *mb_prompt)
 	free(mb_line);
 	if (byte_len == (size_t)-1)
 	{
-		printf("Error: Unable to process UTF8 in input string.\n");
-		mb_line = strdup(""); /* Just ignore it. */
+		prt_error("Error: Unable to process UTF8 in input string.\n");
+		mb_line = strdup(""); /* Just ignore the input line. */
 		return mb_line;
 	}
 	mb_line = malloc(byte_len);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -29,8 +29,6 @@
 
 #include "generator-utilities.h"
 
-#define MAX_SENTENCE 254
-
 int verbosity_level;
 
 /* Argument parsing for the generator */

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -20,6 +20,9 @@
 #include <errno.h>                      // errno
 
 #include "generator-utilities.h"
+#ifdef _MSC_VER
+#include "parser-utilities.h"
+#endif /* _MSC_VER */
 
 #include <link-includes.h>
 #include <dict-api.h>
@@ -471,6 +474,10 @@ int main (int argc, char* argv[])
 	Dictionary      dict;
 	Parse_Options   opts = parse_options_create();
 	Sentence        sent = NULL;
+
+#ifdef _WIN32
+	win32_set_utf8_output();
+#endif /* _WIN32 */
 
 	gen_parameters parms;
 	parms.language = "lt";

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -129,7 +129,7 @@ static void argp2getopt(struct argp_option *a_opt, char *g_optstring,
 		if (a->name == NULL) continue;
 
 		/* Generate long options. */
-		g_opt->name = a->name;
+		g_opt->name = (char *)a->name; /* For (char *) see commit comment. */
 		g_opt->has_arg = (a->arg == NULL) ? no_argument : required_argument;
 		g_opt->flag = NULL;
 		g_opt->val = a->key;

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -100,6 +100,11 @@ static bool end_of_argp_options(const struct argp_option *a_opt)
 	return (a_opt->name == NULL) && (a_opt->doc == NULL);
 }
 
+static bool is_short_option(const struct argp_option *a_opt)
+{
+	return (a_opt->key > 32) && (a_opt->key < 127);
+}
+
 #define ARGP_OPTION_ARRAY_SIZE (sizeof(options)/sizeof(options[0]))
 
 static struct option long_options[ARGP_OPTION_ARRAY_SIZE];
@@ -130,7 +135,7 @@ static void argp2getopt(struct argp_option *a_opt, char *g_optstring,
 		g_opt->val = a->key;
 
 		/* Generate short options. */
-		if ((a->key > 32) && (a->key < 127))
+		if (is_short_option(a))
 		{
 			*g_optstring++ = (char)a->key;
 			if (a->arg) *g_optstring++ = ':';
@@ -163,7 +168,7 @@ static void print_option_help(const struct argp_option *a_opt)
 		return;
 	}
 
-	if ((a_opt->key > 32) && (a_opt->key < 127))
+	if (is_short_option(a_opt))
 		printf("  -%c, ", a_opt->key);
 	else
 		printf("      ");
@@ -244,10 +249,8 @@ static int option_cmp(const void *a, const void *b)
 	const struct argp_option *oa = a;
 	const struct argp_option *ob = b;
 
-	int key_a = oa->key;
-	int key_b = ob->key;
-	if ((oa->key <= 32) || (oa->key >= 127)) key_a = (unsigned char)oa->name[0];
-	if ((ob->key <= 32) || (ob->key >= 127)) key_b = (unsigned char)ob->name[0];
+	int key_a = is_short_option(a) ? oa->key : (unsigned char)oa->name[0];
+	int key_b = is_short_option(b) ? ob->key : (unsigned char)ob->name[0];
 
 	return key_a - key_b;
 }

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -34,6 +34,12 @@
 
 int verbosity_level;
 
+static const char prompt[] = "linkgenerator> ";
+static const char *use_prompt(int verbosity)
+{
+	return (0 == verbosity)? "" : prompt;
+}
+
 /* Argument parsing for the generator */
 typedef struct
 {
@@ -554,15 +560,16 @@ int main (int argc, char* argv[])
 	}
 	else
 	{
-		char sbuf[1024] = { [sizeof(sbuf)-1] = 'x' };
-		char *retbuf = fgets(sbuf, sizeof(sbuf), stdin);
-		if (NULL == retbuf || sbuf[sizeof(sbuf)-1] != 'x')
-		{
-			prt_error("Fatal error: Input line too long (>%zu)\n", sizeof(sbuf)-2);
-			exit(-1);
-		}
-		sent = sentence_create(sbuf, dict);
-		printf("# Sentence template: %s\n", sbuf);
+		char sbuf[1024];
+		char *retbuf = sbuf;
+
+		int rc = get_line(use_prompt(verbosity_level), &retbuf, sizeof(sbuf),
+		                  stdin, stdout, isatty(fileno(stdin)));
+		if (rc == 0) exit(0); /* EOF. */
+		if (rc == -1) exit(-1); /* Error (get_line() issues an error message). */
+
+		sent = sentence_create(retbuf, dict);
+		printf("# Sentence template: %s\n", retbuf);
 	}
 
 	// sentence_split(sent, opts);

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -82,6 +82,10 @@ static struct argp_option
 	{"debug", 1, "debug_specification", 0, 0},
 	{"verbosity", 2, "level"},
 	{"test", 3, "test_list"},
+	{0, 0, 0, 0, "Standard options:", -1},
+	/* These options are default in argparse but are needed for getopt. */
+	{"help", '?', 0, 0, "Give this help list."},
+	{"usage",'u'+128, 0, 0, "Give a short usage message."},
 	{ 0 }
 };
 
@@ -240,12 +244,23 @@ static void getopt_parse(int ac, char *av[], struct argp_option *a_opt,
 			case 4:   parse_options_set_disjunct_cost(gp->opts, atof(optarg)); break;
 			case 5:   parse_options_set_dialect(gp->opts, optarg); break;
 
-			// Error handling.
-			case '?': prt_error("Fatal error: Unknown %s option \"%s\"\n",
-									 program_basename(av[0]), av[optind-1]);
+			// Standard GNU options.
+			case 'u'+128:
+			          usage(av[0]);
+			          exit(0);
+			case '?': if ((strncmp(av[optind-1], "--help",
+			                      strlen(av[optind-1])) == 0) ||
+			              (strcmp(av[optind-1], "-?") == 0))
+			          {
+				          help(av[0], options);
+				          exit(0);
+			          }
 
+			// Error handling.
+			          prt_error("Fatal error: Unknown %s option \"%s\"\n",
+			                    program_basename(av[0]), av[optind-1]);
 			          try_help(av[0]);
-						 exit(-1);
+			          exit(-1);
 			case ':': prt_error("Fatal error: %s: "
 			                    "Missing argument to option \"%s\"\n",
 			                    program_basename(av[0]), av[optind-1]);
@@ -279,7 +294,6 @@ int main (int argc, char* argv[])
 	Parse_Options   opts = parse_options_create();
 	Sentence        sent = NULL;
 
-	/* Process options used by GNU programs. */
 	gen_parameters parms;
 	parms.language = "lt";
 	parms.sentence_length = 6;

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -20,9 +20,7 @@
 #include <errno.h>                      // errno
 
 #include "generator-utilities.h"
-#ifdef _MSC_VER
 #include "parser-utilities.h"
-#endif /* _MSC_VER */
 
 #include <link-includes.h>
 #include <dict-api.h>
@@ -480,9 +478,7 @@ int main (int argc, char* argv[])
 	Parse_Options   opts = parse_options_create();
 	Sentence        sent = NULL;
 
-#ifdef _WIN32
-	win32_set_utf8_output();
-#endif /* _WIN32 */
+	argv = ms_windows_setup(argc);
 
 	gen_parameters parms;
 	parms.language = "lt";

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -189,8 +189,16 @@ static void usage(const char *path)
 
 static void try_help(char *path)
 {
+	/* Flag errors are printed to stderr. Arrange that the following
+	 * prt_error will be printed to stderr too. */
+	void *default_handler = lg_error_set_handler(NULL, NULL);
+	lg_error_set_handler(default_handler, (int []){0});
+
 	prt_error("Try \"%s --help\" or \"%s --usage\" for more information.\n",
 	          program_basename(path), program_basename(path));
+
+	/* Restore stdout for message levels <= lg_Debug. */
+	lg_error_set_handler(default_handler, (int []){lg_Debug});
 }
 
 static void invalid_int_value(const char *name, int value)

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -32,7 +32,7 @@
 #endif /* !getopt_long */
 #endif /* _MSC_VER */
 
-int verbosity_level;
+int verbosity_level = 1;
 
 static const char prompt[] = "linkgenerator> ";
 static const char *use_prompt(int verbosity)
@@ -506,6 +506,7 @@ int main (int argc, char* argv[])
 	{
 		srand(getpid());
 	}
+	parse_options_set_verbosity(opts, verbosity_level);
 
 	printf("#\n# Corpus for language: \"%s\"\n", parms.language);
 	if (parms.sentence_length != 0)

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -19,15 +19,12 @@
 #include <limits.h>
 #include <errno.h>                      // errno
 
-#ifdef _MSC_VER
-#define LINK_GRAMMAR_DLL_EXPORT 0
-#endif /* _MSC_VER */
+#include "generator-utilities.h"
 
 #include <link-includes.h>
 #include <dict-api.h>
 #include <dict-defines.h>               // WILDCARD_WORD
 
-#include "generator-utilities.h"
 
 int verbosity_level;
 

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -28,6 +28,11 @@
 #include <dict-api.h>
 #include <dict-defines.h>               // WILDCARD_WORD
 
+#ifdef _MSC_VER
+#ifndef getopt_long
+#define getopt_long(...) _getopt_internal(__VA_ARGS__, false)
+#endif /* !getopt_long */
+#endif /* _MSC_VER */
 
 int verbosity_level;
 

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -90,6 +90,16 @@ static struct argp_option
 	{ 0 }
 };
 
+static bool is_group_header(const struct argp_option *a_opt)
+{
+	return (a_opt->name == NULL) && (a_opt->doc != NULL);
+}
+
+static bool end_of_argp_options(const struct argp_option *a_opt)
+{
+	return (a_opt->name == NULL) && (a_opt->doc == NULL);
+}
+
 #define ARGP_OPTION_ARRAY_SIZE (sizeof(options)/sizeof(options[0]))
 
 static struct option long_options[ARGP_OPTION_ARRAY_SIZE];
@@ -104,8 +114,7 @@ static void argp2getopt(const struct argp_option *a_opt, char *g_optstring,
 {
 	*g_optstring++ = ':';
 
-	for (const struct argp_option *a = a_opt;
-	     (a->name != NULL) || (a->doc != NULL); a++)
+	for (struct argp_option *a = a_opt; !end_of_argp_options(a); a++)
 	{
 		if (a->name == NULL) continue;
 
@@ -166,11 +175,8 @@ static void help(const char *path, const struct argp_option *a_opt)
 {
 	printf("Usage: %s [OPTIONS...]\n\n", program_basename(path));
 
-	for (const struct argp_option *a = a_opt;
-	     (a->name != NULL) || (a->doc != NULL); a++)
-	{
+	for (const struct argp_option *a = a_opt; !end_of_argp_options(a); a++)
 		print_option_help(a);
-	}
 }
 
 /*

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -69,7 +69,6 @@ static struct argp_option
 	{"length", 's', "length", 0, "Sentence length. If 0 - get sentence template from stdin."},
 	{"count", 'c', "count", 0, "Count of number of sentences to generate."},
 	{"explode", 'x', 0, 0, "Generate all wording samples per linkage."},
-	{"version", 'v', 0, 0, "Print version and exit."},
 	{"disjuncts", 'd', 0, 0, "Display linkage disjuncts."},
 	{"unused", 'u', 0, 0, "Display unused disjuncts."},
 	{"leave-subscripts", '.', 0, 0, "Don't remove word subscripts."},
@@ -86,6 +85,7 @@ static struct argp_option
 	/* These options are default in argparse but are needed for getopt. */
 	{"help", '?', 0, 0, "Give this help list."},
 	{"usage",'u'+128, 0, 0, "Give a short usage message."},
+	{"version", 'v', 0, 0, "Print version and exit."},
 	{ 0 }
 };
 
@@ -238,10 +238,6 @@ static void getopt_parse(int ac, char *av[], struct argp_option *a_opt,
 			case 'w'+128:
 			          gp->walls = false; break;
 
-			case 'v': printf("Version: %s\n", linkgrammar_get_version());
-			          printf("%s\n", linkgrammar_get_configuration());
-			          exit(0);
-
 			// Library options.
 			case 1:   parse_options_set_debug(gp->opts, optarg); break;
 			case 2:   verbosity_level = atoi(optarg);
@@ -255,6 +251,9 @@ static void getopt_parse(int ac, char *av[], struct argp_option *a_opt,
 			// Standard GNU options.
 			case 'u'+128:
 			          usage(av[0]);
+			          exit(0);
+			case 'v': printf("Version: %s\n", linkgrammar_get_version());
+			          printf("%s\n", linkgrammar_get_configuration());
 			          exit(0);
 			case '?': if ((strncmp(av[optind-1], "--help",
 			                      strlen(av[optind-1])) == 0) ||

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -565,7 +565,8 @@ int main (int argc, char* argv[])
 		char *retbuf = sbuf;
 
 		int rc = get_line(use_prompt(verbosity_level), &retbuf, sizeof(sbuf),
-		                  stdin, stdout, isatty(fileno(stdin)));
+		                  stdin, stdout,
+		                  isatty(fileno(stdin)) && isatty(fileno(stdout)));
 		if (rc == 0) exit(0); /* EOF. */
 		if (rc == -1) exit(-1); /* Error (get_line() issues an error message). */
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -60,7 +60,7 @@ static int batch_errors = 0;
 static int verbosity = 0;
 static char * debug = (char *)"";
 static char * test = (char *)"";
-static bool isatty_stdin, isatty_stdout;
+static bool isatty_io; /* Both input and output are tty. */
 
 static const char prompt[] = "linkparser> ";
 static const char *use_prompt(int verbosity_level)
@@ -342,12 +342,12 @@ static const char *process_some_linkages(FILE *in, Sentence sent,
 		{
 			if (!auto_next_linkage)
 			{
-				if ((verbosity > 0) && (!copts->batch_mode) && isatty_stdin && isatty_stdout)
+				if ((verbosity > 0) && (!copts->batch_mode) && isatty_io)
 				{
 					fprintf(stdout, "Press RETURN for the next linkage.\n");
 				}
 				char *rc = fget_input_string(use_prompt(verbosity),  stdin, stdout,
-				                             isatty_stdin, /*check_return*/true);
+				                             isatty_io, /*check_return*/true);
 				if ((NULL == rc) || (*rc != '\n')) return rc;
 			}
 		}
@@ -505,8 +505,7 @@ int main(int argc, char * argv[])
 	Parse_Options   opts;
 	bool batch_in_progress = false;
 
-	isatty_stdin = isatty(fileno(stdin));
-	isatty_stdout = isatty(fileno(stdout));
+	isatty_io = isatty(fileno(stdin)) && isatty(fileno(stdout));
 
 	argv = ms_windows_setup(argc);
 
@@ -712,7 +711,8 @@ int main(int argc, char * argv[])
 		test = parse_options_get_test(opts);
 
 		input_string = fget_input_string(use_prompt(verbosity), input_fh, stdout,
-		                                 isatty_stdin, /*check_return*/false);
+
+		                                 isatty_io, /*check_return*/false);
 
 		if (NULL == input_string)
 		{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -120,7 +120,7 @@ static int get_terminal_line(char **input_string, FILE *in, FILE *out)
 	return rc;
 }
 
-static char * fget_input_string(FILE *in, FILE *out, bool check_return)
+static char *fget_input_string(FILE *in, FILE *out, bool tty, bool check_return)
 {
 	static char *pline;
 	static char input_string[MAX_INPUT_LINE];
@@ -134,7 +134,7 @@ static char * fget_input_string(FILE *in, FILE *out, bool check_return)
 	}
 	pline = input_string;
 
-	if (((in != stdin) && !check_return) || !isatty_stdin)
+	if (((in != stdin) && !check_return) || !tty)
 	{
 		/* Get input from a file. */
 		rc = fgets_with_check(input_string, MAX_INPUT_LINE, in);
@@ -405,7 +405,8 @@ static const char *process_some_linkages(FILE *in, Sentence sent,
 				{
 					fprintf(stdout, "Press RETURN for the next linkage.\n");
 				}
-				char *rc = fget_input_string(stdin, stdout, /*check_return*/true);
+				char *rc = fget_input_string(stdin, stdout, isatty_stdin,
+				                             /*check_return*/true);
 				if ((NULL == rc) || (*rc != '\n')) return rc;
 			}
 		}
@@ -769,7 +770,8 @@ int main(int argc, char * argv[])
 		debug = parse_options_get_debug(opts);
 		test = parse_options_get_test(opts);
 
-		input_string = fget_input_string(input_fh, stdout, /*check_return*/false);
+		input_string = fget_input_string(input_fh, stdout, isatty_stdin,
+		                                 /*check_return*/false);
 
 		if (NULL == input_string)
 		{

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -560,10 +560,6 @@ int main(int argc, char * argv[])
 		exit(-1);
 	}
 
-#ifdef _MSC_VER
-	_set_printf_count_output(1); /* enable %n support for display_1line_help()*/
-#endif /* _MSC_VER */
-
 	win32_set_utf8_output();
 #endif /* _WIN32 */
 

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -63,7 +63,7 @@ static char * debug = (char *)"";
 static char * test = (char *)"";
 static bool isatty_stdin, isatty_stdout;
 #ifdef _WIN32
-static bool running_under_cygwin = false;
+extern bool running_under_cygwin;
 #endif /* _WIN32 */
 
 typedef enum
@@ -544,24 +544,7 @@ int main(int argc, char * argv[])
 	isatty_stdin = isatty(fileno(stdin));
 	isatty_stdout = isatty(fileno(stdout));
 
-#ifdef _WIN32
-	/* If compiled with MSVC/MinGW, we still support running under Cygwin.
-	 * This is done by checking running_under_cygwin to resolve
-	 * incompatibilities. */
-	const char *ostype = getenv("OSTYPE");
-	if ((NULL != ostype) && (0 == strcmp(ostype, "cygwin")))
-		running_under_cygwin = true;
-
-	/* argv encoding is in the current locale. */
-	argv = argv2utf8(argc);
-	if (NULL == argv)
-	{
-		prt_error("Fatal error: Unable to parse command line\n");
-		exit(-1);
-	}
-
-	win32_set_utf8_output();
-#endif /* _WIN32 */
+	argv = ms_windows_setup(argc);
 
 	if ((argc > 1) && (argv[1][0] != '-')) {
 		/* The dictionary is the first argument if it doesn't begin with "-" */

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -177,7 +177,6 @@ int get_console_line(char *inbuf, int inbuf_size)
 	return 1;
 }
 
-
 static int console_input_cp;
 static int console_output_cp;
 static void restore_console_cp(void)
@@ -222,13 +221,13 @@ static void win32_set_utf8_output(void)
 	if (!SetConsoleCP(CP_UTF8))
 	{
 		prt_error("Warning: Cannot set input codepage %d (error %d).\n",
-			CP_UTF8, (int)GetLastError());
+			CP_UTF8, GetLastError());
 	}
 	/* For Console output. */
 	if (!SetConsoleOutputCP(CP_UTF8))
 	{
 		prt_error("Warning: Cannot set output codepage %d (error %d).\n",
-			CP_UTF8, (int)GetLastError());
+			CP_UTF8, GetLastError());
 	}
 }
 
@@ -275,7 +274,7 @@ int lg_isatty(int fd)
 
 	if (!GetFileInformationByHandleEx(fh, FileNameInfo, pfni, sizeof(buf)))
 	{
-		printf("GetFileInformationByHandleEx: Error %d\n", (int)GetLastError());
+		printf("GetFileInformationByHandleEx: Error %d\n", GetLastError());
 		goto no_tty;
 	}
 
@@ -338,12 +337,11 @@ static char **argv2utf8(int argc)
 		if (0 == n)
 		{
 			prt_error("Error: WideCharToMultiByte CP_UTF8 failed: Error %d.\n",
-			         (int)GetLastError());
+			         GetLastError());
 			return NULL;
 		}
 	}
 	LocalFree(warglist);
-
 
 	utf8_argv = nargv;
 	utf8_argc = argc;

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -37,6 +37,7 @@
 #include <string.h>
 
 #include "parser-utilities.h"
+#include "lg_readline.h"
 
 /**
  * Expand an initial '~' to home directory.
@@ -374,24 +375,91 @@ char **ms_windows_setup(int argc)
 
 	return argv;
 }
-
-char *get_utf8_line(char *input_string, int max_input_line, FILE *in)
-{
-	char *pline;
-
-	if (!running_under_cygwin)
-		pline = get_console_line();
-	else
-		pline = fgets(input_string, max_input_line, in);
-
-	return pline;
-}
-#else
-char *get_utf8_line(char *input_string, int max_input_line, FILE *in)
-{
-	return fgets(input_string, max_input_line, in);
-}
 #endif /* _WIN32 */
+
+/*
+ * @return -1: error; 0: EOF; 1: Success.
+ */
+static int fgets_with_check(char *inbuf, unsigned int inbuf_size, FILE *fh)
+{
+	const char *rc = fgets(inbuf, inbuf_size, fh);
+	if (rc == NULL)
+	{
+		/* EOF or error */
+		if (!ferror(fh)) return 0;
+		snprintf(inbuf, inbuf_size, "fgets(): %s", strerror(errno));
+		return -1;
+	}
+
+	size_t len = strlen(inbuf);
+	if ((len == inbuf_size -1) && inbuf[len -2] != '\n')
+	{
+		snprintf(inbuf, inbuf_size, "Input line too long (>%u).", inbuf_size-2);
+		return -1;
+	}
+
+	return 1;
+}
+
+static int get_terminal_line(const char *uprompt, char **buf,
+                             unsigned int bufsize, FILE *in, FILE *out, bool tty)
+{
+	int rc;
+
+#ifdef HAVE_EDITLINE
+	*buf = lg_readline(uprompt);
+	rc = (*buf != NULL);
+#else
+	fprintf(out, "%s", uprompt);
+	fflush(out);
+#ifdef _WIN32
+	if (!running_under_cygwin || tty)
+	{
+		rc = get_console_line(*buf, bufsize);
+	}
+	else
+#endif /* _WIN32 */
+	{
+		rc = fgets_with_check(*buf, bufsize, in);
+	}
+#endif /* HAVE_EDITLINE */
+
+	return rc;
+}
+
+/*
+ * Get an input line. Notify errors.
+ *
+ * @param in: Input file handle.
+ * @param out: Output file handle.
+ * @param tty \c false: from file; \c true: from terminal.
+ * @return \c true if successful, \c false on error.
+ */
+bool get_line(const char *uprompt, char **buf, unsigned int bufsize,
+                     FILE *in, FILE *out, bool tty)
+{
+	int rc;
+
+	if ((in != stdin) || !tty)
+	{
+		/* Get input from a file. */
+		rc = fgets_with_check(*buf, bufsize, in);
+	}
+	else
+	{
+		/* If we are here, the input is from a terminal. */
+		rc = get_terminal_line(uprompt, buf, bufsize, in, out, tty);
+	}
+
+	if (rc == 0) return false; /* EOF */
+	if (rc == -1)
+	{
+		prt_error("Fatal error: %s\n", *buf);
+		return false;
+	}
+
+	return true;
+}
 
 static unsigned int screen_width = INITIAL_SCREEN_WIDTH;
 /**

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -36,10 +36,12 @@ typedef SSIZE_T ssize_t;
 #endif
 
 char *get_console_line(void);
-void win32_set_utf8_output(void);
-char **argv2utf8(int);
+char **ms_windows_setup(int);
 int lg_isatty(int);
 #define isatty lg_isatty
+#else /* !_WIN32 */
+#define ms_windows_setup(argc) (argv)
 #endif /* _WIN32 */
 
+char *get_utf8_line(char *, int, FILE *);
 #endif // _PARSER_UTILITIES_

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -43,5 +43,5 @@ int lg_isatty(int);
 #define ms_windows_setup(argc) (argv)
 #endif /* _WIN32 */
 
-char *get_utf8_line(char *, int, FILE *);
+bool get_line(const char *, char **, unsigned int, FILE *, FILE *, bool);
 #endif // _PARSER_UTILITIES_

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -35,8 +35,8 @@ typedef SSIZE_T ssize_t;
 #define strncasecmp _strnicmp
 #endif
 
-char *get_console_line(void);
 char **ms_windows_setup(int);
+int get_console_line(char *inbuf, int inbuf_size);
 int lg_isatty(int);
 #define isatty lg_isatty
 #else /* !_WIN32 */

--- a/man/link-generator.1
+++ b/man/link-generator.1
@@ -62,7 +62,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH LINK-PARSER 1 "2021-03-30" "Version 5.9.0"
+.TH LINK-GENERATOR 1 "2021-03-30" "Version 5.9.0"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -129,15 +129,21 @@ Print usage and exit.
 Print program version and configuration details, and exit.
 .TP
 .B \-\-usage
-Print a short synposis of the option flags.
+Print a short synopsis of the option flags.
 .TP
 .B \-l\fR language|dict_location, \fB\-\-language\fR=language|dict_location
 Specify the language to use, or the directory file-path to the
 dictionary to use.
 .TP
 .B \-s\fR length, \fB\-\-length\fR=length
-Specify the length of the sentences to generate. All generated
+If \fBlength\fR is 0, read a sentence template. It may consist of fully
+spelled-out words as well as wild-cards. The wild-card \fB\\*\fR represents any
+dictionary word. Wild-card specifications like \fIprefix\fR\fB\\*\fR and
+\fB\\*.n\fR are also recognized.
+
+Otherwise, it specifies the length of the sentences to generate. All generated
 sentences will have exactly this length.
+
 .TP
 .B \-c\fR count, \fB\-\-count\fR=count
 Specify the number of sentences to generate. If this number is less

--- a/msvc/.gitignore
+++ b/msvc/.gitignore
@@ -6,10 +6,11 @@ Debug
 ~AutoRecover.*
 .vs
 
-# This file is created by post-build.bat as part of the MSVC build,
-# to be used by the user for invoking the link-parser binary with the
-# required environment variables.
+# These files is created by post-build.bat as part of the MSVC build,
+# to be used by the user for invoking the link-parser/link-generator binaries
+with the required environment variables.
 link-parser.bat
+link-generator.bat
 
 # The *.user project files are for the sole use of the user and should not
 # be included in the distribution.

--- a/msvc/LinkGenerator.vcxproj
+++ b/msvc/LinkGenerator.vcxproj
@@ -124,7 +124,7 @@
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-generator $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
       <Message>Performing post-build commands</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -150,7 +150,7 @@
       <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-generator $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing post-build commands</Message>
@@ -183,7 +183,7 @@
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-generator $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
       <Message>Performing post-build commands</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -210,7 +210,7 @@
       <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-generator $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing post-build commands</Message>

--- a/msvc/LinkGenerator.vcxproj
+++ b/msvc/LinkGenerator.vcxproj
@@ -21,10 +21,12 @@
   <ItemGroup>
     <ClCompile Include="..\link-parser\link-generator.c" />
     <ClCompile Include="..\link-parser\generator-utilities.c" />
+    <ClCompile Include="..\link-parser\parser-utilities.c" />
     <ClCompile Include="getopt\getopt.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\link-parser\generator-utilities.h" />
+    <ClInclude Include="..\link-parser\parser-utilities.h" />
     <ClInclude Include="getopt\getopt.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/msvc/LinkGenerator.vcxproj
+++ b/msvc/LinkGenerator.vcxproj
@@ -1,0 +1,220 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\link-parser\link-generator.c" />
+    <ClCompile Include="..\link-parser\generator-utilities.c" />
+    <ClCompile Include="getopt\getopt.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\link-parser\generator-utilities.h" />
+    <ClInclude Include="getopt\getopt.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <RootNamespace>LinkGrammarExe</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectGuid>{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="Local.props" />
+    <Import Project="MSVC-common.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="Local.props" />
+    <Import Project="MSVC-common.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="Local.props" />
+    <Import Project="MSVC-common.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="Local.props" />
+    <Import Project="MSVC-common.props" />
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>12.0.21005.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>Temp\$(ProjectName)$(Platform)$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <CompileAs>CompileAsC</CompileAs>
+      <AdditionalIncludeDirectories>getopt;..\link-grammar;..\link-grammar\dict-common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x86.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Message>Performing post-build commands</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <CompileAs>CompileAsC</CompileAs>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <OpenMPSupport>true</OpenMPSupport>
+      <AdditionalIncludeDirectories>getopt;..\link-grammar;..\link-grammar\dict-common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OmitFramePointers>false</OmitFramePointers>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Performing post-build commands</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>getopt;..\link-grammar;..\link-grammar\dict-common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OmitFramePointers>true</OmitFramePointers>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x86.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Message>Performing post-build commands</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>getopt;..\link-grammar;..\link-grammar\dict-common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OmitFramePointers>true</OmitFramePointers>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <PostBuildEvent>
+      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Performing post-build commands</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/LinkGrammar.sln
+++ b/msvc/LinkGrammar.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2035
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32002.261
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LinkGrammarJava", "LinkGrammarJava.vcxproj", "{D74DF531-C18E-4988-8A8C-4F23556DEC1B}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -16,6 +16,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LinkGrammarExe", "LinkGramm
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Python3", "Python3.vcxproj", "{B3AF571B-F80D-4A9C-A8C4-29026316A000}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LinkGenerator", "LinkGenerator.vcxproj", "{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0A6C539A-3140-48BD-865C-05F45637B93B} = {0A6C539A-3140-48BD-865C-05F45637B93B}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,14 +50,6 @@ Global
 		{532EFF4D-758A-4705-91EE-9A4AC72C017B}.Release|Win32.Build.0 = Release|Win32
 		{532EFF4D-758A-4705-91EE-9A4AC72C017B}.Release|x64.ActiveCfg = Release|x64
 		{532EFF4D-758A-4705-91EE-9A4AC72C017B}.Release|x64.Build.0 = Release|x64
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Debug|Win32.ActiveCfg = Debug|Win32
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Debug|Win32.Build.0 = Debug|Win32
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Debug|x64.ActiveCfg = Debug|x64
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Debug|x64.Build.0 = Debug|x64
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Release|Win32.ActiveCfg = Release|Win32
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Release|Win32.Build.0 = Release|Win32
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Release|x64.ActiveCfg = Release|x64
-		{4DBD8AF9-67E2-4F55-B8BD-99903151A98C}.Release|x64.Build.0 = Release|x64
 		{B3AF571B-F80D-4A9C-A8C4-29026316A000}.Debug|Win32.ActiveCfg = Debug|Win32
 		{B3AF571B-F80D-4A9C-A8C4-29026316A000}.Debug|Win32.Build.0 = Debug|Win32
 		{B3AF571B-F80D-4A9C-A8C4-29026316A000}.Debug|x64.ActiveCfg = Debug|x64
@@ -61,6 +58,14 @@ Global
 		{B3AF571B-F80D-4A9C-A8C4-29026316A000}.Release|Win32.Build.0 = Release|Win32
 		{B3AF571B-F80D-4A9C-A8C4-29026316A000}.Release|x64.ActiveCfg = Release|x64
 		{B3AF571B-F80D-4A9C-A8C4-29026316A000}.Release|x64.Build.0 = Release|x64
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Debug|Win32.Build.0 = Debug|Win32
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Debug|x64.ActiveCfg = Debug|x64
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Debug|x64.Build.0 = Debug|x64
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Release|Win32.ActiveCfg = Release|Win32
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Release|Win32.Build.0 = Release|Win32
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Release|x64.ActiveCfg = Release|x64
+		{C86F1C7F-9E10-4E2B-BD8A-7152BDBC0B99}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/msvc/LinkGrammarExe.vcxproj
+++ b/msvc/LinkGrammarExe.vcxproj
@@ -124,7 +124,7 @@
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-parser $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
       <Message>Performing post-build commands</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -150,7 +150,7 @@
       <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-parser $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing post-build commands</Message>
@@ -183,7 +183,7 @@
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-parser $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
       <Message>Performing post-build commands</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -210,7 +210,7 @@
       <AdditionalDependencies>$(SolutionDir)$(Platform)\$(Configuration)\link-grammar-x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>post-build.bat $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
+      <Command>post-build.bat link-parser $(SolutionDir)$(Platform)\$(Configuration)\$(TargetName)$(TargetExt)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Performing post-build commands</Message>

--- a/msvc/MSVC-common.props
+++ b/msvc/MSVC-common.props
@@ -7,7 +7,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>$(CFLAGS);WIN32_LEAN_AND_MEAN;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>$(CFLAGS);HAVE_STRING_H;WIN32_LEAN_AND_MEAN;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4068</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>..;..\link-grammar;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/msvc/getopt/README
+++ b/msvc/getopt/README
@@ -1,0 +1,4 @@
+Downloaded https://gist.github.com/ashelly/7776712.
+Gist description:
+"Port of GNU getopt() to Win32 for anyone who's tired of dealing with getopt() calls in Unix-to-Windows ports."
+Ported by Pete Wilson. Recovered from the Internet Archive's snapshot of www.pwilson.net/sample.html.

--- a/msvc/getopt/getopt.c
+++ b/msvc/getopt/getopt.c
@@ -1,0 +1,1258 @@
+/* Getopt for GNU.
+   NOTE: getopt is now part of the C library, so if you don't know what
+   "Keep this file name-space clean" means, talk to drepper@gnu.org
+   before changing it!
+   Copyright (C) 1987,88,89,90,91,92,93,94,95,96,98,99,2000,2001
+        Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
+/* This tells Alpha OSF/1 not to define a getopt prototype in <stdio.h>.
+   Ditto for AIX 3.2 and <stdlib.h>.  */
+#ifndef _NO_PROTO
+# define _NO_PROTO
+#endif
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#if !defined __STDC__ || !__STDC__
+/* This is a separate conditional since some stdc systems
+   reject `defined (const)'.  */
+# ifndef const
+#  define const
+# endif
+#endif
+
+#include <stdio.h>
+
+/* Comment out all this code if we are using the GNU C Library, and are not
+   actually compiling the library itself.  This code is part of the GNU C
+   Library, but also included in many other GNU distributions.  Compiling
+   and linking in this code is a waste when using the GNU C library
+   (especially if it is a shared library).  Rather than having every GNU
+   program understand `configure --with-gnu-libc' and omit the object files,
+   it is simpler to just do this in the source for each such file.  */
+
+#define GETOPT_INTERFACE_VERSION 2
+#if !defined _LIBC && defined __GLIBC__ && __GLIBC__ >= 2
+# include <gnu-versions.h>
+# if _GNU_GETOPT_INTERFACE_VERSION == GETOPT_INTERFACE_VERSION
+#  define ELIDE_CODE
+# endif
+#endif
+
+#ifndef ELIDE_CODE
+
+
+/* This needs to come after some library #include
+   to get __GNU_LIBRARY__ defined.  */
+#ifdef  __GNU_LIBRARY__
+/* Don't include stdlib.h for non-GNU C libraries because some of them
+   contain conflicting prototypes for getopt.  */
+# include <stdlib.h>
+# include <unistd.h>
+#endif  /* GNU C library.  */
+
+#ifdef VMS
+# include <unixlib.h>
+# if HAVE_STRING_H - 0
+#  include <string.h>
+# endif
+#endif
+
+#ifndef _
+/* This is for other GNU distributions with internationalized messages.  */
+# if (HAVE_LIBINTL_H && ENABLE_NLS) || defined _LIBC
+#  include <libintl.h>
+#  ifndef _
+#   define _(msgid)     gettext (msgid)
+#  endif
+# else
+#  define _(msgid)      (msgid)
+# endif
+# if defined _LIBC && defined USE_IN_LIBIO
+#  include <wchar.h>
+# endif
+#endif
+
+/* This version of `getopt' appears to the caller like standard Unix `getopt'
+   but it behaves differently for the user, since it allows the user
+   to intersperse the options with the other arguments.
+
+   As `getopt' works, it permutes the elements of ARGV so that,
+   when it is done, all the options precede everything else.  Thus
+   all application programs are extended to handle flexible argument order.
+
+   Setting the environment variable POSIXLY_CORRECT disables permutation.
+   Then the behavior is completely standard.
+
+   GNU application programs can use a third alternative mode in which
+   they can distinguish the relative order of options and other arguments.  */
+
+#include "getopt.h"
+
+/* For communication from `getopt' to the caller.
+   When `getopt' finds an option that takes an argument,
+   the argument value is returned here.
+   Also, when `ordering' is RETURN_IN_ORDER,
+   each non-option ARGV-element is returned here.  */
+
+char *optarg;
+
+/* Index in ARGV of the next element to be scanned.
+   This is used for communication to and from the caller
+   and for communication between successive calls to `getopt'.
+
+   On entry to `getopt', zero means this is the first call; initialize.
+
+   When `getopt' returns -1, this is the index of the first of the
+   non-option elements that the caller should itself scan.
+
+   Otherwise, `optind' communicates from one call to the next
+   how much of ARGV has been scanned so far.  */
+
+/* 1003.2 says this must be 1 before any call.  */
+int optind = 1;
+
+/* Formerly, initialization of getopt depended on optind==0, which
+   causes problems with re-calling getopt as programs generally don't
+   know that. */
+
+int __getopt_initialized;
+
+/* The next char to be scanned in the option-element
+   in which the last option character we returned was found.
+   This allows us to pick up the scan where we left off.
+
+   If this is zero, or a null string, it means resume the scan
+   by advancing to the next ARGV-element.  */
+
+static char *nextchar;
+
+/* Callers store zero here to inhibit the error message
+   for unrecognized options.  */
+
+int opterr = 1;
+
+/* Set to an option character which was unrecognized.
+   This must be initialized on some systems to avoid linking in the
+   system's own getopt implementation.  */
+
+int optopt = '?';
+
+/* Describe how to deal with options that follow non-option ARGV-elements.
+
+   If the caller did not specify anything,
+   the default is REQUIRE_ORDER if the environment variable
+   POSIXLY_CORRECT is defined, PERMUTE otherwise.
+
+   REQUIRE_ORDER means don't recognize them as options;
+   stop option processing when the first non-option is seen.
+   This is what Unix does.
+   This mode of operation is selected by either setting the environment
+   variable POSIXLY_CORRECT, or using `+' as the first character
+   of the list of option characters.
+
+   PERMUTE is the default.  We permute the contents of ARGV as we scan,
+   so that eventually all the non-options are at the end.  This allows options
+   to be given in any order, even with programs that were not written to
+   expect this.
+
+   RETURN_IN_ORDER is an option available to programs that were written
+   to expect options and other ARGV-elements in any order and that care about
+   the ordering of the two.  We describe each non-option ARGV-element
+   as if it were the argument of an option with character code 1.
+   Using `-' as the first character of the list of option characters
+   selects this mode of operation.
+
+   The special argument `--' forces an end of option-scanning regardless
+   of the value of `ordering'.  In the case of RETURN_IN_ORDER, only
+   `--' can cause `getopt' to return -1 with `optind' != ARGC.  */
+
+static enum
+{
+  REQUIRE_ORDER, PERMUTE, RETURN_IN_ORDER
+} ordering;
+
+/* Value of POSIXLY_CORRECT environment variable.  */
+static char *posixly_correct;
+
+#ifdef  __GNU_LIBRARY__
+/* We want to avoid inclusion of string.h with non-GNU libraries
+   because there are many ways it can cause trouble.
+   On some systems, it contains special magic macros that don't work
+   in GCC.  */
+# include <string.h>
+# define my_index       strchr
+#else
+
+# if HAVE_STRING_H || WIN32 /* Pete Wilson mod 7/28/02 */
+#  include <string.h>
+# else
+#  include <strings.h>
+# endif
+
+/* Avoid depending on library functions or files
+   whose names are inconsistent.  */
+
+#ifndef getenv
+extern char *getenv ();
+#endif
+
+static char *
+my_index (str, chr)
+     const char *str;
+     int chr;
+{
+  while (*str)
+    {
+      if (*str == chr)
+        return (char *) str;
+      str++;
+    }
+  return 0;
+}
+
+/* If using GCC, we can safely declare strlen this way.
+   If not using GCC, it is ok not to declare it.  */
+#ifdef __GNUC__
+/* Note that Motorola Delta 68k R3V7 comes with GCC but not stddef.h.
+   That was relevant to code that was here before.  */
+# if (!defined __STDC__ || !__STDC__) && !defined strlen
+/* gcc with -traditional declares the built-in strlen to return int,
+   and has done so at least since version 2.4.5. -- rms.  */
+extern int strlen (const char *);
+# endif /* not __STDC__ */
+#endif /* __GNUC__ */
+
+#endif /* not __GNU_LIBRARY__ */
+
+/* Handle permutation of arguments.  */
+
+/* Describe the part of ARGV that contains non-options that have
+   been skipped.  `first_nonopt' is the index in ARGV of the first of them;
+   `last_nonopt' is the index after the last of them.  */
+
+static int first_nonopt;
+static int last_nonopt;
+
+#ifdef _LIBC
+/* Stored original parameters.
+   XXX This is no good solution.  We should rather copy the args so
+   that we can compare them later.  But we must not use malloc(3).  */
+extern int __libc_argc;
+extern char **__libc_argv;
+
+/* Bash 2.0 gives us an environment variable containing flags
+   indicating ARGV elements that should not be considered arguments.  */
+
+# ifdef USE_NONOPTION_FLAGS
+/* Defined in getopt_init.c  */
+extern char *__getopt_nonoption_flags;
+
+static int nonoption_flags_max_len;
+static int nonoption_flags_len;
+# endif
+
+# ifdef USE_NONOPTION_FLAGS
+#  define SWAP_FLAGS(ch1, ch2) \
+  if (nonoption_flags_len > 0)                                                \
+    {                                                                         \
+      char __tmp = __getopt_nonoption_flags[ch1];                             \
+      __getopt_nonoption_flags[ch1] = __getopt_nonoption_flags[ch2];          \
+      __getopt_nonoption_flags[ch2] = __tmp;                                  \
+    }
+# else
+#  define SWAP_FLAGS(ch1, ch2)
+# endif
+#else   /* !_LIBC */
+# define SWAP_FLAGS(ch1, ch2)
+#endif  /* _LIBC */
+
+/* Exchange two adjacent subsequences of ARGV.
+   One subsequence is elements [first_nonopt,last_nonopt)
+   which contains all the non-options that have been skipped so far.
+   The other is elements [last_nonopt,optind), which contains all
+   the options processed since those non-options were skipped.
+
+   `first_nonopt' and `last_nonopt' are relocated so that they describe
+   the new indices of the non-options in ARGV after they are moved.  */
+
+#if defined __STDC__ && __STDC__
+static void exchange (char **);
+#endif
+
+static void
+exchange (argv)
+     char **argv;
+{
+  int bottom = first_nonopt;
+  int middle = last_nonopt;
+  int top = optind;
+  char *tem;
+
+  /* Exchange the shorter segment with the far end of the longer segment.
+     That puts the shorter segment into the right place.
+     It leaves the longer segment in the right place overall,
+     but it consists of two parts that need to be swapped next.  */
+
+#if defined _LIBC && defined USE_NONOPTION_FLAGS
+  /* First make sure the handling of the `__getopt_nonoption_flags'
+     string can work normally.  Our top argument must be in the range
+     of the string.  */
+  if (nonoption_flags_len > 0 && top >= nonoption_flags_max_len)
+    {
+      /* We must extend the array.  The user plays games with us and
+         presents new arguments.  */
+      char *new_str = malloc (top + 1);
+      if (new_str == NULL)
+        nonoption_flags_len = nonoption_flags_max_len = 0;
+      else
+        {
+          memset (__mempcpy (new_str, __getopt_nonoption_flags,
+                             nonoption_flags_max_len),
+                  '\0', top + 1 - nonoption_flags_max_len);
+          nonoption_flags_max_len = top + 1;
+          __getopt_nonoption_flags = new_str;
+        }
+    }
+#endif
+
+  while (top > middle && middle > bottom)
+    {
+      if (top - middle > middle - bottom)
+        {
+          /* Bottom segment is the short one.  */
+          int len = middle - bottom;
+          register int i;
+
+          /* Swap it with the top part of the top segment.  */
+          for (i = 0; i < len; i++)
+            {
+              tem = argv[bottom + i];
+              argv[bottom + i] = argv[top - (middle - bottom) + i];
+              argv[top - (middle - bottom) + i] = tem;
+              SWAP_FLAGS (bottom + i, top - (middle - bottom) + i);
+            }
+          /* Exclude the moved bottom segment from further swapping.  */
+          top -= len;
+        }
+      else
+        {
+          /* Top segment is the short one.  */
+          int len = top - middle;
+          register int i;
+
+          /* Swap it with the bottom part of the bottom segment.  */
+          for (i = 0; i < len; i++)
+            {
+              tem = argv[bottom + i];
+              argv[bottom + i] = argv[middle + i];
+              argv[middle + i] = tem;
+              SWAP_FLAGS (bottom + i, middle + i);
+            }
+          /* Exclude the moved top segment from further swapping.  */
+          bottom += len;
+        }
+    }
+
+  /* Update records for the slots the non-options now occupy.  */
+
+  first_nonopt += (optind - last_nonopt);
+  last_nonopt = optind;
+}
+
+/* Initialize the internal data when the first call is made.  */
+
+#if defined __STDC__ && __STDC__
+static const char *_getopt_initialize (int, char *const *, const char *);
+#endif
+static const char *
+_getopt_initialize (argc, argv, optstring)
+     int argc;
+     char *const *argv;
+     const char *optstring;
+{
+  /* Start processing options with ARGV-element 1 (since ARGV-element 0
+     is the program name); the sequence of previously skipped
+     non-option ARGV-elements is empty.  */
+
+  first_nonopt = last_nonopt = optind;
+
+  nextchar = NULL;
+
+  posixly_correct = getenv ("POSIXLY_CORRECT");
+
+  /* Determine how to handle the ordering of options and nonoptions.  */
+
+  if (optstring[0] == '-')
+    {
+      ordering = RETURN_IN_ORDER;
+      ++optstring;
+    }
+  else if (optstring[0] == '+')
+    {
+      ordering = REQUIRE_ORDER;
+      ++optstring;
+    }
+  else if (posixly_correct != NULL)
+    ordering = REQUIRE_ORDER;
+  else
+    ordering = PERMUTE;
+
+#if defined _LIBC && defined USE_NONOPTION_FLAGS
+  if (posixly_correct == NULL
+      && argc == __libc_argc && argv == __libc_argv)
+    {
+      if (nonoption_flags_max_len == 0)
+        {
+          if (__getopt_nonoption_flags == NULL
+              || __getopt_nonoption_flags[0] == '\0')
+            nonoption_flags_max_len = -1;
+          else
+            {
+              const char *orig_str = __getopt_nonoption_flags;
+              int len = nonoption_flags_max_len = strlen (orig_str);
+              if (nonoption_flags_max_len < argc)
+                nonoption_flags_max_len = argc;
+              __getopt_nonoption_flags =
+                (char *) malloc (nonoption_flags_max_len);
+              if (__getopt_nonoption_flags == NULL)
+                nonoption_flags_max_len = -1;
+              else
+                memset (__mempcpy (__getopt_nonoption_flags, orig_str, len),
+                        '\0', nonoption_flags_max_len - len);
+            }
+        }
+      nonoption_flags_len = nonoption_flags_max_len;
+    }
+  else
+    nonoption_flags_len = 0;
+#endif
+
+  return optstring;
+}
+
+/* Scan elements of ARGV (whose length is ARGC) for option characters
+   given in OPTSTRING.
+
+   If an element of ARGV starts with '-', and is not exactly "-" or "--",
+   then it is an option element.  The characters of this element
+   (aside from the initial '-') are option characters.  If `getopt'
+   is called repeatedly, it returns successively each of the option characters
+   from each of the option elements.
+
+   If `getopt' finds another option character, it returns that character,
+   updating `optind' and `nextchar' so that the next call to `getopt' can
+   resume the scan with the following option character or ARGV-element.
+
+   If there are no more option characters, `getopt' returns -1.
+   Then `optind' is the index in ARGV of the first ARGV-element
+   that is not an option.  (The ARGV-elements have been permuted
+   so that those that are not options now come last.)
+
+   OPTSTRING is a string containing the legitimate option characters.
+   If an option character is seen that is not listed in OPTSTRING,
+   return '?' after printing an error message.  If you set `opterr' to
+   zero, the error message is suppressed but we still return '?'.
+
+   If a char in OPTSTRING is followed by a colon, that means it wants an arg,
+   so the following text in the same ARGV-element, or the text of the following
+   ARGV-element, is returned in `optarg'.  Two colons mean an option that
+   wants an optional arg; if there is text in the current ARGV-element,
+   it is returned in `optarg', otherwise `optarg' is set to zero.
+
+   If OPTSTRING starts with `-' or `+', it requests different methods of
+   handling the non-option ARGV-elements.
+   See the comments about RETURN_IN_ORDER and REQUIRE_ORDER, above.
+
+   Long-named options begin with `--' instead of `-'.
+   Their names may be abbreviated as long as the abbreviation is unique
+   or is an exact match for some defined option.  If they have an
+   argument, it follows the option name in the same ARGV-element, separated
+   from the option name by a `=', or else the in next ARGV-element.
+   When `getopt' finds a long-named option, it returns 0 if that option's
+   `flag' field is nonzero, the value of the option's `val' field
+   if the `flag' field is zero.
+
+   The elements of ARGV aren't really const, because we permute them.
+   But we pretend they're const in the prototype to be compatible
+   with other systems.
+
+   LONGOPTS is a vector of `struct option' terminated by an
+   element containing a name which is zero.
+
+   LONGIND returns the index in LONGOPT of the long-named option found.
+   It is only valid when a long-named option has been found by the most
+   recent call.
+
+   If LONG_ONLY is nonzero, '-' as well as '--' can introduce
+   long-named options.  */
+
+int
+_getopt_internal (argc, argv, optstring, longopts, longind, long_only)
+     int argc;
+     char *const *argv;
+     const char *optstring;
+     const struct option *longopts;
+     int *longind;
+     int long_only;
+{
+  int print_errors = opterr;
+  if (optstring[0] == ':')
+    print_errors = 0;
+
+  if (argc < 1)
+    return -1;
+
+  optarg = NULL;
+
+  if (optind == 0 || !__getopt_initialized)
+    {
+      if (optind == 0)
+        optind = 1;     /* Don't scan ARGV[0], the program name.  */
+      optstring = _getopt_initialize (argc, argv, optstring);
+      __getopt_initialized = 1;
+    }
+
+  /* Test whether ARGV[optind] points to a non-option argument.
+     Either it does not have option syntax, or there is an environment flag
+     from the shell indicating it is not an option.  The later information
+     is only used when the used in the GNU libc.  */
+#if defined _LIBC && defined USE_NONOPTION_FLAGS
+# define NONOPTION_P (argv[optind][0] != '-' || argv[optind][1] == '\0'       \
+                      || (optind < nonoption_flags_len                        \
+                          && __getopt_nonoption_flags[optind] == '1'))
+#else
+# define NONOPTION_P (argv[optind][0] != '-' || argv[optind][1] == '\0')
+#endif
+
+  if (nextchar == NULL || *nextchar == '\0')
+    {
+      /* Advance to the next ARGV-element.  */
+
+      /* Give FIRST_NONOPT and LAST_NONOPT rational values if OPTIND has been
+         moved back by the user (who may also have changed the arguments).  */
+      if (last_nonopt > optind)
+        last_nonopt = optind;
+      if (first_nonopt > optind)
+        first_nonopt = optind;
+
+      if (ordering == PERMUTE)
+        {
+          /* If we have just processed some options following some non-options,
+             exchange them so that the options come first.  */
+
+          if (first_nonopt != last_nonopt && last_nonopt != optind)
+            exchange ((char **) argv);
+          else if (last_nonopt != optind)
+            first_nonopt = optind;
+
+          /* Skip any additional non-options
+             and extend the range of non-options previously skipped.  */
+
+          while (optind < argc && NONOPTION_P)
+            optind++;
+          last_nonopt = optind;
+        }
+
+      /* The special ARGV-element `--' means premature end of options.
+         Skip it like a null option,
+         then exchange with previous non-options as if it were an option,
+         then skip everything else like a non-option.  */
+
+      if (optind != argc && !strcmp (argv[optind], "--"))
+        {
+          optind++;
+
+          if (first_nonopt != last_nonopt && last_nonopt != optind)
+            exchange ((char **) argv);
+          else if (first_nonopt == last_nonopt)
+            first_nonopt = optind;
+          last_nonopt = argc;
+
+          optind = argc;
+        }
+
+      /* If we have done all the ARGV-elements, stop the scan
+         and back over any non-options that we skipped and permuted.  */
+
+      if (optind == argc)
+        {
+          /* Set the next-arg-index to point at the non-options
+             that we previously skipped, so the caller will digest them.  */
+          if (first_nonopt != last_nonopt)
+            optind = first_nonopt;
+          return -1;
+        }
+
+      /* If we have come to a non-option and did not permute it,
+         either stop the scan or describe it to the caller and pass it by.  */
+
+      if (NONOPTION_P)
+        {
+          if (ordering == REQUIRE_ORDER)
+            return -1;
+          optarg = argv[optind++];
+          return 1;
+        }
+
+      /* We have found another option-ARGV-element.
+         Skip the initial punctuation.  */
+
+      nextchar = (argv[optind] + 1
+                  + (longopts != NULL && argv[optind][1] == '-'));
+    }
+
+  /* Decode the current option-ARGV-element.  */
+
+  /* Check whether the ARGV-element is a long option.
+
+     If long_only and the ARGV-element has the form "-f", where f is
+     a valid short option, don't consider it an abbreviated form of
+     a long option that starts with f.  Otherwise there would be no
+     way to give the -f short option.
+
+     On the other hand, if there's a long option "fubar" and
+     the ARGV-element is "-fu", do consider that an abbreviation of
+     the long option, just like "--fu", and not "-f" with arg "u".
+
+     This distinction seems to be the most useful approach.  */
+
+  if (longopts != NULL
+      && (argv[optind][1] == '-'
+          || (long_only && (argv[optind][2] || !my_index (optstring, argv[optind][1])))))
+    {
+      char *nameend;
+      const struct option *p;
+      const struct option *pfound = NULL;
+      int exact = 0;
+      int ambig = 0;
+      int indfound = -1;
+      int option_index;
+
+      for (nameend = nextchar; *nameend && *nameend != '='; nameend++)
+        /* Do nothing.  */ ;
+
+      /* Test all long options for either exact match
+         or abbreviated matches.  */
+      for (p = longopts, option_index = 0; p->name; p++, option_index++)
+        if (!strncmp (p->name, nextchar, nameend - nextchar))
+          {
+            if ((unsigned int) (nameend - nextchar)
+                == (unsigned int) strlen (p->name))
+              {
+                /* Exact match found.  */
+                pfound = p;
+                indfound = option_index;
+                exact = 1;
+                break;
+              }
+            else if (pfound == NULL)
+              {
+                /* First nonexact match found.  */
+                pfound = p;
+                indfound = option_index;
+              }
+            else if (long_only
+                     || pfound->has_arg != p->has_arg
+                     || pfound->flag != p->flag
+                     || pfound->val != p->val)
+              /* Second or later nonexact match found.  */
+              ambig = 1;
+          }
+
+      if (ambig && !exact)
+        {
+          if (print_errors)
+            {
+#if defined _LIBC && defined USE_IN_LIBIO
+              char *buf;
+
+              __asprintf (&buf, _("%s: option `%s' is ambiguous\n"),
+                          argv[0], argv[optind]);
+
+              if (_IO_fwide (stderr, 0) > 0)
+                __fwprintf (stderr, L"%s", buf);
+              else
+                fputs (buf, stderr);
+
+              free (buf);
+#else
+              fprintf (stderr, _("%s: option `%s' is ambiguous\n"),
+                       argv[0], argv[optind]);
+#endif
+            }
+          nextchar += strlen (nextchar);
+          optind++;
+          optopt = 0;
+          return '?';
+        }
+
+      if (pfound != NULL)
+        {
+          option_index = indfound;
+          optind++;
+          if (*nameend)
+            {
+              /* Don't test has_arg with >, because some C compilers don't
+                 allow it to be used on enums.  */
+              if (pfound->has_arg)
+                optarg = nameend + 1;
+              else
+                {
+                  if (print_errors)
+                    {
+#if defined _LIBC && defined USE_IN_LIBIO
+                      char *buf;
+#endif
+
+                      if (argv[optind - 1][1] == '-')
+                        {
+                          /* --option */
+#if defined _LIBC && defined USE_IN_LIBIO
+                          __asprintf (&buf, _("\
+%s: option `--%s' doesn't allow an argument\n"),
+                                      argv[0], pfound->name);
+#else
+                          fprintf (stderr, _("\
+%s: option `--%s' doesn't allow an argument\n"),
+                                   argv[0], pfound->name);
+#endif
+                        }
+                      else
+                        {
+                          /* +option or -option */
+#if defined _LIBC && defined USE_IN_LIBIO
+                          __asprintf (&buf, _("\
+%s: option `%c%s' doesn't allow an argument\n"),
+                                      argv[0], argv[optind - 1][0],
+                                      pfound->name);
+#else
+                          fprintf (stderr, _("\
+%s: option `%c%s' doesn't allow an argument\n"),
+                                   argv[0], argv[optind - 1][0], pfound->name);
+#endif
+                        }
+
+#if defined _LIBC && defined USE_IN_LIBIO
+                      if (_IO_fwide (stderr, 0) > 0)
+                        __fwprintf (stderr, L"%s", buf);
+                      else
+                        fputs (buf, stderr);
+
+                      free (buf);
+#endif
+                    }
+
+                  nextchar += strlen (nextchar);
+
+                  optopt = pfound->val;
+                  return '?';
+                }
+            }
+          else if (pfound->has_arg == 1)
+            {
+              if (optind < argc)
+                optarg = argv[optind++];
+              else
+                {
+                  if (print_errors)
+                    {
+#if defined _LIBC && defined USE_IN_LIBIO
+                      char *buf;
+
+                      __asprintf (&buf,
+                                  _("%s: option `%s' requires an argument\n"),
+                                  argv[0], argv[optind - 1]);
+
+                      if (_IO_fwide (stderr, 0) > 0)
+                        __fwprintf (stderr, L"%s", buf);
+                      else
+                        fputs (buf, stderr);
+
+                      free (buf);
+#else
+                      fprintf (stderr,
+                               _("%s: option `%s' requires an argument\n"),
+                               argv[0], argv[optind - 1]);
+#endif
+                    }
+                  nextchar += strlen (nextchar);
+                  optopt = pfound->val;
+                  return optstring[0] == ':' ? ':' : '?';
+                }
+            }
+          nextchar += strlen (nextchar);
+          if (longind != NULL)
+            *longind = option_index;
+          if (pfound->flag)
+            {
+              *(pfound->flag) = pfound->val;
+              return 0;
+            }
+          return pfound->val;
+        }
+
+      /* Can't find it as a long option.  If this is not getopt_long_only,
+         or the option starts with '--' or is not a valid short
+         option, then it's an error.
+         Otherwise interpret it as a short option.  */
+      if (!long_only || argv[optind][1] == '-'
+          || my_index (optstring, *nextchar) == NULL)
+        {
+          if (print_errors)
+            {
+#if defined _LIBC && defined USE_IN_LIBIO
+              char *buf;
+#endif
+
+              if (argv[optind][1] == '-')
+                {
+                  /* --option */
+#if defined _LIBC && defined USE_IN_LIBIO
+                  __asprintf (&buf, _("%s: unrecognized option `--%s'\n"),
+                              argv[0], nextchar);
+#else
+                  fprintf (stderr, _("%s: unrecognized option `--%s'\n"),
+                           argv[0], nextchar);
+#endif
+                }
+              else
+                {
+                  /* +option or -option */
+#if defined _LIBC && defined USE_IN_LIBIO
+                  __asprintf (&buf, _("%s: unrecognized option `%c%s'\n"),
+                              argv[0], argv[optind][0], nextchar);
+#else
+                  fprintf (stderr, _("%s: unrecognized option `%c%s'\n"),
+                           argv[0], argv[optind][0], nextchar);
+#endif
+                }
+
+#if defined _LIBC && defined USE_IN_LIBIO
+              if (_IO_fwide (stderr, 0) > 0)
+                __fwprintf (stderr, L"%s", buf);
+              else
+                fputs (buf, stderr);
+
+              free (buf);
+#endif
+            }
+          nextchar = (char *) "";
+          optind++;
+          optopt = 0;
+          return '?';
+        }
+    }
+
+  /* Look at and handle the next short option-character.  */
+
+  {
+    char c = *nextchar++;
+    char *temp = my_index (optstring, c);
+
+    /* Increment `optind' when we start to process its last character.  */
+    if (*nextchar == '\0')
+      ++optind;
+
+    if (temp == NULL || c == ':')
+      {
+        if (print_errors)
+          {
+#if defined _LIBC && defined USE_IN_LIBIO
+              char *buf;
+#endif
+
+            if (posixly_correct)
+              {
+                /* 1003.2 specifies the format of this message.  */
+#if defined _LIBC && defined USE_IN_LIBIO
+                __asprintf (&buf, _("%s: illegal option -- %c\n"),
+                            argv[0], c);
+#else
+                fprintf (stderr, _("%s: illegal option -- %c\n"), argv[0], c);
+#endif
+              }
+            else
+              {
+#if defined _LIBC && defined USE_IN_LIBIO
+                __asprintf (&buf, _("%s: invalid option -- %c\n"),
+                            argv[0], c);
+#else
+                fprintf (stderr, _("%s: invalid option -- %c\n"), argv[0], c);
+#endif
+              }
+
+#if defined _LIBC && defined USE_IN_LIBIO
+            if (_IO_fwide (stderr, 0) > 0)
+              __fwprintf (stderr, L"%s", buf);
+            else
+              fputs (buf, stderr);
+
+            free (buf);
+#endif
+          }
+        optopt = c;
+        return '?';
+      }
+    /* Convenience. Treat POSIX -W foo same as long option --foo */
+    if (temp[0] == 'W' && temp[1] == ';')
+      {
+        char *nameend;
+        const struct option *p;
+        const struct option *pfound = NULL;
+        int exact = 0;
+        int ambig = 0;
+        int indfound = 0;
+        int option_index;
+
+        /* This is an option that requires an argument.  */
+        if (*nextchar != '\0')
+          {
+            optarg = nextchar;
+            /* If we end this ARGV-element by taking the rest as an arg,
+               we must advance to the next element now.  */
+            optind++;
+          }
+        else if (optind == argc)
+          {
+            if (print_errors)
+              {
+                /* 1003.2 specifies the format of this message.  */
+#if defined _LIBC && defined USE_IN_LIBIO
+                char *buf;
+
+                __asprintf (&buf, _("%s: option requires an argument -- %c\n"),
+                            argv[0], c);
+
+                if (_IO_fwide (stderr, 0) > 0)
+                  __fwprintf (stderr, L"%s", buf);
+                else
+                  fputs (buf, stderr);
+
+                free (buf);
+#else
+                fprintf (stderr, _("%s: option requires an argument -- %c\n"),
+                         argv[0], c);
+#endif
+              }
+            optopt = c;
+            if (optstring[0] == ':')
+              c = ':';
+            else
+              c = '?';
+            return c;
+          }
+        else
+          /* We already incremented `optind' once;
+             increment it again when taking next ARGV-elt as argument.  */
+          optarg = argv[optind++];
+
+        /* optarg is now the argument, see if it's in the
+           table of longopts.  */
+
+        for (nextchar = nameend = optarg; *nameend && *nameend != '='; nameend++)
+          /* Do nothing.  */ ;
+
+        /* Test all long options for either exact match
+           or abbreviated matches.  */
+        for (p = longopts, option_index = 0; p->name; p++, option_index++)
+          if (!strncmp (p->name, nextchar, nameend - nextchar))
+            {
+              if ((unsigned int) (nameend - nextchar) == strlen (p->name))
+                {
+                  /* Exact match found.  */
+                  pfound = p;
+                  indfound = option_index;
+                  exact = 1;
+                  break;
+                }
+              else if (pfound == NULL)
+                {
+                  /* First nonexact match found.  */
+                  pfound = p;
+                  indfound = option_index;
+                }
+              else
+                /* Second or later nonexact match found.  */
+                ambig = 1;
+            }
+        if (ambig && !exact)
+          {
+            if (print_errors)
+              {
+#if defined _LIBC && defined USE_IN_LIBIO
+                char *buf;
+
+                __asprintf (&buf, _("%s: option `-W %s' is ambiguous\n"),
+                            argv[0], argv[optind]);
+
+                if (_IO_fwide (stderr, 0) > 0)
+                  __fwprintf (stderr, L"%s", buf);
+                else
+                  fputs (buf, stderr);
+
+                free (buf);
+#else
+                fprintf (stderr, _("%s: option `-W %s' is ambiguous\n"),
+                         argv[0], argv[optind]);
+#endif
+              }
+            nextchar += strlen (nextchar);
+            optind++;
+            return '?';
+          }
+        if (pfound != NULL)
+          {
+            option_index = indfound;
+            if (*nameend)
+              {
+                /* Don't test has_arg with >, because some C compilers don't
+                   allow it to be used on enums.  */
+                if (pfound->has_arg)
+                  optarg = nameend + 1;
+                else
+                  {
+                    if (print_errors)
+                      {
+#if defined _LIBC && defined USE_IN_LIBIO
+                        char *buf;
+
+                        __asprintf (&buf, _("\
+%s: option `-W %s' doesn't allow an argument\n"),
+                                    argv[0], pfound->name);
+
+                        if (_IO_fwide (stderr, 0) > 0)
+                          __fwprintf (stderr, L"%s", buf);
+                        else
+                          fputs (buf, stderr);
+
+                        free (buf);
+#else
+                        fprintf (stderr, _("\
+%s: option `-W %s' doesn't allow an argument\n"),
+                                 argv[0], pfound->name);
+#endif
+                      }
+
+                    nextchar += strlen (nextchar);
+                    return '?';
+                  }
+              }
+            else if (pfound->has_arg == 1)
+              {
+                if (optind < argc)
+                  optarg = argv[optind++];
+                else
+                  {
+                    if (print_errors)
+                      {
+#if defined _LIBC && defined USE_IN_LIBIO
+                        char *buf;
+
+                        __asprintf (&buf, _("\
+%s: option `%s' requires an argument\n"),
+                                    argv[0], argv[optind - 1]);
+
+                        if (_IO_fwide (stderr, 0) > 0)
+                          __fwprintf (stderr, L"%s", buf);
+                        else
+                          fputs (buf, stderr);
+
+                        free (buf);
+#else
+                        fprintf (stderr,
+                                 _("%s: option `%s' requires an argument\n"),
+                                 argv[0], argv[optind - 1]);
+#endif
+                      }
+                    nextchar += strlen (nextchar);
+                    return optstring[0] == ':' ? ':' : '?';
+                  }
+              }
+            nextchar += strlen (nextchar);
+            if (longind != NULL)
+              *longind = option_index;
+            if (pfound->flag)
+              {
+                *(pfound->flag) = pfound->val;
+                return 0;
+              }
+            return pfound->val;
+          }
+          nextchar = NULL;
+          return 'W';   /* Let the application handle it.   */
+      }
+    if (temp[1] == ':')
+      {
+        if (temp[2] == ':')
+          {
+            /* This is an option that accepts an argument optionally.  */
+            if (*nextchar != '\0')
+              {
+                optarg = nextchar;
+                optind++;
+              }
+            else
+              optarg = NULL;
+            nextchar = NULL;
+          }
+        else
+          {
+            /* This is an option that requires an argument.  */
+            if (*nextchar != '\0')
+              {
+                optarg = nextchar;
+                /* If we end this ARGV-element by taking the rest as an arg,
+                   we must advance to the next element now.  */
+                optind++;
+              }
+            else if (optind == argc)
+              {
+                if (print_errors)
+                  {
+                    /* 1003.2 specifies the format of this message.  */
+#if defined _LIBC && defined USE_IN_LIBIO
+                    char *buf;
+
+                    __asprintf (&buf,
+                                _("%s: option requires an argument -- %c\n"),
+                                argv[0], c);
+
+                    if (_IO_fwide (stderr, 0) > 0)
+                      __fwprintf (stderr, L"%s", buf);
+                    else
+                      fputs (buf, stderr);
+
+                    free (buf);
+#else
+                    fprintf (stderr,
+                             _("%s: option requires an argument -- %c\n"),
+                             argv[0], c);
+#endif
+                  }
+                optopt = c;
+                if (optstring[0] == ':')
+                  c = ':';
+                else
+                  c = '?';
+              }
+            else
+              /* We already incremented `optind' once;
+                 increment it again when taking next ARGV-elt as argument.  */
+              optarg = argv[optind++];
+            nextchar = NULL;
+          }
+      }
+    return c;
+  }
+}
+
+int
+getopt (argc, argv, optstring)
+     int argc;
+     char *const *argv;
+     const char *optstring;
+{
+  return _getopt_internal (argc, argv, optstring,
+                           (const struct option *) 0,
+                           (int *) 0,
+                           0);
+}
+
+#endif  /* Not ELIDE_CODE.  */
+
+
+/* Compile with -DTEST to make an executable for use in testing
+   the above definition of `getopt'.  */
+
+/* #define TEST */        /* Pete Wilson mod 7/28/02 */
+#ifdef TEST
+
+#ifndef exit         /* Pete Wilson mod 7/28/02 */
+  int exit(int);     /* Pete Wilson mod 7/28/02 */
+#endif               /* Pete Wilson mod 7/28/02 */
+
+int
+main (argc, argv)
+     int argc;
+     char **argv;
+{
+  int c;
+  int digit_optind = 0;
+
+  while (1)
+    {
+      int this_option_optind = optind ? optind : 1;
+
+      c = getopt (argc, argv, "abc:d:0123456789");
+      if (c == -1)
+        break;
+
+      switch (c)
+        {
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+          if (digit_optind != 0 && digit_optind != this_option_optind)
+            printf ("digits occur in two different argv-elements.\n");
+          digit_optind = this_option_optind;
+          printf ("option %c\n", c);
+          break;
+
+        case 'a':
+          printf ("option a\n");
+          break;
+
+        case 'b':
+          printf ("option b\n");
+          break;
+
+        case 'c':
+          printf ("option c with value `%s'\n", optarg);
+          break;
+
+        case '?':
+          break;
+
+        default:
+          printf ("?? getopt returned character code 0%o ??\n", c);
+        }
+    }
+
+  if (optind < argc)
+    {
+      printf ("non-option ARGV-elements: ");
+      while (optind < argc)
+        printf ("%s ", argv[optind++]);
+      printf ("\n");
+    }
+
+  exit (0);
+}
+
+#endif /* TEST */

--- a/msvc/getopt/getopt.h
+++ b/msvc/getopt/getopt.h
@@ -1,0 +1,188 @@
+
+/* getopt.h */
+/* Declarations for getopt.
+   Copyright (C) 1989-1994, 1996-1999, 2001 Free Software
+   Foundation, Inc. This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute
+   it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software
+   Foundation; either version 2.1 of the License, or
+   (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will
+   be useful, but WITHOUT ANY WARRANTY; without even the
+   implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE.  See the GNU Lesser General Public
+   License for more details.
+
+   You should have received a copy of the GNU Lesser General
+   Public License along with the GNU C Library; if not, write
+   to the Free Software Foundation, Inc., 59 Temple Place,
+   Suite 330, Boston, MA 02111-1307 USA.  */
+
+
+
+
+#ifndef _GETOPT_H
+
+#ifndef __need_getopt
+# define _GETOPT_H 1
+#endif
+
+/* If __GNU_LIBRARY__ is not already defined, either we are being used
+   standalone, or this is the first header included in the source file.
+   If we are being used with glibc, we need to include <features.h>, but
+   that does not exist if we are standalone.  So: if __GNU_LIBRARY__ is
+   not defined, include <ctype.h>, which will pull in <features.h> for us
+   if it's from glibc.  (Why ctype.h?  It's guaranteed to exist and it
+   doesn't flood the namespace with stuff the way some other headers do.)  */
+#if !defined __GNU_LIBRARY__
+# include <ctype.h>
+#endif
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+/* For communication from `getopt' to the caller.
+   When `getopt' finds an option that takes an argument,
+   the argument value is returned here.
+   Also, when `ordering' is RETURN_IN_ORDER,
+   each non-option ARGV-element is returned here.  */
+
+extern char *optarg;
+
+/* Index in ARGV of the next element to be scanned.
+   This is used for communication to and from the caller
+   and for communication between successive calls to `getopt'.
+
+   On entry to `getopt', zero means this is the first call; initialize.
+
+   When `getopt' returns -1, this is the index of the first of the
+   non-option elements that the caller should itself scan.
+
+   Otherwise, `optind' communicates from one call to the next
+   how much of ARGV has been scanned so far.  */
+
+extern int optind;
+
+/* Callers store zero here to inhibit the error message `getopt' prints
+   for unrecognized options.  */
+
+extern int opterr;
+
+/* Set to an option character which was unrecognized.  */
+
+extern int optopt;
+
+#ifndef __need_getopt
+/* Describe the long-named options requested by the application.
+   The LONG_OPTIONS argument to getopt_long or getopt_long_only is a vector
+   of `struct option' terminated by an element containing a name which is
+   zero.
+
+   The field `has_arg' is:
+   no_argument          (or 0) if the option does not take an argument,
+   required_argument    (or 1) if the option requires an argument,
+   optional_argument    (or 2) if the option takes an optional argument.
+
+   If the field `flag' is not NULL, it points to a variable that is set
+   to the value given in the field `val' when the option is found, but
+   left unchanged if the option is not found.
+
+   To have a long-named option do something other than set an `int' to
+   a compiled-in constant, such as set a value from `optarg', set the
+   option's `flag' field to zero and its `val' field to a nonzero
+   value (the equivalent single-letter option character, if there is
+   one).  For long options that have a zero `flag' field, `getopt'
+   returns the contents of the `val' field.  */
+
+struct option
+{
+# if (defined __STDC__ && __STDC__) || defined __cplusplus
+  const char *name;
+# else
+  char *name;
+# endif
+  /* has_arg can't be an enum because some compilers complain about
+     type mismatches in all the code that assumes it is an int.  */
+  int has_arg;
+  int *flag;
+  int val;
+};
+
+/* Names for the values of the `has_arg' field of `struct option'.  */
+
+# define no_argument            0
+# define required_argument      1
+# define optional_argument      2
+#endif  /* need getopt */
+
+
+/* Get definitions and prototypes for functions to process the
+   arguments in ARGV (ARGC of them, minus the program name) for
+   options given in OPTS.
+
+   Return the option character from OPTS just read.  Return -1 when
+   there are no more options.  For unrecognized options, or options
+   missing arguments, `optopt' is set to the option letter, and '?' is
+   returned.
+
+   The OPTS string is a list of characters which are recognized option
+   letters, optionally followed by colons, specifying that that letter
+   takes an argument, to be placed in `optarg'.
+
+   If a letter in OPTS is followed by two colons, its argument is
+   optional.  This behavior is specific to the GNU `getopt'.
+
+   The argument `--' causes premature termination of argument
+   scanning, explicitly telling `getopt' that there are no more
+   options.
+
+   If OPTS begins with `--', then non-option arguments are treated as
+   arguments to the option '\0'.  This behavior is specific to the GNU
+   `getopt'.  */
+
+#if (defined __STDC__ && __STDC__) || defined __cplusplus
+# ifdef __GNU_LIBRARY__
+/* Many other libraries have conflicting prototypes for getopt, with
+   differences in the consts, in stdlib.h.  To avoid compilation
+   errors, only prototype getopt for the GNU C library.  */
+extern int getopt (int ___argc, char *const *___argv, const char *__shortopts);
+# else /* not __GNU_LIBRARY__ */
+extern int getopt ();
+# endif /* __GNU_LIBRARY__ */
+
+# ifndef __need_getopt
+extern int getopt_long (int ___argc, char *const *___argv,
+                        const char *__shortopts,
+                        const struct option *__longopts, int *__longind);
+extern int getopt_long_only (int ___argc, char *const *___argv,
+                             const char *__shortopts,
+                             const struct option *__longopts, int *__longind);
+
+/* Internal only.  Users should not call this directly.  */
+extern int _getopt_internal (int ___argc, char *const *___argv,
+                             const char *__shortopts,
+                             const struct option *__longopts, int *__longind,
+                             int __long_only);
+# endif
+#else /* not __STDC__ */
+extern int getopt ();
+# ifndef __need_getopt
+extern int getopt_long ();
+extern int getopt_long_only ();
+
+extern int _getopt_internal ();
+# endif
+#endif /* __STDC__ */
+
+#ifdef  __cplusplus
+}
+#endif
+
+/* Make sure we later can get all the definitions and declarations.  */
+#undef __need_getopt
+
+#endif /* getopt.h */

--- a/msvc/post-build.bat
+++ b/msvc/post-build.bat
@@ -6,12 +6,13 @@
 %= Argument is project target.                                         =%
 
 if "%1"=="" (echo "%~f0: Missing argument" 1>&2 & exit /b)
+if "%2"=="" (echo "%~f0: Missing argument" 1>&2 & exit /b)
 
 setlocal
 if defined ProgramW6432 set ProgramFiles=%ProgramW6432%
 
 %= Command name to create. =%
-set lgcmd=link-parser
+set lgcmd=%1
 
 echo %~f0: Info: Creating %lgcmd%.bat in %cd%
 
@@ -43,5 +44,5 @@ echo %~f0: Info: Creating %lgcmd%.bat in %cd%
 
 	echo REM Chdir to the link-grammar source directory so the data directory is found.
 	echo cd /D %cd%\..
-	echo %1 %%*
+	echo %2 %%*
 ) > %lgcmd%.bat

--- a/msvc/post-build.bat
+++ b/msvc/post-build.bat
@@ -31,16 +31,25 @@ echo %~f0: Info: Creating %lgcmd%.bat in %cd%
 	echo REM Copy it to a directory in your PATH and modify it if needed.
 	echo.
 
-	echo REM The following prepends LG_DDLPATH from msvc\Local.props
-	echo set "PATH=%LG_DLLPATH%;%%PATH%%"
-	echo.
-	echo REM For USE_WORDGRAPH_DISPLAY
-	echo REM Path for "dot.exe"
-	echo REM set "PATH=%%PATH%%;C:\cygwin64\bin"
-	echo set "PATH=%%PATH%%;%ProgramFiles(x86)%\Graphviz2.38\bin"
-	echo REM Path for "PhotoViewer.dll"
-	echo set "PATH=%%PATH%%;%ProgramFiles%\Windows Photo Viewer"
-	echo.
+	if not "%LG_DLLPATH%"=="" (
+		echo REM The following prepends LG_DDLPATH from msvc\Local.props
+		echo set "PATH=%LG_DLLPATH%;%%PATH%%"
+		echo.
+	) else (
+		echo REM Prepends DLL path
+		echo REM set "PATH=%DLLPATH%;%%PATH%%"
+		echo.
+	)
+
+	if "%lgcmd%"=="link-parser" (
+		echo REM For USE_WORDGRAPH_DISPLAY
+		echo REM Path for "dot.exe"
+		echo REM set "PATH=%%PATH%%;C:\cygwin64\bin"
+		echo set "PATH=%%PATH%%;%ProgramFiles(x86)%\Graphviz2.38\bin"
+		echo REM Path for "PhotoViewer.dll"
+		echo set "PATH=%%PATH%%;%ProgramFiles%\Windows Photo Viewer"
+		echo.
+	)
 
 	echo REM Chdir to the link-grammar source directory so the data directory is found.
 	echo cd /D %cd%\..


### PR DESCRIPTION
See issue #1266.

The main change here is the porting of `link-generator` to MS Windows:
- Install GNU `getopt` under `msvc/getopt`.
- Use `getopt` instead of `argp (still using the original `argp` definitions, which are more readable and easy to change).
- Add `--help` and `-usage` support that exactly mimics those of `argp`.
- Make changes and additions for MSVC and MS Windows support.
- Use `parser-utilities.[ch]` (see below).
- Create `link-generator.bat`.

In addition, implement these changes for `link-generator`:
- Convert numeric arguments with better error checking.
- Add prompt **linkgenerator>** when reading a sentence template (`editline` is not supported yet).
- Refactor system-dependent functions and move them to `parser-utilities.[ch]`. This removes most of the system-dependent stuff from `link-parser.c`, and makes the Windows support for `link-generator` very easy to implement.
- Use library verbosity 1 as a default.

Documentation changes (@linas, please correct my wording if needed):
- Update the `link-generator` manual.
- Update the main README file (among other things, remove the obsolete Windows regex info).

Additional changes:
- link-parser: Remove the use of %n.
- Minor cleanup in `parser-utilities.[ch]`.






