### PR TITLE
minisat: remove `#include <fpu_control.h>`

### DIFF
--- a/link-grammar/minisat/minisat/utils/System.h
+++ b/link-grammar/minisat/minisat/utils/System.h
@@ -21,10 +21,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_System_h
 #define Minisat_System_h
 
-#if defined(__linux__)
-#include <fpu_control.h>
-#endif
-
 #include "minisat/mtl/IntTypes.h"
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* `fpu_control.h` doesn't exist on musl, and doesn't do anything
  on glibc anymore for the past years. Remove it to unbreak musl
  builds.

Bug: https://bugs.gentoo.org/717404