### PR TITLE
Disjunct building speedup

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -96,7 +96,7 @@ struct Parse_Options_s
 #endif
 
 	/* Options governing the parser internals operation */
-	double disjunct_cost;  /* Max disjunct cost to allow */
+	float disjunct_cost;  /* Max disjunct cost to allow */
 	short min_null_count;  /* The minimum number of null links to allow */
 	short max_null_count;  /* The maximum number of null links to allow */
 	bool islands_ok;       /* If TRUE, then linkages with islands

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -141,6 +141,8 @@ struct Sentence_s
 	Pool_desc * X_node_pool;
 	Pool_desc * Disjunct_pool;
 	Pool_desc * Connector_pool;
+	Pool_desc * Clause_pool;
+	Pool_desc * Tconnector_pool;
 
 	/* Connector encoding, packing & sharing. */
 	size_t min_len_encoding;     /* Encode from this sentence length. */

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -556,6 +556,16 @@ void sentence_delete(Sentence sent)
 	pool_delete(sent->wordvec_pool);
 	pool_delete(sent->Exp_pool);
 	pool_delete(sent->X_node_pool);
+
+	/* Usually the memory pools created in build_disjuncts_for_exp() are
+	 * deleted in build_sentence_disjuncts(). Delete them here inn case
+	 * build_disjuncts_for_exp() is directly called. */
+	if (sent->Clause_pool != NULL)
+	{
+		pool_delete(sent->Clause_pool);
+		pool_delete(sent->Tconnector_pool);
+	}
+
 	if (IS_DB_DICT(sent->dict))
 	{
 #if 0 /* Cannot reuse in case a previous sentence is not deleted yet. */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -79,7 +79,7 @@ struct condesc_struct
 	lc_enc_t lc_mask;
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
-	// double *cost; /* Array of cost by connector length (cost[0]: default) */
+	// float *cost;    /* Array of cost by connector length (cost[0]: default) */
 	connector_hash_t uc_num; /* uc part enumeration. */
 	uint8_t length_limit; /* If not 0, it gives the limit of the length of the
 	                       * link that can be used on this connector type. The

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -103,9 +103,9 @@ struct Dictionary_s
 	const char * lang;
 	const char * version;
 	const char * locale;    /* Locale name */
-	double default_max_disjunct_cost;
 	locale_t     lctype;    /* Locale argument for the *_l() functions */
 	int          num_entries;
+	float default_max_disjunct_cost;
 	define_s     define;    /* Name-value definitions */
 
 	bool         use_unknown_word;

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -14,6 +14,8 @@
 #ifndef _LG_DICT_STRUCTURES_H_
 #define _LG_DICT_STRUCTURES_H_
 
+#include <stdint.h>
+
 #include "link-includes.h"
 
 #ifndef SWIG
@@ -100,6 +102,7 @@ typedef struct
 #ifndef SWIG
 bool cost_eq(float cost1, float cost2);
 const char *cost_stringify(float cost);
+uint64_t count_clause(const Exp *);
 #endif /* !SWIG */
 
 /* API to access the above structure. */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -49,11 +49,14 @@ typedef enum { Exptag_none=0, Exptag_dialect, Exptag_macro } Exptag_type;
  * list of operands (when each of them points to the next one through
  * "operand_next"). Else "condesc" is the connector descriptor, when "dir"
  * indicates the connector direction.
+ * For CONNECTOR_type, the "pos" filed is the expression ordinal position
+ * (found when building the disjuncts, for "!!word/m").
  */
 struct Exp_struct
 {
 	Exp_type type:8;      /* One of three types: AND, OR, or connector. */
-	unsigned int unused:24;
+	unsigned int unsued:8;
+	unsigned int pos:16;  /* The position in the expression. */
 	union
 	{
 		struct /* For non-terminals. */

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -37,7 +37,7 @@ typedef enum
 
 #ifndef SWIG
 static const int cost_max_dec_places = 3;
-static const double cost_epsilon = 1E-5;
+static const float cost_epsilon = 1E-5;
 
 #define EXPTAG_SZ 100 /* Initial size for the Exptag array. */
 typedef enum { Exptag_none=0, Exptag_dialect, Exptag_macro } Exptag_type;
@@ -95,8 +95,8 @@ typedef struct
 } Category_cost;
 
 #ifndef SWIG
-bool cost_eq(double cost1, double cost2);
-const char *cost_stringify(double cost);
+bool cost_eq(float cost1, float cost2);
+const char *cost_stringify(float cost);
 #endif /* !SWIG */
 
 /* API to access the above structure. */

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1156,7 +1156,7 @@ display_word_split_error:
  * Only one minor cheat here: we are ignoring the cost_cutoff, so
  * this potentially over-counts if the cost_cutoff is set low.
  */
-static unsigned int count_clause(Exp *e)
+static unsigned int count_clause(const Exp *e)
 {
 	unsigned int cnt = 0;
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -30,7 +30,7 @@
 #include "utilities.h"                  // GNU_UNUSED
 /* ======================================================================== */
 
-bool cost_eq(double cost1, double cost2)
+bool cost_eq(float cost1, float cost2)
 {
 	return (fabs(cost1 - cost2) < cost_epsilon);
 }
@@ -38,7 +38,7 @@ bool cost_eq(double cost1, double cost2)
 /**
  * Convert cost to a string with at most cost_max_dec_places decimal places.
  */
-const char *cost_stringify(double cost)
+const char *cost_stringify(float cost)
 {
 	static TLS char buf[16];
 
@@ -119,7 +119,7 @@ static void print_expression_tag_end(Dictionary dict, dyn_str *e, const Exp *n,
 	}
 }
 
-static void get_expression_cost(const Exp *e, unsigned int *icost, double *dcost)
+static void get_expression_cost(const Exp *e, unsigned int *icost, float *dcost)
 {
 	if (e->cost < -cost_epsilon)
 	{
@@ -170,7 +170,7 @@ static void print_expression_parens(Dictionary dict, dyn_str *e, const Exp *n,
                                     bool need_parens, int *indent)
 {
 	unsigned int icost;
-	double dcost;
+	float dcost;
 	get_expression_cost(n, &icost, &dcost);
 	for (unsigned int i = 0; i < icost; i++) dyn_strcat(e, "[");
 	print_expression_tag_start(dict, e, n, indent);
@@ -784,7 +784,7 @@ static char *display_disjuncts(Dictionary dict, const Dict_node *dn,
 	const Regex_node *rn = arg[0];
 	const char *flags = arg[1];
 	const Parse_Options opts = (Parse_Options)arg[2];
-	double max_cost = opts->disjunct_cost;
+	float max_cost = opts->disjunct_cost;
 	uint32_t int_flags = make_flags(flags);;
 
 	/* build_disjuncts_for_exp() needs memory pools for efficiency. */

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1156,7 +1156,7 @@ display_word_split_error:
  * Only one minor cheat here: we are ignoring the cost_cutoff, so
  * this potentially over-counts if the cost_cutoff is set low.
  */
-static uint64_t count_clause(const Exp *e)
+uint64_t count_clause(const Exp *e)
 {
 	uint64_t cnt = 0;
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1158,7 +1158,7 @@ display_word_split_error:
  */
 uint64_t count_clause(const Exp *e)
 {
-	uint64_t cnt = 0;
+	uint64_t cnt;
 
 	assert(e != NULL, "count_clause called with null parameter");
 	if (e->type == AND_type)
@@ -1171,6 +1171,7 @@ uint64_t count_clause(const Exp *e)
 	else if (e->type == OR_type)
 	{
 		/* Just additive */
+		cnt = 0;
 		for (Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
 			cnt += count_clause(opd);
 	}

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -1156,9 +1156,9 @@ display_word_split_error:
  * Only one minor cheat here: we are ignoring the cost_cutoff, so
  * this potentially over-counts if the cost_cutoff is set low.
  */
-static unsigned int count_clause(const Exp *e)
+static uint64_t count_clause(const Exp *e)
 {
-	unsigned int cnt = 0;
+	uint64_t cnt = 0;
 
 	assert(e != NULL, "count_clause called with null parameter");
 	if (e->type == AND_type)
@@ -1189,7 +1189,7 @@ static unsigned int count_clause(const Exp *e)
 /**
  * Count number of disjuncts given the dict node dn.
  */
-static unsigned int count_disjunct_for_dict_node(Dict_node *dn)
+static uint64_t count_disjunct_for_dict_node(Dict_node *dn)
 {
 	return (NULL == dn) ? 0 : count_clause(dn->exp);
 }
@@ -1204,7 +1204,7 @@ static char *display_counts(const char *word, Dict_node *dn)
 	dyn_strcat(s, "matches:\n");
 	for (; dn != NULL; dn = dn->right)
 	{
-		append_string(s, "    %-*s %8u  disjuncts",
+		append_string(s, "    %-*s %8zu  disjuncts",
 		              display_width(DJ_COL_WIDTH, dn->string), dn->string,
 		              count_disjunct_for_dict_node(dn));
 

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -121,7 +121,7 @@ static void section_add(Dialect *di, const char *token, unsigned int *size,
 * @return Table index of the added entry.
 */
 static unsigned int dialect_table_add(Dialect *di, const char *token,
-                                      unsigned int *size, double cost)
+                                      unsigned int *size, float cost)
 {
 	if (di->num_table_tags == *size)
 	{

--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -28,7 +28,7 @@ struct Linkage_info_struct
 	short unused_word_cost;
 	short link_cost;
 
-	double disjunct_cost;
+	float disjunct_cost;
 	const char *pp_violation_msg;
 };
 

--- a/link-grammar/linkage/score.c
+++ b/link-grammar/linkage/score.c
@@ -54,10 +54,10 @@ static int unused_word_cost(Linkage lkg)
  * Computes the cost of the current parse of the current sentence
  * due to the cost of the chosen disjuncts.
  */
-static double compute_disjunct_cost(Linkage lkg)
+static float compute_disjunct_cost(Linkage lkg)
 {
 	size_t i;
-	double lcost;
+	float lcost;
 	lcost =  0.0;
 	for (i = 0; i < lkg->num_words; i++)
 	{

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -56,7 +56,7 @@ struct Parse_set_struct
 #ifdef RECOUNT
 	count_t recount;  /* Exactly the same as above, but counted at a later stage. */
 	count_t cut_count;  /* Count only low-cost parses, i.e. below the cost cutoff */
-	//double cost_cutoff;
+	//float cost_cutoff;
 #undef RECOUNT
 #define RECOUNT(X) X
 #else

--- a/link-grammar/parse/histogram.c
+++ b/link-grammar/parse/histogram.c
@@ -37,7 +37,7 @@ Count_bin hist_one(void)
  * That is, the bins are shifted over by the integer part of the cost
  * (scaled to the bin-width).
  */
-void hist_accum(Count_bin* sum, double cost, const Count_bin* a)
+void hist_accum(Count_bin* sum, float cost, const Count_bin* a)
 {
 	unsigned int i;
 	unsigned int start;
@@ -68,7 +68,7 @@ void hist_accum(Count_bin* sum, double cost, const Count_bin* a)
 }
 
 /** Same as above */
-void hist_accumv(Count_bin* sum, double cost, const Count_bin a)
+void hist_accumv(Count_bin* sum, float cost, const Count_bin a)
 {
 	hist_accum(sum, cost, &a);
 }
@@ -139,19 +139,19 @@ void hist_prod(Count_bin* prod, const Count_bin* a, const Count_bin* b)
  * Multiply two histograms 'a' and 'b', and accumulate them into 'acc'.
  * The accumulated histogram is first shifted by 'cost'.
  */
-void hist_muladd(Count_bin* acc, const Count_bin* a, double cost, const Count_bin* b)
+void hist_muladd(Count_bin* acc, const Count_bin* a, float cost, const Count_bin* b)
 {
 	Count_bin tmp = hist_zero();
 	hist_prod(&tmp, a, b);
 	hist_accum(acc, cost, &tmp);
 }
 
-void hist_muladdv(Count_bin* acc, const Count_bin* a, double cost, const Count_bin b)
+void hist_muladdv(Count_bin* acc, const Count_bin* a, float cost, const Count_bin b)
 {
 	hist_muladd(acc, a, cost, &b);
 }
 
-double hist_cost_cutoff(Count_bin* hist, int count)
+float hist_cost_cutoff(Count_bin* hist, int count)
 {
 	int i;
 	w_count_t cnt = 0;
@@ -160,7 +160,7 @@ double hist_cost_cutoff(Count_bin* hist, int count)
 	{
 		cnt += hist->bin[i];
 		if (count <= cnt)
-			return ((double) i + hist->base) * BIN_WIDTH;
+			return ((float) i + hist->base) * BIN_WIDTH;
 	}
 	return 1.0e38;
 }

--- a/link-grammar/parse/histogram.h
+++ b/link-grammar/parse/histogram.h
@@ -55,16 +55,16 @@ typedef Count_bin w_Count_bin;
 Count_bin hist_zero(void);
 Count_bin hist_one(void);
 
-void hist_accum(Count_bin* sum, double, const Count_bin*);
-void hist_accumv(Count_bin* sum, double, const Count_bin);
+void hist_accum(Count_bin* sum, float, const Count_bin*);
+void hist_accumv(Count_bin* sum, float, const Count_bin);
 void hist_prod(Count_bin* prod, const Count_bin*, const Count_bin*);
-void hist_muladd(Count_bin* prod, const Count_bin*, double, const Count_bin*);
-void hist_muladdv(Count_bin* prod, const Count_bin*, double, const Count_bin);
+void hist_muladd(Count_bin* prod, const Count_bin*, float, const Count_bin*);
+void hist_muladdv(Count_bin* prod, const Count_bin*, float, const Count_bin);
 
 static inline w_count_t hist_total(Count_bin* tot) { return tot->total; }
 w_count_t hist_cut_total(Count_bin* tot, count_t min_total);
 
-double hist_cost_cutoff(Count_bin*, count_t count);
+float hist_cost_cutoff(Count_bin*, count_t count);
 
 #else
 
@@ -84,7 +84,7 @@ static inline count_t hist_one(void) { return 1; }
 #define hist_total(tot) (*tot)
 
 #define hist_cut_total(tot, min_total) (*tot)
-static inline double hist_cost_cutoff(count_t* tot, count_t count) { return 1.0e38; }
+static inline float hist_cost_cutoff(count_t* tot, count_t count) { return 1.0e38; }
 
 #endif /* PERFORM_COUNT_HISTOGRAMMING */
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -121,6 +121,11 @@ static void build_sentence_disjuncts(Sentence sent, float cost_cutoff,
 		}
 		sent->word[w].d = d;
 	}
+
+	/* Delete the memory pools created in build_disjuncts_for_exp(). */
+	pool_delete(sent->Clause_pool);
+	pool_delete(sent->Tconnector_pool);
+	sent->Clause_pool = NULL;
 }
 
 

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -96,7 +96,7 @@ void gword_record_in_connector(Sentence sent)
  * Turn sentence expressions into disjuncts.
  * Sentence expressions must have been built, before calling this routine.
  */
-static void build_sentence_disjuncts(Sentence sent, double cost_cutoff,
+static void build_sentence_disjuncts(Sentence sent, float cost_cutoff,
                                      Parse_Options opts)
 {
 	Disjunct * d;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -225,8 +225,8 @@ static Clause * build_clause(Exp *e, clause_context *ct, Clause **c_last)
 		 */
 		c1->maxcost += e->cost;
 		/* Note: The above computation is used as a saving shortcut in
-		 * build_clause(). If it is changed here, it needs to be changed
-		 * there too. */
+		 * the inner loop of AND_type. If it is changed here, it needs to be
+		 * changed there too. */
 	}
 	return c;
 }

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -33,16 +33,16 @@ typedef struct clause_struct Clause;
 struct clause_struct
 {
 	Clause * next;
-	double cost;
-	double maxcost;
+	float cost;
+	float maxcost;
 	Tconnector * c;
 };
 
 typedef struct
 {
-	double cost_cutoff;
 	Pool_desc *Tconnector_pool;
 	Pool_desc *Clause_pool;
+	float cost_cutoff;
 	int exp_pos;
 } clause_context;
 
@@ -175,7 +175,7 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 			{
 				for (c4 = c2; c4 != NULL; c4 = c4->next)
 				{
-					double maxcost = MAX(c3->maxcost,c4->maxcost);
+					float maxcost = MAX(c3->maxcost,c4->maxcost);
 					if (maxcost + e->cost > ct->cost_cutoff) continue;
 
 					c = pool_alloc(ct->Clause_pool);
@@ -256,7 +256,7 @@ static Clause * build_clause(Exp *e, clause_context *ct)
  */
 static Disjunct *
 build_disjunct(Sentence sent, Clause * cl, const char * string,
-               const gword_set *gs, double cost_cutoff, Parse_Options opts)
+               const gword_set *gs, float cost_cutoff, Parse_Options opts)
 {
 	Disjunct *dis, *ndis;
 	Pool_desc *connector_pool = NULL;
@@ -328,7 +328,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 }
 
 Disjunct *build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
-                                  const gword_set *gs, double cost_cutoff,
+                                  const gword_set *gs, float cost_cutoff,
                                   Parse_Options opts)
 {
 	Clause *c;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -92,16 +92,8 @@ static Tconnector * catenate(Tconnector * e1, Tconnector * e2, Pool_desc *tp)
 		preve->next = newe;
 		preve = newe;
 	}
-	for (;e2 != NULL; e2 = e2->next)
-	{
-		newe = pool_alloc(tp);
-		*newe = *e2;
 
-		preve->next = newe;
-		preve = newe;
-	}
-
-	newe->next = NULL;
+	preve->next = e2;
 	return head.next;
 }
 

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -155,7 +155,7 @@ static Tconnector * build_terminal(Exp *e, clause_context *ct)
 /**
  * Build the clause for the expression e.  Does not change e
  */
-static Clause * build_clause(Exp *e, clause_context *ct)
+static Clause * build_clause(Exp *e, clause_context *ct, Clause *c_last)
 {
 	Clause *c = NULL, *c1, *c2, *c3, *c4, *c_head;
 
@@ -169,7 +169,7 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 		c1->maxcost = 0.0;
 		for (Exp *opd = e->operand_first; opd != NULL; opd = opd->operand_next)
 		{
-			c2 = build_clause(opd, ct);
+			c2 = build_clause(opd, ct, NULL);
 			c_head = NULL;
 			for (c3 = c1; c3 != NULL; c3 = c3->next)
 			{
@@ -196,11 +196,11 @@ static Clause * build_clause(Exp *e, clause_context *ct)
 	}
 	else if (e->type == OR_type)
 	{
-		c = build_clause(e->operand_first, ct);
+		c = build_clause(e->operand_first, ct, NULL);
 		/* we'll catenate the lists of clauses */
 		for (Exp *opd = e->operand_first->operand_next; opd != NULL; opd = opd->operand_next)
 		{
-			c1 = build_clause(opd, ct);
+			c1 = build_clause(opd, ct, c_last);
 			if (c1 == NULL) continue;
 			if (c == NULL)
 			{
@@ -343,8 +343,8 @@ Disjunct *build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
 	                   /*num_elements*/32768, sizeof(Tconnector),
 	                   /*zero_out*/false, /*align*/false, /*exact*/false);
 
-	// printf("%s\n", exp_stringify(exp));
-	c = build_clause(exp, &ct);
+	// printf("%s\n", lg_exp_stringify(exp));
+	c = build_clause(exp, &ct, NULL);
 	// print_clause_list(c);
 	dis = build_disjunct(sent, c, word, gs, cost_cutoff, opts);
 	// print_disjunct_list(dis);

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -25,8 +25,7 @@ typedef struct Tconnector_struct Tconnector;
 struct Tconnector_struct
 {
 	Tconnector * next;
-	const Exp *e; /* a CONNECTOR_type element from which to get the connector  */
-	int exp_pos;  /* the position in the originating expression */
+	Exp *e; /* a CONNECTOR_type element from which to get the connector  */
 };
 
 typedef struct clause_struct Clause;
@@ -114,7 +113,7 @@ static Tconnector * build_terminal(Exp *e, clause_context *ct)
 	Tconnector *c = pool_alloc(ct->Tconnector_pool);
 	c->e = e;
 	c->next = NULL;
-	c->exp_pos = ct->exp_pos++;
+	c->e->pos = ct->exp_pos++;
 	return c;
 }
 
@@ -267,7 +266,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			Connector *n = connector_new(connector_pool, t->e->condesc, opts);
 			Connector **loc = ('-' == t->e->dir) ? &ndis->left : &ndis->right;
 
-			n->exp_pos = t->exp_pos;
+			n->exp_pos = t->e->pos;
 			n->multi = t->e->multi;
 			n->farthest_word = t->e->farthest_word;
 			n->next = *loc;   /* prepend the connector to the current list */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -264,7 +264,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 	dis = NULL;
 	for (; cl != NULL; cl = cl->next)
 	{
-		if (NULL == cl->c) continue; /* no connectors */
+		if (unlikely(NULL == cl->c)) continue; /* no connectors */
 		if (cl->maxcost > cost_cutoff) continue;
 
 #if USE_SAT_SOLVER

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -75,40 +75,6 @@ static void free_clause_list(Clause *c, clause_context *ct)
 }
 #endif
 
-#if 0 /* old stuff */
-/**
- * reverse the order of the list e.  destructive
- */
-static Tconnector * Treverse(Tconnector *e)
-{
-	Tconnector * head, *x;
-	head = NULL;
-	while (e != NULL) {
-		x = e->next;
-		e->next = head;
-		head = e;
-		e = x;
-	}
-	return head;
-}
-
-/**
- * reverse the order of the list e.  destructive
- */
-static Connector * reverse(Connector *e)
-{
-	Connector * head, *x;
-	head = NULL;
-	while (e != NULL) {
-		x = e->next;
-		e->next = head;
-		head = e;
-		e = x;
-	}
-	return head;
-}
-#endif
-
 /**
  * Builds a new list of connectors that is the catenation of e1 with e2.
  * does not effect lists e1 or e2.   Order is maintained.

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -249,7 +249,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 		if (cl->maxcost > cost_cutoff) continue;
 
 #if USE_SAT_SOLVER
-		if (NULL == sent) /* For the SAT-parser, until fixed. */
+		if (opts->use_sat_solver) /* For the SAT-parser, until fixed. */
 		{
 			ndis = xalloc(sizeof(Disjunct));
 		}

--- a/link-grammar/prepare/build-disjuncts.h
+++ b/link-grammar/prepare/build-disjuncts.h
@@ -18,6 +18,6 @@
 #include "link-includes.h"
 
 Disjunct *build_disjuncts_for_exp(Sentence sent, Exp *, const char *,
-                                  const gword_set *, double cost_cutoff,
+                                  const gword_set *, float cost_cutoff,
                                   Parse_Options opts);
 #endif /* _LINKGRAMMAR_BUILD_DISJUNCTS_H */

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -194,8 +194,8 @@ static Exp* purge_Exp(exprune_context *ctxt, int, Exp *, char);
 static bool or_purge_operands(exprune_context *ctxt, int w, Exp *e, char dir)
 {
 #if NOTYET
-	const double nullexp_nonexistence = -9999;
-	double nullexp_mincost = nullexp_nonexistence;
+	const float nullexp_nonexistence = -9999;
+	float nullexp_mincost = nullexp_nonexistence;
 	int nullexp_count = 0;
 #endif
 

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -48,6 +48,7 @@
  */
 
 #define D_EXPRUNE 9
+#define D_PRINT_NUM_DISJUNCTS 5
 
 #ifdef DEBUG
 #define DBG(p, w, X) \
@@ -393,6 +394,23 @@ static char *print_expression_sizes(Sentence sent)
 	return dyn_str_take(e);
 }
 
+
+static void print_expression_disjunct_count(Sentence sent)
+{
+	uint64_t dcnt, t = 0;
+
+	for (WordIdx i = 0; i < sent->length; i++)
+	{
+		dcnt = 0;
+		for (const X_node *x = sent->word[i].x; x != NULL; x = x->next)
+			dcnt += count_clause(x->exp);
+		prt_error("%s(%zu) ", sent->word[i].alternatives[0], dcnt);
+		t += dcnt;
+	}
+	prt_error("\n\\");
+	prt_error("Total: %zu disjuncts\n\n", t);
+}
+
 void expression_prune(Sentence sent, Parse_Options opts)
 {
 	size_t w;
@@ -407,6 +425,12 @@ void expression_prune(Sentence sent, Parse_Options opts)
 	ctxt.N_deleted = 1;  /* a lie to make it always do at least 2 passes */
 
 	DBG_EXPSIZES("Initial expression sizes\n%s", e);
+
+	if (verbosity_level(D_PRINT_NUM_DISJUNCTS))
+	{
+		prt_error("Debug: Before expression_prune():\n\\");
+		print_expression_disjunct_count(sent);
+	}
 
 	for (int pass = 0; ; pass++)
 	{
@@ -485,6 +509,12 @@ void expression_prune(Sentence sent, Parse_Options opts)
 	}
 
 	free_connector_table(&ctxt);
+
+	if (verbosity_level(D_PRINT_NUM_DISJUNCTS))
+	{
+		prt_error("Debug: After expression_prune():\n\\");
+		print_expression_disjunct_count(sent);
+	}
 }
 
 #if 0 // VERY_DEAD_NO_GOOD_IDEA

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -251,7 +251,7 @@ char * linkage_print_disjuncts(const Linkage linkage)
 	for (w = 0; w < nwords; w++)
 	{
 		int pad = 21;
-		double cost;
+		float cost;
 		const char *infword;
 		Disjunct *disj = linkage->chosen_disjuncts[w];
 		if (NULL == disj) continue;
@@ -269,7 +269,7 @@ char * linkage_print_disjuncts(const Linkage linkage)
 
 		dj = linkage_get_disjunct_str(linkage, w);
 		if (NULL == dj) dj = "";
-		cost = linkage_get_disjunct_cost(linkage, w);
+		cost = (float)linkage_get_disjunct_cost(linkage, w);
 
 		append_string(s, "%*s    % 4.3f  %s\n", pad, infword, cost, dj);
 	}

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -1889,7 +1889,7 @@ bool SATEncoderConjunctionFreeSentences::sat_extract_links(Linkage lkg)
 #else
     cost_cutoff = 1000.0;
 #endif // LIMIT_TOTAL_LINKAGE_COST
-    d = build_disjuncts_for_exp(NULL, de, xnode_word[wi]->string,
+    d = build_disjuncts_for_exp(_sent, de, xnode_word[wi]->string,
                                 &xnode_word[wi]->word->gword_set_head,
                                 cost_cutoff, _opts);
 

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -760,10 +760,10 @@ bool strtodC(const char *s, float *r)
 	char *err;
 
 #if defined(HAVE_LOCALE_T) && !defined(__sun__) && !defined(__OpenBSD__)
-	double val = strtod_l(s, &err, get_C_LC_NUMERIC());
+	float val = strtof_l(s, &err, get_C_LC_NUMERIC());
 #else
 	/* dictionary_setup_locale() invokes setlocale(LC_NUMERIC, "C") */
-	double val = strtod(s, &err);
+	float val = strtof(s, &err);
 #endif /* HAVE_LOCALE_T */
 
 	if ('\0' != *err) return false; /* *r unaffected */


### PR DESCRIPTION
This patch speeds up disjunct build for typical sentences by a few tens of percent.
When tested on the English corpus batches, the resulted speedup is a few percent.
(It also speeds up generation by a few percent, but in the case of wildcard words, there is more to do - I'm now preparing a PR for that, that will also fix the buggy unused disjunct count).

Most of the speedup here is due to this simple change:
- `build_clause()`: Implement a more efficient `Tconnector` catenation

In addition, in order to investigate the memory exhaustion problem with the `micro-disinfo` dict when more than one unknown word is used, I added a debug printout (at verbosity=5) just before and after `expression_prune()`.
The result shows the problem:

`echo 'This is a test test' | data/micro-disinfo -v=9 -debug=exprune.c`
```
link-grammar: Info: Dictionary found at ./data/micro-disinfo/dict.db
link-grammar: Info: Dictionary version 5.6.0, locale en_US.UTF-8
link-grammar: Info: Library version link-grammar-5.10.4. Enter "!help" for help.
#### Finished tokenizing (5 tokens)
expression_prune: Initial expression sizes
This[85454] is[85503] a[31417] test[522980] test[522980] 

Debug: Before expression_prune():
This(596854799544) is(483921501177) a(3397807) test(5525349327306844725) test(5525349327306844725) 
Total: 11050699735393387978 disjuncts

expression_prune: l->r pass removed 230135
This[11201] is[35627] a[12196] test[212485] test[503409] 

expression_prune: r->l pass removed 197226
This[10935] is[34499] a[11995] test[203262] test[73204] 

expression_prune: l->r pass removed 14
This[10935] is[34499] a[11995] test[203262] test[73190] 

expression_prune: r->l pass removed 0
This[10935] is[34499] a[11995] test[203262] test[73190] 

Debug: After expression_prune():
This(10276) is(79151) a(9493) test(12166744394147993390) test(4783562197) 
Total: 12166744398931654507 disjuncts

++++ Finished expression pruning                 0.14 seconds
```

Maybe implementing power pruning on expressions may solve this problem for this particular dict (for normal dicts it has no benefit).

In any case (not related to the problem of `micro-disinfo`) I would like to implement a better algo for building disjunct, inspired by `list_links()`.



