### PR TITLE
Cleanup and minor bug fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Version 5.11.0 (XXX 2022)
  * Thai updates #1322
  * Punctuation fixes #1331
  * Affixes can now be specified with regexes #1334
+ * The regex library PCRE2 is required by default.
 
 Version 5.10.5 (17 June 2022)
  * Updated Docker files. #1288

--- a/bindings/swig/link_grammar.i
+++ b/bindings/swig/link_grammar.i
@@ -4,6 +4,12 @@
 * shared (dynamic) library.
 *
 ***********************************************************************/
+%begin %{
+#ifdef _WIN32
+#define _STL_CRT_SECURE_INVALID_PARAMETER _CRT_SECURE_INVALID_PARAMETER
+#endif
+%}
+
 %module clinkgrammar
 %{
 

--- a/configure.ac
+++ b/configure.ac
@@ -697,7 +697,7 @@ case "$with_regexlib" in
 		AC_CHECK_LIB([regex], [regexec], [REGEX_LIBS=-lregex],
 		             [AC_MSG_ERROR([$lgregexlib: regexec() not found])])
 		;;
-	c)
+	c|C)
 		AC_CHECK_HEADERS([regex.h], ,[AC_MSG_ERROR([No regex.h header found])])
 		AC_CHECK_FUNCS(regexec, [REGEX_LIBS=-lc],
 		               [AC_MSG_ERROR([$lgregexlib: regexec() not found])])

--- a/link-grammar/.gitignore
+++ b/link-grammar/.gitignore
@@ -1,2 +1,4 @@
 link-parser
 link-features.h
+# MacOS
+._pp_lexer.c

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -558,7 +558,7 @@ void sentence_delete(Sentence sent)
 	pool_delete(sent->X_node_pool);
 
 	/* Usually the memory pools created in build_disjuncts_for_exp() are
-	 * deleted in build_sentence_disjuncts(). Delete them here inn case
+	 * deleted in build_sentence_disjuncts(). Delete them here in case
 	 * build_disjuncts_for_exp() is directly called. */
 	if (sent->Clause_pool != NULL)
 	{

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -25,6 +25,7 @@
 #include "post-process/post-process.h"  // post_process_new
 #include "prepare/exprune.h"
 #include "string-set.h"
+#include "tokenize//wordgraph.h"        // wordgraph_delete
 #include "resources.h"
 #include "sat-solver/sat-encoder.h"
 #include "tokenize/tokenize.h"

--- a/link-grammar/dict-common/dialect.c
+++ b/link-grammar/dict-common/dialect.c
@@ -186,7 +186,7 @@ static void print_cost_table(Dictionary dict, Dialect *di, dialect_info *dinfo)
 		return;
 	}
 
-	prt_error("Dialect cost table (%u components%s):\n\\",
+	prt_error("Dialect cost table (%u component%s):\n\\",
 	          dt->num, dt->num == 1 ? "" : "s");
 	prt_error("%-15s %s\n", "component", "cost");
 

--- a/link-grammar/dict-common/dict-affix.h
+++ b/link-grammar/dict-common/dict-affix.h
@@ -86,12 +86,13 @@ static const afdict_classnum affix_strippable[] =
 	{AFDICT_UNITS, AFDICT_LPUNC, AFDICT_RPUNC, AFDICT_MPUNC};
 
 /**
- * Return a positive number if \p s is in affix regex format, else return -1.
+ * Return the capture group number if \p s is in affix regex format,
+ * else return -1.
  * Regex format: /regex/.\N (N is a digit).
  * \N denotes the capture group that should match an affix
  * (the whole pattern is capture group 0).
  *
- * The regex much contain at least one character.
+ * The regex must contain at least one character.
  */
 static inline int get_affix_regex_cg(const char *s)
 {

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -499,7 +499,7 @@ void affix_list_add(Dictionary afdict, Afdict_class * ac,
 		size_t new_sz;
 		ac->mem_elems += AFFIX_COUNT_MEM_INCREMENT;
 		new_sz = ac->mem_elems * sizeof(const char *);
-		ac->string = (char const **) realloc((void *)ac->string, new_sz);
+		ac->string = realloc(ac->string, new_sz);
 	}
 	ac->string[ac->length] = string_set_add(affix, afdict->string_set);
 	ac->length++;
@@ -656,7 +656,7 @@ bool afdict_init(Dictionary dict)
 		prt_error("Error: afdict_init: Invalid value for class %s in file %s"
 		          " (should have been one ASCII punctuation - ignored)\n",
 		          afdict_classname[AFDICT_INFIXMARK], afdict->name);
-		free((void *)ac->string);
+		free(ac->string);
 		ac->length = 0;
 		ac->mem_elems = 0;
 		ac->string = NULL;

--- a/link-grammar/dict-common/dict-impl.c
+++ b/link-grammar/dict-common/dict-impl.c
@@ -18,11 +18,11 @@
 #include "dict-api.h"
 #include "dict-defines.h"
 #include "dict-impl.h"
+#include "dict-structures.h"
 #include "print/print-util.h"           // patch_subscript_mark
 #include "regex-morph.h"
-#include "dict-structures.h"
-#include "string-set.h"
 #include "string-id.h"
+#include "string-set.h"
 #include "utilities.h"
 
 /* ======================================================================= */

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -129,7 +129,7 @@ static void increment_current_name(Dictionary dict)
 		if (dict->current_idiom[i] <= 'Z') return;
 		dict->current_idiom[i] = 'A';
 	} while (i-- > 0);
-	assert(0, "increment_current_name: Overflow");
+	assert(0, "Overflow");
 }
 
 /**

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -12,6 +12,7 @@
 /*************************************************************************/
 
 #include <ctype.h>
+#include <inttypes.h>                   // format macros
 #include <math.h>                       // fabsf signbit
 
 #include "api-structures.h"             // Parse_Options_s  (seems hacky to me)
@@ -1211,7 +1212,7 @@ static char *display_counts(const char *word, Dict_node *dn)
 	dyn_strcat(s, "matches:\n");
 	for (; dn != NULL; dn = dn->right)
 	{
-		append_string(s, "    %-*s %8zu  disjuncts",
+		append_string(s, "    %-*s %8"PRIu64" disjuncts",
 		              display_width(DJ_COL_WIDTH, dn->string), dn->string,
 		              count_disjunct_for_dict_node(dn));
 

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -27,7 +27,7 @@
 #include "regex-morph.h"
 #include "tokenize/tokenize.h"          // word_add
 #include "tokenize/word-structures.h"   // Word_struct
-#include "utilities.h"                  // GNU_UNUSED
+#include "utilities.h"                  // GNUC_UNUSED
 /* ======================================================================== */
 
 bool cost_eq(float cost1, float cost2)

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -337,6 +337,7 @@ static void reg_free(Regex_node *rn)
 static bool check_capture_group(const Regex_node *rn)
 {
 	if (rn->capture_group <= 0) return true;
+	assert(rn->capture_group <= 9, "Bogus capture group %d", rn->capture_group);
 
 	Regex_node check_cg = *rn;
 	const size_t pattern_len = strlen(rn->pattern);

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -89,7 +89,7 @@ static unsigned int max_capture_groups(const Regex_node *rn)
 {
 	if (rn->capture_group < 0) return 0;
 
-	int Nov = 1;
+	unsigned int Nov = 1;
 	for (const char *p = rn->pattern; *p != '\0'; p++)
 		if (*p == '(') Nov++;
 
@@ -137,7 +137,7 @@ static bool reg_comp(Regex_node *rn)
 static bool reg_match(const char *s, const Regex_node *rn)
 {
 	reg_info *re = (reg_info *)rn->re;
-	int nmatch = (rn->capture_group < 0) ? 0 : re->Nre_md;
+	size_t nmatch = (rn->capture_group < 0) ? 0 : re->Nre_md;
 	int rc = regexec(&re->re_code, s, nmatch, re->re_md, /*eflags*/0);
 
 	if (rc == REG_NOMATCH) return false;
@@ -242,8 +242,8 @@ static void reg_span(Regex_node *rn)
 	}
 	else
 	{
-		rn->ovector[0] = ovector[2*cgn];
-		rn->ovector[1] = ovector[2*cgn + 1];
+		rn->ovector[0] = (int)ovector[2*cgn];
+		rn->ovector[1] = (int)ovector[2*cgn + 1];
 	}
 }
 
@@ -310,8 +310,8 @@ static void reg_span(Regex_node *rn)
 	}
 	else
 	{
-		rn->ovector[0] = re_md.position(cgn);
-		rn->ovector[1] = rn->ovector[0] + re_md.length(cgn);
+		rn->ovector[0] = (int)re_md.position(cgn);
+		rn->ovector[1] = rn->ovector[0] + (int)re_md.length(cgn);
 	}
 }
 
@@ -345,7 +345,7 @@ static bool check_capture_group(const Regex_node *rn)
 	strcpy(check_cg.pattern, rn->pattern);
 
 	check_cg.pattern[pattern_len] = '\\';
-	check_cg.pattern[pattern_len + 1] = '0' + rn->capture_group;
+	check_cg.pattern[pattern_len + 1] = '0' + (char)rn->capture_group;
 	check_cg.pattern[pattern_len + 2] = '\0';
 
 	bool rc = reg_comp(&check_cg);

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -992,7 +992,7 @@ static bool read_entry(Dictionary dict)
 			goto syntax_error;
 		}
 
-		/* If it's a word-file name */
+		/* If it's a word-file name. */
 		/* However, be careful to reject "/.v" which is the division symbol
 		 * used in equations (.v means verb-like). Also reject an affix regex
 		 * specification (may appear only in the affix file). */

--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -640,7 +640,7 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 			dict->allow_duplicate_idioms = disallow_dup_idioms ? -1 : 1;
 		}
 
-		if (dup_word_status(dict, newnode) == 1) return true;
+		if (dup_word_status(dict, newnode) == 1) return false;
 	}
 
 	/* FIXME: Make central. */

--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -634,11 +634,8 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 		dict->allow_duplicate_words =
 			((s != NULL) && (0 == strcasecmp(s, "true"))) ? 1 : -1;
 
-		if (dict->allow_duplicate_idioms == 0)
-		{
-			bool disallow_dup_idioms = !!test_enabled("disallow-dup-idioms");
-			dict->allow_duplicate_idioms = disallow_dup_idioms ? -1 : 1;
-		}
+		bool disallow_dup_idioms = !!test_enabled("disallow-dup-idioms");
+		dict->allow_duplicate_idioms = disallow_dup_idioms ? -1 : 1;
 
 		if (dup_word_status(dict, newnode) == 1) return false;
 	}
@@ -651,18 +648,13 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 		.operand_next = NULL,
 	};
 
-	if (dup_word_status(dict, newnode) == -1)
-	{
-		dict_error2(dict, "Ignoring word which has been multiply defined:",
-		            newnode->string);
+	dict_error2(dict, "Ignoring word which has been multiply defined:",
+	            newnode->string);
 
-		/* Too late to skip insertion - insert it with a null expression. */
-		newnode->exp = &null_exp;
+	/* Too late to skip insertion - insert it with a null expression. */
+	newnode->exp = &null_exp;
 
-		return true;
-	}
-
-	return false;
+	return true;
 }
 
 /**

--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -748,7 +748,7 @@ void add_category(Dictionary dict, Exp *e, Dict_node *dn, int n)
 			        sizeof(*dict->category) * dict->num_categories_alloced);
 	}
 	dict->category[dict->num_categories].word =
-		malloc(sizeof(dict->category[0].word) * n);
+		malloc(sizeof(*dict->category[0].word) * n);
 
 	n = 0;
 	for (Dict_node *dnx = dn; dnx != NULL; dnx = dnx->left)

--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -640,19 +640,11 @@ static bool dup_word_error(Dictionary dict, Dict_node *newnode)
 		if (dup_word_status(dict, newnode) == 1) return false;
 	}
 
-	/* FIXME: Make central. */
-	static Exp null_exp =
-	{
-		.type = AND_type,
-		.operand_first = NULL,
-		.operand_next = NULL,
-	};
-
 	dict_error2(dict, "Ignoring word which has been multiply defined:",
 	            newnode->string);
 
 	/* Too late to skip insertion - insert it with a null expression. */
-	newnode->exp = &null_exp;
+	newnode->exp = make_zeroary_node(dict->Exp_pool);
 
 	return true;
 }

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -486,7 +486,7 @@ static void add_categories(Dictionary dict)
 
 		dict->category[i].num_words = bs.count;
 		dict->category[i].word =
-			malloc(bs.count * sizeof(dict->category[0].word));
+			malloc(bs.count * sizeof(*dict->category[0].word));
 
 		/* ------------------ */
 		/* For each category, get the (subscripted) words in the category */

--- a/link-grammar/externs.h
+++ b/link-grammar/externs.h
@@ -12,7 +12,7 @@
 
 #ifndef _EXTERNS_H
 #define _EXTERNS_H
-/* verbosity global is held in api.c */
+/* These globals are held in api.c */
 extern int verbosity;          /* the verbosity level for error messages */
 extern char * debug;           /* comma-separated functions/files to debug */
 extern char * test;            /* comma-separated features to test */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -303,7 +303,6 @@ static void free_table_lrcnt(count_context_t *ctxt)
 
 static void init_table_lrcnt(count_context_t *ctxt)
 {
-	if (ctxt->is_short) return;
 	Sentence sent = ctxt->sent;
 
 	for (unsigned int dir = 0; dir < 2; dir++)
@@ -1583,11 +1582,14 @@ count_context_t * alloc_count_context(Sentence sent, Tracon_sharing *ts)
 	ctxt->is_short =
 		(sent->length <= min_len_word_vector) && !IS_GENERATION(ctxt->sent->dict);
 
-	/* next_id keeps the last tracon_id used, so we need +1 for array size.  */
-	for (unsigned int dir = 0; dir < 2; dir++)
-		ctxt->table_lrcnt[dir].sz = ts->next_id[!dir] + 1;
+	if (!ctxt->is_short)
+	{
+		/* next_id keeps the last tracon_id used, so we need +1 for array size.  */
+		for (unsigned int dir = 0; dir < 2; dir++)
+			ctxt->table_lrcnt[dir].sz = ts->next_id[!dir] + 1;
 
-	init_table_lrcnt(ctxt);
+		init_table_lrcnt(ctxt);
+	}
 
 	/* consecutive blocks of this many words are considered as
 	 * one null link. */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -1475,7 +1475,7 @@ static Count_bin do_count(
 
 					if (0 < hist_total(&rightcount))
 					{
-						parse_count_clamp(&rightcount); /* May be up to 4*INT_MAX. */
+						parse_count_clamp(&rightcount); /* May be up to 4*2^31. */
 						if (le == NULL)
 						{
 							lrcnt_found = true;

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -486,7 +486,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 
 		if (le != NULL)
 			mlcl = get_cached_match_list(ctxt, 0, w, le);
-		if (re != NULL && ((le == NULL) || (re->farthest_word <= w)))
+		if (fml_re != NULL && ((le == NULL) || (re->farthest_word <= w)))
 			mlcr = get_cached_match_list(ctxt, 1, w, re);
 
 		size_t mlb = form_match_list(mchxt, w, le, lw, fml_re, rw, mlcl, mlcr);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -811,8 +811,7 @@ static void list_random_links(Linkage lkg, unsigned int *rand_state,
 		new_index = rand_r(rand_state) % num_pc;
 
 		num_pc = 0;
-		for (pc = set->first; pc != NULL; pc = pc->next) {
-			if (new_index == num_pc) break;
+		for (pc = set->first; new_index != num_pc; pc = pc->next) {
 			num_pc++;
 		}
 	}

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -484,10 +484,10 @@ typedef struct
  * An optimization for English checks if one of the connectors belongs
  * to an original sentence word (c2 is checked first for an inline
  * optimization opportunity).
- * If a wordgraph word of the checked connector is the same
- * as of the previously checked one, use the cached result.
- * (The first wordgraph word is used for cache validity indication,
- * but there is only one most of the times anyway.)
+ * If the first wordgraph word of the checked connector is the same as
+ * of the previously checked one, use the cached result. (Using more
+ * than the first one would increase the cache hit, but there is only
+ * one most of the times so this would be an overhead.)
  */
 #define OPTIMIZE_EN
 static bool alt_connection_possible(Connector *c1, Connector *c2,

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -503,6 +503,9 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 			if (verbosity >= D_USER_INFO)
 			{
+				/* FIXME:
+				 * 1. Issue this message if verbosity != 0.
+				 * 2. Don't continue parsing with higher null counts. */
 				if ((sent->num_linkages_post_processed > 0) &&
 				    (sent->num_linkages_post_processed == sent->num_linkages_alloced) &&
 				    ((int)opts->linkage_limit < sent->num_linkages_found) &&

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -503,10 +503,10 @@ void classic_parse(Sentence sent, Parse_Options opts)
 
 			if (verbosity >= D_USER_INFO)
 			{
-				if ((sent->num_valid_linkages == 0) &&
-				    (sent->num_linkages_post_processed > 0) &&
+				if ((sent->num_linkages_post_processed > 0) &&
+				    (sent->num_linkages_post_processed == sent->num_linkages_alloced) &&
 				    ((int)opts->linkage_limit < sent->num_linkages_found) &&
-				    (PARSE_NUM_OVERFLOW >= sent->num_linkages_found))
+				    !IS_GENERATION(sent->dict))
 					prt_error("Info: All examined linkages (%zu) had P.P. violations.\n"
 					          "Consider increasing the linkage limit.\n"
 					          "At the command line, use !limit\n",

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -276,7 +276,7 @@ static void put_into_power_table(Pool_desc *mp, unsigned int size, C_list **t,
 {
 	C_list **e = get_power_table_entry(size, t, c);
 
-	assert(NULL != e, "put_into_power_table: Overflow");
+	assert(NULL != e, "Overflow");
 	assert(c->refcount > 0, "refcount %d", c->refcount);
 
 	C_list *m = pool_alloc(mp);
@@ -466,7 +466,7 @@ static void clean_table(unsigned int size, C_list **t)
 
 		while (NULL != *m)
 		{
-			assert(0 <= (*m)->c->refcount, "clean_table: refcount < 0 (%d)",
+			assert(0 <= (*m)->c->refcount, "refcount < 0 (%d)",
 			       (*m)->c->refcount);
 			if (0 == (*m)->c->refcount)
 			{

--- a/link-grammar/post-process/pp_lexer.l
+++ b/link-grammar/post-process/pp_lexer.l
@@ -83,7 +83,7 @@ PPLexTable *pp_lexer_open(FILE *f)
   PPLexTable *lt;
   bool yylex_ok = false;
 
-  assert(f, "pp_lexer_open: passed a NULL file pointer");
+  assert(f, "Passed a NULL file pointer");
 
   lt = (PPLexTable*) malloc (sizeof(PPLexTable));
   setup(lt);

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -83,11 +83,10 @@ static Tconnector * catenate(Tconnector * e1, Tconnector * e2, Pool_desc *tp)
 {
 	Tconnector head;
 	Tconnector *preve = &head;
-	Tconnector *newe = &head;
 
 	for (;e1 != NULL; e1 = e1->next)
 	{
-		newe = pool_alloc(tp);
+		Tconnector *newe = pool_alloc(tp);
 		*newe = *e1;
 
 		preve->next = newe;

--- a/link-grammar/prepare/exprune.c
+++ b/link-grammar/prepare/exprune.c
@@ -11,6 +11,8 @@
 /*                                                                       */
 /*************************************************************************/
 
+#include <inttypes.h>                    // format macros
+
 #include "api-structures.h"              // for Sentence_s
 #include "connectors.h"
 #include "dict-common/dict-structures.h" // expression_stringify
@@ -404,11 +406,11 @@ static void print_expression_disjunct_count(Sentence sent)
 		dcnt = 0;
 		for (const X_node *x = sent->word[i].x; x != NULL; x = x->next)
 			dcnt += count_clause(x->exp);
-		prt_error("%s(%zu) ", sent->word[i].alternatives[0], dcnt);
+		prt_error("%s(%"PRIu64") ", sent->word[i].alternatives[0], dcnt);
 		t += dcnt;
 	}
 	prt_error("\n\\");
-	prt_error("Total: %zu disjuncts\n\n", t);
+	prt_error("Total: %"PRIu64" disjuncts\n\n", t);
 }
 
 void expression_prune(Sentence sent, Parse_Options opts)

--- a/link-grammar/tokenize/README.md
+++ b/link-grammar/tokenize/README.md
@@ -33,9 +33,7 @@ word at once.
 The tokenizing code is still based much on the old code and further
 work is needed to clean it up (or to replace it, e.g. by a
 regex-tokenizer). It still doesn't use the full power of the word-graph,
-and there are constructs that need to be tokenized but they are not (they
-are also not in the sentence test batches). E.g. `--` between words without
-whitespace.
+and there are constructs that need to be tokenized but they are not.
 
 There is still no API to get information from the word-graph. In particular,
 it is not possible to find out the sentence words after punctuation

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -262,11 +262,11 @@ static bool morpheme_match(Sentence sent, const char *word, unsigned int nunits,
 	Dictionary afdict = sent->dict->affix_table;
 	anysplit_params *as = afdict->anysplit;
 	char *word_part = alloca(strlen(word) + 1);
+	size_t bos = 0, upos = 0; /* word offset, unit offset (both in bytes) */
 
 	lgdebug(+D_MM, "word=%s: ", word);
 	for (int p = 0; p < as->nparts; p++)
 	{
-		size_t bos = 0, upos = 0; /* word offset, unit offset (both in bytes) */
 		size_t b = word_upos[pl[p] - 1] - upos;
 		Regex_node *re;
 

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3264,16 +3264,9 @@ static X_node * build_word_expressions(Sentence sent, const Gword *w,
 		 * result is valid (in case of "\*" it means an empty dict or a dict
 		 * only with walls that are not used).  Use a null-expression
 		 * instead, to prevent an error at the caller. */
-		static Exp null_exp =
-		{
-			.type = AND_type,
-			.operand_first = NULL,
-			.operand_next = NULL,
-		};
-
 		y = pool_alloc(sent->X_node_pool);
 		y->next = NULL;
-		y->exp = &null_exp;
+		y->exp = make_zeroary_node(sent->Exp_pool);
 	}
 
 	return x;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -2664,7 +2664,7 @@ static void separate_word(Sentence sent, Gword *unsplit_word, Parse_Options opts
 		 * true:
 		 * - If the root word (temp_word) is known.
 		 * - If the unsplit_word is unknown. This happens with an unknown word
-		 *   that has punctuation after it). */
+		 *   that has punctuation after it. */
 		if (n_stripped > 0)
 		{
 			sz = wend-word;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -505,7 +505,7 @@ static PER_GWORD_FUNC(set_word_status)//(Sentence sent, Gword *w, int *arg)
 #endif /* HAVE_HUNSPELL */
 
 		default:
-			assert(0, "set_dict_word_status: Invalid status 0x%x\n", status);
+			assert(0, "Invalid status 0x%x\n", status);
 	}
 
 	lgdebug(+D_SW, "Word %s: status=%s\n", w->subword, gword_status(sent, w));
@@ -2093,7 +2093,7 @@ static bool strip_right(Sentence sent,
 		return false;
 
 	const char * temp_wend = *wend;
-	assert(temp_wend>w, "strip_right: unexpected empty-string word");
+	assert(temp_wend>w, "Unexpected empty-string word");
 	char *word = alloca(temp_wend-w+1);
 
 	Afdict_class *rword_list = AFCLASS(afdict, classnum);

--- a/link-grammar/tokenize/tokenize.h
+++ b/link-grammar/tokenize/tokenize.h
@@ -19,7 +19,6 @@
 bool separate_sentence(Sentence, Parse_Options);
 bool sentence_in_dictionary(Sentence);
 bool flatten_wordgraph(Sentence, Parse_Options);
-void wordgraph_delete(Sentence);
 void tokenization_done(Sentence, Gword *);
 
 void altappend(Sentence, const char ***, const char *);

--- a/link-grammar/tokenize/wordgraph.h
+++ b/link-grammar/tokenize/wordgraph.h
@@ -30,6 +30,7 @@ Gword *wg_get_sentence_word(const Sentence, Gword *);
 void gwordlist_append_list(const Gword ***, const Gword **);
 #endif
 
+void wordgraph_delete(Sentence);
 const Gword **wordgraph_hier_position(Gword *);
 void print_hier_position(const Gword *);
 bool in_same_alternative(Gword *, Gword *);

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -67,7 +67,7 @@ static unsigned int find_prime_for(size_t count)
 	for (i = 0; i < MAX_S_PRIMES; i ++)
 	   if (count < MAX_TRACON_SET_TABLE_SIZE(s_prime[i])) return i;
 
-	assert(0, "find_prime_for(%zu): Absurdly big count", count);
+	assert(0, "%zu: Absurdly big count", count);
 	return 0;
 }
 
@@ -205,7 +205,7 @@ void tracon_set_shallow(bool shallow, Tracon_set *ss)
 
 Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 {
-	assert(clist != NULL, "Connector-ID: Can't insert a null list");
+	assert(clist != NULL, "Can't insert a null list");
 
 	/* We may need to add it to the table. If the table got too big,
 	 * first we grow it. */

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -925,6 +925,12 @@ open_error:
 						parse_options_set_min_null_count(opts, 1);
 						parse_options_set_max_null_count(opts, sentence_length(sent));
 						num_linkages = sentence_parse(sent, opts);
+						if (num_linkages < 0)
+						{
+							sentence_delete(sent);
+							sent = NULL;
+							continue;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Main changes:
- Windows fix: Work around Python build bug in VS DEBUG build.
- Fix Integer conversion warning (not enabled by default on the POSIX build).
- -Fix Windows/MacOs warnings.
- Fix 3 efficiency bugs.
- -Fix a `dup_word_error()` bug and refactor it.
-  Fix amy/ady REGPRE/REGMID/REGSUF bug (due to a recent change).
-  `ChangeLOg`: Add a note on PCRE2.
- Fix typos/wording.
- Various types of source code cleanup.
- Fix conditions for "Consider increasing the linkage limit" + add FIXME.
  The FIXME needs a discussion (not urgent, since this is a very old problem).

**Important**:
`link-parser lt` gives warnings on affixes in `lt/4.0.affix`.
Since the test suite uses the `lt` dict, it gives warnings too (twice).
This has to be fixed before the next release.

