### PR TITLE
Fix duplicate word detection

### DIFF
--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -78,6 +78,7 @@ bool as_open(Dictionary dict)
 {
 	const char * stns = get_dict_define(dict, STORAGE_NODE_STRING);
 	if (nullptr == stns) return false;
+	dict->name = stns;
 
 	Local* local = new Local;
 	local->node_str = stns;

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -122,6 +122,16 @@ struct Dictionary_s
 	bool         shuffle_linkages;
 	bool         dynamic_lookup;
 
+	/* Duplicate words are disallowed in 4.0.dict unless
+	 * allow_duplicate_words is defined to "true".
+	 * Duplicate idioms are allowed, unless the "test" parse option
+	 * is set to "disalow-dup-idioms" (listing them for debug).
+	 * If these variables are 0, they get their allow/disallow values
+	 * when the first duplicate word/idiom is encountered.
+	 * 0: not set; 1: allow; -1: disallow */
+	int8_t       allow_duplicate_words;
+	int8_t       allow_duplicate_idioms;
+
 	Dialect *dialect;                  /* "4.0.dialect" info */
 	expression_tag dialect_tag;        /* Expression dialect tag info */
 	expression_tag *macro_tag;         /* Macro tags for expression debug */

--- a/link-grammar/dict-common/idiom.h
+++ b/link-grammar/dict-common/idiom.h
@@ -12,7 +12,8 @@
 
 #include "dict-structures.h"
 #include "link-includes.h"
+#include "utilities.h"
 
 void insert_idiom(Dictionary dict, Dict_node *);
-bool  contains_underbar(const char *);
-bool  is_idiom_word(const char *);
+bool contains_underbar(const char *) ATTR_PURE;
+bool is_idiom_word(const char *) ATTR_PURE;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -127,6 +127,21 @@ void dict_error2(Dictionary dict, const char * s, const char *s2)
 	int pos = 1;
 	int i;
 
+	if (IS_DYNAMIC_DICT(dict))
+	{
+		if (s2)
+		{
+			prt_error("Error: While handling storage-node\n  \"%s\":\n"
+			          "%s \"%s\"\n", dict->name, s, s2);
+		}
+		else
+		{
+			prt_error("Error: While handling storage-node\n  \"%s\":\n"
+			          "%s\n", dict->name, s);
+		}
+		return;
+	}
+
 	/* The link_advance used to print the error message can
 	 * throw more errors while printing... */
 	if (dict->recursive_error) return;

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -120,7 +120,7 @@
 
 static bool link_advance(Dictionary dict);
 
-static void dict_error2(Dictionary dict, const char * s, const char *s2)
+void dict_error2(Dictionary dict, const char * s, const char *s2)
 {
 #define ERRBUFLEN 1024
 	char tokens[ERRBUFLEN], t[ERRBUFLEN];

--- a/link-grammar/dict-file/read-dict.h
+++ b/link-grammar/dict-file/read-dict.h
@@ -20,6 +20,7 @@ Dictionary dictionary_six(const char *lang, const char *dict_name,
                           const char *affix_name, const char *regex_name);
 Dictionary dictionary_create_from_file(const char *lang);
 bool read_dictionary(Dictionary dict);
+void dict_error2(Dictionary dict, const char *s, const char *s2);
 
 void insert_list(Dictionary dict, Dict_node * p, int l);
 void free_insert_list(Dict_node *ilist);

--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -16,6 +16,7 @@
 #include "dict-common/dict-common.h"
 #include "dict-common/dict-utils.h"     // patch_subscript
 #include "dict-common/idiom.h"
+#include "dict-file/read-dict.h"        // dict_error2
 #include "string-id.h"
 #include "string-set.h"
 
@@ -652,13 +653,9 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 
 	if (dup_word_status(dict, newnode) == -1)
 	{
-/*
 		dict_error2(dict, "Ignoring word which has been multiply defined:",
 		            newnode->string);
-*/
-prt_error("Error: Ignoring word which has been multiply defined: %s\n"
-"(This error message should be fixed to print dict name and line)\n",
-newnode->string);
+
 		/* Too late to skip insertion - insert it with a null expression. */
 		newnode->exp = &null_exp;
 

--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -600,21 +600,46 @@ Dict_node * dsw_vine_to_tree (Dict_node *root, int size)
  *
  * The following dictionary definition allows duplicate words:
  * #define allow-duplicate-words true
- * An idiom duplicate check can be requested using the test "dup-idioms".
+ * An idiom duplicate check can be requested using the test:
+ * "disallow_dup-idioms"
  */
+
+/**
+ * Return the relevant status of allow_duplicate_words/idioms.
+ */
+static int dup_word_status(Dictionary dict, const Dict_node *newnode)
+{
+	if (dict->allow_duplicate_words == dict->allow_duplicate_idioms)
+		return dict->allow_duplicate_words;
+
+	if (contains_underbar(newnode->string))
+	{
+		return dict->allow_duplicate_idioms;
+	}
+	else
+	{
+		return dict->allow_duplicate_words;
+	}
+}
+
 static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 {
-	static int dup_idioms = -1;
-	static int allow_duplicate_words = -1;
 
-	if (allow_duplicate_words == 1) return false;
-	if (allow_duplicate_words == -1)
+	if (dup_word_status(dict, newnode) == 1) return false;
+
+	if (dict->allow_duplicate_words == 0)
 	{
 		const char *s = linkgrammar_get_dict_define(dict, "allow-duplicate-words");
+		dict->allow_duplicate_words =
+			((s != NULL) && (0 == strcasecmp(s, "true"))) ? 1 : -1;
 
-		allow_duplicate_words = ((s != NULL) && (0 == strcasecmp(s, "true")));
-		if (allow_duplicate_words) return false;
-		if (dup_idioms == -1) dup_idioms = !!test_enabled("dup-idioms");
+		if (dict->allow_duplicate_idioms == 0)
+		{
+			bool disallow_dup_idioms = !!test_enabled("disallow-dup-idioms");
+			dict->allow_duplicate_idioms = disallow_dup_idioms ? -1 : 1;
+		}
+
+		if (dup_word_status(dict, newnode) == 1) return true;
 	}
 
 	/* FIXME: Make central. */
@@ -625,7 +650,7 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 		.operand_next = NULL,
 	};
 
-	if (!contains_underbar(newnode->string) || dup_idioms)
+	if (dup_word_status(dict, newnode) == -1)
 	{
 /*
 		dict_error2(dict, "Ignoring word which has been multiply defined:",

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -253,12 +253,14 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
  * support C11. So it already supports all the features below. */
 
 /* Optimizations etc. that only gcc understands */
+/* FIXME: Change to ATTR_* and define also for MSVC. */
 #if __GNUC__
 #define GCC_DIAGNOSTIC
 #define UNREACHABLE(x) (__extension__ ({if (x) __builtin_unreachable();}))
 #define GNUC_MALLOC __attribute__ ((__malloc__))
 #define GNUC_UNUSED __attribute__ ((__unused__))
 #define GNUC_NORETURN __attribute__ ((__noreturn__))
+#define ATTR_PURE __attribute__ ((__pure__))
 #define NO_SAN __attribute__ ((no_sanitize_address, no_sanitize_undefined))
 
 /* Define when configuring with ASAN/UBSAN - for fast dict load (of course
@@ -280,6 +282,7 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 #define GNUC_MALLOC
 #define GNUC_UNUSED
 #define GNUC_NORETURN
+#define ATTR_PURE
 #define NO_SAN_DICT
 
 #define likely(x) x


### PR DESCRIPTION
`dup_word_error()` uses a static variable as a cache, which is of course wrong.
I fixed it by caching in `Dictionary_s`.
(In a  branch in which I restored the ram dict of `4.0.dict`, this enabled me to allow duplicate words w/o a `#define`.)

I also fixed `dup_word_error()` to again use dict_error2(), which prints the location of the duplicates in the dict file.
For a dynamic dict, it uses the `storage-node` as the dict name in the message (I initialized it in `lookup-atomese.cc`).

Because the rewritten `dup_word_error()` may now call the function `contains_underbar()` more than once (with the same argument), I defined `ontains_underbar()` as "pure"  (and in the same occasion also `is_idiom_word()`). I used `ATTR_PURE` for that (instead of `GNUC_PURE`) and later I will replace all the rest of `GNUC_` with `ATTR_` and add MSVC definitions.
