### PR TITLE
Strip "._I" from subscripted idioms

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 Version 5.10.4 (XXX 2022)
  * English dict: fix relative clause, per mailing list.
+ * Add missing files for building link-generator on Windows. #1285
+ * Strip the internally added "._I" from subscripted idioms. #1287
 
 Version 5.10.3 (14 Feb 2022)
  * Remove `node.js/package-lock.json` from tarball distribution. #1251

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1018,6 +1018,8 @@ class XLookupListTestCase(unittest.TestCase):
 
     def test_file_lookup_list_no_subscr(self):
         dictnode = clg.dictionary_lookup_list(self.d_en._obj, 'test')
+        # The following supposes there are no idioms with the word "test".
+        # If such idioms are added, filter out the subscript "._I".
         self.assertEqual(sorted([dictnode[i].string for i in range(len(dictnode))]), [sm('test.n'), sm('test.v')])
         for i in range(len(dictnode)):
             self.assertIn("(", str(dictnode[i].exp), "Missing expression")

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -45,7 +45,7 @@
  */
 bool is_stem(const char* w)
 {
-	const char *subscrmark = strchr(w, SUBSCRIPT_MARK);
+	const char *subscrmark = get_word_subscript(w);
 
 	if (NULL == subscrmark) return false;
 	if (subscrmark == w) return false;

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -196,7 +196,7 @@ static inline const char *subscript_mark_str(void)
  */
 static inline char *get_word_subscript(const char *word)
 {
-	return strrchr(word, SUBSCRIPT_MARK);
+	return (char *)strrchr(word, SUBSCRIPT_MARK); /* (char *) for MSVC */
 }
 #define get_word_subscript(word) _Generic((word), \
 	const char * : (const char *)(get_word_subscript)((word)), \

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -188,4 +188,17 @@ static inline const char *subscript_mark_str(void)
 	static const char sm[] = { SUBSCRIPT_MARK, '\0' };
 	return sm;
 }
+
+/**
+ * Get the subscript of the given word.
+ * In case of more than one subscript, return the last subscript.
+ * The returned value constness is the same as the argument.
+ */
+static inline char *get_word_subscript(const char *word)
+{
+	return strrchr(word, SUBSCRIPT_MARK);
+}
+#define get_word_subscript(word) _Generic((word), \
+	const char * : (const char *)(get_word_subscript)((word)), \
+	char *       :               (get_word_subscript)((word)))
 #endif /* _LG_DICT_COMMON_H_ */

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -538,7 +538,7 @@ static void get_dict_affixes(Dictionary dict, Dict_node * dn,
 	get_dict_affixes(dict, dn->right, infix_mark, w_last);
 
 	w = dn->string;
-	w_sm = strrchr(w, SUBSCRIPT_MARK);
+	w_sm = get_word_subscript(w);
 	w_len = (NULL == w_sm) ? strlen(w) : (size_t)(w_sm - w);
 	if (w_len > MAX_WORD)
 	{

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -101,7 +101,7 @@ static Dict_node * make_idiom_Dict_nodes(Dictionary dict, const char * string)
 	Dict_node * dn = NULL;
 	char * s = strdupa(string);
 	const char * t;
-	const char *sm = strchr(s, SUBSCRIPT_MARK);
+	const char *sm = get_word_subscript(s);
 
 	for (t = s; NULL != s; t = s)
 	{
@@ -312,7 +312,7 @@ void insert_idiom(Dictionary dict, Dict_node * dn)
  */
 bool is_idiom_word(const char * s)
 {
-	const char *sm = strchr(s, SUBSCRIPT_MARK);
+	const char *sm = get_word_subscript(s);
 
 	if (NULL == sm) return false;
 	if ((sm[1] == '_') && (sm[2] == 'I') && (sm[3] == '\0')) return true;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -612,8 +612,8 @@ static Dict_node * prune_lookup_list(Dict_node * restrict llist, const char * re
 /* ======================================================================== */
 static bool subscr_match(const char *s, const Dict_node * dn)
 {
-	const char * s_sub = strrchr(s, SUBSCRIPT_MARK);
-	const char * t_sub = strrchr(dn->string, SUBSCRIPT_MARK);
+	const char * s_sub = get_word_subscript(s);
+	const char * t_sub = get_word_subscript(dn->string);
 
 	if (NULL == s_sub)
 	{
@@ -1569,7 +1569,7 @@ void insert_list(Dictionary dict, Dict_node * p, int l)
 	dn_second_half = dn->left;
 	dn->left = dn->right = NULL;
 
-	const char *sm = strchr(dn->string, SUBSCRIPT_MARK);
+	const char *sm = get_word_subscript(dn->string);
 	if ((NULL != sm) && ('_' == sm[1]))
 	{
 		prt_error("Warning: Word \"%s\" found near line %d of \"%s\".\n"

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -51,7 +51,7 @@ static void add_morpheme_unmarked(Sentence sent, char *join_buff,
                                   const char *wm, Morpheme_type mt)
 {
 	const char infix_mark = INFIX_MARK(sent->dict->affix_table);
-	const char *sm =  strrchr(wm, SUBSCRIPT_MARK);
+	const char *sm =  get_word_subscript(wm);
 
 	if (NULL == sm) sm = (char *)wm + strlen(wm);
 
@@ -482,7 +482,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 				if (is_idiom_word(t))
 				{
 					s = strdupa(t);
-					sm = strrchr(s, SUBSCRIPT_MARK); /* Possible double subscript. */
+					sm = (char *)get_word_subscript(s); /* Possible double subscript. */
 					UNREACHABLE(NULL == sm); /* We know it has a subscript. */
 					*sm = '\0';
 					t = string_set_add(s, sent->string_set);
@@ -570,7 +570,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 								}
 							}
 
-							sm =  strchr(cdjp[i+m]->word_string, SUBSCRIPT_MARK);
+							sm =  get_word_subscript(cdjp[i+m]->word_string);
 
 							if (NULL != sm)
 							{
@@ -633,7 +633,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 			{
 
 				s = strdupa(t);
-				sm = strrchr(s, SUBSCRIPT_MARK);
+				sm = get_word_subscript(s);
 				if (sm) *sm = SUBSCRIPT_DOT;
 
 				if ((!(w->status & WS_GUESS) && (w->status & WS_INDICT))

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -476,7 +476,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 			}
 			else
 			{
-				/* Get rid of those ugly "I" */
+				/* Get rid of those ugly ".I" */
 				if (is_idiom_word(t))
 				{
 					s = strdupa(t);

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -465,9 +465,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 		else
 		{
 			/* This word has a linkage. */
-
 			/* TODO: Suppress "virtual-morphemes", currently the dictcap ones. */
-			char *sm;
 
 			t = cdj->word_string;
 			/* Print the subscript, as in "dog.n" as opposed to "dog". */
@@ -482,7 +480,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 				if (is_idiom_word(t))
 				{
 					s = strdupa(t);
-					sm = (char *)get_word_subscript(s); /* Possible double subscript. */
+					char *sm = (char *)get_word_subscript(s);
 					UNREACHABLE(NULL == sm); /* We know it has a subscript. */
 					*sm = '\0';
 					t = string_set_add(s, sent->string_set);
@@ -570,7 +568,8 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 								}
 							}
 
-							sm =  get_word_subscript(cdjp[i+m]->word_string);
+							const char *sm =
+								get_word_subscript(cdjp[i+m]->word_string);
 
 							if (NULL != sm)
 							{
@@ -633,7 +632,7 @@ static void compute_chosen_words(Sentence sent, Linkage linkage,
 			{
 
 				s = strdupa(t);
-				sm = get_word_subscript(s);
+				char *sm = get_word_subscript(s);
 				if (sm) *sm = SUBSCRIPT_DOT;
 
 				if ((!(w->status & WS_GUESS) && (w->status & WS_INDICT))

--- a/link-grammar/print/print-util.h
+++ b/link-grammar/print/print-util.h
@@ -23,6 +23,7 @@
 #include <stdarg.h>
 
 #include "link-includes.h"
+#include "dict-common/dict-common.h"  /* get_word_subscript */
 #include "dict-common/dict-defines.h" /* SUBSCRIPT_MARK, SUBSCRIPT_DOT */
 #include "error.h"
 #include "utilities.h"
@@ -36,14 +37,14 @@ int utf8_charwidth(const char *);
 
 static inline void patch_subscript_mark(char *s)
 {
-	s = strchr(s, SUBSCRIPT_MARK);
+	s = get_word_subscript(s);
 	if (NULL != s)
 		*s = SUBSCRIPT_DOT;
 }
 
 static inline void patch_subscript_marks(char *s)
 {
-	while (NULL != (s = strchr(s, SUBSCRIPT_MARK)))
+	while (NULL != (s = get_word_subscript(s)))
 		*s = SUBSCRIPT_DOT;
 }
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3068,7 +3068,7 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w,
 		else
 		{
 			dyn_str *xs = dyn_str_new();
-			const char *sm = strrchr(dn->string, SUBSCRIPT_MARK);
+			const char *sm = get_word_subscript(dn->string);
 
 			dyn_strcat(xs, w->subword);
 			if (NULL != sm) dyn_strcat(xs, sm);

--- a/msvc/MSVC-common.props
+++ b/msvc/MSVC-common.props
@@ -8,8 +8,9 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>$(CFLAGS);HAVE_STRING_H;WIN32_LEAN_AND_MEAN;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4068</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>..;..\link-grammar;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <DisableSpecificWarnings>4068;5105;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes the bug described in my comment in [PR #1279](https://github.com/opencog/link-grammar/pull/1279#issuecomment-1052940863).
Reference: PR #1279.

The main fix here is:
- Use `get_word_subscript()` instead of directly searching for `SUBSCRIPT_MARK`.
Since `get_word_subscript()` searches for `SUBSCRIPT_MARK` from the string end, this solves the bug of not stripping idiom subscripts.

Note that ChangeLog includes a line added in the yet-unapplied PR #1285, in a hope that this will prevent a conflict when applied.
