### PR TITLE
Add .gitattributes to prevent misclassification of LG data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+.gitattributes     text export-ignore
+.gitignore         text export-ignore
+.editorconfig      text
+
+data/*                      linguist-documentation
+data/*/*                    linguist-documentation
+data/*/*.scm               -linguist-documentation
+data/*/words/*              linguist-documentation
+data/*/tools/*             -linguist-documentation
+data/**/[Ma]akefile*       -linguist-documentation
+*.m4                       -linguist-documentation


### PR DESCRIPTION
Currently the languages of the LG repository are shown as:
``` text
C                  Roff                M4
40.8%              19.9%               12.4%

C++                Assembly
10.0%              3.9%

Python             Other
3.1%               9.9%
```

The Roff is due to files in `words/` with a numeric extension, and the Assembly is due to a file there with `.s`.
The Other is due to `words/` files classified as OpenEdge, Yacc, Pascal, Haskell, and more (again due to their extensions).
(The M4 classification is fine - `4.0.dict.m4`, `configure.ac`, and `lg_visibility.m4`. )

This PR adds a `.gitattributes` file, which defines all of the offending files as text.
An **`export-ignore`** attribute can also be defined there, so you can control what not to include in GitHub's TAR release.

BTW, if desired we can also add `.editorconfig` (not included here) to document the source formatting conventions we use.
(I hoped to be able to control the tab width of GitHub diffs but it didn't work for me for that.)


 
