### PR TITLE
Configure pcre2 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,10 @@ be without it altogether. The library names may be without the prefix `lib`.
 * `libz1g-dev` or `libz-devel` (currently needed for the bundled `minisat2`)<br>
 * `libedit-dev` (see [Editline](#Editline))<br>
 * `libhunspell-dev` or `libaspell-dev` (and the corresponding English dictionary).<br>
-* `libtre-dev` or `libpcre2-dev` (usually much faster than the libc REGEX
-implementation, and needed for correctness on FreeBSD and Cygwin)
+* `libtre-dev` or `libpcre2-dev` (much faster than the libc REGEX
+implementation, and needed for correctness on FreeBSD and Cygwin).<br>
+Using `libpcre2-dev` is strongly recommended. It must be used on certain
+systems (as specified in their BUILDING sections).
 
 Note: BSD-derived operating systems (including macOS) need the
 `argp-standalone` library in order to build the `link-generator` program.

--- a/configure.ac
+++ b/configure.ac
@@ -662,6 +662,13 @@ AC_ARG_WITH([regexlib],
 	                         [],
 	                         [with_regexlib=pcre2])
 
+AC_ARG_ENABLE(pcre2,
+	          [AS_HELP_STRING([--disable-pcre2],
+	                          [disable the use of the PCRE2 regex library
+	                           (default is enabled)])],
+	                           [test "$with_regexlib" = pcre2 && with_regexlib=],
+	                           [check_pcre2=1])
+
 lgregexlib=--with-regexlib="$with_regexlib"
 
 case "$with_regexlib" in
@@ -711,7 +718,7 @@ dnl libpcre2-8, libtre, libregex, libc.
 if test -n "$regexlib_cxx"; then
 	AC_MSG_RESULT([... using C++ regex])
 else
-	if test -z "$REGEX_LIBS"; then
+	if test -z "$REGEX_LIBS" -a -n "$check_pcre2"; then
 		AC_CHECK_HEADER([pcre2.h],
 			[PKG_CHECK_MODULES([REGEX], [libpcre2-8],
 									 [AC_DEFINE([HAVE_PCRE2_H], 1)],

--- a/configure.ac
+++ b/configure.ac
@@ -655,9 +655,12 @@ fi
 dnl AC_CHECK_HEADERS defines HAVE_FILENAME_H if found.
 
 AC_ARG_WITH([regexlib],
-	[AS_HELP_STRING([--with-regexlib=pcre2|tre|regex|c|c++],
-	[Use the specified regex library (default=first found)])],
-	[], with_regexlib=)
+	        [AS_HELP_STRING([--with-regexlib=pcre2|tre|regex|c|c++],
+	                        [use the specified regex library (pcre2 is the
+	                         default unless --disable-pcre2 is specified).
+	                         The use of PCRE2 is strongly recommended.])],
+	                         [],
+	                         [with_regexlib=pcre2])
 
 lgregexlib=--with-regexlib="$with_regexlib"
 
@@ -669,12 +672,14 @@ case "$with_regexlib" in
 		AC_CHECK_HEADERS([pcre2.h], ,
 		                 [AC_MSG_ERROR([$lgregexlib: pcre2.h not found])],
 							  [#define PCRE2_CODE_UNIT_WIDTH 8])
-		PKG_CHECK_MODULES([REGEX], [libpcre2-8])
+		PKG_CHECK_MODULES([PCRE2], [libpcre2-8], [],
+								[AC_MSG_ERROR([$lgregexlib: libpcre2-8 not found])])
 		;;
 	tre)
 		AC_CHECK_HEADERS([tre/regex.h], ,
 		                 [AC_MSG_ERROR([$lgregexlib: tre/regex.h not found])])
-		PKG_CHECK_MODULES([REGEX], [tre])
+		PKG_CHECK_MODULES([TRE], [tre], [],
+								[AC_MSG_ERROR([$lgregexlib: libtre not found])])
 		;;
 	regex)
 		AC_CHECK_HEADERS([regex.h], ,[AC_MSG_ERROR([No regex.h header found])])

--- a/configure.ac
+++ b/configure.ac
@@ -669,18 +669,22 @@ AC_ARG_ENABLE(pcre2,
 	                           [test "$with_regexlib" = pcre2 && with_regexlib=],
 	                           [check_pcre2=1])
 
+pcre2_message='PCRE2 is strongly recommended. If you wish to compile without this, then say "configure --disable-pcre2"'
+
 lgregexlib=--with-regexlib="$with_regexlib"
 
 case "$with_regexlib" in
 	'')
 		break
 		;;
-	pcre2)
-		AC_CHECK_HEADERS([pcre2.h], ,
-		                 [AC_MSG_ERROR([$lgregexlib: pcre2.h not found])],
-							  [#define PCRE2_CODE_UNIT_WIDTH 8])
-		PKG_CHECK_MODULES([PCRE2], [libpcre2-8], [],
-								[AC_MSG_ERROR([$lgregexlib: libpcre2-8 not found])])
+	  pcre2)
+	   AC_CHECK_HEADERS([pcre2.h], ,
+	                    [AS_BOX(m4_normalize($pcre2_message))]
+	                    [AC_MSG_ERROR([$lgregexlib: pcre2.h not found])],
+	                    [#define PCRE2_CODE_UNIT_WIDTH 8])
+	   PKG_CHECK_MODULES([PCRE2], [libpcre2-8], [],
+	                     [AS_BOX(m4_normalize($pcre2_message))]
+	                     [AC_MSG_ERROR([$lgregexlib: libpcre2-8 not found])])
 		;;
 	tre)
 		AC_CHECK_HEADERS([tre/regex.h], ,


### PR DESCRIPTION
(Per discussion at PR #1338.)
- `configure`: Make PCRE2 the default regex library.
This makes `--with-regexlib=pcre2` the default. Because it is specified as the required regex library, it is then an error if it is not found.
- `configure`: Add `--disable-pcre2` to ignore PCRE2.
This provides a way not to use PCRE2 w/o  explicitly specifying another library. `configure` will then pick up the fisrt library according to its hardcoded list. Alternatively, the desired other library can be specified with `--with-regexlib=...`.
- configure: Add a message if PCRE2 is not found.
This is what is shown if PCRE2 is not found:
``` text
...
checking for pcre2.h... yes
checking for PCRE2... no
## -------------------------------------------------------------------------------------------------------- ##
## PCRE2 is strongly recommended. If you wish to compile without this, then say "configure --disable-pcre2" ##
## -------------------------------------------------------------------------------------------------------- ##
configure: error: --with-regexlib=pcre2: libpcre2-8 not found
```
---

How to check this patch: Temporarily rename `libpcre2-8.pc`, then restore it and rename `pcre2.h`. `configure` will then notify the message above unless explicitly not configured with pcre2.