### PR TITLE
4.0.regex: Auto-expand non-ASCII ranges in character classes

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST =               \
    parses-dialect-en.txt   \
    parses-en.txt           \
    parses-lt.txt           \
+   parses-th.txt           \
    parses-pos-en.txt       \
    parses-pos-he.txt       \
    parses-pos-ru.txt       \

--- a/bindings/python-examples/parses-th.txt
+++ b/bindings/python-examples/parses-th.txt
@@ -1,0 +1,29 @@
+% This file contains test sentences, and the expected parses and
+% constituents output, for the Thai dictionary
+
+% Test that the character ranges in THAI-PART-NUMBER and
+% THAI-NUMBERS actually work.
+
+-display_morphology = True
+
+I5-123/๙456#ฮ๐
+O
+O    +---------LWn---------+
+O    |                     |
+OLEFT-WALL 5-123/๙456#ฮ๐[!THAI-PART-NUMBER]
+O
+
+I๙ สาย
+O
+O    +-------------LWn------------+
+O    |              +<----NUnl<---+
+O    |              |             |
+OLEFT-WALL ๙[!THAI-NUMBERS].nu สาย.na
+O
+N
+O
+O    +------------LWn------------+
+O    |              +<---NUnl<---+
+O    |              |            |
+OLEFT-WALL ๙[!THAI-NUMBERS].nu สาย.n
+O

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1252,6 +1252,11 @@ class ZRULangTestCase(unittest.TestCase):
              '.', 'RIGHT-WALL'])
 
 
+class ZTHLangTestCase(unittest.TestCase):
+    def test_thai(self):
+        linkage_testfile(self, Dictionary(lang='th'), ParseOptions())
+
+
 class ZXDictDialectTestCase(unittest.TestCase):
     def test_dialect(self):
         linkage_testfile(self, Dictionary(lang='en'), ParseOptions(dialect='headline'), 'dialect')

--- a/data/en/4.0.regex
+++ b/data/en/4.0.regex
@@ -242,13 +242,14 @@
 % n-amino-3-azabicyclo[3.3.0]octane
 % 3'-Amino-2',3'-dideoxyguanosine
 % N-Phenylsulphonyl-N'-(3-azabicycloalkyl)
-% []...] means "match right-bracket"
+% []...] means "match right-bracket" -> Replaced by |\] because it
+% doesn't work in c++ <regex>.
 % Explicitly call out (5'|3') so that we don't all a generic match to 'll
 %  /^[[:alnum:]][][:alnum:],:.\[-]*-[][:alnum:],:.\[-]*[[:alnum:]]$/
 <HYPHENATED-WORDS>: !/--/
 <HYPHENATED-WORDS>: !/[[:punct:]]$/
 <HYPHENATED-WORDS>:
-  /^([[:alnum:]]|5'|3'|2'|N')([][:alnum:],:.()[-]|5'|3'|2'|N')*-[][:alnum:],:.()[-]*[[:alnum:]]*$/
+  /^([[:alnum:]]|5'|3'|2'|N')([[:alnum:],:.()[-]|\]|5'|3'|2'|N')*-([[:alnum:],:.()[-]|\])*[[:alnum:]]*$/
 
 % Emoticon checks must come *after* the above, so that the above take precedence.
 % See Wikipedia List_of_emoticons (also the References section).

--- a/data/th/4.0.regex
+++ b/data/th/4.0.regex
@@ -18,6 +18,13 @@
 % Regex'es that are preceded by !, if they match a token, stop
 % further match tries of the same regex name. Thus, they can serve
 % as a kind of a negative look-ahead.
+%
+% To allow non-ASCII ranges in character classes for libraries other
+% than recent PCRE2, such ranges are expanded by default. Since various
+% regex libraries have different syntax features for character classes,
+% it is hard to do such an expansion only inside character classes, so
+% this expansion is always done. To avoid it, add:
+% NO-EXPAND: //
 
 % Numbers.
 % XXX, we need to add utf8 U+00A0 "no-break space"

--- a/data/th/4.0.regex
+++ b/data/th/4.0.regex
@@ -89,12 +89,13 @@ CAPITALIZED-WORD:     /^[[:upper:]][^'’]*[^[:punct:]]$/
 % never a verb. To return to this ordering, move this regex just
 % after the CAPITALIZED-WORDS regex.
 % We also match on commas, dots, brackets: n-amino-3-azabicyclo[3.3.0]octane
-% []] means "match right-bracket"
+% []...] means "match right-bracket" -> Replaced by |\] because it
+% doesn't work in c++ <regex>.
 % Explicitly call out (5'|3') so that we don't all a generic match to 'll
 % But something is funky about this 5'-3' business since 2' also matches ???
 %  /^[[:alnum:]][][:alnum:],:.\[-]*-[][:alnum:],:.\[-]*[[:alnum:]]$/
 HYPHENATED-WORD:
-  /^[[:alnum:](5'|3')][][:alnum:](5'|3'),:.\(\)\[-]*-[][:alnum:],:.\(\)\[-]*[[:alnum:]]$/
+  /^([[:alnum:]]|5'|3'|2'|N')([[:alnum:],:.()[-]|\]|5'|3'|2'|N')*-([[:alnum:],:.()[-]|\])*[[:alnum:]]*$/
 
 % Emoticon checks must come *after* the above, so that the above take precedence.
 % See Wikipedia List_of_emoticons (also the References section).

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -227,7 +227,7 @@ dictionary_six_str(const char * lang,
 	 * We have to compile regexs using the dictionary locale,
 	 * so make a temporary locale swap.
 	 */
-	if (read_regex_file(dict, regex_name)) goto failure;
+	if (!read_regex_file(dict, regex_name)) goto failure;
 
 	const char *locale = setlocale(LC_CTYPE, NULL); /* Save current locale. */
 	locale = strdupa(locale); /* setlocale() uses its own memory. */

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -44,6 +44,12 @@
   stop further match tries until a different regex name is encountered.
   Thus, they can serve as a kind of a negative look-ahead.
 
+  To allow non-ASCII ranges in character classes for libraries other
+  than recent PCRE2, such ranges are expanded by default. Since various
+  regex libraries have different syntax features for character classes,
+  it is hard to do such an expansion only inside character classes, so
+  this expansion is always done. To avoid it, add:
+  NO-EXPAND://
 */
 
 #define MAX_REGEX_NAME_LENGTH 50

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -205,7 +205,8 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		{
 			if (i >= MAX_REGEX_NAME_LENGTH-1)
 			{
-				prt_error("Error: Regex name too long on line %d.\n", line);
+				prt_error("Error: File \"%s\", line %d: "
+				          "Regex name too long.\n", file_name, line);
 				goto failure;
 			}
 			name[i++] = c;
@@ -222,7 +223,8 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		}
 		if (c != ':')
 		{
-			prt_error("Error: Regex missing colon on line %d.\n", line);
+			prt_error("Error: File \"%s\", line %d: "
+			          "Regex missing colon.\n", file_name, line);
 			goto failure;
 		}
 
@@ -245,7 +247,8 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		}
 		if (c != '/')
 		{
-			prt_error("Error: Regex missing leading slash on line %d.\n", line);
+			prt_error("Error: File \"%s\", line %d: "
+			          "Regex missing leading slash.\n", file_name, line);
 			goto failure;
 		}
 
@@ -255,7 +258,8 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		{
 			if (i > MAX_REGEX_LENGTH-1)
 			{
-				prt_error("Error: Regex too long on line %d.\n", line);
+				prt_error("Error: File \"%s\", line %d: "
+				          "Regex too long.\n", file_name, line);
 				goto failure;
 			}
 			prev = c;
@@ -271,7 +275,8 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		/* Expect termination by a slash. */
 		if (c != '/')
 		{
-			prt_error("Error: Regex missing trailing slash on line %d.\n", line);
+			prt_error("Error: File \"%s\", line %d: "
+			          "Regex missing trailing slash.\n", file_name, line);
 			goto failure;
 		}
 

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -157,6 +157,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 	Regex_node *new_re;
 	int c,prev,i,line=1;
 	FILE *fp;
+	bool no_expand = false;
 	char name[MAX_REGEX_NAME_LENGTH];
 	char regex[MAX_REGEX_LENGTH];
 
@@ -270,7 +271,13 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 
 		lgdebug(+D_REGEX+1, "%s: %s\n", name, regex);
 
-		if (!expand_character_ranges(file_name, line, name, regex))
+		if (strcmp(name, "NO-EXPAND") == 0)
+		{
+			no_expand = true;
+			continue;
+		}
+
+		if (!no_expand && !expand_character_ranges(file_name, line, name, regex))
 			goto failure;
 
 		/* Create new Regex_node and add to dict list. */

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -42,7 +42,6 @@
 */
 
 #define MAX_REGEX_NAME_LENGTH 50
-// #define MAX_REGEX_LENGTH      255
 #define MAX_REGEX_LENGTH      10240
 
 bool read_regex_file(Dictionary dict, const char *file_name)

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -45,7 +45,7 @@
 // #define MAX_REGEX_LENGTH      255
 #define MAX_REGEX_LENGTH      10240
 
-int read_regex_file(Dictionary dict, const char *file_name)
+bool read_regex_file(Dictionary dict, const char *file_name)
 {
 	Regex_node **tail = &dict->regex_root; /* Last Regex_node * in list */
 	Regex_node *new_re;
@@ -58,7 +58,7 @@ int read_regex_file(Dictionary dict, const char *file_name)
 	if (fp == NULL)
 	{
 		prt_error("Error: cannot open regex file %s\n", file_name);
-		return 1;
+		return false;
 	}
 
 	/* read in regexs. loop broken on EOF. */
@@ -174,9 +174,9 @@ int read_regex_file(Dictionary dict, const char *file_name)
 	}
 
 	fclose(fp);
-	return 0;
+	return true;
 failure:
 	fclose(fp);
-	return 1;
+	return false;
 }
 

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -56,7 +56,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 	fp = dictopen(file_name, "r");
 	if (fp == NULL)
 	{
-		prt_error("Error: Cannot open regex file %s\n", file_name);
+		prt_error("Error: Cannot open regex file %s.\n", file_name);
 		return false;
 	}
 
@@ -91,7 +91,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		{
 			if (i >= MAX_REGEX_NAME_LENGTH-1)
 			{
-				prt_error("Error: Regex name too long on line %d\n", line);
+				prt_error("Error: Regex name too long on line %d.\n", line);
 				goto failure;
 			}
 			name[i++] = c;
@@ -108,7 +108,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		}
 		if (c != ':')
 		{
-			prt_error("Error: Regex missing colon on line %d\n", line);
+			prt_error("Error: Regex missing colon on line %d.\n", line);
 			goto failure;
 		}
 
@@ -131,7 +131,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		}
 		if (c != '/')
 		{
-			prt_error("Error: Regex missing leading slash on line %d\n", line);
+			prt_error("Error: Regex missing leading slash on line %d.\n", line);
 			goto failure;
 		}
 
@@ -141,7 +141,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		{
 			if (i > MAX_REGEX_LENGTH-1)
 			{
-				prt_error("Error: Regex too long on line %d\n", line);
+				prt_error("Error: Regex too long on line %d.\n", line);
 				goto failure;
 			}
 			prev = c;
@@ -157,7 +157,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 		/* Expect termination by a slash. */
 		if (c != '/')
 		{
-			prt_error("Error: Regex missing trailing slash on line %d\n", line);
+			prt_error("Error: Regex missing trailing slash on line %d.\n", line);
 			goto failure;
 		}
 

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -48,10 +48,10 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 {
 	Regex_node **tail = &dict->regex_root; /* Last Regex_node * in list */
 	Regex_node *new_re;
-	char name[MAX_REGEX_NAME_LENGTH];
-	char regex[MAX_REGEX_LENGTH];
 	int c,prev,i,line=1;
 	FILE *fp;
+	char name[MAX_REGEX_NAME_LENGTH];
+	char regex[MAX_REGEX_LENGTH];
 
 	fp = dictopen(file_name, "r");
 	if (fp == NULL)

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -79,10 +79,11 @@ static bool expand_character_ranges(const char *file_name, int line,
 
 		if (b_len + 1 > (int)(MAX_REGEX_LENGTH - (regex - r)))
 		{
-			prt_error("Error: File \"%s\", line %d, position %d: \"%s\": "
-			          "Expanded definition overflow (>%d chars)\n",
-			          file_name, line, (int)(p - orig_regex), name,
-			          MAX_REGEX_LENGTH-1);
+			lgdebug(D_REGEX, "Warning: File \"%s\", line %d, position %d: "
+			        "\"%s\": Expanded definition overflow (>%d chars)\n",
+			        file_name, line, (int)(p - orig_regex), name,
+			        MAX_REGEX_LENGTH-1);
+			strcpy(regex, orig_regex);
 			return false;
 		}
 
@@ -104,28 +105,28 @@ static bool expand_character_ranges(const char *file_name, int line,
 
 			if (b_len != e_len)
 			{
-				prt_error("Error: File \"%s\", line %d: \"%s\": "
-				          "Range \"%.*s-%.*s\": "
-							 "Characters with an unequal number of bytes.\n",
-							 file_name, line, name, b_len, b_char, e_len, p);
-				return false;
+				lgdebug(D_REGEX, "Warning: File \"%s\", line %d: \"%s\": "
+				        "Range \"%.*s-%.*s\": "
+				        "Characters with an unequal number of bytes.\n",
+				        file_name, line, name, b_len, b_char, e_len, p);
+				return true;
 			}
 
 			size_t prefix_len = b_len - 1;
 			if (strncmp(b_char, p, prefix_len) != 0)
 			{
-				prt_error("Error: File \"%s\", line %d: \"%s\": "
-				          "Range \"%.*s-%.*s\": "
-							 "No common prefix before the last byte.\n",
-							 file_name, line, name, b_len, b_char, e_len, p);
-				return false;
+				lgdebug(D_REGEX, "Warning: File \"%s\", line %d: \"%s\": "
+				        "Range \"%.*s-%.*s\": "
+				        "No common prefix before the last byte.\n",
+				        file_name, line, name, b_len, b_char, e_len, p);
+				return true;
 			}
 			if ((unsigned char)b_char[prefix_len] > (unsigned char)p[prefix_len])
 			{
-				prt_error("Error: File \"%s\", line %d: \"%s\": "
-				          "Range \"%.*s-%.*s\": Decreasing order.\n",
-							 file_name, line, name, b_len, b_char, e_len, p);
-				return false;
+				lgdebug(D_REGEX, "Warning: File \"%s\", line %d: \"%s\": "
+				        "Range \"%.*s-%.*s\": Decreasing order.\n",
+				        file_name, line, name, b_len, b_char, e_len, p);
+				return true;
 			}
 
 			for (unsigned char last_byte = b_char[prefix_len] + 1;
@@ -133,12 +134,13 @@ static bool expand_character_ranges(const char *file_name, int line,
 			{
 				if (b_len + 1 > (int)(MAX_REGEX_LENGTH - (r - regex)))
 				{
-					prt_error("Error: File \"%s\", line %d: ,position %d: \"%s\": "
-					          "Range \"%.*s-%.*s\": "
-					          "Expanded definition overflow (>%d chars)\n",
-					          file_name, line, (int)(r - regex), name,
-					          b_len, b_char, e_len, p, MAX_REGEX_LENGTH-1);
-					return false;
+					lgdebug(D_REGEX, "Warning: : File \"%s\", line %d: ,position %d: "
+					        "\"%s\": Range \"%.*s-%.*s\": "
+					        "Expanded definition overflow (>%d chars)\n",
+					        file_name, line, (int)(r - regex), name,
+					        b_len, b_char, e_len, p, MAX_REGEX_LENGTH-1);
+					strcpy(regex, orig_regex);
+					return true;
 				}
 				memcpy(r, b_char, prefix_len);
 				r += prefix_len;

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -57,7 +57,7 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 	fp = dictopen(file_name, "r");
 	if (fp == NULL)
 	{
-		prt_error("Error: cannot open regex file %s\n", file_name);
+		prt_error("Error: Cannot open regex file %s\n", file_name);
 		return false;
 	}
 

--- a/link-grammar/dict-file/read-regex.h
+++ b/link-grammar/dict-file/read-regex.h
@@ -10,4 +10,6 @@
 
 #include <stdbool.h>
 
+#include <link-includes.h>              // Dictionary
+
 bool read_regex_file(Dictionary dict, const char *file_name);

--- a/link-grammar/dict-file/read-regex.h
+++ b/link-grammar/dict-file/read-regex.h
@@ -8,4 +8,6 @@
 /*                                                                       */
 /*************************************************************************/
 
-int read_regex_file(Dictionary dict, const char *file_name);
+#include <stdbool.h>
+
+bool read_regex_file(Dictionary dict, const char *file_name);


### PR DESCRIPTION
See issue #1296.
This patch solves the problem of unhandled non-ASCII ranges by expanding them before compiling the regexes.
Checked for the configurable regex libraries.
Can be disabled by adding the dummy definition:
`NO_EXPAND: //`

On the same occasion:
- Improved the error messages.
- Remove the commented-out definition for MAX_REGEX_LENGTH, as increasing its size have no efficiency implications.
- read-regex.h: Add link-includes.h to prevent IDE errors
- Add a test for the 2 problematic `th` regexes. More sentences can be added there if desired.
- Fix the syntax for matching `]` in `HYPHENATED-WORD`, which causes a problem in C++ `<regex>`.

BTW, `ಠ-ಠ` triggers `HYPHENATED-WORD` in PCRE2 but `EMOTICON` in C++ (this seems to be the only difference in the distribution corpora between the regex packages).

Regarding my idea to support:
[:thai-alpha:] : /[ก-ฮ]/
[:thai-digits:] : /[๐-๙]/
This support is not included in this patch, because I found that the direct expansion of the ranges, as done here, is a simpler solution.

But I actually wrote this code and the WIP is in [online here](https://github.com/ampli/link-grammar/tree/regex-class) (it needs a cleanup).
You can see the relevant definitions in [`data/th/4.0.regex`](https://github.com/ampli/link-grammar/blob/regex-class/data/th/4.0.regex). For now, I don't think we need it.


Update: 
In order not to produce unexpected errors in non-fatal cases, I turned all the errors (but the UTF8 bad encoding) to warnings in debug verbosity.  It also seems a good idea to add a runtime regex range test and expand ranges only if it fails (not like the case of issue #1296, it usually doesn't cause a fatal error but just doesn't work as expected).
- expand_character_ranges(): Convert most errors to debug warnings.
