### PR TITLE
Speedup by tracon memory-sharing when building disjuncts

### DIFF
--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -263,6 +263,12 @@ static bool disjuncts_equal(Disjunct * d1, Disjunct * d2, bool ignore_string)
 {
 	Connector *e1, *e2;
 
+	/* A shortcut to detect NULL and non-NULL jets on the same side.
+	 * Note that it is not possible to share memory between the
+	 * right/left jets due to filed value differences (sharing would
+	 * invalidate this check). */
+	if (d1->left == d2->right) return false;
+
 	e1 = d1->left;
 	e2 = d2->left;
 	while ((e1 != NULL) && (e2 != NULL)) {

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -821,7 +821,7 @@ static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 	Disjunct *newd;
 	uintptr_t token;
 
-	newd = (ts->dblock)++;
+	newd = ts->dblock++;
 	newd->word_string = d->word_string;
 	newd->cost = d->cost;
 	newd->is_category = d->is_category;

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -715,6 +715,18 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 	{
 		newc = NULL;
 
+		/* The shallow indication is used only for pruning, but mark it
+		 * also for parsing anyway. tracon_set_add() uses it if
+		 * tracon_set_shallow() has been called (it is called if the
+		 * encoding is for pruning, but not when it is for parsing). The
+		 * shallow indication is also copied to the cblock connector (see
+		 * "No sharing yet" below), to be cached in the tracon_set and be
+		 * used by power_prune(). Note that due to memory sharing of the
+		 * original connectors (done in build_disjunct()), there is a need
+		 * to reset here the shallow indicator in non-shallow ones.
+		 * See also: Connector encoding, sharing and packing. */
+		o->shallow = (o == origc);
+
 		if (NULL != ts->csid[dir])
 		{
 			/* Encoding is used - share tracons. */

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -819,7 +819,7 @@ static Connector *pack_connectors(Tracon_sharing *ts, Connector *origc, int dir,
 static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 {
 	Disjunct *newd;
-	uintptr_t token = (uintptr_t)w;
+	uintptr_t token;
 
 	newd = (ts->dblock)++;
 	newd->word_string = d->word_string;
@@ -828,15 +828,20 @@ static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 	newd->originating_gword = d->originating_gword;
 	newd->ordinal = d->ordinal;
 
-	if (NULL == ts->tracon_list)
-		 token = (uintptr_t)d->originating_gword;
-
-	if ((token != ts->last_token) && (NULL != ts->csid[0]))
+	if (NULL != ts->csid[0])
 	{
-		ts->last_token = token;
-		//printf("Token %ld\n", token);
-		tracon_set_reset(ts->csid[0]);
-		tracon_set_reset(ts->csid[1]);
+		if (NULL == ts->tracon_list)
+			token = (uintptr_t)d->originating_gword;
+		else
+			token = (uintptr_t)w;
+
+		if (token != ts->last_token)
+		{
+			ts->last_token = token;
+			//printf("Token %ld\n", token);
+			tracon_set_reset(ts->csid[0]);
+			tracon_set_reset(ts->csid[1]);
+		}
 	}
 	newd->left = pack_connectors(ts, d->left, 0, w);
 	newd->right = pack_connectors(ts, d->right, 1,  w);

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -103,6 +103,14 @@ typedef struct
 	size_t element_number;
 } Pool_location;
 
+/**
+ * Return the number of allocated elements in the given pool.
+ */
+static inline size_t pool_num_elements_alloced(Pool_desc *mp)
+{
+	return mp->curr_elements;
+}
+
 static inline void *pool_alloc(Pool_desc *mp)
 {
 	return pool_alloc_vec(mp, 1);

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -106,6 +106,10 @@ static void build_sentence_disjuncts(Sentence sent, float cost_cutoff,
 	                   /*num_elements*/8192, sizeof(Connector),
 	                   /*zero_out*/true, /*align*/false, /*exact*/false);
 
+#ifdef DEBUG
+	size_t num_con_alloced = pool_num_elements_alloced(sent->Connector_pool);
+#endif
+
 	for (w = 0; w < sent->length; w++)
 	{
 		d = NULL;
@@ -117,6 +121,14 @@ static void build_sentence_disjuncts(Sentence sent, float cost_cutoff,
 		}
 		sent->word[w].d = d;
 	}
+
+#ifdef DEBUG
+	unsigned int dcnt, ccnt;
+	count_disjuncts_and_connectors(sent, &dcnt, &ccnt);
+	lgdebug(+D_PREP, "%u disjucts, %u connectors (%zu allocated)\n",
+	        dcnt, ccnt,
+	        pool_num_elements_alloced(sent->Connector_pool) - num_con_alloced);
+#endif
 
 	/* Delete the memory pools created in build_disjuncts_for_exp(). */
 	pool_delete(sent->Clause_pool);

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -44,8 +44,7 @@ static int set_dist_fields(Connector * c, size_t w, int delta)
 /**
  * Initialize the word fields of the connectors,
  * eliminate those disjuncts that are so long, that they
- * would need to connect past the end of the sentence,
- * and mark the shallow connectors.
+ * would need to connect past the end of the sentence.
  */
 static void setup_connectors(Sentence sent)
 {
@@ -67,9 +66,6 @@ static void setup_connectors(Sentence sent)
 			{
 				d->next = head;
 				head = d;
-				if (NULL != d->left) d->left->shallow = true;
-				if (NULL != d->right) d->right->shallow = true;
-
 			}
 		}
 		sent->word[w].d = head;

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -155,7 +155,7 @@ static Clause * build_clause(Exp *e, clause_context *ct, Clause **c_last)
 					if ((c_head == NULL) && (c_last != NULL)) *c_last = c;
 					c->cost = c3->cost + c4->cost;
 					c->maxcost = maxcost;
-					c->c = catenate(c3->c, c4->c, ct->Tconnector_pool);
+					c->c = catenate(c4->c, c3->c, ct->Tconnector_pool);
 					c->next = c_head;
 					c_head = c;
 				}
@@ -259,16 +259,18 @@ build_disjunct(Sentence sent, Clause * cl, const char * string,
 		ndis->left = ndis->right = NULL;
 
 		/* Build a list of connectors from the Tconnectors. */
+		Connector **jet[2] = { &ndis->left, &ndis->right };
 		for (Tconnector *t = cl->c; t != NULL; t = t->next)
 		{
+			int idir = ('+' == t->e->dir);
 			Connector *n = connector_new(connector_pool, t->e->condesc, opts);
-			Connector **loc = ('-' == t->e->dir) ? &ndis->left : &ndis->right;
 
 			n->exp_pos = t->e->pos;
 			n->multi = t->e->multi;
 			n->farthest_word = t->e->farthest_word;
-			n->next = *loc;   /* prepend the connector to the current list */
-			*loc = n;         /* update the connector list */
+
+			*(jet[idir]) = n;
+			jet[idir] = &n->next;
 		}
 
 		/* XXX add_category() starts category strings by ' '.

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -325,7 +325,7 @@ Disjunct *build_disjuncts_for_exp(Sentence sent, Exp* exp, const char *word,
 	clause_context ct = { 0 };
 
 	ct.cost_cutoff = cost_cutoff;
-	if (sent->Clause_pool == NULL)
+	if (unlikely(sent->Clause_pool == NULL))
 	{
 		ct.Clause_pool = pool_new(__func__, "Clause",
 		                          /*num_elements*/4096, sizeof(Clause),


### PR DESCRIPTION
Sharing tracon memory is already done in the encoding of disjuncts for pruning and parsing.
This PR uses the same idea while building disjuncts from expressions.

Consider this expression: `(A+ OR B+) & (C+ OR D+) & E+`
The generated 4 disjuncts have these connector lists:
1: `(A+ C+ E+)`
2: `(B+ C+ E+)`
3: `(A+ D+ E+)`
4: `(B+ D+ E+)`
Total number of connector memory allocations: 12.
Note that the trailing connector lists (aka "tracons") (`C+ E+)` and also `(D+ E+)` repeat.
We can exploit this fact in `(B+ C+  E+)` if instead of allocating memory for 2 connectors (`C+ E+)`, we point the `Next` filed of `B+` to the address of  `(C+ E+)` on the first disjunct `(A+ C+ E+)`.
``` text
A+ C+ E+
  /
B +
```
Here the total number of connector memory allocations is 4 (instead of 6).
Implementing this while building disjuncts made possible by commit  db4b4a1f165efdca87128d0040c99ba7c1ff5fcc (which, by itself significantly speeds up the disjunct generation): instead of copying the trailing Tconnectors, it uses a pointer to them. There is a triple-speed here: 1. Vastly simplified code. 2. No need for allocation of new Tconnectors. 3. Memory sharing of the trailing Tconnector lists in many `clause`'s (reduced memory footprint) with its benefits.

How tracon sharing when building the disjuncts works:
1. The address of each connector is cached in its corresponding Tconnector. This address represents a tracon.
2. Due to the sharing of trailing Tconnectors, it is immediately available through all the `clause`'s that share this sequence.
3. When such a `clause` is encountered when building the next disjuncts, if a cached tracon is found its address is used, and then building the next connectors in the same direction is skipped.

For long sentences, this saves tens of percent of connector allocations.
The reduced memory footprint (improved CPU caching and reduced memory bandwidth) speeds up the next steps too: duplicate elimination, setting distances, and encoding for pruning.

This PR also includes an additional change that contributes to its speedup:
- `disjuncts_equal()`: Add a shortcut to detect a clear false case

As usual with such changes, the speedup is noticeable only for long sentences and sentence generation:
~4%    `en/corpus-fix-long.batch`
~5%    `en/corpus-failures.batch`
~5.5% `pandp-union.txt`

Additional changes here, with a minor speedup:
- `pack_disjunct()`: Improve efficiency
- `build_disjuncts_for_exp()`: Add unlikely()
