### PR TITLE
Change cost from double to float

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -287,11 +287,11 @@ int parse_options_get_linkage_limit(Parse_Options opts)
 	return opts->linkage_limit;
 }
 
-void parse_options_set_disjunct_cost(Parse_Options opts, double dummy)
+void parse_options_set_disjunct_cost(Parse_Options opts, float dummy)
 {
 	opts->disjunct_cost = dummy;
 }
-double parse_options_get_disjunct_cost(Parse_Options opts)
+float parse_options_get_disjunct_cost(Parse_Options opts)
 {
 	return opts->disjunct_cost;
 }
@@ -626,7 +626,7 @@ int sentence_num_violations(Sentence sent, LinkageIdx i)
 	return sent->lnkages[i].lifo.N_violations;
 }
 
-double sentence_disjunct_cost(Sentence sent, LinkageIdx i)
+float sentence_disjunct_cost(Sentence sent, LinkageIdx i)
 {
 	if (!sent) return 0.0;
 

--- a/link-grammar/dict-common/dialect.h
+++ b/link-grammar/dict-common/dialect.h
@@ -20,10 +20,10 @@
 #include "string-id.h"
 
 /* dialect_tag costs with a special meaning. See also link-includes.h. */
-#define DIALECT_COST_MAX         9999.0    /* Less than that is a real cost */
-#define DIALECT_COST_DISABLE    10000.0
-#define DIALECT_SUB             10001.0    /* Sub-dialect (a vector name) */
-#define DIALECT_SECTION         10002.0    /* Section header (a vector name) */
+#define DIALECT_COST_MAX         9999.0F    /* Less than that is a real cost */
+#define DIALECT_COST_DISABLE    10000.0F
+#define DIALECT_SUB             10001.0F    /* Sub-dialect (a vector name) */
+#define DIALECT_SECTION         10002.0F    /* Section header (a vector name) */
 
 
 /* Used for dialect table entries and Dialect_Option component cost array. */

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -29,8 +29,8 @@
 
 /* If the maximum disjunct cost is yet uninitialized, the value defined in the
  * dictionary (or if not defined then DEFAULT_MAX_DISJUNCT_COST) is used. */
-static const double UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0;
-static const double DEFAULT_MAX_DISJUNCT_COST = 2.7;
+static const float UNINITIALIZED_MAX_DISJUNCT_COST = -10000.0f;
+static const float DEFAULT_MAX_DISJUNCT_COST = 2.7f;
 /* We need some of these as literal strings. */
 #define LG_DISJUNCT_COST                        "max-disjunct-cost"
 #define LG_DICTIONARY_VERSION_NUMBER            "dictionary-version-number"

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -334,7 +334,7 @@ const char * linkgrammar_get_dict_version(Dictionary dict)
 	return dict->version;
 }
 
-double linkgrammar_get_dict_max_disjunct_cost(Dictionary dict)
+float linkgrammar_get_dict_max_disjunct_cost(Dictionary dict)
 {
 	return dict->default_max_disjunct_cost;
 }

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -406,7 +406,7 @@ static bool dictionary_setup_max_disjunct_cost(Dictionary dict)
 		float disjunct_cost_value;
 		if (!strtofC(disjunct_cost_str, &disjunct_cost_value))
 		{
-			prt_error("Error: %s: Invalid cost \"%s\"", LG_DISJUNCT_COST,
+			prt_error("Error: %s: Invalid cost \"%s\"\n", LG_DISJUNCT_COST,
 			          disjunct_cost_str);
 			return false;
 		}

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -404,7 +404,7 @@ static bool dictionary_setup_max_disjunct_cost(Dictionary dict)
 	else
 	{
 		float disjunct_cost_value;
-		if (!strtodC(disjunct_cost_str, &disjunct_cost_value))
+		if (!strtofC(disjunct_cost_str, &disjunct_cost_value))
 		{
 			prt_error("Error: %s: Invalid cost \"%s\"", LG_DISJUNCT_COST,
 			          disjunct_cost_str);

--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -38,8 +38,8 @@ typedef enum
 } Exp_type;
 
 #ifndef SWIG
-static const int cost_max_dec_places = 3;
-static const float cost_epsilon = 1E-5;
+#define COST_MAX_DEC_PLACES 3 /* Max. decimal places when printing. */
+static const float cost_epsilon = 1E-5f;
 
 #define EXPTAG_SZ 100 /* Initial size for the Exptag array. */
 typedef enum { Exptag_none=0, Exptag_dialect, Exptag_macro } Exptag_type;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -35,8 +35,9 @@ bool cost_eq(float cost1, float cost2)
 	return (fabs(cost1 - cost2) < cost_epsilon);
 }
 
-#define COMBINE(a, b) a ## b
-#define EXP10(a, s) COMBINE(a ## e, s)
+/* Create a float constant with mantissa a and exponent s. */
+#define COMBINE(a, b, c) a ## b ## c
+#define EXP10(a, s) COMBINE(a ## e, s, F)
 /**
  * Convert \p cost to a string with COST_MAX_DEC_PLACES decimal places.
  * Always use dot as a radix character.

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -12,7 +12,7 @@
 /*************************************************************************/
 
 #include <ctype.h>
-#include <math.h>                       // fabs
+#include <math.h>                       // fabs signbit
 
 #include "api-structures.h"             // Parse_Options_s  (seems hacky to me)
 #include "dict-common.h"
@@ -35,14 +35,24 @@ bool cost_eq(float cost1, float cost2)
 	return (fabs(cost1 - cost2) < cost_epsilon);
 }
 
+#define COMBINE(a, b) a ## b
+#define EXP10(a, s) COMBINE(a ## e, s)
 /**
- * Convert cost to a string with at most cost_max_dec_places decimal places.
+ * Convert \p cost to a string with COST_MAX_DEC_PLACES decimal places.
+ * Always use dot as a radix character.
+ * @return A static thread-local pointer to the result string.
  */
 const char *cost_stringify(float cost)
 {
 	static TLS char buf[16];
 
-	int l = snprintf(buf, sizeof(buf), "%.*f", cost_max_dec_places, cost);
+	const int scale = EXP10(1, COST_MAX_DEC_PLACES);
+	const bool sign = signbit(cost);
+	const float roundinc = (1 / EXP10(2, COST_MAX_DEC_PLACES));
+	int c = (int)((fabs(cost) + roundinc) * scale);
+
+	int l = snprintf(buf, sizeof(buf), "%s%d.%0*d", sign ? "-" : "",
+	                 c / scale, COST_MAX_DEC_PLACES, c - c / scale * scale);
 	if ((l < 0) || (l >= (int)sizeof(buf))) return "ERR_COST";
 
 	return buf;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -12,7 +12,7 @@
 /*************************************************************************/
 
 #include <ctype.h>
-#include <math.h>                       // fabs signbit
+#include <math.h>                       // fabsf signbit
 
 #include "api-structures.h"             // Parse_Options_s  (seems hacky to me)
 #include "dict-common.h"
@@ -32,7 +32,7 @@
 
 bool cost_eq(float cost1, float cost2)
 {
-	return (fabs(cost1 - cost2) < cost_epsilon);
+	return (fabsf(cost1 - cost2) < cost_epsilon);
 }
 
 /* Create a float constant with mantissa a and exponent s. */
@@ -50,7 +50,7 @@ const char *cost_stringify(float cost)
 	const int scale = (int)EXP10F(1, COST_MAX_DEC_PLACES);
 	const bool sign = signbit(cost);
 	const float roundinc = (1 / EXP10F(2, COST_MAX_DEC_PLACES));
-	int c = (int)((fabs(cost) + roundinc) * scale);
+	int c = (int)((fabsf(cost) + roundinc) * scale);
 
 	int l = snprintf(buf, sizeof(buf), "%s%d.%0*d", sign ? "-" : "",
 	                 c / scale, COST_MAX_DEC_PLACES, c - c / scale * scale);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -146,7 +146,7 @@ static void get_expression_cost(const Exp *e, unsigned int *icost, float *dcost)
 			if (*icost > 4)
 			{
 				/* don't print too many [] levels */
-				*dcost = *icost;
+				*dcost = (float)*icost;
 				*icost = 1;
 			}
 			else

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -47,7 +47,7 @@ const char *cost_stringify(float cost)
 {
 	static TLS char buf[16];
 
-	const int scale = EXP10F(1, COST_MAX_DEC_PLACES);
+	const int scale = (int)EXP10F(1, COST_MAX_DEC_PLACES);
 	const bool sign = signbit(cost);
 	const float roundinc = (1 / EXP10F(2, COST_MAX_DEC_PLACES));
 	int c = (int)((fabs(cost) + roundinc) * scale);

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -37,7 +37,7 @@ bool cost_eq(float cost1, float cost2)
 
 /* Create a float constant with mantissa a and exponent s. */
 #define COMBINE(a, b, c) a ## b ## c
-#define EXP10(a, s) COMBINE(a ## e, s, F)
+#define EXP10F(a, s) COMBINE(a ## e, s, F)
 /**
  * Convert \p cost to a string with COST_MAX_DEC_PLACES decimal places.
  * Always use dot as a radix character.
@@ -47,9 +47,9 @@ const char *cost_stringify(float cost)
 {
 	static TLS char buf[16];
 
-	const int scale = EXP10(1, COST_MAX_DEC_PLACES);
+	const int scale = EXP10F(1, COST_MAX_DEC_PLACES);
 	const bool sign = signbit(cost);
-	const float roundinc = (1 / EXP10(2, COST_MAX_DEC_PLACES));
+	const float roundinc = (1 / EXP10F(2, COST_MAX_DEC_PLACES));
 	int c = (int)((fabs(cost) + roundinc) * scale);
 
 	int l = snprintf(buf, sizeof(buf), "%s%d.%0*d", sign ? "-" : "",

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -203,10 +203,6 @@ dictionary_six_str(const char * lang,
 
 	/* Read dictionary from the input string. */
 
-	/* Make sure "." is used in string conversion to floating point.
-	 * FIXME: Use a locale-agnostic conversion function. */
-	setlocale(LC_NUMERIC, "C");
-
 	dict->input = input;
 	dict->pin = dict->input;
 	if (!read_dictionary(dict))

--- a/link-grammar/dict-file/read-dialect.c
+++ b/link-grammar/dict-file/read-dialect.c
@@ -312,7 +312,7 @@ static bool dialect_read_from_str(Dictionary dict, Dialect *di,
 						next = end + 1;
 						*end = '\0';
 					}
-					if (!strtodC(dfile->pin, &cost))
+					if (!strtofC(dfile->pin, &cost))
 					{
 						prt_error("Error: %s:%s After \"%s\": Invalid cost \"%s\".\n",
 						          dfile->fname, suppress_0(dfile->line_number, buf),

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -85,7 +85,10 @@
 
   A number following a square bracket over-rides the cost of that bracket.
   Thus, [...].5 has a cost of 0.5 while [...]2.0 has a cost of 2; that
-  is it is the same as [[...]].  Any floating point number is allowed.
+  is it is the same as [[...]]. Only a sign, decimal digits and a point
+  are allowed. The maximum recognized number is "99.9999". Digits which
+  are more than 4 positions to the right of the decimal point are
+  ignored.
 
   Instead of a numerical cost, a symbolic cost can be used, a.k.a. a
   "dialect component name".  The file "4.0.dialect" defines dialect names

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -720,7 +720,7 @@ static Exp *make_expression(Dictionary dict)
 				else
 				{
 					warning(dict, "Invalid cost (using 1.0)\n");
-					nl->cost += 1.0;
+					nl->cost += 1.0F;
 				}
 				if (!link_advance(dict)) {
 					return NULL;
@@ -750,7 +750,7 @@ static Exp *make_expression(Dictionary dict)
 			}
 			else
 			{
-				nl->cost += 1.0;
+				nl->cost += 1.0F;
 			}
 		}
 		else if (!dict->is_special)

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -713,7 +713,7 @@ static Exp *make_expression(Dictionary dict)
 			{
 				float cost;
 
-				if (strtodC(dict->token, &cost))
+				if (strtofC(dict->token, &cost))
 				{
 					nl->cost += cost;
 				}

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -163,7 +163,7 @@ static int exp_cb(void *user_data, int argc, char **argv, char **colName)
 	make_expression(dict, argv[0], &exp);
 	assert(NULL != exp, "Failed expression %s", argv[0]);
 
-	if (!strtodC(argv[1], &exp->cost))
+	if (!strtofC(argv[1], &exp->cost))
 	{
 		prt_error("Warning: Invalid cost \"%s\" in expression \"%s\" "
 		          "(using 1.0)\n", argv[1], argv[0]);

--- a/link-grammar/link-includes.h
+++ b/link-grammar/link-includes.h
@@ -52,7 +52,7 @@ link_public_api(const char *)
 link_public_api(const char *)
 	linkgrammar_get_dict_locale(Dictionary);
 
-link_public_api(double)
+link_public_api(float)
 	linkgrammar_get_dict_max_disjunct_cost(Dictionary);
 
 #define LG_PANIC_DISJUNCT_COST "panic-max-disjunct-cost"
@@ -163,8 +163,8 @@ link_public_api(void)
 link_public_api(int)
      parse_options_get_linkage_limit(Parse_Options opts);
 link_public_api(void)
-     parse_options_set_disjunct_cost(Parse_Options opts, double disjunct_cost);
-link_public_api(double)
+     parse_options_set_disjunct_cost(Parse_Options opts, float disjunct_cost);
+link_public_api(float)
      parse_options_get_disjunct_cost(Parse_Options opts);
 link_public_api(void)
      parse_options_set_min_null_count(Parse_Options opts, int null_count);
@@ -282,7 +282,7 @@ link_public_api(int)
      sentence_num_linkages_post_processed(Sentence sent);
 link_public_api(int)
      sentence_num_violations(Sentence sent, LinkageIdx linkage_num);
-link_public_api(double)
+link_public_api(float)
      sentence_disjunct_cost(Sentence sent, LinkageIdx linkage_num);
 link_public_api(int)
      sentence_link_cost(Sentence sent, LinkageIdx linkage_num);
@@ -331,7 +331,7 @@ link_public_api(const char **)
      linkage_get_words(const Linkage linkage);
 link_public_api(const char *)
      linkage_get_disjunct_str(const Linkage linkage, WordIdx word_num);
-link_public_api(double)
+link_public_api(float)
      linkage_get_disjunct_cost(const Linkage linkage, WordIdx word_num);
 link_public_api(const char *)
      linkage_get_word(const Linkage linkage, WordIdx word_num);
@@ -361,7 +361,7 @@ link_public_api(void)
      linkage_free_pp_msgs(char * str);
 link_public_api(int)
      linkage_unused_word_cost(const Linkage linkage);
-link_public_api(double)
+link_public_api(float)
      linkage_disjunct_cost(const Linkage linkage);
 link_public_api(int)
      linkage_link_cost(const Linkage linkage);

--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -894,7 +894,7 @@ const char * linkage_get_disjunct_str(const Linkage linkage, WordIdx w)
 	return linkage->disjunct_list_str[w];
 }
 
-double linkage_get_disjunct_cost(const Linkage linkage, WordIdx w)
+float linkage_get_disjunct_cost(const Linkage linkage, WordIdx w)
 {
 	Disjunct *dj;
 
@@ -921,7 +921,7 @@ int linkage_unused_word_cost(const Linkage linkage)
 	return linkage->lifo.unused_word_cost;
 }
 
-double linkage_disjunct_cost(const Linkage linkage)
+float linkage_disjunct_cost(const Linkage linkage)
 {
 	/* The sat solver (currently) fails to fill in info */
 	if (!linkage) return 0.0;

--- a/link-grammar/parse/histogram.h
+++ b/link-grammar/parse/histogram.h
@@ -84,7 +84,7 @@ static inline count_t hist_one(void) { return 1; }
 #define hist_total(tot) (*tot)
 
 #define hist_cut_total(tot, min_total) (*tot)
-static inline float hist_cost_cutoff(count_t* tot, count_t count) { return 1.0e38; }
+static inline float hist_cost_cutoff(count_t* tot, count_t count) { return 1.0e38f; }
 
 #endif /* PERFORM_COUNT_HISTOGRAMMING */
 

--- a/link-grammar/print/print.c
+++ b/link-grammar/print/print.c
@@ -271,7 +271,8 @@ char * linkage_print_disjuncts(const Linkage linkage)
 		if (NULL == dj) dj = "";
 		cost = (float)linkage_get_disjunct_cost(linkage, w);
 
-		append_string(s, "%*s    % 4.3f  %s\n", pad, infword, cost, dj);
+		append_string(s, "%*s    %6s  %s\n",
+		              pad, infword, cost_stringify(cost), dj);
 	}
 	return dyn_str_take(s);
 }

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -761,8 +761,8 @@ bool strtofC(const char *s, float *r)
 		FP_BY_POS(10), FP_BY_POS(1), FP_BY_POS(0.1f), FP_BY_POS(0.01f),
 		FP_BY_POS(0.001f), FP_BY_POS(0.0001f)
 	};
-	static const unsigned int max_int_digits = 2;
-	static const unsigned int max_frac_digits = 4;
+	static const int max_int_digits = 2;
+	static const int max_frac_digits = 4;
 	static const char max_str[] = "99.9999";
 
 	const char *si = s;
@@ -824,7 +824,7 @@ bool strtofC(const char *s, float *r)
 			lgdebug(+D_SITOF, "\"%s\": Invalid digit \"%c\"\n", s, *si);
 			return false;
 		}
-		if ((int)(decpoint - si) >= (int)-max_frac_digits)
+		if ((int)(decpoint - si) >= -max_frac_digits)
 			total += fpconv[pos][d];
 		pos++;
 	}

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -747,7 +747,7 @@ char * get_default_locale(void)
  * @return \c true iff \p s is valid.
  */
 #define D_SITOF 5
-bool strtodC(const char *s, float *r)
+bool strtofC(const char *s, float *r)
 {
 #define DFP(n) (1.0f * n)
 #define FP_BY_POS(p) \

--- a/link-grammar/utilities.c
+++ b/link-grammar/utilities.c
@@ -728,32 +728,6 @@ char * get_default_locale(void)
 	return safe_strdup(locale);
 }
 
-#ifdef HAVE_LOCALE_T
-static void free_C_LC_NUMERIC(void);
-
-static locale_t get_C_LC_NUMERIC(void)
-{
-	static locale_t locobj;
-
-	if ((locale_t)0 != locobj) return locobj;
-
-#ifdef _WIN32
-	locobj = _create_locale(LC_NUMERIC, "C");
-#else
-	locobj = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
-#endif /* _WIN32 */
-
-	atexit(free_C_LC_NUMERIC);
-
-	return locobj;
-}
-
-static void free_C_LC_NUMERIC(void)
-{
-	freelocale(get_C_LC_NUMERIC());
-}
-#endif /* HAVE_LOCALE_T */
-
 /**
  * Convert to float a scaled integer string in the format:
  * ([-+])?0*\d{,1}(\.\d*)?

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -521,7 +521,7 @@ size_t get_max_space_used(void);
 char * get_default_locale(void);
 void set_utf8_program_locale(void);
 bool try_locale(const char *);
-bool strtodC(const char *, float *);
+bool strtofC(const char *, float *);
 
 /**
  * Returns the smallest power of two that is at least i and at least 1

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -239,7 +239,7 @@ static const char *switch_value_string(const Switch *as)
 	switch (as->param_type)
 	{
 		case Float: /* Float point print! */
-			snprintf(buf, sizeof(buf), "%.2f", *((float *)as->ptr));
+			snprintf(buf, sizeof(buf), "%.3f", *((float *)as->ptr));
 			break;
 		case Bool:
 			/* FALLTHRU */
@@ -955,7 +955,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 			}
 
 			*((float *) as[j].ptr) = val;
-			printf("%s set to %5.2f\n", as[j].string, val);
+			printf("%s set to %5.3f\n", as[j].string, val);
 			return 'c';
 		}
 		else

--- a/link-parser/command-line.c
+++ b/link-parser/command-line.c
@@ -41,7 +41,7 @@ static struct
 #endif
 	int echo_on;
 	Cost_Model_type cost_model;
-	double max_cost;
+	float max_cost;
 	int screen_width;
 	int display_on;
 	ConstituentDisplayStyle display_constituents;
@@ -239,7 +239,7 @@ static const char *switch_value_string(const Switch *as)
 	switch (as->param_type)
 	{
 		case Float: /* Float point print! */
-			snprintf(buf, sizeof(buf), "%.2f", *((double *)as->ptr));
+			snprintf(buf, sizeof(buf), "%.2f", *((float *)as->ptr));
 			break;
 		case Bool:
 			/* FALLTHRU */
@@ -946,7 +946,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 		if (as[j].param_type == Float)
 		{
 			char *err;
-			double val = strtod(y, &err);
+			float val = strtof(y, &err);
 			if (('\0' == *y) || ('\0' != *err))
 			{
 				prt_error("Error: Invalid value \"%s\" for variable \"%s\". %s\n",
@@ -954,7 +954,7 @@ static int x_issue_special_command(char * line, Command_Options *copts, Dictiona
 				return -1;
 			}
 
-			*((double *) as[j].ptr) = val;
+			*((float *) as[j].ptr) = val;
 			printf("%s set to %5.2f\n", as[j].string, val);
 			return 'c';
 		}

--- a/link-parser/command-line.h
+++ b/link-parser/command-line.h
@@ -31,7 +31,7 @@
 
 typedef struct
 {
-	double max_cost;
+	float max_cost;
 	int linkage_limit;
 	int max_null_count;
 	int short_length;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -367,7 +367,7 @@ static int there_was_an_error(Label label, Sentence sent, Parse_Options opts)
 			batch_errors++;
 			return UNGRAMMATICAL;
 		}
-		if ((sentence_disjunct_cost(sent, 0) == 0.0) &&
+		if ((sentence_disjunct_cost(sent, 0) == 0.0F) &&
 			(label == PARSE_WITH_DISJUNCT_COST_GT_0)) {
 			batch_errors++;
 			return PARSE_WITH_DISJUNCT_COST_GT_0;
@@ -618,7 +618,7 @@ int main(int argc, char * argv[])
 	{
 		const char *locale =  setlocale(LC_NUMERIC, "C");
 		char *err;
-		double panic_max_cost = strtod(panic_max_cost_str, &err);
+		float panic_max_cost = strtof(panic_max_cost_str, &err);
 		setlocale(LC_NUMERIC, locale);
 
 		if ('\0' == *err)


### PR DESCRIPTION
See issue #1231.
The original idea was to reduce the memory footage of various structures.

In this patch, I change the conversions for floating-point to/from strings to use locale-independent conversions instead of C library ones. The string to floating-point conversion is also faster but this is insignificant due to the relatively low number of cost strings in the library.


In order to avoid double/float conversions, I changed all the floating-point constants to single-precision.
I also changed all the API functions to single-precision.  This is not ABI-compatible.
