### PR TITLE
Parsing acceleration by match list caching

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -68,11 +68,8 @@ static inline bool is_connector_subscript_char(unsigned char c)
 }
 /* End of connector string character validation. */
 
-/* The size of the following struct on a 64-bit machine is 32 bytes.
- * It should be kept at this size. If needed, uc_length
- * and uc_start can be eliminate or moved out. Also, there not enough
- * space here to implement cost per connector length - an index to a
- * cost table should be used instead.*/
+/* Note: If more byte-size fields are needed, to save space
+ * uc_length and uc_start may be moved to struct hdesc. */
 struct condesc_struct
 {
 	lc_enc_t lc_letters;

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -19,6 +19,7 @@
 #include "connectors.h"                 // Connector
 #include "api-types.h"
 #include "api-structures.h"             // Sentence
+#include "parse/histogram.h"            // count_t
 
 // Can undefine VERIFY_MATCH_LIST when done debugging...
 #define VERIFY_MATCH_LIST
@@ -52,7 +53,11 @@ struct Disjunct_struct
 	union
 	{
 		Disjunct *dup_table_next; /* Duplicate elimination | before pruning */
-		Disjunct *unused1;        /* Unused now | before parsing */
+		struct
+		{
+			count_t lrcount;       /* Left/right count | during counting */
+			uint32_t rcount_index; /* Right count index | set by form_match_list */
+		};
 	}; /* 8 bytes */
 
 	/* Shared by different steps. For what | when. */

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -133,8 +133,15 @@ void pool_delete (const char *func, Pool_desc *mp)
  */
 void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 {
-	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
-	        vecsize, mp->num_elements);
+	dassert(vecsize < mp->num_elements,
+	        "Pool %s: num_elements is too small %zu >= %zu)",
+	        mp->name, vecsize, mp->num_elements);
+	if (vecsize >= mp->num_elements)
+	{
+		prt_error("Warning: Pool %s: num_elements is too small %zu >= %zu)\n",
+		          mp->name, vecsize, mp->num_elements);
+		return NULL;
+	}
 
 	mp->curr_elements += vecsize; /* skipped space disregarded when vecsize > 1 */
 

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -18,7 +18,9 @@
 #include "error.h"
 #include "utilities.h"                  // GNUC_MALLOC (XXX separate include?)
 
+#ifndef D_MEMPOOL                       // Allow redefining for debug.
 #define D_MEMPOOL (D_SPEC+4)
+#endif
 #define MIN_ALIGNMENT sizeof(void *)    // Minimum element alignment.
 #define MAX_ALIGNMENT 64                // Maximum element alignment.
 //#define POOL_FREE                       // Allow to reuse individual elements.

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -657,18 +657,16 @@ static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
 	wordvecp *wv = &ctxt->table_lrcnt[dir][c->tracon_id];
 	if (*wv == NULL)
 	{
-		if (null_start != NULL)
-		{
-			/* Create a new cache entry, to be updated by lrcnt_cache_update(). */
-			const size_t wordvec_size = abs(c->farthest_word - c->nearest_word) + 1;
-			*wv = pool_alloc_vec(ctxt->sent->wordvec_pool, wordvec_size);
-			memset(*wv, -1, sizeof(Table_lrcnt) * wordvec_size);
+		if (null_start == NULL) return NULL;
+		*null_start = 0;
 
-			*null_start = 0;
-			assert(wordvec_index < wordvec_size, "Bad wordvec index");
-			return &(*wv)[wordvec_index]; /* Needs update */
-		}
-		return NULL;
+		/* Create a new cache entry, to be updated by lrcnt_cache_update(). */
+		const size_t wordvec_size = abs(c->farthest_word - c->nearest_word) + 1;
+		*wv = pool_alloc_vec(ctxt->sent->wordvec_pool, wordvec_size);
+		memset(*wv, -1, sizeof(Table_lrcnt) * wordvec_size);
+
+		assert(wordvec_index < wordvec_size, "Bad wordvec index");
+		return &(*wv)[wordvec_index]; /* Needs update */
 	}
 
 	return lrcnt_check(&(*wv)[wordvec_index], null_count, null_start);

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2004                                                    */
 /* Daniel Sleator, David Temperley, and John Lafferty                    */
 /* Copyright (c) 2013,2014,2015 Linas Vepstas                            */
+/* Copyright (c) 2015-2022 Amir Plivatsky                                */
 /* All rights reserved                                                   */
 /*                                                                       */
 /* Use of the link grammar parsing system is subject to the terms of the */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -593,15 +593,15 @@ static void generate_word_skip_vector(count_context_t *ctxt, wordvecp wv,
  * @param dir Direction - 0: leftcount; 1: rightcount.
  * @param c The connector that starts the range.
  * @param wordvec_index Word-vector index.
- * @param null_count The current null-count to check.
+ * @param null_count[in] The current null-count to check.
  *
  * Return these values:
- * @param lnull_start First null count to check (the previous ones can be
+ * @param null_start[out] First null count to check (the previous ones can be
  * skipped because the cache indicates they yield a zero count.)
  * @return Cache entry for the given range. Possible values:
- *    NULL - A nonzero count may be encountered for \c null_count>=lnull_start.
+ *    NULL - A nonzero count may be encountered for \c null_count>=null_start.
  *    lrcnt_cache_zero - A zero count would result.
- *    Cache pointer - An update for \c null_count>=lnull_start is needed.
+ *    Cache pointer - An update for \c null_count>=null_start is needed.
  */
 static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
                              unsigned int wordvec_index,

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1243,7 +1243,6 @@ static Count_bin do_count(
 					if (0 < hist_total(&leftcount))
 					{
 						lrcnt_found = true;
-						lrcnt_optimize = true;
 
 						/* Evaluate using the left match, but not the right */
 						CACHE_COUNT(l_bnr, hist_muladdv(&total, &leftcount, d->cost, count),
@@ -1271,7 +1270,6 @@ static Count_bin do_count(
 						if (le == NULL)
 						{
 							lrcnt_found = true;
-							lrcnt_optimize = true;
 
 							/* Evaluate using the right match, but not the left */
 							CACHE_COUNT(r_bnl, hist_muladdv(&total, &rightcount, d->cost, count),

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -69,6 +69,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  * check_next skips all the words for which the count is known to be zero. */
 typedef struct
 {
+	Disjunct **d_lkg_nc0;    /* Disjuncts with a jet linkage for null_count==0 */
 	null_count_m null_count; /* status==0 valid up to this null count */
 	int8_t status;         /* -1: Needs update; 0: No count; 1: Count possible */
 	WordIdx_m check_next;    /* Next word to check */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -658,16 +658,23 @@ static void lrcnt_cache_match_list(wordvecp lrcnt_cache, fast_matcher_t *mchxt,
 	        get_match_list_element(mchxt, mlb)->match_id, dir, mlb, dcnt, i-mlb);
 
 	Disjunct **ml = pool_alloc_vec(mchxt->mld_pool, dcnt + 1);
+	count_t *c = pool_alloc_vec(mchxt->mlc_pool, dcnt);
 	dcnt = 0;
 	for (i = mlb; get_match_list_element(mchxt, i) != NULL; i++)
 	{
 		Disjunct *d = get_match_list_element(mchxt, i);
 		if ((dir == 0) ? d->match_left : d->match_right)
-			ml[dcnt++] = d;
+		{
+			ml[dcnt] = d;
+			assert(d->lrcount > 0, "Invalid linkage count %d", d->lrcount);
+			c[dcnt] = d->lrcount;
+			dcnt++;
+		}
 	}
 	ml[dcnt] = NULL;
 
 	lrcnt_cache->d_lkg_nc0 = ml;
+	lrcnt_cache->count_nc0 = c;
 }
 
 /**

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -238,6 +238,7 @@ static void free_table_lrcnt(count_context_t *ctxt)
 	if (verbosity_level(D_COUNT))
 	{
 		unsigned int nonzero = 0, any_null = 0, zero = 0, non_max_null = 0;
+		unsigned int cml = 0, cml_disjunct = 0; /* Cashed match lists */
 		Pool_location loc = { 0 };
 		wordvecp t;
 
@@ -248,7 +249,15 @@ static void free_table_lrcnt(count_context_t *ctxt)
 		{
 			if (t->status == -1) continue;
 			if (t->status == 1)
+			{
 				nonzero++;
+				if (t->d_lkg_nc0 && (t->d_lkg_nc0 != NULL))
+				{
+					cml++;
+					for (Disjunct **d = t->d_lkg_nc0; *d != NULL; d++)
+						cml_disjunct++;
+				}
+			}
 			else if (t->null_count == ANY_NULL_COUNT)
 				any_null++;
 			else if (ctxt->sent->null_count > t->null_count)
@@ -259,9 +268,10 @@ static void free_table_lrcnt(count_context_t *ctxt)
 
 		const unsigned int num_values = ctxt->sent->wordvec_pool->curr_elements;
 		lgdebug(+0, "Values %u (usage = non_max_null %u + other %u, "
-		        "other = any_null_zero %u + zero %u + nonzero %u)\n",
+		        "other = any_null_zero %u + zero %u + nonzero %u); "
+		        "%u disjuncts in %u cache entries\n",
 		        num_values, non_max_null, num_values-non_max_null,
-		        any_null, zero, nonzero);
+		        any_null, zero, nonzero, cml_disjunct, cml);
 
 		for (unsigned int dir = 0; dir < 2; dir++)
 		{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -314,9 +314,12 @@ static void init_table_lrcnt(count_context_t *ctxt)
 	}
 }
 
+#ifdef DEBUG
+#define DEBUG_TABLE_STAT
+#endif /* DEBUG */
 //#define DEBUG_TABLE_STAT
-#if defined(DEBUG) || defined(DEBUG_TABLE_STAT)
-static uint64_t hit, miss;  /* Table value found/not found */
+#ifdef DEBUG_TABLE_STAT
+static uint64_t hit, miss;  /* Table entry stats */
 #define TABLE_STAT(...) __VA_ARGS__
 #else
 #define TABLE_STAT(...)

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -69,8 +69,11 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
  * check_next skips all the words for which the count is known to be zero. */
 typedef struct
 {
-	Disjunct **d_lkg_nc0;    /* Disjuncts with a jet linkage for null_count==0 */
-	count_t *count_nc0;      /* The counts for that linkage. */
+	/* Arrays of match list information for sentences with null_count==0.
+	 * The count at index x is due to the disjuncts at the same index x. */
+	Disjunct **d_lkg_nc0;    /* Disjuncts with a jet linkage */
+	count_t *count_nc0;      /* The counts for that linkage */
+
 	null_count_m null_count; /* status==0 valid up to this null count */
 	int8_t status;         /* -1: Needs update; 0: No count; 1: Count possible */
 	WordIdx_m check_next;    /* Next word to check */
@@ -1214,6 +1217,16 @@ static Count_bin do_count(
 
 			if (using_cached_match_list)
 			{
+				/* If a cached left match list is used, form_match_list() always
+				 * uses all of its disjuncts. But if a cached right match list
+				 * is used and le!=0, form_match_list() omits its disjuncts that
+				 * don't have a left match (see "lc optimization" there)).
+				 * Since the left/right cached count elements correspond to the
+				 * full cached match lists (see count_expectation), an
+				 * incremental counter can be used for the cached left count,
+				 * but for the cached right count we depend on form_match_list()
+				 * to set d->rcount_index as the index into the corresponding
+				 * cached right count array. */
 				if (Lmatch && (l_cache != NULL))
 				{
 					leftpcount = true;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -310,7 +310,7 @@ static void init_table_lrcnt(count_context_t *ctxt)
 	{
 		ctxt->sent->wordvec_pool =
 			pool_new(__func__, "count_expectation", /*num_elements*/initial_size,
-			         sizeof(count_expectation), /*zero_out*/false,
+			         sizeof(count_expectation), /*zero_out*/true,
 			         /*align*/false, /*exact*/false);
 	}
 }
@@ -672,8 +672,13 @@ static wordvecp is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
 		/* Create a new cache entry, to be updated by lrcnt_cache_update(). */
 		const size_t wordvec_size = abs(c->farthest_word - c->nearest_word) + 1;
 		*wv = pool_alloc_vec(ctxt->sent->wordvec_pool, wordvec_size);
-		memset(*wv, -1, sizeof(count_expectation) * wordvec_size);
-
+		/* FIXME: Eliminate the need to initialize these fields with -1. */
+		for (size_t i = 0; i < wordvec_size; i++)
+		{
+			(*wv)[i].status = -1;
+			(*wv)[i].null_count = -1;
+			(*wv)[i].check_next = -1;
+		}
 		assert(wordvec_index < wordvec_size, "Bad wordvec index");
 		return &(*wv)[wordvec_index]; /* Needs update */
 	}

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1043,14 +1043,15 @@ static Count_bin do_count(
 		 * extremely effective for long sentences, but doesn't speed up
 		 * short ones.
 		 *
-		 * FIXME: lrcnt_optimize==false doubles the Table_connector cache!
+		 * FIXME: l/rcnt_optimize==false doubles the Table_connector cache!
 		 * Try to fix it by not caching zero counts in Table_connector when
-		 * lrcnt_optimize==false. If this can be fixed, a significant
+		 * l/rcnt_optimize==false. If this can be fixed, a significant
 		 * speedup is expected. */
 
 		wordvecp lrcnt_cache = NULL;
 		bool lrcnt_found = false;     /* TRUE iff a range yielded l/r count */
-		bool lrcnt_optimize = true;   /* Perform l/r count optimization */
+		bool lcnt_optimize = true;   /* Perform left count optimization */
+		bool rcnt_optimize = true;   /* Perform right count optimization */
 		unsigned int lnull_start = 0; /* First null_count to check */
 		unsigned int lnull_end = null_count; /* Last null_count to check */
 		Connector *fml_re = re;       /* For form_match_list() only */
@@ -1067,7 +1068,7 @@ static Count_bin do_count(
 
 			if (lrcnt_cache != NULL)
 			{
-				lrcnt_optimize = false;
+				lcnt_optimize = false;
 			}
 			else if ((re != NULL) && (re->farthest_word <= w))
 			{
@@ -1089,7 +1090,7 @@ static Count_bin do_count(
 
 			if (lrcnt_cache != NULL)
 			{
-				lrcnt_optimize = false;
+				rcnt_optimize = false;
 				if (rnull_start <= null_count)
 					lnull_end -= rnull_start;
 			}
@@ -1231,7 +1232,7 @@ static Count_bin do_count(
 				w_Count_bin leftcount = hist_zero();
 				w_Count_bin rightcount = hist_zero();
 				if (leftpcount &&
-				    (!lrcnt_optimize || rightpcount || (0 != hist_total(&l_bnr))))
+				    (!lcnt_optimize || rightpcount || (0 != hist_total(&l_bnr))))
 				{
 					CACHE_COUNT(l_any, leftcount = count,
 						do_count(ctxt, lw, w, le->next, d->left->next, lnull_cnt));
@@ -1256,7 +1257,7 @@ static Count_bin do_count(
 				}
 
 				if (rightpcount &&
-				    (!lrcnt_optimize || (0 < hist_total(&leftcount)) || (0 != hist_total(&r_bnl))))
+				    (!rcnt_optimize || (0 < hist_total(&leftcount)) || (0 != hist_total(&r_bnl))))
 				{
 					CACHE_COUNT(r_any, rightcount = count,
 						do_count(ctxt, w, rw, d->right->next, re->next, rnull_cnt));

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -70,6 +70,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 typedef struct
 {
 	Disjunct **d_lkg_nc0;    /* Disjuncts with a jet linkage for null_count==0 */
+	count_t *count_nc0;      /* The counts for that linkage. */
 	null_count_m null_count; /* status==0 valid up to this null count */
 	int8_t status;         /* -1: Needs update; 0: No count; 1: Count possible */
 	WordIdx_m check_next;    /* Next word to check */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -13,7 +13,7 @@
 /*************************************************************************/
 
 #include <limits.h>
-#include <inttypes.h>                 // PRIu64
+#include <inttypes.h>                   // PRIu64
 #if HAVE_THREADS_H
 #include <threads.h>
 #endif /* HAVE_THREADS_H */
@@ -26,7 +26,7 @@
 #include "disjunct-utils.h"
 #include "fast-match.h"
 #include "resources.h"
-#include "tokenize/word-structures.h" // for Word_struct
+#include "tokenize/word-structures.h"   // for Word_struct
 #include "utilities.h"
 
 /* This file contains the exhaustive search algorithm. */
@@ -38,7 +38,7 @@ struct Table_connector_s
 {
 	Table_connector  *next;
 	int              l_id, r_id;
-	Count_bin          count;
+	Count_bin        count;
 	unsigned int     null_count;
 	size_t           hash;
 };
@@ -315,7 +315,6 @@ static void init_table_lrcnt(count_context_t *ctxt)
 
 	const size_t initial_size = MIN(sent->length/2, 16) *
 		                   (ctxt->table_lrcnt[0].sz + ctxt->table_lrcnt[1].sz);
-
 
 	if (NULL != sent->wordvec_pool)
 	{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -620,7 +620,7 @@ static Table_lrcnt *is_lrcnt(count_context_t *ctxt, int dir, Connector *c,
 			memset(*wv, -1, sizeof(Table_lrcnt) * wordvec_size);
 
 			*null_start = 0;
-			assert(wordvec_index < ctxt->sent->length, "Bad wordvec index");
+			assert(wordvec_index < wordvec_size, "Bad wordvec index");
 			return &(*wv)[wordvec_index]; /* Needs update */
 		}
 		return NULL;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -662,6 +662,9 @@ static void lrcnt_cache_match_list(wordvecp lrcnt_cache, fast_matcher_t *mchxt,
 
 	Disjunct **ml = pool_alloc_vec(mchxt->mld_pool, dcnt + 1);
 	count_t *c = pool_alloc_vec(mchxt->mlc_pool, dcnt);
+
+	if ((ml == NULL) || (c == NULL)) return; /* Cannot allocate cache array */
+
 	dcnt = 0;
 	for (i = mlb; get_match_list_element(mchxt, i) != NULL; i++)
 	{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1205,18 +1205,15 @@ static Count_bin do_count(
 
 				if (!leftpcount && !rightpcount) continue;
 
-				if (!(leftpcount && rightpcount))
+				if (leftpcount)
 				{
-					if (leftpcount)
-					{
-						/* Evaluate using the left match, but not the right. */
-						COUNT(l_bnr, do_count(ctxt, w, rw, d->right, re, rnull_cnt));
-					}
-					else if (le == NULL)
-					{
-						/* Evaluate using the right match, but not the left. */
-						COUNT(r_bnl, do_count(ctxt, lw, w, le, d->left, lnull_cnt));
-					}
+					/* Evaluate using the left match, but not the right. */
+					COUNT(l_bnr, do_count(ctxt, w, rw, d->right, re, rnull_cnt));
+				}
+				else if (le == NULL)
+				{
+					/* Evaluate using the right match, but not the left. */
+					COUNT(r_bnl, do_count(ctxt, lw, w, le, d->left, lnull_cnt));
 				}
 
 #define CACHE_COUNT(c, how_to_count, do_count) \

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1114,6 +1114,8 @@ static Count_bin do_count(
 			bool Lmatch = d->match_left;
 			bool Rmatch = d->match_right;
 
+			d->match_left = d->match_right = false;
+
 #ifdef VERIFY_MATCH_LIST
 			assert(id == d->match_id, "Modified id (%u!=%u)", id, d->match_id);
 #endif
@@ -1249,6 +1251,7 @@ static Count_bin do_count(
 					if (0 < hist_total(&leftcount))
 					{
 						lrcnt_found = true;
+						d->match_left = true;
 
 						/* Evaluate using the left match, but not the right */
 						CACHE_COUNT(l_bnr, hist_muladdv(&total, &leftcount, d->cost, count),
@@ -1276,6 +1279,7 @@ static Count_bin do_count(
 						if (le == NULL)
 						{
 							lrcnt_found = true;
+							d->match_right = true;
 
 							/* Evaluate using the right match, but not the left */
 							CACHE_COUNT(r_bnl, hist_muladdv(&total, &rightcount, d->cost, count),

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1126,7 +1126,8 @@ static Count_bin do_count(
 			{
 				lcnt_optimize = false;
 			}
-			else if ((re != NULL) && (re->farthest_word <= w))
+
+			if ((re != NULL) && (re->farthest_word <= w))
 			{
 				/* If it is already known that "re" would yield a zero
 				 * rightcount, there is no need to fetch the right match list.

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1203,17 +1203,19 @@ static Count_bin do_count(
 #define COUNT(c, do_count) \
 	{ c = TRACE_LABEL(c, do_count); }
 
-				if (!leftpcount && !rightpcount) continue;
-
 				if (leftpcount)
 				{
 					/* Evaluate using the left match, but not the right. */
 					COUNT(l_bnr, do_count(ctxt, w, rw, d->right, re, rnull_cnt));
 				}
-				else if (le == NULL)
+				else
 				{
-					/* Evaluate using the right match, but not the left. */
-					COUNT(r_bnl, do_count(ctxt, lw, w, le, d->left, lnull_cnt));
+					if (!rightpcount) continue; /* Left and right counts are 0. */
+					if (le == NULL)
+					{
+						/* Evaluate using the right match, but not the left. */
+						COUNT(r_bnl, do_count(ctxt, lw, w, le, d->left, lnull_cnt));
+					}
 				}
 
 #define CACHE_COUNT(c, how_to_count, do_count) \

--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -24,6 +24,7 @@ Count_bin *table_lookup(count_context_t *, int, int,
                         unsigned int, size_t *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 bool no_count(count_context_t *, int, Connector *, unsigned int, unsigned int);
+Disjunct ***get_cached_match_list(count_context_t *, int, int, Connector *);
 
 count_context_t *alloc_count_context(Sentence, Tracon_sharing*);
 void free_count_context(count_context_t*, Sentence);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -482,7 +482,14 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 		}
 		/* End of nonzero leftcount/rightcount range cache check. */
 
-		size_t mlb = form_match_list(mchxt, w, le, lw, fml_re, rw);
+		Disjunct ***mlcl = NULL, ***mlcr = NULL;
+
+		if (le != NULL)
+			mlcl = get_cached_match_list(ctxt, 0, w, le);
+		if (re != NULL && ((le == NULL) || (re->farthest_word <= w)))
+			mlcr = get_cached_match_list(ctxt, 1, w, re);
+
+		size_t mlb = form_match_list(mchxt, w, le, lw, fml_re, rw, mlcl, mlcr);
 		if (pex->sort_match_list) sort_match_list(mchxt, mlb);
 
 		for (size_t mle = mlb; get_match_list_element(mchxt, mle) != NULL; mle++)

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -94,7 +94,7 @@ void free_fast_matcher(Sentence sent, fast_matcher_t *mchxt)
 
 	free(mchxt->l_table[0]);
 	free(mchxt->match_list);
-	lgdebug(6, "Sentence length %zu, match_list_size %zu\n",
+	lgdebug(+6, "Sentence length %zu, match_list_size %zu\n",
 	        mchxt->size, mchxt->match_list_size);
 
 	xfree(mchxt->l_table_size, mchxt->size * sizeof(unsigned int));

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2004                                                     */
 /* Daniel Sleator, David Temperley, and John Lafferty                     */
 /* Copyright (c) 2014 Linas Vepstas                                       */
+/* Copyright (c) 2015-2022 Amir Plivatsky                                 */
 /* All rights reserved                                                    */
 /*                                                                        */
 /* Use of the link grammar parsing system is subject to the terms of the  */

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -558,7 +558,8 @@ static size_t terminate_match_list(fast_matcher_t *ctxt, int id,
 size_t
 form_match_list(fast_matcher_t *ctxt, int w,
                 Connector *lc, int lw,
-                Connector *rc, int rw)
+                Connector *rc, int rw,
+                Disjunct ***mlcl, Disjunct ***mlcr)
 {
 	Match_node *mx, *mr_end;
 	size_t front = get_match_list_position(ctxt);

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -68,7 +68,7 @@ struct sortbin_s
 /**
  * Push a match-list element into the match-list array.
  */
-static void push_match_list_element(fast_matcher_t *ctxt, Disjunct *d)
+static void push_match_list_element(fast_matcher_t *ctxt, int id, Disjunct *d)
 {
 	if (ctxt->match_list_end >= ctxt->match_list_size)
 	{
@@ -77,6 +77,9 @@ static void push_match_list_element(fast_matcher_t *ctxt, Disjunct *d)
 		                      ctxt->match_list_size * sizeof(*ctxt->match_list));
 	}
 
+#ifdef VERIFY_MATCH_LIST
+	if (id != 0) d->match_id = id;
+#endif
 	ctxt->match_list[ctxt->match_list_end++] = d;
 }
 
@@ -517,7 +520,7 @@ static size_t terminate_match_list(fast_matcher_t *ctxt, int id,
                              Connector *lc, int lw,
                              Connector *rc, int rw)
 {
-	push_match_list_element(ctxt, NULL);
+	push_match_list_element(ctxt, 0, NULL);
 	print_match_list(ctxt, id, ml_start, w, lc, lw, rc, rw);
 	return ml_start;
 }
@@ -603,10 +606,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 		if (!mx->d->match_left) continue;
 		mx->d->match_right = false;
 
-#ifdef VERIFY_MATCH_LIST
-		mx->d->match_id = lid;
-#endif
-		push_match_list_element(ctxt, mx->d);
+		push_match_list_element(ctxt, lid, mx->d);
 	}
 
 	if ((lc != NULL) && is_no_match_list(ctxt, front)) /* lc optimization */
@@ -628,10 +628,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 			                  alt_connection_possible(mx->d->right, rc, &gc);
 		if (!mx->d->match_right || mx->d->match_left) continue;
 
-#ifdef VERIFY_MATCH_LIST
-		mx->d->match_id = lid;
-#endif
-		push_match_list_element(ctxt, mx->d);
+		push_match_list_element(ctxt, lid, mx->d);
 	}
 
 	return terminate_match_list(ctxt, lid, front, w, lc, lw, rc, rw);

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -259,13 +259,15 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 			         /*num_elements*/2048, sizeof(Match_node),
 			         /*zero_out*/false, /*align*/true, /*exact*/false);
 	}
+	const size_t match_list_pool_size = 512*1024; /* Currently a hard limit. */
+	/* FIXME: Modify pool_alloc_vec() to use dynamic block sizes. */
 	ctxt->mld_pool =
 		pool_new(__func__, "Match list cache",
-		         /*num_elements*/512*1024, sizeof(Disjunct *),
+		         /*num_elements*/match_list_pool_size, sizeof(Disjunct *),
 		         /*zero_out*/false, /*align*/false, /*exact*/false);
 	ctxt->mlc_pool =
 		pool_new(__func__, "Match list counts",
-		         /*num_elements*/512*1024, sizeof(count_t),
+		         /*num_elements*/match_list_pool_size, sizeof(count_t),
 		         /*zero_out*/false, /*align*/false, /*exact*/false);
 
 	sortbin *sbin = alloca(sent->length * sizeof(sortbin));

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -98,6 +98,7 @@ void free_fast_matcher(Sentence sent, fast_matcher_t *mchxt)
 	        mchxt->size, mchxt->match_list_size);
 
 	pool_delete(mchxt->mld_pool);
+	pool_delete(mchxt->mlc_pool);
 	xfree(mchxt->l_table_size, mchxt->size * sizeof(unsigned int));
 	xfree(mchxt->l_table, mchxt->size * sizeof(Match_node **));
 	xfree(mchxt, sizeof(fast_matcher_t));
@@ -260,6 +261,10 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 	ctxt->mld_pool =
 		pool_new(__func__, "Match list cache",
 		         /*num_elements*/512*1024, sizeof(Disjunct *),
+		         /*zero_out*/false, /*align*/false, /*exact*/false);
+	ctxt->mlc_pool =
+		pool_new(__func__, "Match list counts",
+		         /*num_elements*/512*1024, sizeof(count_t),
 		         /*zero_out*/false, /*align*/false, /*exact*/false);
 
 	sortbin *sbin = alloca(sent->length * sizeof(sortbin));

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -691,6 +691,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 		{
 			if ((lc != NULL) && !(*cmx)->match_left) continue; /* lc optimization*/
 			(*cmx)->match_right = true;
+			(*cmx)->rcount_index = (uint32_t)(cmx - *mlcr);
 			if ((*cmx)->match_left) continue;
 			push_match_list_element(ctxt, lid, *cmx);
 		}

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -42,6 +42,8 @@
  * by unwinding this stack.
  */
 
+#define D_FAST_MATCHER 9 /* General debug level for this file. */
+
 #define MATCH_LIST_SIZE_INIT 4096 /* the initial size of the match-list stack */
 #define MATCH_LIST_SIZE_INC 2     /* match-list stack increase size factor */
 
@@ -399,7 +401,7 @@ static void print_match_list(fast_matcher_t *ctxt, int id, size_t mlb, int w,
                              Connector *lc, int lw,
                              Connector *rc, int rw)
 {
-	if (!verbosity_level(9)) return;
+	if (!verbosity_level(D_FAST_MATCHER)) return;
 	Disjunct **m = &ctxt->match_list[mlb];
 
 	for (; NULL != *m; m++)

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -97,6 +97,7 @@ void free_fast_matcher(Sentence sent, fast_matcher_t *mchxt)
 	lgdebug(+6, "Sentence length %zu, match_list_size %zu\n",
 	        mchxt->size, mchxt->match_list_size);
 
+	pool_delete(mchxt->mld_pool);
 	xfree(mchxt->l_table_size, mchxt->size * sizeof(unsigned int));
 	xfree(mchxt->l_table, mchxt->size * sizeof(Match_node **));
 	xfree(mchxt, sizeof(fast_matcher_t));
@@ -256,6 +257,10 @@ fast_matcher_t* alloc_fast_matcher(const Sentence sent, unsigned int *ncu[])
 			         /*num_elements*/2048, sizeof(Match_node),
 			         /*zero_out*/false, /*align*/true, /*exact*/false);
 	}
+	ctxt->mld_pool =
+		pool_new(__func__, "Match list cache",
+		         /*num_elements*/512*1024, sizeof(Disjunct *),
+		         /*zero_out*/false, /*align*/false, /*exact*/false);
 
 	sortbin *sbin = alloca(sent->length * sizeof(sortbin));
 

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -15,6 +15,8 @@
 
 #include <stddef.h> // for size_t
 #include "api-types.h"
+#include "disjunct-utils.h"             // Disjunct_struct
+#include "error.h"                      // lgdebug
 #include "link-includes.h" // for Sentence
 #include "memory-pool.h"
 
@@ -62,6 +64,12 @@ static inline Disjunct *get_match_list_element(fast_matcher_t *ctxt, size_t mli)
 static inline void pop_match_list(fast_matcher_t *ctxt, size_t match_list_last)
 {
 	ctxt->match_list_end = match_list_last;
+	if (verbosity_level(9))
+	{
+		if (get_match_list_element(ctxt, match_list_last) != NULL)
+			lgdebug(+9, "MATCH_LIST %9d pop\n",
+			        get_match_list_element(ctxt, match_list_last)->match_id);
+	}
 }
 
 /**

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -42,6 +42,9 @@ struct fast_matcher_s
 	Disjunct ** match_list;      /* match-list stack */
 	size_t match_list_end;       /* index to the match-list stack end */
 	size_t match_list_size;      /* number of allocated elements */
+
+	/* Match list cache. */
+	Pool_desc *mld_pool; /* disjuncts pointers */
 };
 
 /* See the source file for documentation. */

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -45,6 +45,7 @@ struct fast_matcher_s
 
 	/* Match list cache. */
 	Pool_desc *mld_pool; /* disjuncts pointers */
+	Pool_desc *mlc_pool; /* linkage counts */
 };
 
 /* See the source file for documentation. */

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -51,7 +51,8 @@ struct fast_matcher_s
 fast_matcher_t* alloc_fast_matcher(const Sentence, unsigned int *[]);
 void free_fast_matcher(Sentence sent, fast_matcher_t*);
 
-size_t form_match_list(fast_matcher_t *, int, Connector *, int, Connector *, int);
+size_t form_match_list(fast_matcher_t *, int, Connector *, int, Connector *,
+                       int, Disjunct ***, Disjunct ***);
 
 /**
  * Return the match-list element at the given index.

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -13,11 +13,11 @@
 #ifndef _FAST_MATCH_H_
 #define _FAST_MATCH_H_
 
-#include <stddef.h> // for size_t
+#include <stddef.h>                     // for size_t
 #include "api-types.h"
 #include "disjunct-utils.h"             // Disjunct_struct
 #include "error.h"                      // lgdebug
-#include "link-includes.h" // for Sentence
+#include "link-includes.h"              // for Sentence
 #include "memory-pool.h"
 
 typedef struct Match_node_struct Match_node;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -269,7 +269,7 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 
 	if (verbosity >= D_USER_INFO)
 	{
-		prt_error("Info: sane_morphism(): %zu of %d linkages had "
+		lgdebug(0, "Info: sane_morphism(): %zu of %d linkages had "
 		        "invalid morphology construction\n", N_invalid_morphism,
 		        itry + (itry != maxtries));
 	}


### PR DESCRIPTION
Benchmark results:
```  text
1.002x    data/en/corpus-basic.batch
1.000x    data/en/corpus-fixes.batch
1.007x    data/ru/corpus-basic.batch
1.185x    data/en/corpus-fix-long.batch
1.140x    data/en/corpus-failures.batch
1.060x    pandp-union.txt
```
This PR accelerates the `fix-long` corpus batch by ~18%, and the `pandp-union` one by ~6%. It is especially effective for generation - (`link-generator --language=en --length=7` is accelerated ~10x).
Currently, the acceleration is only for parsing w/o nulls.

How it works:
The match lists disjuncts and parse-counts are cached after they are created for the first time. The trick is that only the match list disjuncts that yield a positive count are cached (along with their leftcount/rightcount). The caching of the match lists saves much processing in `form_match_list()` and in the main loop of `do_count()` which doesn't need anymore to iterate over disjuncts that don't yield a count. The cached leftcount/rightcount, which is stored in directly-addressed arrays, saves many branches and `do_count()` calls, and especially `Table_connector` lookups which usually cause CPU cache misses (by average more than one lookup per leftcount/rightcount, due to `multi` connectors).

Notes:
1. The reason that the short-length corpora batches are not accelerated is that the parsing-related functions take negligible time for them - for the `fixes` corpus batch the functions in the files `count.c`, `fast-match.c` and `extract-links.c` take together about 2 (two) percent!

2. I have more parsing acceleration branches, specific generation accelerations and memory usage reductions, and also pruning ideas, that I would like to release before releasing feature PRs.

3. Now that the parsing functions for long sentences take about 25% of the CPU, other speed improvements would become significant (e.g. in tokenization, postprocessing, memory handling, etc.).