### PR TITLE
Fixes for "amy" and more

### DIFF
--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -27,6 +27,8 @@ EXTRA_DIST =               \
    parses-en.txt           \
    parses-lt.txt           \
    parses-th.txt           \
+   parses-amy.txt          \
+   parses-any.txt          \
    parses-pos-en.txt       \
    parses-pos-he.txt       \
    parses-pos-ru.txt       \

--- a/bindings/python-examples/Makefile.am
+++ b/bindings/python-examples/Makefile.am
@@ -20,6 +20,7 @@ EXTRA_DIST =               \
    LICENSE                 \
    README.md               \
    example.py              \
+   gen-parses-file.py      \
    sentence-check.py       \
    parses-demo-sql.txt     \
    parses-dialect-en.txt   \

--- a/bindings/python-examples/gen-parses-file.py
+++ b/bindings/python-examples/gen-parses-file.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Generate linkage diagrams in the order and format used in the
+parses-xx.txt files of tests.py.
+Note: For the correct order, linkage_limit here and in test.py
+should be enough to produce all the sentence linkages.
+
+TODO: Add constituents.
+"""
+
+import sys
+import re
+import argparse
+
+from linkgrammar import (Sentence, ParseOptions, Dictionary,
+                         LG_Error, LG_TimerExhausted, Clinkgrammar as clg)
+
+import lg_testutils  # Found in the same directory of this test script
+
+def nsuffix(q):
+    return '' if q == 1 else 's'
+
+class Formatter(argparse.HelpFormatter):
+    """ Display the "lang" argument as a first one, as in link-parser. """
+    def _format_usage(self, usage, actions, groups, prefix):
+        usage_message = super(Formatter, self)._format_usage(usage, actions, groups, prefix)
+        return re.sub(r'(usage: \S+) (.*) \[lang]', r'\1 [lang] \2', str(usage_message))
+
+#-----------------------------------------------------------------------------#
+
+
+print("Version:", clg.linkgrammar_get_version())
+
+# Decorate Sentence.parse with eqcost_sorted_parse.
+lg_testutils.add_eqcost_linkage_order(Sentence)
+
+is_stdin_atty = sys.stdin.isatty()
+
+PROMPT = "sentence: " if is_stdin_atty else ""
+
+args = argparse.ArgumentParser(formatter_class=Formatter)
+args.add_argument('lang', nargs='?', default='en',
+                  help="language or dictionary location")
+args.add_argument("-v", "--verbosity", type=int, default=0,
+                  choices=range(0, 199), metavar='[0-199]',
+                  help="1: Basic verbosity; 2-4: Trace; >5: Debug")
+args.add_argument("-d", "--debug", type=ascii, default="",
+                  help="comma-separated list of files and/or functions to debug")
+args.add_argument("-p", "--position", action="store_true",
+                  help="show word sentence position")
+args.add_argument("-s", "--spell_guess", action="store_true",
+                  help="set spell guessing")
+args.add_argument("-nm", "--no-morphology", dest='morphology', action='store_false',
+                  help="do not display morphology")
+args.add_argument("-i", "--interactive", action="store_true",
+                  help="interactive mode after each result")
+
+arg = args.parse_args()
+
+try:
+    lgdict = Dictionary(arg.lang)
+except LG_Error:
+    # The default error handler will print the error message
+    args.print_usage()
+    sys.exit(2)
+
+po = ParseOptions(verbosity=arg.verbosity)
+
+MAX_DISPLAY_LINKAGES = 6
+po.max_null_count = 999    # > allowed maximum number of words
+po.linkage_limit = 100000  # maximum number of linkages to generate
+                           # (should be >= num_linkages_found)
+po.max_parse_time = 10     # actual parse timeout may be about twice bigger
+po.spell_guess = arg.spell_guess
+po.display_morphology = arg.morphology
+po.debug = arg.debug.replace("'", "")
+
+while True:
+    try:
+        sentence_text = input(PROMPT)
+    except EOFError:
+        print("EOF")
+        exit(0)
+
+    if not is_stdin_atty and sentence_text:
+        if sentence_text[0] == '%':
+            continue
+        if sentence_text[0] == '!':  # ignore user-settings for now
+            continue
+    if sentence_text.strip() == '':
+        continue
+    if not is_stdin_atty:
+        print("\n" + sentence_text)
+
+    sent = Sentence(str(sentence_text), lgdict, po)
+    try:
+        linkages = sent.parse()
+    except LG_TimerExhausted:
+        print('Sentence too complex for parsing in ~{} second{}.'.format(
+            po.max_parse_time, nsuffix(po.max_parse_time)))
+        continue
+    if not linkages:
+        print('Error occurred - sentence ignored.')
+        continue
+    if len(linkages) <= 0:
+        print('Cannot parse the input sentence')
+        continue
+    null_count = sent.null_count()
+
+    """
+    if arg.position:
+        print(' ' * len(PROMPT), end='')
+        for p in range(0, len(sentence_text)):
+            print(p % 10, end="")
+        print()
+    """
+
+    linkages = list(linkages)
+    if clg.sentence_num_linkages_found(sent._obj) > po.linkage_limit:
+        print('Warning: linkage_limit too low (should be at least',
+              str(clg.sentence_num_linkages_found(sent._obj)) + ')')
+
+    # Show results with unlinked words or guesses
+
+    result_no = 0
+    uniqe_parse = {}
+    for linkage in linkages:
+        words = list(linkage.words())
+        result_no += 1
+
+        if arg.position:
+            words_char = []
+            words_byte = []
+            for wi, w in enumerate(words):
+                words_char.append(w + str((linkage.word_char_start(wi), linkage.word_char_end(wi))))
+                words_byte.append(w + str((linkage.word_byte_start(wi), linkage.word_byte_end(wi))))
+
+                print(u"{}{}".format("P", ' '.join(words_char)))
+                print(u"{}{}".format("P", ' '.join(words_byte)))
+        else:
+            if result_no == 1:
+                print(u"{}{}".format("I", sentence_text))
+            else:
+                print("N")
+            diagram = linkage.diagram()
+            for line in iter(diagram.splitlines()):
+                print(u"{}{}".format("O", line))
+
+        if result_no == MAX_DISPLAY_LINKAGES:
+            break
+
+    if arg.interactive:
+        print("Interactive session (^D to end):")
+        import code
+        code.interact(local=locals())

--- a/bindings/python-examples/parses-amy.txt
+++ b/bindings/python-examples/parses-amy.txt
@@ -1,0 +1,31 @@
+% This file contains test sentences, and the expected parses
+% for the "amy" language, for splitting up to 3 parts
+% (REGPARTS definition in amy/4.0.affix).
+
+Ithis is a test
+O
+O    +-----ANY----+------ANY-----+-----ANY-----+-----ANY-----+
+O    |            |              |             |             |
+OLEFT-WALL this[!ANY-WORD] is[!ANY-WORD] a[!ANY-WORD] test[!ANY-WORD]
+O
+N
+O
+O                                              +-------------ANY------------+
+O    +-----ANY----+------ANY-----+-----ANY-----+             +------LL------+
+O    |            |              |             |             |              |
+OLEFT-WALL this[!ANY-WORD] is[!ANY-WORD] a[!ANY-WORD] t[!MOR-STEM].= =est[!MOR-SUFF]
+O
+N
+O
+O                                              +-------------ANY-------------+
+O    +-----ANY----+------ANY-----+-----ANY-----+              +------LL------+
+O    |            |              |             |              |              |
+OLEFT-WALL this[!ANY-WORD] is[!ANY-WORD] a[!ANY-WORD] tes[!MOR-STEM].= =t[!MOR-SUFF]
+O
+N
+O
+O                                              +-------------ANY-------------+
+O    +-----ANY----+------ANY-----+-----ANY-----+             +-------LL------+
+O    |            |              |             |             |               |
+OLEFT-WALL this[!ANY-WORD] is[!ANY-WORD] a[!ANY-WORD] te[!MOR-STEM].= =st[!MOR-SUFF]
+O

--- a/bindings/python-examples/parses-any.txt
+++ b/bindings/python-examples/parses-any.txt
@@ -1,0 +1,30 @@
+% This file contains test sentences, and the expected parses
+% for the "any" language.
+
+Ithis is a test
+O
+O    +---ANY--+--ANY-+-ANY-+-ANY-+
+O    |        |      |     |     |
+OLEFT-WALL this[!] is[!] a[!] test[!]
+O
+N
+O
+O                    +----ANY----+
+O    +---ANY--+--ANY-+     +-ANY-+
+O    |        |      |     |     |
+OLEFT-WALL this[!] is[!] a[!] test[!]
+O
+N
+O
+O                    +----ANY----+
+O    +---ANY--+--ANY-+-ANY-+     |
+O    |        |      |     |     |
+OLEFT-WALL this[!] is[!] a[!] test[!]
+O
+N
+O
+O                    +----ANY----+
+O    +---ANY--+--ANY-+-ANY-+-ANY-+
+O    |        |      |     |     |
+OLEFT-WALL this[!] is[!] a[!] test[!]
+O

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1470,6 +1470,7 @@ def linkage_testfile(self, lgdict, popt, desc=''):
         else:
             self.fail('\nTest file "{}": Invalid opcode "{}" (ord={})'.format(testfile, line[0], ord(line[0])))
 
+    self.assertIsNotNone(last_opcode, "Missing opcode in " + testfile)
     self.assertIn(last_opcode, 'OCP', "Missing result comparison in " + testfile)
 
 def warning(*msg):

--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1134,6 +1134,35 @@ class YGenerationTestCase(unittest.TestCase):
         self.assertTrue(len(linkages) > 0, "No linkages")
 
 
+class ZANYAMYTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.amy_dict = Dictionary(lang='amy')
+        cls.any_dict = Dictionary(lang='any')
+        cls.amy_po = ParseOptions(display_morphology=True, linkage_limit=20000)
+        cls.any_po = ParseOptions(display_morphology=False, linkage_limit=200)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.any_dict
+        del cls.amy_dict
+
+    def find_num_linkages(self, sentense_text, dict, po):
+        return len(Sentence(sentense_text, dict, po).parse())
+
+    def test_amy_num_linkages(self):
+       self.assertEqual(5292, self.find_num_linkages('this is a test', self.amy_dict, self.amy_po))
+
+    def test_amy(self):
+        linkage_testfile(self, self.amy_dict, self.amy_po)
+
+    def test_any_num_linkages(self):
+       self.assertEqual(156, self.find_num_linkages('this is a test', self.any_dict, self.any_po))
+
+    def test_any(self):
+        linkage_testfile(self, self.any_dict, self.any_po)
+
+
 class ZENConstituentsCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/data/amy/4.0.dict
+++ b/data/amy/4.0.dict
@@ -7,8 +7,7 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.3.15 (formatted as V5v3v15+)
-<dictionary-version-number>: V5v3v15+;
+#define dictionary-version-number 5.3.15;
 #define dictionary-locale C;
 
 LEFT-WALL: ANY+;

--- a/data/amy/4.0.dict
+++ b/data/amy/4.0.dict
@@ -9,6 +9,7 @@
 
 % Dictionary version number is 5.3.15 (formatted as V5v3v15+)
 <dictionary-version-number>: V5v3v15+;
+#define dictionary-locale C;
 
 LEFT-WALL: ANY+;
 ANY-WORD: {@ANY-} & {@ANY+};

--- a/data/any/4.0.dict
+++ b/data/any/4.0.dict
@@ -7,8 +7,7 @@
  %                                                                           %
  %***************************************************************************%
 
-% Dictionary version number is 5.4.3 (formatted as V5v4v3+)
-<dictionary-version-number>: V5v4v3+;
+#define dictionary-version-number 5.4.3;
 #define dictionary-locale C;
 
 % Left-wall @ANY allows multiple head-words, e.g. head-nouns and also

--- a/data/any/4.0.dict
+++ b/data/any/4.0.dict
@@ -9,6 +9,7 @@
 
 % Dictionary version number is 5.4.3 (formatted as V5v4v3+)
 <dictionary-version-number>: V5v4v3+;
+#define dictionary-locale C;
 
 % Left-wall @ANY allows multiple head-words, e.g. head-nouns and also
 % head-verbs. See the README.md file for more.

--- a/data/ar/4.0.dict
+++ b/data/ar/4.0.dict
@@ -2,7 +2,7 @@
 %
 % Copyright (c) 2006 Warren Casbeer and Jon Dehdari
 %
-#define dictionary-version-number 5.9.0
+#define dictionary-version-number 5.9.0;
 #define dictionary-locale C; % Only the English alphabet is in use here
 
 

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -314,7 +314,7 @@ static Regex_node * regbuild(const char **regstring, int n, int classnum)
 
 		/* Create a new Regex_node and add to the list. */
 		new_re = malloc(sizeof(*new_re));
-		new_re->name    = strdup(afdict_classname[classnum]);
+		new_re->name    = afdict_classname[classnum];
 		new_re->re      = NULL;
 		new_re->next    = NULL;
 		new_re->neg     = ('!' == r[0]);

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -754,7 +754,8 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 				if (MT_PUNC == morpheme_type) /* It's a terminal token */
 					tokenization_done(sent, subword);
 
-				if (!sent->dict->affix_table->pre_suf_class_exists && last_split)
+				if (!sent->dict->affix_table->pre_suf_class_exists && last_split &&
+				    !(sent->dict->affix_table && sent->dict->affix_table->anysplit))
 				{
 					/* XXX The "tr" and "kz" dictionaries depend on specifying
 					 * compound suffixes which are not in the dict file, in the


### PR DESCRIPTION
1. Fix the bit-rot that broke "amy" (see issue #1310).
2. Add tests for "any" and "amy".
3. Fix a memleak in `anysplit.c`.
4. Add `gen-parses-file.py` to generate test diagrams in the needed format and canonical order.

P.S.
https://github.com/opencog/link-grammar/blob/a0e4d727d5e9346207a169e7d36522d8afacc1a8/data/amy/4.0.affix#L19-L22
https://github.com/opencog/link-grammar/blob/a0e4d727d5e9346207a169e7d36522d8afacc1a8/link-grammar/tokenize/anysplit.c#L614-L620

It is possible to fix that, but I will need to know how exactly to mark the extra splits.
Should all the middle ones be marked as `=x=`, or maybe as `x.=`?

















