### PR TITLE
Fixes for Python

### DIFF
--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -230,7 +230,14 @@ static void PythonCallBack(lg_errinfo *lge, void *func_and_data)
    PyObject *data = PyTuple_GetItem((PyObject *)func_and_data, 1);
 
    PyObject *args = Py_BuildValue("OO", pylge, data);
-   PyObject *rc = PyEval_CallObject(func, args); /* Py LG error cb. */
+
+   /* Call Python LG error callback. */
+   PyObject *rc =
+#if PY_VERSION_HEX >= 0x03090000 // PyEval_CallObject() got deprecated on 3.9
+       PyObject_CallObject(func, args);
+#else
+       PyEval_CallObject(func, args);
+#endif
 
    Py_DECREF(pylge);
    Py_DECREF(args);

--- a/configure.ac
+++ b/configure.ac
@@ -851,8 +851,21 @@ define([AC_MSG_ERROR],
 PythonFound=no
 if test "x$enable_python_bindings" = xyes; then
 	AM_PATH_PYTHON(PYTHON3_REQUIRED, [PythonFound=yes])
-	AX_PYTHON_DEVEL(>= 'PYTHON3_REQUIRED')
-	test -n "$lg_python_unusable" && PythonFound=no
+	AX_PYTHON_DEVEL()
+	AX_COMPARE_VERSION($PYTHON_VERSION, [ge], 'PYTHON3_REQUIRED',,
+							 [lg_python_unusable=yes])
+	if test -n "$lg_python_unusable"; then
+		dnl Use the message from AX_PYTHON_DEVEL, but with " instead of ''
+		dnl so (for debug) we can know it is from here.
+		AC_MSG_NOTICE([
+this package requires Python >= ]'PYTHON3_REQUIRED'[
+If you have it installed, but it isn't the default Python
+interpreter in your system path, please pass the PYTHON_VERSION
+variable to configure. See "configure --help" for reference.
+		])
+		PythonFound=no
+		PYTHON_VERSION= # Avoid confusion
+	fi
 	if test x$PythonFound = xyes; then
 		PythonFound=$PYTHON_VERSION
 		lg_display_PYTHON=" ($PYTHON)"


### PR DESCRIPTION
- `configure.ac`: Bypass a version check bug in `AX_PYTHON_DEVEL`

`AX_PYTHON_DEVEL` on my system (Fedora 36) has a bug in checking the python version (it makes a simple string comparison). So it thinks that Python 3.10 is less then 3.4.

It was supposed to get fixed by now, but it is not. This guess this may happen in other distributions.
So I just added a bypass of this problem.

- `link_grammar.i`: `Fix PyEval_CallObject()` deprecation.

I fixed it using a version check, so old Python versions would not get affected.
