### PR TITLE
A fix for undetected count overflows

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1354,7 +1354,7 @@ static Count_bin do_count(
 
 #define CACHE_COUNT(c, how_to_count, do_count) \
 	{ \
-		w_Count_bin count = (hist_total(&c) == NO_COUNT) ? \
+		Count_bin count = (hist_total(&c) == NO_COUNT) ? \
 			TRACE_LABEL(c, do_count) : c; \
 		how_to_count; \
 	}

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1130,7 +1130,6 @@ static Count_bin do_count(
 		Count_bin *l_cache = NULL;
 		Count_bin *r_cache = NULL;
 		unsigned int lcount_index = 0; /* Cached left count index */
-#define S(c) (!c?"(nil)":connector_string(c))
 
 		if (ctxt->is_short)
 		{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1377,6 +1377,7 @@ static Count_bin do_count(
 
 					if (0 < hist_total(&leftcount))
 					{
+						parse_count_clamp(&leftcount); /* May be up to 4*INT_MAX. */
 						lrcnt_found = true;
 						d->match_left = true;
 
@@ -1406,6 +1407,7 @@ static Count_bin do_count(
 
 					if (0 < hist_total(&rightcount))
 					{
+						parse_count_clamp(&rightcount); /* May be up to 4*INT_MAX. */
 						if (le == NULL)
 						{
 							lrcnt_found = true;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -930,6 +930,52 @@ static Count_bin do_count(int lineno, count_context_t *ctxt,
 	return r;
 }
 
+/*
+ * See do_parse() for the purpose of this function.
+ *
+ * The returned number of parses (called here "count") is a 32-bit
+ * integer. However, this count may sometimes be very big - much more than
+ * can be represented in 32-bits. In such a case it is just enough to know
+ * that such an "overflow" occurred. Internally, big counts are clamped to
+ * INT_MAX (2^31-1) - see parse_count_clamp() (we refer below to such
+ * values as "clamped"). If the top-level do_count() (the one that is
+ * called from do_parse()) returns this value, it means such an overflow
+ * has occurred.
+ *
+ * The function uses a 64-bit signed integer as a count accumulator - named
+ * "total". The maximum value it can hold is 2^63-1. If it becomes greater
+ * than INT_MAX, it is considered as a count overflow. A care should be
+ * taken that this total itself would not overflow, else this detection
+ * mechanism would be rendered useless. To that end, each value from which
+ * this total is computed should be small enough so it would not overflow.
+ *
+ * The function has 4 code sections to calculate the count. Each of them,
+ * when entered, returns a value which is clamped (or doesn't need to be
+ * clamped). The are marked in the code with "Path 1a", "Path 1b",
+ * "Path 2", and "Path 3".
+ *
+ * Path 1a, Path 1b: If there is a possible linkage between the given
+ * words, return 1, else return 0. Here a count overflow cannot occur.
+ *
+ * Path 2: The total accumulate the result of the do_count() invocations
+ * that are done in a loop. The upper bound on the number of iterations is
+ * twice (out loop) the maximum number of word disjuncts )inner loop).
+ * Assuming no more than 2^31 disjuncts per word, and considering that
+ * each value is a result of do_count() which is clamped, the total is
+ * less than (2*2^31)*(2^31`-1), which is less than 2^63-1, and hence just
+ * needs to be clamped before returning.
+ *
+ * Path 3: The total is calculated as a sum of series of multiplications.
+ * To prevent its overflow, we ensure that each term (including the total
+ * itself) would not be greater than INT_MAX (2^31-1), so the result will
+ * not be more than (2^31-1)+((2^31-1)*(2^31-1)) which is less than
+ * 2^63-1. In this path, each multiplication term that may be greater then
+ * INT_MAX (leftcount and rightcount) is clamped before the
+ * multiplication, and the total is clamped after the multiplication.
+ * Multiplication terms that result from caching (or directly from
+ * do_count()) are already clamped.
+ */
+
 #define do_count do_count1
 #else
 #define TRACE_LABEL(l, do_count) (do_count)
@@ -968,6 +1014,8 @@ static Count_bin do_count(
 
 	unsigned int unparseable_len = rw-lw-1;
 
+	/* Path 1a. */
+
 #if 1
 	/* This check is not necessary for correctness, as it is handled in
 	 * the general case below. It looks like it should be slightly faster. */
@@ -982,11 +1030,14 @@ static Count_bin do_count(
 	}
 #endif
 
+
 	/* The left and right connectors are null, but the two words are
 	 * NOT next to each-other. */
 	if ((le == NULL) && (re == NULL))
 	{
 		int nopt_words = num_optional_words(ctxt, lw, rw);
+
+		/* Path 1b. */
 
 		if ((null_count == 0) ||
 		    (!ctxt->islands_ok && (lw != -1) && (ctxt->sent->word[lw].d != NULL)))
@@ -1003,6 +1054,8 @@ static Count_bin do_count(
 
 			return table_store(ctxt, lw, rw, le, re, null_count, h, hist_zero());
 		}
+
+		/* Path 2. */
 
 		/* Here null_count != 0 and we allow islands (a set of words
 		 * linked together but separate from the rest of the sentence).
@@ -1038,6 +1091,8 @@ static Count_bin do_count(
 		}
 		return table_store(ctxt, lw, rw, le, re, null_count, h, total);
 	}
+
+	/* Path 3. */
 
 	/* The word range (lw, rw) gets split in all tentatively possible ways
 	 * to LHS term and RHS term.

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1028,12 +1028,13 @@ static Count_bin do_count(
 
 			hist_accumv(&total, 0.0,
 				do_count(ctxt, w, rw, NULL, NULL, try_null_count-1));
-			if (parse_count_clamp(&total))
-			{
+		}
+
+		if (parse_count_clamp(&total))
+		{
 #if 0
-				printf("OVERFLOW 1\n");
+			printf("OVERFLOW 1\n");
 #endif
-			}
 		}
 		return table_store(ctxt, lw, rw, le, re, null_count, h, total);
 	}

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1024,12 +1024,6 @@ static Count_bin do_count(
 					hist_accumv(&total, d->cost,
 						do_count(ctxt, w, rw, d->right, NULL, try_null_count-1));
 				}
-				if (parse_count_clamp(&total))
-				{
-#if 0
-					printf("OVERFLOW 1\n");
-#endif
-				}
 			}
 
 			hist_accumv(&total, 0.0,
@@ -1037,7 +1031,7 @@ static Count_bin do_count(
 			if (parse_count_clamp(&total))
 			{
 #if 0
-				printf("OVERFLOW 2\n");
+				printf("OVERFLOW 1\n");
 #endif
 			}
 		}


### PR DESCRIPTION
See issue #1325.

I added comments both at a function comment block and inside the function.
naturally, they overlap.

@linas,
As always, please feel free to modify my wording, or propose modified wording and I will resend the PR.

While inspecting the current code, I noted that there is a comment-rot in the function comments of `do_parse()` as `null_count` is no longer an explicit parameter. I left it as it is because the intention is still clear.
(I also noted a yet more speedup potential, that I will inspect after I send the "amy" and tokenizer fixes.)
