### PR TITLE
More `configure` modifications

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,8 +6,6 @@
 #
 # Note: this dependency on Perl is fine: only developers use autogen.sh
 #       and we can state that dev people need Perl on their machine
-#
-# TODO: make sure that ac_pkg_swig.m4 gets installed in m4 directory ...
 
 rm -f autogen.err
 

--- a/bindings/perl/Makefile.am
+++ b/bindings/perl/Makefile.am
@@ -45,7 +45,15 @@ clinkgrammar_la_CPPFLAGS =      \
    -I$(top_srcdir)/link-grammar \
    -I$(top_builddir)
 
-clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(PERL_LDFLAGS) -module -no-undefined
+if OS_WIN32
+AVOID_VERSION = -avoid-version
+endif
+if OS_NETBSD
+AVOID_VERSION = -avoid-version
+endif
+
+clinkgrammar_la_LDFLAGS = -version-info $(AVOID_VERSION) @VERSION_INFO@ \
+								  $(PERL_LDFLAGS) -module -no-undefined
 clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la
 
 if HAVE_HUNSPELL

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -84,6 +84,9 @@ if !OS_CYGWIN
 PYMODULE_EXT = -shrext .pyd
 endif
 endif
+if OS_NETBSD
+AVOID_VERSION = -avoid-version
+endif
 _clinkgrammar_la_LDFLAGS =                        \
     -version-info @VERSION_INFO@ $(AVOID_VERSION) \
     $(PYTHON_LDFLAGS) -module -no-undefined $(PYMODULE_EXT)

--- a/configure.ac
+++ b/configure.ac
@@ -275,8 +275,8 @@ then
 	# But not the NetBSD sh, so use sed instead.
 	# CFLAGS="${CFLAGS//-O[[2-9]]} -g"
 	# CXXFLAGS="${CXXFLAGS//-O[[2-9]]} -g"
-	CFLAGS=`AS_ECHO["-g ${CFLAGS}] |$SED "s/-O[[2-9]]//g"`
-	CXXFLAGS=`AS_ECHO[-g ${CXXFLAGS}] |$SED "s/-O[[2-9]]//g"`
+	CFLAGS=`AS_ECHO["-g ${CFLAGS}"] |$SED "s/-O[[2-9]]//g"`
+	CXXFLAGS=`AS_ECHO["-g ${CXXFLAGS}"] |$SED "s/-O[[2-9]]//g"`
 	LDFLAGS="-g ${LDFLAGS}"
 	AC_DEFINE(DEBUG,1)
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -275,8 +275,8 @@ then
 	# But not the NetBSD sh, so use sed instead.
 	# CFLAGS="${CFLAGS//-O[[2-9]]} -g"
 	# CXXFLAGS="${CXXFLAGS//-O[[2-9]]} -g"
-	CFLAGS=`AS_ECHO["-g ${CFLAGS}"] |$SED "s/-O[[2-9]]//g"`
-	CXXFLAGS=`AS_ECHO["-g ${CXXFLAGS}"] |$SED "s/-O[[2-9]]//g"`
+	CFLAGS=`AS_ECHO["${CFLAGS}"] |$SED "s/-O[[2-9]]//g"`
+	CXXFLAGS=`AS_ECHO["${CXXFLAGS}"] |$SED "s/-O[[2-9]]//g"`
 	LDFLAGS="-g ${LDFLAGS}"
 	AC_DEFINE(DEBUG,1)
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1041,7 +1041,7 @@ man/Makefile
 AC_OUTPUT
 
 # ====================================================================
-lglibs=`${ECHO} "$LIBEDIT_LIBS $HUNSPELL_LIBS $ASPELL_LIBS $REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS $LIBS"|${SED} 's/  */ /g'`
+lglibs=`AS_ECHO(["$LIBEDIT_LIBS $HUNSPELL_LIBS $ASPELL_LIBS $REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS $LIBS"])|${SED} 's/  */ /g'`
 test -n "$regexlib_cxx" && REGEX_LIBS='C++'
 
 AS_ECHO_N(["

--- a/configure.ac
+++ b/configure.ac
@@ -1044,7 +1044,7 @@ AC_OUTPUT
 lglibs=`${ECHO} "$LIBEDIT_LIBS $HUNSPELL_LIBS $ASPELL_LIBS $REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS $LIBS"|${SED} 's/  */ /g'`
 test -n "$regexlib_cxx" && REGEX_LIBS='C++'
 
-AS_ECHO["
+AS_ECHO_N(["
 $PACKAGE-$VERSION  build configuration settings
 
 	prefix:                         ${prefix}
@@ -1068,4 +1068,10 @@ $PACKAGE-$VERSION  build configuration settings
 	SQLite-backed dictionary:       ${SQLiteFound}
 	Definitions:                    ${LG_DEFS}
 	Libraries:                      ${lglibs}
-]"
+])"
+# Show LDFLAGS if set (usually by environment of argument).
+if test -n "$LDFLAGS"; then
+	AS_ECHO(["	Loader flags:                   $LDFLAGS"])
+else
+	AS_ECHO([])
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1053,7 +1053,9 @@ man/Makefile
 AC_OUTPUT
 
 # ====================================================================
-lglibs=`AS_ECHO(["$LIBEDIT_LIBS $HUNSPELL_LIBS $ASPELL_LIBS $REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS $LIBS"])|${SED} 's/  */ /g'`
+lglibs=`AS_ECHO(m4_normalize(["$LIBEDIT_LIBS $HUNSPELL_LIBS $ASPELL_LIBS
+										$REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS
+										$LIBS"]))|${SED} 's/  */ /g'`
 test -n "$regexlib_cxx" && REGEX_LIBS='C++'
 
 AS_ECHO_N(["

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,11 @@ AC_ARG_ENABLE( debug,
 
 if test "x$enable_debug" = "xyes"
 then
+	# Use -Og if possible
+	AX_CHECK_COMPILE_FLAG([-Og],
+		[CFLAGS="${CFLAGS} -Og" CXXFLAGS="${CXXFLAGS} -Og"],
+		[CFLAGS="${CFLAGS} -O0" CXXFLAGS="${CXXFLAGS} -O0"], [])
+
 	# Only bash supports double-backslash... Well, dash does too...
 	# But not the NetBSD sh, so use sed instead.
 	# CFLAGS="${CFLAGS//-O[[2-9]]} -g"

--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,18 @@ esac
 AC_MSG_RESULT([$apple_osx])
 AM_CONDITIONAL(OS_X, test "x$apple_osx" = "xyes")
 
+AC_MSG_CHECKING([for NetBSD])
+case "$host_os" in
+  *netbsd*)
+    netbsd=yes
+    ;;
+  *)
+    netbsd=no
+    ;;
+esac
+AC_MSG_RESULT([$netbsd])
+AM_CONDITIONAL(OS_NETBSD, test "x$netbsd" = "xyes")
+
 HOST_OS="$host_os"
 AC_SUBST(HOST_OS)
 # ====================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,7 @@ AM_CONDITIONAL(OS_CYGWIN, test "x$cygwin" = "xyes")
 
 AC_MSG_CHECKING([for 64-bit Apple OSX])
 case "$host_os" in
-  darwin*)
+  x86_64-*darwin*)
     apple_osx=yes
     ;;
   *)

--- a/configure.ac
+++ b/configure.ac
@@ -282,7 +282,6 @@ then
 	# CXXFLAGS="${CXXFLAGS//-O[[2-9]]} -g"
 	CFLAGS=`AS_ECHO["${CFLAGS}"] |$SED "s/-O[[2-9]]//g"`
 	CXXFLAGS=`AS_ECHO["${CXXFLAGS}"] |$SED "s/-O[[2-9]]//g"`
-	LDFLAGS="-g ${LDFLAGS}"
 	AC_DEFINE(DEBUG,1)
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -292,8 +292,8 @@ then
 	# But not the NetBSD sh, so use sed instead.
 	# CFLAGS="${CFLAGS//-O[[2-9]]} -g"
 	# CXXFLAGS="${CXXFLAGS//-O[[2-9]]} -g"
-	CFLAGS=`AS_ECHO["${CFLAGS}"] |$SED "s/-O[[2-9]]//g"`
-	CXXFLAGS=`AS_ECHO["${CXXFLAGS}"] |$SED "s/-O[[2-9]]//g"`
+	CFLAGS=`AS_ECHO(["${CFLAGS}"]) |$SED "s/-O[[2-9]]//g"`
+	CXXFLAGS=`AS_ECHO(["${CXXFLAGS}"]) |$SED "s/-O[[2-9]]//g"`
 	AC_DEFINE(DEBUG,1)
 fi
 
@@ -1004,7 +1004,7 @@ AC_FUNC_STRERROR_R
 
 dnl Save the compilation definitions for an extended version printout
 AC_OUTPUT_MAKE_DEFS()
-LG_DEFS=`AS_ECHO["$DEFS"] | $SED 's/\\\\//g'`
+LG_DEFS=`AS_ECHO(["$DEFS"]) | $SED 's/\\\\//g'`
 AC_SUBST(LG_DEFS)
 
 AC_CONFIG_FILES([

--- a/configure.ac
+++ b/configure.ac
@@ -292,8 +292,8 @@ then
 	# But not the NetBSD sh, so use sed instead.
 	# CFLAGS="${CFLAGS//-O[[2-9]]} -g"
 	# CXXFLAGS="${CXXFLAGS//-O[[2-9]]} -g"
-	CFLAGS=`AS_ECHO(["${CFLAGS}"]) |$SED "s/-O[[2-9]]//g"`
-	CXXFLAGS=`AS_ECHO(["${CXXFLAGS}"]) |$SED "s/-O[[2-9]]//g"`
+	CFLAGS=`AS_ECHO(["${CFLAGS}"]) | $SED "s/-O[[2-9]]//g"`
+	CXXFLAGS=`AS_ECHO(["${CXXFLAGS}"]) | $SED "s/-O[[2-9]]//g"`
 	AC_DEFINE(DEBUG,1)
 fi
 
@@ -1055,7 +1055,7 @@ AC_OUTPUT
 # ====================================================================
 lglibs=`AS_ECHO(m4_normalize(["$LIBEDIT_LIBS $HUNSPELL_LIBS $ASPELL_LIBS
 										$REGEX_LIBS $MINISAT_LIBS $SQLITE3_LIBS
-										$LIBS"]))|${SED} 's/  */ /g'`
+										$LIBS"])) | ${SED} 's/  */ /g'`
 test -n "$regexlib_cxx" && REGEX_LIBS='C++'
 
 AS_ECHO_N(["

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -331,7 +331,6 @@ static void table_stat(count_context_t *ctxt)
 	size_t N = 0;          /* NULL table slots */
 	size_t null_count[256] = { 0 };   /* null_count histogram */
 	int chain_length[64] = { 0 };     /* Chain length histogram */
-	int n;                 /* For printf() pretty printing */
 	bool table_stat_entries = test_enabled("count-table-entries");
 
 	for (size_t i = 0; i < ctxt->table_size; i++)
@@ -410,7 +409,7 @@ static void table_stat(count_context_t *ctxt)
 				{
 					if (t->null_count != nc) continue;
 
-					printf("[%zu]%n", i, &n);
+					int n = printf("[%zu]", i);
 					printf("%*d %5d c=%"COUNT_FMT"\n",  15-n, t->l_id, t->r_id, t->count);
 				}
 			}

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -759,7 +759,7 @@ bool strtodC(const char *s, float *r)
 {
 	char *err;
 
-#if defined(HAVE_LOCALE_T) && !defined(__sun__)
+#if defined(HAVE_LOCALE_T) && !defined(__sun__) && !defined(__OpenBSD__)
 	double val = strtod_l(s, &err, get_C_LC_NUMERIC());
 #else
 	/* dictionary_setup_locale() invokes setlocale(LC_NUMERIC, "C") */

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -166,7 +166,7 @@ int strncasecmp(const char *s1, const char *s2, size_t n);
 #ifdef HAVE_LOCALE_T
 locale_t newlocale_LC_CTYPE(const char *);
 #else
-typedef int locale_t;
+typedef void *locale_t;
 #define iswupper_l(c, l) iswupper(c)
 #define iswalpha_l(c, l) iswalpha(c)
 #define iswdigit_l(c, l) iswdigit(c)


### PR DESCRIPTION
Fix bugs:
- configure.ac: Fix shell syntax error with `--enable-debug` (introduced in PR #1273).
It was a harmful bug.
- configure.ac: Use `AS_ECHO` as documented - with `()`.
This bug was not harmful.

Cleanup:
- configure.ac: Omit redundant `-g`.
- configure.ac: No need to set `LDFLAGS` for `--enable-debug`.
- configure.ac: Replace a forgotten `$ECHO` by `AS_ECHO`.
- autogen.sh: Installation of `PKG_SWIG` is now being checked (`m4_pattern_forbid`).
- configure.ac: Fold source line in `lglibs=`
- configure.ac: Add whitespace over pipe symbols.

Improvements:
- configure.ac: Add `-Og` with `--enable-debug` (use `-O0` if -Og` is not supported).
- configure.ac: Add `LDFLAGS` to the build configuration settings list.

Portability:
- python: `-avoid-version` for OpenBSD.
- perl: `-avoid-version` for OpenBSD.
- count.c: Remove the use of `%n`.
- strtodC: Use `strtod()` also for NetBSD.
FIXME: Use a string-to-float conversion code that always uses ".".
- Use `void *locale_t` if `!HAVE_LOCALE_T` (not checked).
- `--enable-java-bindings` on Mac: Use `-arch x86_64` only for x86_64.
This intends to address the problem in issue #1270 when `--disable-java-bindings` was needed in order to compile for native M1 architecture. I validated that on X86_64 the Java bindings work fine after this fix, but I don't have M1 to test it further.

N.B. The NetBSD fixes are from:
http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/textproc/link-grammar/patches/patch-bindings_perl_Makefile_in?rev=1.5&content-type=text/x-cvsweb-markup
I didn't apply most of the `locale_t` fix because it modifies some code that is needed for other OSs. Anyway, I hope that recent NetBSD versions already support `locale_t`.