### PR TITLE
Assorted bug fixes and improvments

### DIFF
--- a/link-grammar/dict-common/file-utils.c
+++ b/link-grammar/dict-common/file-utils.c
@@ -530,11 +530,9 @@ char *get_file_contents(const char * dict_name)
 
 			if (err)
 			{
-				char errbuf[64];
-
-				lg_strerror(errno, errbuf, sizeof(errbuf));
+				prt_error("Error: %s: Read error (%s)\n", dict_name,
+				          syserror_msg(errno));
 				fclose(fp);
-				prt_error("Error: %s: Read error (%s)\n", dict_name, errbuf);
 				free(contents);
 				return NULL;
 			}

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -475,6 +475,7 @@ Disjunct *eliminate_duplicate_disjuncts(Disjunct *dw, bool multi_string)
 	}
 
 	lgdebug(+D_DISJ+(0==count)*1024, "w%zu: Killed %u duplicates%s\n",
+	        dw->originating_gword == NULL ? 0 :
 	        dw->originating_gword->o_gword->sent_wordidx, count,
 	        multi_string ? " (different word-strings)" : "");
 

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -436,7 +436,7 @@ const char *feature_enabled(const char * list, ...)
 /**
  * Issue the assert() macro (see error.h) error message.
  */
-void (* assert_failure_trap)(void);
+link_public_api(void) (* lg_assert_failure_trap)(void);
 void assert_failure(const char cond_str[], const char func[],
                     const char *src_location, const char *fmt, ...)
 {
@@ -463,10 +463,10 @@ void assert_failure(const char cond_str[], const char func[],
 	}
 	va_end(args);
 
-	if (assert_failure_trap == NULL)
+	if (lg_assert_failure_trap == NULL)
 		DEBUG_TRAP;  /* leave stack trace in debugger */                      \
 	else
-		assert_failure_trap();
+		lg_assert_failure_trap();
 
 	exit(1);
 }

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -502,3 +502,10 @@ void debug_msg(int level, int v, char print_func, const char func[],
 		va_end(args);
 	}
 }
+
+const char *syserror_msg(int errno)
+{
+	TLS static char errbuf[64];
+	lg_strerror(errno, errbuf, sizeof(errbuf));
+	return errbuf;
+}

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -436,7 +436,7 @@ const char *feature_enabled(const char * list, ...)
 /**
  * Issue the assert() macro (see error.h) error message.
  */
-link_public_api(void) (* lg_assert_failure_trap)(void);
+void (*lg_library_failure_hook)(void);
 void assert_failure(const char cond_str[], const char func[],
                     const char *src_location, const char *fmt, ...)
 {
@@ -463,10 +463,10 @@ void assert_failure(const char cond_str[], const char func[],
 	}
 	va_end(args);
 
-	if (lg_assert_failure_trap == NULL)
+	if (lg_library_failure_hook == NULL)
 		DEBUG_TRAP;  /* leave stack trace in debugger */                      \
 	else
-		lg_assert_failure_trap();
+		lg_library_failure_hook();
 
 	exit(1);
 }
@@ -508,4 +508,11 @@ const char *syserror_msg(int errno)
 	TLS static char errbuf[64];
 	lg_strerror(errno, errbuf, sizeof(errbuf));
 	return errbuf;
+}
+
+void lg_lib_failure(void)
+{
+	if (lg_library_failure_hook != NULL)
+		lg_library_failure_hook();
+	exit(1);
 }

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -38,6 +38,7 @@ const char *feature_enabled(const char *, ...);
 void debug_msg(int, int, char, const char[], const char[], const char *fmt, ...)
 	GNUC_PRINTF(6,7);
 bool verbosity_check(int, int, char, const char[], const char[], const char *);
+const char *syserror_msg(int);
 
 /**
  * Print a debug messages according to their level.

--- a/link-grammar/error.h
+++ b/link-grammar/error.h
@@ -39,6 +39,7 @@ void debug_msg(int, int, char, const char[], const char[], const char *fmt, ...)
 	GNUC_PRINTF(6,7);
 bool verbosity_check(int, int, char, const char[], const char[], const char *);
 const char *syserror_msg(int);
+void lg_lib_failure(void);
 
 /**
  * Print a debug messages according to their level.

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -101,6 +101,8 @@ link_public_api(int)
 link_public_api(bool)
      lg_error_flush(void);
 
+link_public_api(extern void) (*lg_library_failure_hook)(void);
+
 /**********************************************************************
  *
  * Functions to manipulate Dictionaries

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -218,6 +218,7 @@ void pool_reuse(Pool_desc *mp)
 	        mp->curr_elements, mp->name, mp->func);
 	mp->ring = mp->chain;
 	mp->alloc_next = mp->ring;
+	if ((mp->ring != NULL) && (mp->zero_out)) memset(mp->ring, 0, mp->data_size);
 	mp->curr_elements = 0;
 #ifdef POOL_FREE
 	mp->free_list = NULL;

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -13,7 +13,7 @@
 
 #include "error.h"
 #include "memory-pool.h"
-#include "utilities.h"                  // MIN/MAX, aligned_alloc, lg_strerror
+#include "utilities.h"                  // MIN/MAX, aligned_alloc
 
 /* TODO: Add valgrind descriptions. See:
  * http://valgrind.org/docs/manual/mc-manual.html#mc-manual.mempools */
@@ -178,15 +178,11 @@ void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 		{
 			/* Allocate a new block and chain it. */
 			mp->ring = aligned_alloc(mp->alignment, mp->block_size);
-			if (NULL == mp->ring)
-			{
-				/* aligned_alloc() has strict requirements. */
-				char errbuf[64];
-				lg_strerror(errno, errbuf, sizeof(errbuf));
-				prt_error("Fatal error: aligned_alloc(%zu, %zu): %s",
-				          mp->block_size, mp->element_size, errbuf);
-				exit(1);
-			}
+
+			/* aligned_alloc() has strict requirements. */
+			assert(NULL != mp->ring, "Aligned_alloc(%zu, %zu): %s",
+			       mp->block_size, mp->element_size, syserror_msg(errno));
+
 			if (NULL == mp->alloc_next)
 				mp->chain = mp->ring; /* This is the start of the chain. */
 			else
@@ -345,11 +341,7 @@ void pool_delete (const char *func, Pool_desc *mp)
 void pool_free(Pool_desc *mp, void *e)
 {
 	mp->curr_elements--;
-	if (ASAN_ADDRESS_IS_POISONED(e))
-	{
-		prt_error("Fatal error: Double pool free of %p\n", e);
-		exit(1);
-	}
+	assert(!ASAN_ADDRESS_IS_POISONED(e), "Double pool free of %p\n", e);
 	ASAN_POISON_MEMORY_REGION(e, sizeof(alloc_attr) + ((alloc_attr *)e)->size);
 }
 #endif // POOL_FREE

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -233,6 +233,11 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 {
 	Disjunct *dis, *ndis;
 	Pool_desc *connector_pool = NULL;
+	bool sat_solver = false;
+
+#if USE_SAT_SOLVER
+		sat_solver = (opts != NULL) && opts->use_sat_solver;
+#endif /* USE_SAT_SOLVER */
 
 	dis = NULL;
 	for (; cl != NULL; cl = cl->next)
@@ -241,7 +246,7 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 		if (cl->maxcost > cost_cutoff) continue;
 
 #if USE_SAT_SOLVER
-		if (opts->use_sat_solver) /* For the SAT-parser, until fixed. */
+		if (sat_solver) /* For the SAT-parser, until fixed. */
 		{
 			ndis = xalloc(sizeof(Disjunct));
 		}
@@ -265,11 +270,6 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 			n->next = *loc;   /* prepend the connector to the current list */
 			*loc = n;         /* update the connector list */
 		}
-
-		bool sat_solver = false;
-#if USE_SAT_SOLVER
-		sat_solver = opts->use_sat_solver;
-#endif /* USE_SAT_SOLVER */
 
 		/* XXX add_category() starts category strings by ' '.
 		 * FIXME Replace it by a better indication. */

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -148,7 +148,8 @@ static Clause * build_clause(Exp *e, clause_context *ct, Clause **c_last)
 				for (c4 = c2; c4 != NULL; c4 = c4->next)
 				{
 					float maxcost = MAX(c3->maxcost,c4->maxcost);
-					if (maxcost + e->cost > ct->cost_cutoff) continue;
+					/* Cannot use this shortcut due to negative costs. */
+					//if (maxcost + e->cost > ct->cost_cutoff) continue;
 
 					c = pool_alloc(ct->Clause_pool);
 					if ((c_head == NULL) && (c_last != NULL)) *c_last = c;

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -254,7 +254,7 @@ static int wctomb_check(char *s, wchar_t wc)
 	nr = wcrtomb(s, wc, &mbss);
 	if (nr < 0) {
 		prt_error("Fatal Error: unknown character set %s\n", nl_langinfo(CODESET));
-		exit(1);
+		lg_lib_failure();
 	}
 #endif /* _WIN32 */
 	return nr;


### PR DESCRIPTION
- `pool_reuse()`: Zero-out the first block if `zero_out==true` 
   It is a potentially severe bug, but no need for an immediate new release (see the detailed commit description).

- Convert `exit()` calls to  a library failure handler hook.
  I left `xalloc()` / `exalloc()` (obsolete but still used) with `exit()`. No memory conditions should be handled in
a new memory management.

- `build_clause()`: Remove shortcut for overcost temporary clauses.
   This seems to have a potential for problems but somehow currently it doesn't have a negative affects (see the detailed commit description).

- `build_disjunct()`: Fix crash on `!!test//m` while using SAT.

- lg_library_failure_hook: Rename assert_failure_trap and export..
  (I implemented this hook long ago, but it is currently inaccessible to the library user.)

BTW, while enabling SAT for the check of this fix, I found that 2 sentences from the basic corpus don't parse when running the batch, but are parsed just fine manually. Maybe this is due to misinitializations. However, I am not going to check that for now.