### PR TITLE
Implement affix regexes

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -32,6 +32,10 @@ if re.search(r'_MSC_FULL_VER', clg.linkgrammar_get_configuration()) and \
    not re.search(r'USE_SQLITE', clg.linkgrammar_get_configuration()):
     NO_SQLITE_ERROR = 'Library is not configures with SQLite support'
 
+NOT_COMPILED_WITH_PCRE2 = ''
+if not re.search(r'HAVE_PCRE2_H', clg.linkgrammar_get_configuration()):
+   NOT_COMPILED_WITH_PCRE2 = 'Library not configured with PCRE2 support'
+
 # Show the location and version of the bindings modules
 for imported_module in 'linkgrammar$', 'clinkgrammar', '_clinkgrammar', 'lg_testutils':
     module_found = False
@@ -1137,22 +1141,26 @@ class YGenerationTestCase(unittest.TestCase):
 class ZANYAMYTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.amy_dict = Dictionary(lang='amy')
+        if NOT_COMPILED_WITH_PCRE2 == '':
+           cls.amy_dict = Dictionary(lang='amy')
+           cls.amy_po = ParseOptions(display_morphology=True, linkage_limit=20000)
         cls.any_dict = Dictionary(lang='any')
-        cls.amy_po = ParseOptions(display_morphology=True, linkage_limit=20000)
         cls.any_po = ParseOptions(display_morphology=False, linkage_limit=200)
 
     @classmethod
     def tearDownClass(cls):
+        if NOT_COMPILED_WITH_PCRE2 == '':
+            del cls.amy_dict
         del cls.any_dict
-        del cls.amy_dict
 
     def find_num_linkages(self, sentense_text, dict, po):
         return len(Sentence(sentense_text, dict, po).parse())
 
+    @unittest.skipIf(NOT_COMPILED_WITH_PCRE2, NOT_COMPILED_WITH_PCRE2)
     def test_amy_num_linkages(self):
        self.assertEqual(5292, self.find_num_linkages('this is a test', self.amy_dict, self.amy_po))
 
+    @unittest.skipIf(NOT_COMPILED_WITH_PCRE2, NOT_COMPILED_WITH_PCRE2)
     def test_amy(self):
         linkage_testfile(self, self.amy_dict, self.amy_po)
 

--- a/data/en/4.0.affix
+++ b/data/en/4.0.affix
@@ -5,6 +5,11 @@
 % Some of the funky UTF-8 parenthesis are used in Asian texts.
 % 。is an end-of-sentence marker used in Japanese texts.
 
+% An LPUNC/RPUNC/MPUNC token can be specified as "/regex/.\N", when \N is
+% the capture group that should match the affix (the whole pattern is
+% capture group 0). Disregarding the position in which they appear, they
+% are checked last - but in the same order. (Experimental.)
+
 % Punctuation appearing on the right-side of words.
 ")" "}" "]" ">" """ » 〉 ） 〕 》 】 ］ 』 」 "’’" "’" ” '' ' `
 "%" "," ... "." 。 ‧ ":" ";" "?" "!" ‽ ؟ ？ ！
@@ -28,15 +33,20 @@ _ ‐ ‑ ‒ – — ― ～ – ━ ー -- - ‧
   : LPUNC+;
 
 % Split words that contain the following tokens in the middle of them.
-% We don't want comma's in this list; it tends to mess up numbers. e.g.
-% "The enzyme has a weight of 125,000 to 130,000"
-% We don't want colon's in this list, it tends to mess up time
-% expressions: "The train arriaves at 13:42"
-% Some kind of fancier technique is needed for tokenizing those.
 %
 % TODO: this list should be expanded with other "typical"(?) junk
 % that is commonly (?) in broken texts.
 -- ‒ – — ― "(" ")" "[" "]" ... ";" ±: MPUNC+;
+% Split on commas, but be careful with numbers:
+% "The enzyme has a weight of 125,000 to 130,000"
+% Also split on colons, but be careful not to mess up time
+% expressions: "The train arrives at 13:42"
+"/[^0-9]([,:])/.\1" "/([,:])[^0-9]/.\1": MPUNC+;
+
+
+% This also selectively splits on [,:] but is only supported by the PCRE2
+% regex library.
+%"/(?<!\d)[,:]|[,:](?!\d)/.\0": MPUNC+;
 
 % Suffixes
 % 't and ’t show up as Shakesperean contractions of "it", but collide

--- a/data/en/corpus-fixes.batch
+++ b/data/en/corpus-fixes.batch
@@ -6713,6 +6713,14 @@ He tried but failed to acheive his goal.
 *Therefo, I declare I love Computer Science.
 !spell=0
 
+% Test tokenization by affix regexes.
+% Sentence that should not be affected.
+The enzyme has a weight of 125,000 to 130,000
+The train arrives at 13:42
+% Sentences that use punctuation without a trailing whitespace.
+We used the same colors (red,blue,yellow).
+The price of this item:$100
+
 % The very long sentences that take forever to  parse are now in the
 % file 4.0.fix-long.batch
 % --------------------------------------------------------------------

--- a/link-grammar/dict-common/dict-affix.h
+++ b/link-grammar/dict-common/dict-affix.h
@@ -85,4 +85,29 @@ Afdict_class * afdict_find(Dictionary, const char *, bool);
 static const afdict_classnum affix_strippable[] =
 	{AFDICT_UNITS, AFDICT_LPUNC, AFDICT_RPUNC, AFDICT_MPUNC};
 
+/**
+ * Return a positive number if \p s is in affix regex format, else return -1.
+ * Regex format: /regex/.\N (N is a digit).
+ * \N denotes the capture group that should match an affix
+ * (the whole pattern is capture group 0).
+ *
+ * The regex much contain at least one character.
+ */
+static inline int get_affix_regex_cg(const char *s)
+{
+	if (s[0] != '/') return -1;
+
+	const char *endslash = strrchr(s, '/');
+	if ((endslash == NULL) || (endslash < s + 3)) return -1;
+
+	if (((endslash[1] == '.') || (endslash[1] == SUBSCRIPT_MARK)) &&
+	    (endslash[2] == '\\'))
+	{
+		if ((endslash[3] >= '0') && (endslash[3] <= '9'))
+			return (endslash[3] - '0');
+	}
+
+	return -1;
+}
+
 #endif /* _LG_DICT_AFFIX_H_ */

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -308,6 +308,12 @@ static void affix_list_delete(Dictionary dict)
 	for (size_t i = 0;  i < AFDICT_NUM_ENTRIES; i++)
 	{
 		if (atc[i].length > 0) free(atc[i].string);
+		if (atc[i].Nregexes > 0)
+		{
+			for (size_t r = 0; r < atc[i].Nregexes; r++)
+				free_regexs(atc[i].regex[r]);
+			free(atc[i].regex);
+		}
 	}
 	free(dict->afdict_class);
 	dict->afdict_class = NULL;

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -54,13 +54,15 @@ struct Regex_node_s
 {
 	const char *name;/* The identifying name of the regex */
 	char *pattern;   /* The regular expression pattern */
-	bool neg;        /* Negate the match */
 	void *re;        /* The compiled regex. void * to avoid
 	                    having re library details invading the
 	                    rest of the LG system; regex-morph.c
 	                    takes care of all matching.
 	                  */
 	Regex_node *next;
+	bool neg;        /* Negate the match */
+	int capture_group;  /* Capture group number (-1 if none) for ovector */
+	int ovector[2];  /* 0: start offset; 1: end offset */
 };
 
 struct Afdict_class_struct

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -65,9 +65,11 @@ struct Regex_node_s
 
 struct Afdict_class_struct
 {
-	size_t mem_elems;     /* number of memory elements allocated */
-	size_t length;        /* number of strings */
-	char const ** string;
+	uint16_t mem_elems;     /* number of memory elements allocated */
+	uint16_t length;        /* number of elements */
+	uint16_t Nregexes;      /* number of regexes */
+	const char ** string;   /* indexed by [0..length) */
+	Regex_node ** regex;    /* indexed by [0..Nregexes) */
 };
 
 #define MAX_TOKEN_LENGTH 250     /* Maximum number of chars in a token */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -65,6 +65,20 @@ struct Regex_node_s
 	int ovector[2];  /* 0: start offset; 1: end offset */
 };
 
+static inline Regex_node *regex_new(const char *name, const char *pattern)
+{
+	Regex_node *rn = (Regex_node *)malloc(sizeof(Regex_node));
+
+	rn->name = name;
+	rn->pattern = strdup(pattern);
+	rn->re = NULL;
+	rn->neg = false;
+	rn->capture_group = -1;
+	rn->next = NULL;
+
+	return rn;
+}
+
 struct Afdict_class_struct
 {
 	uint16_t mem_elems;     /* number of memory elements allocated */

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -726,10 +726,8 @@ bool afdict_init(Dictionary dict)
 
 	if (!IS_DYNAMIC_DICT(dict))
 	{
-		/* Validate that the strippable tokens are in the dict.
-		 * UNITS are assumed to be from the dict only.
-		 * Possible FIXME: Allow also tokens that match a regex (a tokenizer
-		 * change is needed to recognize them). */
+		/* Validate that the strippable tokens are in the dict. UNITS are
+		 * assumed to be from the dict only. */
 		for (size_t i = 0; i < ARRAY_SIZE(affix_strippable); i++)
 		{
 			if (AFDICT_UNITS != affix_strippable[i])
@@ -737,7 +735,7 @@ bool afdict_init(Dictionary dict)
 				ac = AFCLASS(afdict, affix_strippable[i]);
 				bool not_in_dict = false;
 
-				for (size_t n = 0;  n < ac->length; n++)
+				for (int n = 0;  n < ac->length - ac->Nregexes; n++)
 				{
 					if (!dict_has_word(dict, ac->string[n]))
 					{

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -689,7 +689,6 @@ bool afdict_init(Dictionary dict)
 	ac = AFCLASS(afdict, AFDICT_SANEMORPHISM);
 	if (0 != ac->length)
 	{
-		Regex_node *sm_re = malloc(sizeof(*sm_re));
 		dyn_str *rebuf = dyn_str_new();
 
 		/* The regex used to be converted to: ^((original-regex)b)+$
@@ -706,15 +705,11 @@ bool afdict_init(Dictionary dict)
 #else
 		dyn_strcat(rebuf, ")+$");
 #endif
-		sm_re->pattern = strdup(rebuf->str);
+
+		afdict->regex_root = regex_new(afdict_classname[AFDICT_SANEMORPHISM],
+		                               rebuf->str);
 		dyn_str_delete(rebuf);
 
-		afdict->regex_root = sm_re;
-		sm_re->name = string_set_add(afdict_classname[AFDICT_SANEMORPHISM],
-		                             afdict->string_set);
-		sm_re->re = NULL;
-		sm_re->next = NULL;
-		sm_re->neg = false;
 		if (!compile_regexs(afdict->regex_root, afdict))
 		{
 			prt_error("Error: afdict_init: Failed to compile "
@@ -724,8 +719,8 @@ bool afdict_init(Dictionary dict)
 		}
 		else
 		{
-			lgdebug(+D_AI, "%s regex %s\n",
-			        afdict_classname[AFDICT_SANEMORPHISM], sm_re->pattern);
+			lgdebug(+D_AI, "%s regex %s\n", afdict_classname[AFDICT_SANEMORPHISM],
+			        afdict->regex_root->pattern);
 		}
 	}
 

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -460,16 +460,10 @@ bool dictionary_setup_defines(Dictionary dict)
 /** initialize the affix class table */
 void afclass_init(Dictionary dict)
 {
-	size_t i;
+	const size_t sz = sizeof(*dict->afdict_class) * AFDICT_NUM_ENTRIES;
 
-	dict->afdict_class =
-		malloc(sizeof(*dict->afdict_class) * AFDICT_NUM_ENTRIES);
-	for (i = 0; i < AFDICT_NUM_ENTRIES; i++)
-	{
-		dict->afdict_class[i].mem_elems = 0;
-		dict->afdict_class[i].length = 0;
-		dict->afdict_class[i].string = NULL;
-	}
+	dict->afdict_class = malloc(sz);
+	memset(dict->afdict_class, 0, sz);
 }
 
 /**

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -594,6 +594,7 @@ static void concat_class(Dictionary afdict, int classno)
  * Sort order:
  * 1. Longest base words first.
  * 2. Equal base words one after the other.
+ * 3. Regexes last, in file order.
  */
 static int split_order(const void *a, const void *b)
 {
@@ -602,6 +603,12 @@ static int split_order(const void *a, const void *b)
 
 	size_t len_a = strcspn(*sa, subscript_mark_str());
 	size_t len_b = strcspn(*sb, subscript_mark_str());
+	bool is_regex_a = (get_affix_regex_cg(*sa) >= 0);
+	bool is_regex_b = (get_affix_regex_cg(*sb) >= 0);
+
+	if (is_regex_a && is_regex_b) return 0;
+	if (is_regex_a) return 1;
+	if (is_regex_b) return -1;
 
 	int len_order = (int)(len_b - len_a);
 	if (0 == len_order) return strncmp(*sa, *sb, len_a);

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -747,6 +747,8 @@ bool afdict_init(Dictionary dict)
 			if (ac->Nregexes > 0)
 			{
 				ac->regex = malloc(ac->Nregexes * sizeof(Regex_node *));
+				/* Zero-out to prevent uninitialized access on error. */
+				memset(ac->regex, 0, ac->Nregexes * sizeof(Regex_node *));
 
 				size_t re_index = 0;
 				for (size_t n = 0;  n < ac->length; n++)

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -882,12 +882,7 @@ static size_t copy_quoted(const char *q, char *dst, const char *src, size_t len)
 
 static Regex_node *new_disjunct_regex_node(Regex_node *current, char *regpat)
 {
-	Regex_node *rn = malloc(sizeof(Regex_node));
-
-	rn->name = "Disjunct regex";
-	rn->pattern = strdup(regpat);
-	rn->re = NULL;
-	rn->neg = false;
+	Regex_node *rn = regex_new("Disjunct regex", regpat);
 	rn->next = current;
 
 	return rn;

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -83,8 +83,8 @@ static bool reg_comp(Regex_node *rn)
 	{
 		char errbuf[ERRBUFFLEN];
 		regerror(rc, re, errbuf, ERRBUFFLEN);
-		prt_error("Error: Failed to compile regex: \"%s: %s\": %s (code %d)\n)",
-		          rn->name, rn->pattern, errbuf, rc);
+		prt_error("Error: Failed to compile regex: \"%s\" (pattern \"%s\"): %s "
+		          "(code %d)\n", rn->name, rn->pattern, errbuf, rc);
 		free(re);
 		return false;
 	}
@@ -103,8 +103,8 @@ static bool reg_match(const char *s, const Regex_node *rn)
 	/* We have an error. */
 	char errbuf[ERRBUFFLEN];
 	regerror(rc, (regex_t *)rn->re, errbuf, ERRBUFFLEN);
-	prt_error("Error: Regex matching error: \"%s: %s\": %s (code %d)\n)",
-	          rn->name, rn->pattern, errbuf, rc);
+	prt_error("Error: Regex matching error: \"%s\" (pattern \"%s\"): %s "
+	          "(code %d)\n", rn->name, rn->pattern, errbuf, rc);
 	return false;
 }
 
@@ -131,7 +131,7 @@ static bool reg_comp(Regex_node *rn)
 		re->re_md = pcre2_match_data_create(0, NULL);
 		if (re->re_md == NULL)
 		{
-			prt_error("Error: pcre2_match_data_create(0, NULL) failed\n");
+			prt_error("Error: pcre2_match_data_create failed\n");
 			free(re);
 			return false;
 		}
@@ -141,7 +141,8 @@ static bool reg_comp(Regex_node *rn)
 	/* We have an error. */
 	PCRE2_UCHAR errbuf[ERRBUFFLEN];
 	pcre2_get_error_message(rc, errbuf, ERRBUFFLEN);
-	prt_error("Error: Failed to compile regex: \"%s: %s\": %s (code %d) at %d\n",
+	prt_error("Error: Failed to compile regex: \"%s\" (pattern \"%s\": %s "
+	          "(code %d) at %d\n",
 	          rn->name, rn->pattern, errbuf, rc, (int)erroffset);
 	free(re);
 	return false;
@@ -160,8 +161,8 @@ static int reg_match(const char *s, const Regex_node *rn)
 	/* We have an error. */
 	PCRE2_UCHAR errbuf[ERRBUFFLEN];
 	pcre2_get_error_message(rc, errbuf, ERRBUFFLEN);
-	prt_error("Error: Regex matching error: \"%s: %s\": %s (code %d)\n",
-	          rn->name, rn->pattern, errbuf, rc);
+	prt_error("Error: Regex matching error: \"%s\" (pattern \"%s\"): %s "
+	          "(code %d)\n", rn->name, rn->pattern, errbuf, rc);
 	return false;
 }
 
@@ -185,8 +186,8 @@ static bool reg_comp(Regex_node *rn)
 	}
 	catch (const std::regex_error& e)
 	{
-		prt_error("Error: Failed to compile regex '%s' (%s): %s (code %d)",
-		          rn->pattern, rn->name, e.what(), e.code());
+		prt_error("Error: Failed to compile regex \"%s\" (pattern \"%s\"): %s "
+		          "(code %d)\n", rn->pattern, rn->name, e.what(), e.code());
 		return false;
 	}
 
@@ -203,8 +204,8 @@ static bool reg_match(const char *s, const Regex_node *rn)
 	}
 	catch (const std::regex_error& e)
 	{
-		prt_error("Error: Regex matching error '%s' (%s): %s (code %d)",
-		          rn->pattern, rn->name, e.what(), e.code());
+		prt_error("Error: Regex matching error \"%s\" (pattern \"%s\"): %s "
+		          "(code %d)\n", rn->pattern, rn->name, e.what(), e.code());
 		match = false;
 	}
 
@@ -240,7 +241,7 @@ bool compile_regexs(Regex_node *rn, Dictionary dict)
 			if ((dict != NULL) && !dict_has_word(dict, rn->name))
 			{
 				/* TODO: better error handing. Maybe remove the regex? */
-				prt_error("Error: Regex name %s not found in dictionary!\n",
+				prt_error("Error: Regex name \"%s\" not found in dictionary!\n",
 				          rn->name);
 			}
 		}

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -62,6 +62,20 @@ typedef struct {
 /* ========================================================================= */
 #if HAVE_REGEX_H
 /**
+ * Find an upper limit to the number of capture groups in the pattern.
+ */
+static unsigned int max_capture_groups(const Regex_node *rn)
+{
+	if (rn->capture_group < 0) return 0;
+
+	int Nov = 1;
+	for (const char *p = rn->pattern; *p != '\0'; p++)
+		if (*p == '(') Nov++;
+
+	return Nov;
+}
+
+/**
  * Compile the given regex..
  * Return \c true on success, \c false otherwise.
  */

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -236,7 +236,9 @@ static void reg_free(Regex_node *rn)
 
 /**
  * Compile all the given regexs.
- * Return \c true on success, else \c false.
+ * @param rn Regex list
+ * @param dict Validate that the pattern is in the given dict.
+ * @retrun \c true on success, else \c false.
  */
 bool compile_regexs(Regex_node *rn, Dictionary dict)
 {

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -272,6 +272,7 @@ static bool reg_comp(Regex_node *rn)
 	{
 		prt_error("Error: Failed to compile regex \"%s\" (pattern \"%s\"): %s "
 		          "(code %d)\n", rn->pattern, rn->name, e.what(), e.code());
+		delete (reg_info *)rn->re;
 		return false;
 	}
 
@@ -348,7 +349,7 @@ static bool check_capture_group(const Regex_node *rn)
 	check_cg.pattern[pattern_len + 2] = '\0';
 
 	bool rc = reg_comp(&check_cg);
-	if (rc) free(check_cg.re);
+	if (rc) reg_free(&check_cg);
 
 	return rc;
 }
@@ -373,7 +374,6 @@ bool compile_regexs(Regex_node *rn, Dictionary dict)
 				rn->re = NULL;
 				return false;
 			}
-
 			if (!check_capture_group(rn)) return false;
 
 			/* Check that the regex name is defined in the dictionary. */

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -47,19 +47,40 @@ LINK_BEGIN_DECLS
 #include "dict-common/regex-morph.h"
 LINK_END_DECLS
 
+/* ovector     - returned start and end offsets.
+ * re_code     - compiled regex.
+ * re_md       - match data.
+ */
+
 #if HAVE_PCRE2_H
 typedef struct {
 	pcre2_code *re_code;
 	pcre2_match_data* re_md;
-} regex_t;
+} reg_info;
+#endif
+
+#if HAVE_REGEX_H
+typedef struct {
+	regex_t re_code;
+	unsigned int Nre_md;
+	regmatch_t re_md[];
+} reg_info;
+#endif
+
+#if USE_CXXREGEX
+typedef struct {
+	std::regex *re_code;
+	std::cmatch re_md;
+} reg_info;
 #endif
 
 #define ERRBUFFLEN 120
 
-/* Define reg_comp(), reg_match() and reg_free() for the selected
- * regex implementation. */
+/* Define reg_comp(), reg_match() and reg_free(), and reg_span()
+ * for the selected regex implementation. */
 
 /* ========================================================================= */
+
 #if HAVE_REGEX_H
 /**
  * Find an upper limit to the number of capture groups in the pattern.
@@ -88,15 +109,21 @@ static bool reg_comp(Regex_node *rn)
 #define REG_GNU 0
 #endif
 
-	regex_t *re = (regex_t *)malloc(sizeof(regex_t));
+	const bool nosub = (rn->capture_group < 0);
+	const unsigned int Novector = nosub ? 0 : (max_capture_groups(rn) + 1);
+	int options = REG_EXTENDED|REG_ENHANCED|REG_GNU|(nosub ? REG_NOSUB : 0);
 
-	int rc =
-		regcomp(re, rn->pattern, REG_NOSUB|REG_EXTENDED|REG_ENHANCED|REG_GNU);
+	reg_info *re = malloc(sizeof(reg_info) + sizeof(regmatch_t) * 2 * Novector);
+	memset(re, 0, sizeof(reg_info)); /* No need to initialize re_md. */
 
-	if (rc)
+	re->Nre_md = Novector;
+
+	int rc = regcomp(&re->re_code, rn->pattern, options);
+
+	if (rc != 0)
 	{
 		char errbuf[ERRBUFFLEN];
-		regerror(rc, re, errbuf, ERRBUFFLEN);
+		regerror(rc, &re->re_code, errbuf, ERRBUFFLEN);
 		prt_error("Error: Failed to compile regex: \"%s\" (pattern \"%s\"): %s "
 		          "(code %d)\n", rn->name, rn->pattern, errbuf, rc);
 		free(re);
@@ -109,24 +136,42 @@ static bool reg_comp(Regex_node *rn)
 
 static bool reg_match(const char *s, const Regex_node *rn)
 {
-	int rc = regexec((regex_t *)rn->re, s, 0, NULL, /*eflags*/0);
+	reg_info *reinfo = (reg_info *)rn->re;
+	int nmatch = (rn->capture_group < 0) ? 0 : reinfo->Nre_md;
+	int rc = regexec(&reinfo->re_code, s, nmatch, reinfo->re_md, /*eflags*/0);
 
 	if (rc == REG_NOMATCH) return false;
 	if (rc == 0) return true;
 
 	/* We have an error. */
 	char errbuf[ERRBUFFLEN];
-	regerror(rc, (regex_t *)rn->re, errbuf, ERRBUFFLEN);
+	regerror(rc, &reinfo->re_code, errbuf, ERRBUFFLEN);
 	prt_error("Error: Regex matching error: \"%s\" (pattern \"%s\"): %s "
 	          "(code %d)\n", rn->name, rn->pattern, errbuf, rc);
 	return false;
 }
 
+static void reg_span(Regex_node *rn)
+{
+	int cgn = rn->capture_group;
+	reg_info *reinfo = rn->re;
+
+	if (unlikely(cgn > rn->capture_group))
+	{
+		rn->ovector[0] = rn->ovector[1] = -1;
+	}
+	else
+	{
+		rn->ovector[0] = reinfo->re_md[cgn].rm_so;
+		rn->ovector[1] = reinfo->re_md[cgn].rm_eo;
+	}
+}
+
 static void reg_free(Regex_node *rn)
 {
-	regex_t *re = (regex_t *)rn->re;
-	regfree(re);
-	free(re);
+	regex_t *re_code = &((reg_info *)rn->re)->re_code;
+	regfree(re_code);
+	free(rn->re);
 }
 #endif // HAVE_REGEX_H
 
@@ -134,15 +179,18 @@ static void reg_free(Regex_node *rn)
 #if HAVE_PCRE2_H
 static bool reg_comp(Regex_node *rn)
 {
-	regex_t *re = rn->re = malloc(sizeof(regex_t));
+	reg_info *re = rn->re = malloc(sizeof(reg_info));
 	PCRE2_SIZE erroffset;
 	int rc;
 
+	const bool nosub = (rn->capture_group < 0);
+	uint32_t options = PCRE2_UTF|PCRE2_UCP| (nosub ? PCRE2_NO_AUTO_CAPTURE : 0);
+
 	re->re_code = pcre2_compile((PCRE2_SPTR)rn->pattern, PCRE2_ZERO_TERMINATED,
-	                            PCRE2_UTF|PCRE2_UCP, &rc, &erroffset, NULL);
+	                            options, &rc, &erroffset, NULL);
 	if (re->re_code != NULL)
 	{
-		re->re_md = pcre2_match_data_create(0, NULL);
+		re->re_md = pcre2_match_data_create_from_pattern(re->re_code, NULL);
 		if (re->re_md == NULL)
 		{
 			prt_error("Error: pcre2_match_data_create failed\n");
@@ -164,11 +212,11 @@ static bool reg_comp(Regex_node *rn)
 
 static int reg_match(const char *s, const Regex_node *rn)
 {
-	regex_t *re = rn->re;
+	reg_info *reinfo = rn->re;
 
-	int rc = pcre2_match(re->re_code, (PCRE2_SPTR)s,
+	int rc = pcre2_match(reinfo->re_code, (PCRE2_SPTR)s,
 	                     PCRE2_ZERO_TERMINATED, /*startoffset*/0,
-	                     PCRE2_NO_UTF_CHECK, re->re_md, NULL);
+	                     PCRE2_NO_UTF_CHECK, reinfo->re_md, NULL);
 	if (rc == PCRE2_ERROR_NOMATCH) return false;
 	if (rc >= 0) return true;
 
@@ -180,9 +228,26 @@ static int reg_match(const char *s, const Regex_node *rn)
 	return false;
 }
 
+static void reg_span(Regex_node *rn)
+{
+	int cgn = rn->capture_group;
+	reg_info *reinfo = rn->re;
+	PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(reinfo->re_md);
+
+	if (unlikely(cgn >= (int)pcre2_get_ovector_count(reinfo->re_md)))
+	{
+		rn->ovector[0] = rn->ovector[1] = -1;
+	}
+	else
+	{
+		rn->ovector[0] = ovector[2*cgn];
+		rn->ovector[1] = ovector[2*cgn + 1];
+	}
+}
+
 static void reg_free(Regex_node *rn)
 {
-	regex_t *re = rn->re;
+	reg_info *re = rn->re;
 
 	pcre2_match_data_free(re->re_md);
 	pcre2_code_free(re->re_code);
@@ -194,9 +259,11 @@ static void reg_free(Regex_node *rn)
 #if USE_CXXREGEX
 static bool reg_comp(Regex_node *rn)
 {
+	rn->re = new reg_info;
+
 	try
 	{
-		rn->re = new std::regex(rn->pattern);
+		((reg_info *)rn->re)->re_code = new std::regex(rn->pattern);
 	}
 	catch (const std::regex_error& e)
 	{
@@ -210,11 +277,13 @@ static bool reg_comp(Regex_node *rn)
 
 static bool reg_match(const char *s, const Regex_node *rn)
 {
+	/* "nosub" not used, as no time difference found w/o using reinfo->re_md. */
 	bool match;
+	reg_info *reinfo = (reg_info *)rn->re;
 
 	try
 	{
-		match = std::regex_search(s, *(std::regex*)rn->re);
+		match = std::regex_search(s, reinfo->re_md, *reinfo->re_code);
 	}
 	catch (const std::regex_error& e)
 	{
@@ -226,9 +295,26 @@ static bool reg_match(const char *s, const Regex_node *rn)
 	return match;
 }
 
+static void reg_span(Regex_node *rn)
+{
+	int cgn = rn->capture_group;
+	std::cmatch re_md = ((reg_info *)rn->re)->re_md;
+
+	if (unlikely(cgn >= (int)re_md.size()))
+	{
+		rn->ovector[0] = rn->ovector[1] = -1;
+	}
+	else
+	{
+		rn->ovector[0] = re_md.position(cgn);
+		rn->ovector[1] = rn->ovector[0] + re_md.length(cgn);
+	}
+}
+
 static void reg_free(Regex_node *rn)
 {
-	delete (std::regex *)rn->re;
+	delete ((reg_info *)rn->re)->re_code;
+	delete (reg_info *)rn->re;
 }
 #endif // USE_CXXREGEX
 

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -173,6 +173,7 @@ static void reg_free(Regex_node *rn)
 
 	regfree(&re->re_code);
 	free(re);
+	rn->re = NULL;
 }
 #endif // HAVE_REGEX_H
 
@@ -253,6 +254,7 @@ static void reg_free(Regex_node *rn)
 	pcre2_match_data_free(re->re_md);
 	pcre2_code_free(re->re_code);
 	free(re);
+	rn->re = NULL;
 }
 #endif // HAVE_PCRE2_H
 
@@ -318,6 +320,7 @@ static void reg_free(Regex_node *rn)
 
 	delete re->re_code;
 	delete re;
+	rn->re = NULL;
 }
 #endif // USE_CXXREGEX
 

--- a/link-grammar/dict-common/regex-morph.h
+++ b/link-grammar/dict-common/regex-morph.h
@@ -17,6 +17,7 @@
 LINK_BEGIN_DECLS
 bool compile_regexs(Regex_node *, Dictionary);
 const char *match_regex(const Regex_node *, const char *);
+const char *matchspan_regex(Regex_node *, const char *, int *, int *);
 void free_regexs(Regex_node *);
 LINK_END_DECLS
 

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -976,8 +976,10 @@ static bool read_entry(Dictionary dict)
 
 		/* If it's a word-file name */
 		/* However, be careful to reject "/.v" which is the division symbol
-		 * used in equations (.v means verb-like) */
-		if ((dict->token[0] == '/') && (dict->token[1] != '.'))
+		 * used in equations (.v means verb-like). Also reject an affix regex
+		 * specification (may appear only in the affix file). */
+		if ((dict->token[0] == '/') &&
+		    (dict->token[1] != '.') && (get_affix_regex_cg(dict->token) < 0))
 		{
 			Dict_node *new_dn = read_word_file(dict, dn, dict->token);
 			if (new_dn == NULL)

--- a/link-grammar/dict-file/read-regex.c
+++ b/link-grammar/dict-file/read-regex.c
@@ -162,7 +162,6 @@ static bool expand_character_ranges(const char *file_name, int line,
 bool read_regex_file(Dictionary dict, const char *file_name)
 {
 	Regex_node **tail = &dict->regex_root; /* Last Regex_node * in list */
-	Regex_node *new_re;
 	int c,prev,i,line=1;
 	FILE *fp;
 	bool no_expand = false;
@@ -294,12 +293,9 @@ bool read_regex_file(Dictionary dict, const char *file_name)
 			goto failure;
 
 		/* Create new Regex_node and add to dict list. */
-		new_re = (Regex_node *) malloc(sizeof(Regex_node));
-		new_re->name    = string_set_add(name, dict->string_set);
-		new_re->pattern = strdup(regex);
-		new_re->neg     = neg;
-		new_re->re      = NULL;
-		new_re->next    = NULL;
+		Regex_node *new_re =
+			regex_new(string_set_add(name, dict->string_set), regex);
+		new_re->neg = neg;
 		*tail = new_re;
 		tail = &new_re->next;
 	}
@@ -310,4 +306,3 @@ failure:
 	fclose(fp);
 	return false;
 }
-

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -303,21 +303,19 @@ static Regex_node * regbuild(const char **regstring, int n, int classnum)
 {
 	Regex_node *regex_root = NULL;
 	Regex_node **tail = &regex_root; /* Last Regex_node in list */
-	Regex_node *new_re;
 	int i;
 
 	for (i = 0; i < n; i++)
 	{
 		const char *r = regstring[i];
 
+		bool neg = ('!' == r[0]);
+		if (neg || (0 == strncmp(r, "\\!", 2))) r++;
+
 		/* Create a new Regex_node and add to the list. */
-		new_re = malloc(sizeof(*new_re));
-		new_re->name    = afdict_classname[classnum];
-		new_re->re      = NULL;
-		new_re->next    = NULL;
-		new_re->neg     = ('!' == r[0]);
-		if (new_re->neg || (0 == strncmp(r, "\\!", 2))) r++;
-		new_re->pattern = strdup(r);
+		Regex_node *new_re = regex_new(afdict_classname[classnum], r);
+		new_re->neg = neg;
+
 		/* read_entry() (read-dict.c) invokes patch_subscript() also for the affix
 		 * file. As a result, if a regex contains a dot it is patched by
 		 * SUBSCRIPT_MARK. We undo it here. */

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -51,7 +51,7 @@ struct gword_set
 
 typedef enum
 {
-	MT_INVALID,            /* Zero, to be changed to the correct type */
+	MT_NOT_SET,            /* Zero, to be changed to the correct type */
 	MT_WORD,               /* Regular word */
 	MT_FEATURE,            /* Pseudo morpheme, currently capitalization marks */
 	MT_INFRASTRUCTURE,     /* Start and end Wordgraph pseudo-words */

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2359,16 +2359,12 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 			issue_word_alternative(sent, unsplit_word, "rL",
 			                       0,NULL, n_stripped,x_stripped, 0,NULL);
 
-			/* Its possible that the token consisted entirely of
-			 * left-punctuation, in which case, wp is an empty-string.
-			 * In case this is a single token (n_stripped == 1), we have
-			 * to continue processing, because it may match a regex. */
-			if ('\0' == *wp && n_stripped != 1)
+			if ('\0' == *wp)
 			{
-				/* Suppose no more alternatives in such a case. */
-				lgdebug(+D_SW, "1: Word '%s' all left-puncts - done\n",
+				/* The token consists entirely of left-punctuation. */
+				lgdebug(+D_SW, "1: Word '%s' all left-puncts - "
+				        "continue for possible regex alternative\n",
 						  unsplit_word->subword);
-				return;
 			}
 
 			n_stripped = 0;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1760,30 +1760,26 @@ static int split_mpunc(Sentence sent, const char *word, char *w,
                                 stripped_t stripped)
 {
 	const Dictionary afdict = sent->dict->affix_table;
-	const Afdict_class * mpunc_list;
-	const char * const * mpunc;
-	size_t l_strippable;
-	int n_stripped = 0;
-
 	if (NULL == afdict) return 0;
-	mpunc_list = AFCLASS(afdict, AFDICT_MPUNC);
-	l_strippable = mpunc_list->length;
-	mpunc = mpunc_list->string;
+
+	const Afdict_class *mpunc = AFCLASS(afdict, AFDICT_MPUNC);
+	size_t l_strippable = mpunc->length;
+	int n_stripped = 0;
 
 	strcpy(w, word);
 
-	// +1: mpunc in start position is not allowed
+	// +1:      mpunc at start position is not allowed
 	for (char *sep = w+1; '\0' != *sep; sep++)
 	{
 		for (size_t i = 0; i < l_strippable; i++)
 		{
 			/* Find the token length, but stop at the subscript mark if exists. */
-			size_t sz = strcspn(mpunc[i], subscript_mark_str());
-			if (0 == strncmp(sep, mpunc[i], sz))
+			size_t sz = strcspn(mpunc->string[i], subscript_mark_str());
+
+			if (0 == strncmp(sep, mpunc->string[i], sz))
 			{
 				if ('\0' == sep[sz]) continue; // mpunc in end position
-
-				lgdebug(D_UN, "w='%s' found mpunc '%s'\n", w, mpunc[i]);
+				lgdebug(D_UN, "w='%s' found mpunc '%s'\n", w, mpunc->string[i]);
 
 				if (sep != w)
 				{
@@ -1792,7 +1788,7 @@ static int split_mpunc(Sentence sent, const char *word, char *w,
 					stripped[n_stripped++] = w;
 				}
 				if (n_stripped >= MAX_STRIP-1) goto max_strip_ovfl;
-				stripped[n_stripped++] = mpunc[i];
+				stripped[n_stripped++] = mpunc->string[i];
 
 				w = sep + sz;
 				sep += sz - 1;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2042,10 +2042,8 @@ static bool strip_right(Sentence sent,
 
 	/* If there is a non-null root, we require that it ends with a number,
 	 * to ensure we stripped off all units. This prevents striping
-	 * off "h." from "20th.".
-	 * FIXME: is_utf8_digit(temp_wend-1, dict) here can only check ASCII digits,
-	 * since it is invoked with the last byte... */
-	if (rootdigit && (sz > 0) && !is_utf8_digit(temp_wend-1, dict->lctype))
+	 * off "h." from "20th.". Only the last byte is checked here. */
+	if (rootdigit && (sz > 0) && !isdigit((unsigned int)temp_wend[-1]))
 	{
 		lgdebug(+D_UN, "%d: %s: return FALSE; root='%s' (%c is not a digit)\n",
 			 p, afdict_classname[classnum], word, temp_wend[-1]);

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2045,8 +2045,8 @@ static bool strip_right(Sentence sent,
 	 * off "h." from "20th.". Only the last byte is checked here. */
 	if (rootdigit && (sz > 0) && !isdigit((unsigned int)temp_wend[-1]))
 	{
-		lgdebug(+D_UN, "%d: %s: return FALSE; root='%s' (%c is not a digit)\n",
-			 p, afdict_classname[classnum], word, temp_wend[-1]);
+		lgdebug(+D_UN, "%d: %s: return FALSE; root='%s' (0x%02x is not a digit)\n",
+			 p, afdict_classname[classnum], word, (unsigned char)temp_wend[-1]);
 		return false;
 	}
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -550,7 +550,7 @@ Gword *issue_word_alternative(Sentence sent, Gword *unsplit_word,
 	Gword *subword;                 /* subword of the current token */
 	Gword *psubword = NULL;         /* subword of the previous token */
 	const int token_tot = prefnum + stemnum + suffnum; /* number of tokens */
-	Morpheme_type morpheme_type = MT_INVALID;
+	Morpheme_type morpheme_type = MT_NOT_SET;
 	Gword *alternative_id = NULL;   /* to be set to the start subword */
 	bool subword_eq_unsplit_word;
 	bool last_split = false;        /* this is a final token */

--- a/link-grammar/tokenize/wg-display.c
+++ b/link-grammar/tokenize/wg-display.c
@@ -46,8 +46,8 @@ GNUC_UNUSED const char *gword_morpheme(Sentence sent, const Gword *w)
 
 	switch (w->morpheme_type)
 	{
-		case MT_INVALID:
-			mt = "MT_INVALID";
+		case MT_NOT_SET:
+			mt = "MT_NOT_SET";
 			break;
 		case MT_WORD:
 			mt = "MT_WORD";


### PR DESCRIPTION
This patch implements affix regexes.
The idea is to be able to strip off affixes and split words according to regexes.

I initially found it useful for `amy`/`ady`/`any` (one of the PRs I would like to send next).
We still need to see if this feature is really useful for real languages and whether its implementation needs changes or extensions. Hence I labeled it in `en/4.0.affix` as "experimental".
In this PR I defined MPUNC regexes for `en.
I didn't have too useful ideas for LPUNC/RPUNC (besides for `amy`/`ady`/`any`).

To `en/corpus-fixes.batch` I added the example sentences from the comments in `en/4.0.affix` as sentences that should be
neglected by these MPUNC regexes, and added two sentences demonstrating the ability of the MPUNC regexes.
These sentences need a review and maybe more sentences should be added.
I used simple regexes, but maybe more complex ones are needed to prevent bad splits.

In order to allow using regex libraries that don't support look-around, I added the ability to use a capture group to indicate the location of the affix. Since the subscript of regex affixes is not generally useful (besides using it to prevent converting a dot in the regex to SUBSCRIPT_MARK), I used it to denote this capture group, as follows:
`/regex/.\N` when N is a digit 0..9.
E.g: `"/[^0-9]([,:])/.\1"` means that capture group matches the affix. When defined as MPUNC, it separates the `[,:]` punctuations if they don't follow a number.  (An alternative syntax can be implemented, that is harder to parse: `/regex/\1/`. In addition the dict code that converts to SUBSCRIPT_MARK can recognize and skip it, so subscripting it will not be needed. I chose to implement the subscript syntax for simplicity.)

The first group of commits (6 commits) is not directly related.
I can separate it if desired (all of it but the tests.py patch should be applied first because it touches the same code).

While digging in the stripping/splitting code I found an idea to (hopefully) significantly sped it up that I would like to implement next.