### PR TITLE
Windows fixes

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -22,6 +22,8 @@
 %ignore parse_options_get_max_memory(Parse_Options opts);
 // End of ignored API calls.
 
+%ignore lg_library_failure_hook;     /* Not supported. */
+
 %nodefaultdtor lg_errinfo;
 
 #define link_public_api(x) x

--- a/link-grammar/error.c
+++ b/link-grammar/error.c
@@ -503,10 +503,10 @@ void debug_msg(int level, int v, char print_func, const char func[],
 	}
 }
 
-const char *syserror_msg(int errno)
+const char *syserror_msg(int errnum)
 {
 	TLS static char errbuf[64];
-	lg_strerror(errno, errbuf, sizeof(errbuf));
+	lg_strerror(errnum, errbuf, sizeof(errbuf));
 	return errbuf;
 }
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -469,7 +469,7 @@ static Count_bin table_store(count_context_t *ctxt,
                            int lw, int rw,
                            const Connector *le, const Connector *re,
                            unsigned int null_count,
-                           size_t hash, Count_bin c)
+                           size_t hash, w_Count_bin c)
 {
 	if (ctxt->table_available_count == 0) table_grow(ctxt);
 
@@ -485,11 +485,11 @@ static Count_bin table_store(count_context_t *ctxt,
 	n->r_id = r_id;
 	n->null_count = null_count;
 	n->next = ctxt->table[i];
-	n->count = c;
+	n->count = (Count_bin)c; /* c is already clamped (by parse_count_clamp()) */
 	n->hash = hash;
 	ctxt->table[i] = n;
 
-	return c;
+	return n->count;
 }
 
 /**

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -130,7 +130,7 @@ typedef SSIZE_T ssize_t;
 #define iswspace_l  _iswspace_l
 #define towlower_l  _towlower_l
 #define towupper_l  _towupper_l
-#define strtod_l    _strtod_l
+#define strtof_l    _strtof_l
 #define freelocale _free_locale
 #endif /* HAVE_LOCALE_T */
 

--- a/msvc/LinkGenerator.vcxproj
+++ b/msvc/LinkGenerator.vcxproj
@@ -38,21 +38,21 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/msvc/LinkGrammar.vcxproj
+++ b/msvc/LinkGrammar.vcxproj
@@ -27,19 +27,19 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">

--- a/msvc/LinkGrammar.vcxproj
+++ b/msvc/LinkGrammar.vcxproj
@@ -235,6 +235,8 @@
     <ClInclude Include="..\link-grammar\api-structures.h" />
     <ClInclude Include="..\link-grammar\api-types.h" />
     <ClInclude Include="..\link-grammar\connectors.h" />
+    <ClInclude Include="..\link-grammar\dict-atomese\lookup-atomese.h" />
+    <ClInclude Include="..\link-grammar\dict-atomese\read-atomese.h" />
     <ClInclude Include="..\link-grammar\dict-common\dialect.h" />
     <ClInclude Include="..\link-grammar\dict-common\dict-affix.h" />
     <ClInclude Include="..\link-grammar\dict-common\dict-api.h" />
@@ -250,6 +252,7 @@
     <ClInclude Include="..\link-grammar\dict-file\read-dict.h" />
     <ClInclude Include="..\link-grammar\dict-file\read-regex.h" />
     <ClInclude Include="..\link-grammar\dict-file\word-file.h" />
+    <ClInclude Include="..\link-grammar\dict-ram\dict-ram.h" />
     <ClInclude Include="..\link-grammar\dict-sql\read-sql.h" />
     <ClInclude Include="..\link-grammar\disjunct-utils.h" />
     <ClInclude Include="..\link-grammar\error.h" />
@@ -294,6 +297,8 @@
   <ItemGroup>
     <ClCompile Include="..\link-grammar\api.c" />
     <ClCompile Include="..\link-grammar\connectors.c" />
+    <ClCompile Include="..\link-grammar\dict-atomese\lookup-atomese.cc" />
+    <ClCompile Include="..\link-grammar\dict-atomese\read-atomese.c" />
     <ClCompile Include="..\link-grammar\dict-common\dialect.c" />
     <ClCompile Include="..\link-grammar\dict-common\dict-common.c" />
     <ClCompile Include="..\link-grammar\dict-common\dict-impl.c" />
@@ -312,6 +317,7 @@
     <ClCompile Include="..\link-grammar\dict-file\read-dict.c" />
     <ClCompile Include="..\link-grammar\dict-file\read-regex.c" />
     <ClCompile Include="..\link-grammar\dict-file\word-file.c" />
+    <ClCompile Include="..\link-grammar\dict-ram\dict-ram.c" />
     <ClCompile Include="..\link-grammar\disjunct-utils.c" />
     <ClCompile Include="..\link-grammar\error.c" />
     <ClCompile Include="..\link-grammar\linkage\analyze-linkage.c" />

--- a/msvc/LinkGrammar.vcxproj.filters
+++ b/msvc/LinkGrammar.vcxproj.filters
@@ -171,6 +171,15 @@
     <ClCompile Include="..\link-grammar\dict-file\read-dialect.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-ram\dict-ram.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-atomese\lookup-atomese.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\link-grammar\dict-atomese\read-atomese.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\link-grammar\api-structures.h">
@@ -345,6 +354,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\link-grammar\dict-common\dialect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-ram\dict-ram.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-atomese\lookup-atomese.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\link-grammar\dict-atomese\read-atomese.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msvc/LinkGrammarExe.vcxproj
+++ b/msvc/LinkGrammarExe.vcxproj
@@ -38,21 +38,21 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/msvc/LinkGrammarJava.vcxproj
+++ b/msvc/LinkGrammarJava.vcxproj
@@ -26,19 +26,19 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/msvc/Python3.vcxproj
+++ b/msvc/Python3.vcxproj
@@ -113,23 +113,23 @@ swig.exe -c++ -python -py3 -outdir $(OutDir) -module clinkgrammar -I..\..\..\lin
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
1. Fix build break due to the change of  `strltod_l()` to `strltof_l()` in 5.10.4.
    (It means that in 5.10.4 and 5.10.5 building on Windows was broken.)
2. Fix build break due to recent changes (lg_library_failure_hook, dict-ram, dict-atomese).
3. Fix some Windows warnings that it is a good idea to fix anyway.

@linas,
As I cannot afford to compile the library under Windows and macOS too often, if you tell me before a new release I will try to do a build check there in a timely manner.