### PR TITLE
Remove pointless MAX_WORD limitation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.10.4 (XXX 2022)
  * English dict: fix relative clause, per mailing list.
+ * Remove assorted length restrictions on word-size. #1283
 
 Version 5.10.3 (14 Feb 2022)
  * Remove `node.js/package-lock.json` from tarball distribution. #1251

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -527,7 +527,8 @@ static int revcmplen(const void *a, const void *b)
  * The saved affixes don't include the infix mark.
  */
 static void get_dict_affixes(Dictionary dict, Dict_node * dn,
-                             char infix_mark, char * w_last)
+                             char infix_mark,
+                             const char** plast, size_t lastlen)
 {
 	const char *w;         /* current dict word */
 	const char *w_sm;      /* SUBSCRIPT_MARK position in the dict word */
@@ -535,37 +536,33 @@ static void get_dict_affixes(Dictionary dict, Dict_node * dn,
 	Dictionary afdict = dict->affix_table;
 
 	if (dn == NULL) return;
-	get_dict_affixes(dict, dn->right, infix_mark, w_last);
+	get_dict_affixes(dict, dn->right, infix_mark, plast, lastlen);
 
 	w = dn->string;
 	w_sm = strrchr(w, SUBSCRIPT_MARK);
 	w_len = (NULL == w_sm) ? strlen(w) : (size_t)(w_sm - w);
-	if (w_len > MAX_WORD)
-	{
-		prt_error("Error: word '%s' too long (%zu), program may malfunction\n",
-		          w, w_len);
-		w_len = MAX_WORD;
-	}
-	/* (strlen(w_last) can be cached for speedup) */
-	if ((strlen(w_last) != w_len) || (0 != strncmp(w_last, w, w_len)))
-	{
-		strncpy(w_last, w, w_len);
-		w_last[w_len] = '\0';
 
-		if (infix_mark == w_last[0])
+	if (lastlen != w_len || 0 != strncmp(*plast, w, w_len))
+	{
+		char* wtrunc = strdupa(w);
+		wtrunc[w_len] = '\0';
+
+		if (infix_mark == w[0])
 		{
-			affix_list_add(afdict, &afdict->afdict_class[AFDICT_SUF], w_last+1);
+			affix_list_add(afdict, &afdict->afdict_class[AFDICT_SUF], wtrunc+1);
 		}
 		else
-		if (infix_mark == w_last[w_len-1])
+		if (infix_mark == w[w_len-1])
 		{
-			w_last[w_len-1] = '\0';
-			affix_list_add(afdict, &afdict->afdict_class[AFDICT_PRE], w_last);
-			w_last[w_len-1] = infix_mark;
+			wtrunc[w_len-1] = '\0';
+			affix_list_add(afdict, &afdict->afdict_class[AFDICT_PRE], wtrunc);
 		}
+
+		*plast = w;
+		lastlen = w_len;
 	}
 
-	get_dict_affixes(dict, dn->left, infix_mark, w_last);
+	get_dict_affixes(dict, dn->left, infix_mark, plast, lastlen);
 }
 
 /**
@@ -672,8 +669,8 @@ bool afdict_init(Dictionary dict)
 		if ((0 == AFCLASS(afdict, AFDICT_PRE)->length) &&
 		    (0 == AFCLASS(afdict, AFDICT_SUF)->length))
 		{
-			char last_entry[MAX_WORD+1] = "";
-			get_dict_affixes(dict, dict->root, ac->string[0][0], last_entry);
+			const char *last = 0x0;
+			get_dict_affixes(dict, dict->root, ac->string[0][0], &last, 0);
 		}
 		else
 		{

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -528,7 +528,7 @@ static int revcmplen(const void *a, const void *b)
  */
 static void get_dict_affixes(Dictionary dict, Dict_node * dn,
                              char infix_mark,
-                             const char** plast, size_t lastlen)
+                             const char** plast, size_t *lastlen)
 {
 	const char *w;         /* current dict word */
 	const char *w_sm;      /* SUBSCRIPT_MARK position in the dict word */
@@ -542,7 +542,7 @@ static void get_dict_affixes(Dictionary dict, Dict_node * dn,
 	w_sm = strrchr(w, SUBSCRIPT_MARK);
 	w_len = (NULL == w_sm) ? strlen(w) : (size_t)(w_sm - w);
 
-	if (lastlen != w_len || 0 != strncmp(*plast, w, w_len))
+	if (*lastlen != w_len || 0 != strncmp(*plast, w, w_len))
 	{
 		char* wtrunc = strdupa(w);
 		wtrunc[w_len] = '\0';
@@ -559,7 +559,7 @@ static void get_dict_affixes(Dictionary dict, Dict_node * dn,
 		}
 
 		*plast = w;
-		lastlen = w_len;
+		*lastlen = w_len;
 	}
 
 	get_dict_affixes(dict, dn->left, infix_mark, plast, lastlen);
@@ -670,7 +670,8 @@ bool afdict_init(Dictionary dict)
 		    (0 == AFCLASS(afdict, AFDICT_SUF)->length))
 		{
 			const char *last = 0x0;
-			get_dict_affixes(dict, dict->root, ac->string[0][0], &last, 0);
+			size_t len = 0;
+			get_dict_affixes(dict, dict->root, ac->string[0][0], &last, &len);
 		}
 		else
 		{

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -14,7 +14,6 @@
 #include "api-types.h"
 #include "dict-api.h"
 #include "dict-common.h"
-#include "dict-defines.h" // For MAX_WORD
 #include "error.h"
 #include "idiom.h"
 #include "string-set.h"
@@ -74,9 +73,10 @@ static bool is_idiom_string(const char * s)
  * This is the same as s, but with a postfix of ".I". */
 static const char * build_idiom_word_name(Dictionary dict, const char * s)
 {
-	char buff[2*MAX_WORD];
+	size_t n = strlen(s);
+	char *buff = alloca(n+5);
 
-	size_t n = lg_strlcpy(buff, s, sizeof(buff));
+	strcpy(buff, s);
 	buff[n] = SUBSCRIPT_MARK;
 	buff[n + 1] = '_';
 	buff[n + 2] = 'I';

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -965,7 +965,6 @@ exprint_constituent_structure(con_context_t *ctxt,
 	bool *leftdone = alloca(numcon_total * sizeof(bool));
 	bool *rightdone = alloca(numcon_total * sizeof(bool));
 	int best, bestright, bestleft;
-	char s[MAX_WORD];
 	dyn_str * cs = dyn_str_new();
 
 	assert (numcon_total < ctxt->conlen, "Too many constituents (b)");
@@ -1006,6 +1005,7 @@ exprint_constituent_structure(con_context_t *ctxt,
 		/* Don't print out right wall */
 		if (w < linkage->num_words - 1)
 		{
+			char s[MAX_WORD];
 			char *p;
 			strncpy(s, linkage->word[w], MAX_WORD);
 			s[MAX_WORD-1] = 0;

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -16,7 +16,7 @@
 
 #include "api-structures.h"
 #include "dict-common/dict-common.h"    // Dictionary_s
-#include "dict-common/dict-defines.h"   // RIGHT_WALL_WORD, MAX_WORD
+#include "dict-common/dict-defines.h"   // RIGHT_WALL_WORD
 #include "error.h"
 #include "linkage/linkage.h"
 #include "post-process/post-process.h"
@@ -1005,10 +1005,8 @@ exprint_constituent_structure(con_context_t *ctxt,
 		/* Don't print out right wall */
 		if (w < linkage->num_words - 1)
 		{
-			char s[MAX_WORD];
 			char *p;
-			strncpy(s, linkage->word[w], MAX_WORD);
-			s[MAX_WORD-1] = 0;
+			char *s = strdupa(linkage->word[w]);
 
 			/* Constituent processing will crash if the sentence contains
 			 * square brackets, so we have to do something ... replace

--- a/link-grammar/post-process/constituents.c
+++ b/link-grammar/post-process/constituents.c
@@ -1006,7 +1006,15 @@ exprint_constituent_structure(con_context_t *ctxt,
 		if (w < linkage->num_words - 1)
 		{
 			char *p;
-			char *s = strdupa(linkage->word[w]);
+
+			/* All dict words are smaller than MAX_WORD;
+			 * However, user-inputs may be unknown-words of
+			 * unbounded length, and could overflow the stack,
+			 * if hostile. Truncate these to finite size.
+			 */
+			char s[MAX_WORD];
+			strncpy(s, linkage->word[w], MAX_WORD);
+			s[MAX_WORD-1] = 0;
 
 			/* Constituent processing will crash if the sentence contains
 			 * square brackets, so we have to do something ... replace

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -41,7 +41,7 @@
 #include "anysplit.h"
 
 
-#define MAX_WORD_TO_SPLIT 31 /* in codepoins */
+#define MAX_WORD_TO_SPLIT 31 /* in codepoints */
 
 extern const char * const afdict_classname[];
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -22,7 +22,7 @@
 #include "dict-common/dict-affix.h"
 #include "dict-common/dict-api.h"
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h" // for MAX_WORD
+#include "dict-common/dict-defines.h" // for RIGHT_WALL_WORD
 #include "dict-common/dict-utils.h"
 #include "dict-common/regex-morph.h"
 #include "error.h"
@@ -1362,16 +1362,12 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 			for (j = 0; j < p_strippable; j++)
 			{
 				size_t prelen = strlen(prefix[j]);
-				/* The remaining w is too short for a possible match.
-				 * NOTE: A zero length "stem" is not allowed here. In any
-				 * case, it cannot be handled (yet) by the rest of the code. */
-				if ((wend-w) - suflen <= prelen) continue;
-				if (strncmp(w, prefix[j], prelen) == 0)
-				{
-					size_t sz = MIN((wend-w) - suflen - prelen, MAX_WORD);
 
-					strncpy(newword, w+prelen, sz);
-					newword[sz] = '\0';
+				/* A zero length "stem" is not allowed here. In any case,
+				 * it cannot be handled (yet) by the rest of the code. */
+				if (suflen+prelen < wend-w && strncmp(w, prefix[j], prelen) == 0)
+				{
+					strcpy(newword, w+prelen);
 					/* ??? Do we need a regex match? */
 					if (dict_has_word(dict, newword))
 					{
@@ -1464,7 +1460,7 @@ static bool mprefix_split(Sentence sent, Gword *unsplit_word, const char *word)
 	memset(pseen, 0, mp_strippable * sizeof(*pseen));
 
 	w = word;
-	wordlen = strlen(word);  /* guaranteed < MAX_WORD by separate_word() */
+	wordlen = strlen(word);
 	do
 	{
 		pfound = -1;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1318,7 +1318,7 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 			suflen = strlen(*suffix);
 			 /* The remaining w is too short for a possible match.
 			  * In addition, don't allow empty stems. */
-			if ((wend-suflen) < (w+1)) continue;
+			if ((size_t) (wend-w) < suflen+1) continue;
 
 			/* A lang like Russian allows empty suffixes, which have a real
 			 * morphological linkage. In the following check, the empty suffix
@@ -1365,7 +1365,8 @@ static bool suffix_split(Sentence sent, Gword *unsplit_word, const char *w)
 
 				/* A zero length "stem" is not allowed here. In any case,
 				 * it cannot be handled (yet) by the rest of the code. */
-				if (suflen+prelen < wend-w && strncmp(w, prefix[j], prelen) == 0)
+				if (suflen+prelen < (size_t) (wend-w)
+				    && strncmp(w, prefix[j], prelen) == 0)
 				{
 					strcpy(newword, w+prelen);
 					/* ??? Do we need a regex match? */


### PR DESCRIPTION
There were four places that applied a buffer size limit of `MAX_WORD` that weren't really needed.  Remove those uses.  Two usages remain: during dict printing (seems harmless) and in dict reading (seems practical).