### PR TITLE
Finish  changes for any / ady / amy

### DIFF
--- a/data/ady/4.0.affix
+++ b/data/ady/4.0.affix
@@ -19,6 +19,13 @@
 
 % Anysplit parameters
 
+% A PCRE2 regex defining a character sequence that shouldn't get split.
+% The LG library must be configured with PCRE2 in order to use it. If not,
+% or if this definition is missing, a single utf8 codpoint is used  as a
+% byte sequence that should not get split.
+%#define atomic-unit "\X";       % split at grapheme boundaries.
+#define atomic-unit "\X\pM*";   % ... but include trailing mark codepoints.
+
 % Number of alternatives to issue for a word. Two values: minimum and maximum.
 % If the word has more possibilities to split than the minimum, but less
 % than the maximum, then issue them without sampling. Else use pseudo-random

--- a/data/ady/4.0.regex
+++ b/data/ady/4.0.regex
@@ -5,17 +5,35 @@
  %                                                                           %
  %***************************************************************************%
 
-% Want to match apostrophes, for abbreviations (I'm I've, etc.) since
-% these cannot be auto-split with the current splitter.
-% Hyphenated words, and words with underbars in them, get split.
-ANY-WORD:  /^[[:alnum:]']+$/
-ANY-PUNCT:  /^[[:punct:]]+$/
+% The regexes here use the PCRE2 pattern syntax.
+% The LG library must be configured with PCRE2 in order to use them.
+
+% Punctuation characters are getting strip from start and end of words,
+% and words that contain punctuation are getting split at them. See the
+% "any/affix-punc" file.
+% These punctuation characters will match here. The \x03 is to match
+% subscripted punctuation that may be specified in this file.
+ANY-PUNCT: /^[[:punct:]]+(:?\x03|$)/
 
 % Simple two-part random morphology: match any string of one or more
 % letters as a stem, and the rest as a suffix.
-% We are currently using .= to denote the end of a stem.
-SIMPLE-STEM: /^[[:alnum:]']+.=/
-SIMPLE-SUFF: /=[[:alnum:]']+$/
+% We are currently using .= to denote the end of a stem (the \x03
+% is the internal representation of the dot in .=).
+SIMPLE-STEM: /^\X+\x03=$/
+SIMPLE-SUFF: /^=\X+/
+
+% Reject anything that contains punctuation, so that the tokenizer will
+% have a chance to split them off as affixes.
+ANY-WORD: /^[^[:punct:]]+$/
+
+% The regexes below don't need the PCRE2 regex library, but:
+% 1. They work fine only with ASCII.
+% 2. They are not checked to work fine with the latest changes
+%    to the other configuration files.
+% ANY-WORD:  /^[[:alnum:]]+$/
+% ANY-PUNCT:  /^[[:punct:]]+$/
+% SIMPLE-STEM: /^[[:alnum:]]+.=/
+% SIMPLE-SUFF: /=[[:alnum:]]+$/
 
 % Match anything that doesn't match the above.
 % Match anything that isn't white-space.

--- a/data/amy/4.0.regex
+++ b/data/amy/4.0.regex
@@ -28,8 +28,6 @@ MOR-SUFF: /^=\X+/
 
 % Reject anything that contains punctuation, so that the tokenizer will
 % have a chance to split them off as affixes.
-% Most of the script-dependent punctuation characters are not mentioned in
-% the "any/affix-punc" file and thus may be included in words.
 ANY-WORD: /^[^[:punct:]]+$/
 
 % For ASCII input and non-PCRE2 regex libraries you can use these instead:

--- a/data/amy/4.0.regex
+++ b/data/amy/4.0.regex
@@ -30,7 +30,10 @@ MOR-SUFF: /^=\X+/
 % have a chance to split them off as affixes.
 ANY-WORD: /^[^[:punct:]]+$/
 
-% For ASCII input and non-PCRE2 regex libraries you can use these instead:
+% The regexes below don't need the PCRE2 regex library, but:
+% 1. They work fine only with ASCII.
+% 2. They are not checked to work fine with the latest changes
+%    to the other configuration files.
 % ANY-WORD: /^[[:alnum:]]+$/
 % ANY-PUNCT: /^[[:punct:]].*$/  % The .* is to match an optional subscript.
 % MOR-PREF: /^[[:alnum:]]+=$/

--- a/data/any/4.0.regex
+++ b/data/any/4.0.regex
@@ -5,14 +5,26 @@
  %                                                                           %
  %***************************************************************************%
 
-% For Unicode scripts that use graphemes, use the corresponding regexes
-% from amy/4.0.regex.
+% The regexes here use the PCRE2 pattern syntax.
+% The LG library must be configured with PCRE2 in order to use them.
 
-% Want to match apostrophes, for abbreviations (I'm I've, etc.) since
-% these cannot be auto-split with the current splitter.
-% Hyphenated words, and words with underbars in them, get split.
-ANY-WORD:  /^[[:alnum:]]+$/
-ANY-PUNCT:  /^[[:punct:]]+$/
+% Punctuation characters are getting strip from start and end of words,
+% and words that contain punctuation are getting split at them. See the
+% "any/affix-punc" file.
+% These punctuation characters will match here. The \x03 is to match
+% subscripted punctuation that may be specified in this file.
+ANY-PUNCT: /^[[:punct:]]+(:?\x03|$)/
+
+% Reject anything that contains punctuation, so that the tokenizer will
+% have a chance to split them off as affixes.
+ANY-WORD: /^[^[:punct:]]+$/
+
+% The regexes below don't need the PCRE2 regex library, but:
+% 1. They work fine only with ASCII.
+% 2. They are not checked to work fine with the latest changes
+%    to the other configuration files.
+% ANY-WORD:  /^[[:alnum:]]+$/
+% ANY-PUNCT:  /^[[:punct:]]+$/
 
 % Match anything that doesn't match the above.
 % Match anything that isn't white-space.


### PR DESCRIPTION
- Change `any` and `ady` according to the recent `amy` changes.
- `amy`: Update comments
- Add a fix for commit 56247cb71 (`afdict_init()`: Validate affixes w/`dictionary_word_is_known()`):
-- Read `4.0.regex` before `4.0.affix`

@linas, please make some checks to see that `ady`/`amy`/`any` work as expected.

Regarding the fix for `lt/4.0.affix` that is still needed, I guess that maybe `!` can be added to `"."` in the dict, and the rest should be just null linked there (I can do it unless you have a better idea).

(I still need to send a few PRs regarding `4.0.affix`, an PR for REGPARTS>3, then a cleanup PR, and then fixes for Windows & macOS.)

(Edited to fix a  typo.)