### PR TITLE
Assorted generation fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Version 5.11.1 (XXX 2022)
  * Fix crash when using the Atomese backend.
- * Fix generation issues.
+ * Fix generation tokenization bug when dict has no unknown word token.
 
 Version 5.11.0 (27 Sept 2022)
  * Prototype support for dictionary in the AtomSpace.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 5.11.1 (XXX 2022)
  * Fix crash when using the Atomese backend.
+ * Fix generation issues.
 
 Version 5.11.0 (27 Sept 2022)
  * Prototype support for dictionary in the AtomSpace.

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -185,13 +185,12 @@ static size_t count_sections(Local* local, const Handle& germ)
 {
 	// Are there any Sections in the local atomspace?
 	size_t nsects = germ->getIncomingSetSizeByType(SECTION);
-	if (0 == nsects and local->stnp)
-	{
-		local->stnp->fetch_incoming_by_type(germ, SECTION);
-		local->stnp->barrier();
-	}
+	if (0 < nsects or nullptr == local->stnp) return nsects;
 
+	local->stnp->fetch_incoming_by_type(germ, SECTION);
+	local->stnp->barrier();
 	nsects = germ->getIncomingSetSizeByType(SECTION);
+
 	return nsects;
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -112,9 +112,11 @@ Disjunct ** sentence_unused_disjuncts(Sentence sent)
 
 #define D_DISJ 5                        /* Verbosity level for this file. */
 
+#ifdef USE_SAT_SOLVER
 /**
  * free_disjuncts() -- free the list of disjuncts pointed to by c
  * (does not free any strings)
+ * Almost dead code -- not used anywhere, except by the SAT solver.
  */
 void free_disjuncts(Disjunct *c)
 {
@@ -126,6 +128,7 @@ void free_disjuncts(Disjunct *c)
 		xfree((char *)c, sizeof(Disjunct));
 	}
 }
+#endif // USE_SAT_SOLVER
 
 void free_categories_from_disjunct_array(Disjunct *dbase,
                                          unsigned int num_disjuncts)

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -830,12 +830,15 @@ static Disjunct *pack_disjunct(Tracon_sharing *ts, Disjunct *d, int w)
 	Disjunct *newd;
 	uintptr_t token;
 
+	size_t off = ts->dblock - ts->dblock_base;
 	newd = ts->dblock++;
 	newd->word_string = d->word_string;
 	newd->cost = d->cost;
 	newd->is_category = d->is_category;
 	newd->originating_gword = d->originating_gword;
 	newd->ordinal = d->ordinal;
+	if (0 == d->ordinal)
+		newd->ordinal = off;
 
 	if (NULL != ts->csid[0])
 	{

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -77,7 +77,9 @@ struct Disjunct_struct
 };
 
 /* Disjunct utilities ... */
+#ifdef USE_SAT_SOLVER
 void free_disjuncts(Disjunct *);
+#endif // USE_SAT_SOLVER
 void free_sentence_disjuncts(Sentence, bool);
 void free_categories(Sentence);
 void free_categories_from_disjunct_array(Disjunct *, unsigned int);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -851,7 +851,7 @@ static void mark_used_disjunct(Parse_set *set, bool *disjunct_used)
 
 	for (Parse_choice *pc = set->first; pc != NULL; pc = pc->next)
 	{
-		if (pc->md->ordinal != -1)
+		if (0 <= pc->md->ordinal)
 			disjunct_used[pc->md->ordinal] = true;
 	}
 }

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -209,6 +209,7 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	print_time(opts, "Built disjuncts");
 
 	bool wildcard_word_found = false;
+	int nord = 0;
 	for (i=0; i<sent->length; i++)
 	{
 		sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d, false);
@@ -219,9 +220,8 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 				/* Also with different word_string. */
 				sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d, true);
 
-				int n = 0;
 				for (Disjunct *d = sent->word[i].d; d != NULL; d = d->next)
-					d->ordinal = n++;
+					d->ordinal = nord++;
 
 				if (!wildcard_word_found)
 				{

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -208,7 +208,6 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 	print_time(opts, "Built disjuncts");
 
-	bool wildcard_word_found = false;
 	int nord = 0;
 	for (i=0; i<sent->length; i++)
 	{
@@ -222,12 +221,6 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 
 				for (Disjunct *d = sent->word[i].d; d != NULL; d = d->next)
 					d->ordinal = nord++;
-
-				if (!wildcard_word_found)
-				{
-					wildcard_word_found = true;
-					create_wildcard_word_disjunct_list(sent, opts);
-				}
 			}
 			else
 			{
@@ -248,6 +241,10 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 			return;
 #endif
 	}
+
+	if (IS_GENERATION(sent->dict))
+		create_wildcard_word_disjunct_list(sent, opts);
+
 	print_time(opts, "Eliminated duplicate disjuncts");
 
 	if (verbosity_level(D_PREP))

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -225,7 +225,10 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 			else
 			{
 				for (Disjunct *d = sent->word[i].d; d != NULL; d = d->next)
-					d->ordinal = -1;
+				{
+					nord++;
+					d->ordinal = -nord;
+				}
 			}
 		}
 #if 0

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -208,7 +208,6 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 	}
 	print_time(opts, "Built disjuncts");
 
-	int nord = 0;
 	for (i=0; i<sent->length; i++)
 	{
 		sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d, false);
@@ -218,17 +217,13 @@ void prepare_to_parse(Sentence sent, Parse_Options opts)
 			{
 				/* Also with different word_string. */
 				sent->word[i].d = eliminate_duplicate_disjuncts(sent->word[i].d, true);
-
 				for (Disjunct *d = sent->word[i].d; d != NULL; d = d->next)
-					d->ordinal = nord++;
+					d->ordinal = 0;
 			}
 			else
 			{
 				for (Disjunct *d = sent->word[i].d; d != NULL; d = d->next)
-				{
-					nord++;
-					d->ordinal = -nord;
-				}
+					d->ordinal = -1;
 			}
 		}
 #if 0

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3326,23 +3326,18 @@ static bool determine_word_expressions(Sentence sent, Gword *w,
 			          w->subword);
 		}
 #endif /* DEBUG */
-		if (dict->unknown_word_defined && dict->use_unknown_word)
-		{
-			bool is_wildcard = IS_GENERATION(dict) &&
-				(NULL != strstr(s, WILDCARD_WORD));
 
-			if (!IS_GENERATION(dict) || !is_wildcard)
-			{
-				we = build_word_expressions(sent, w, UNKNOWN_WORD, opts);
-				assert(we, UNKNOWN_WORD " supposed to be defined in the dictionary!");
-				w->status |= WS_UNKNOWN;
-			}
-			else
-			{
-				lgdebug(+D_DWE, "Wildcard word %s\n", s);
-				we = build_word_expressions(sent, w, NULL, opts);
-				w->status = WS_INDICT; /* Prevent marking as "unknown word". */
-			}
+		if (IS_GENERATION(dict) && (NULL != strstr(s, WILDCARD_WORD)))
+		{
+			lgdebug(+D_DWE, "Wildcard word %s\n", s);
+			we = build_word_expressions(sent, w, NULL, opts);
+			w->status = WS_INDICT; /* Prevent marking as "unknown word". */
+		}
+		else if (dict->unknown_word_defined && dict->use_unknown_word)
+		{
+			we = build_word_expressions(sent, w, UNKNOWN_WORD, opts);
+			assert(we, UNKNOWN_WORD " supposed to be defined in the dictionary!");
+			w->status |= WS_UNKNOWN;
 		}
 		else
 		{

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -3686,7 +3686,8 @@ bool sentence_in_dictionary(Sentence sent)
 		for (ialt=0; NULL != sent->word[w].alternatives[ialt]; ialt++)
 		{
 			s = sent->word[w].alternatives[ialt];
-			if (!dictionary_word_is_known(dict, s))
+			if (!dictionary_word_is_known(dict, s) &&
+			    !(IS_GENERATION(dict) && (NULL != strstr(s, WILDCARD_WORD))))
 			{
 				if (ok_so_far)
 				{

--- a/man/link-generator.1
+++ b/man/link-generator.1
@@ -171,6 +171,22 @@ linkages, then more than one sentence will be printed for each
 linkage. Each sentence will have a distinct random word-choice for
 that linkage.
 
+.TP
+.B \-d\fR, \fB\-\-disjuncts\fR
+Display linkage disjuncts.
+
+.TP
+.B \-\-no\-walls\fR
+Don't attach to walls in wildcard words.
+
+.TP
+.B \-r\fR, \fB\-\-random\fR
+Use unrepeatable random numbers.
+
+.TP
+.B \-u\fR, \fB\-\-unused\fR
+Display unused disjuncts.
+
 .SH SEE ALSO
 .nh
 The \%link\-parser is a command-line tool for parsing sentences. It


### PR DESCRIPTION
Several fixes in this pull req. In chronological order:
1. A minor Atomese fix
2. Genereation accidentally required `UNKNOWN-WORD` to be present in the dict.
3. Fix ordinal numbering for unused disjuncts.

FYI @ampli -- The for the last two fixes can be verified by using this dict:
```
LEFT-WALL: A+;
this: A- & B+;
is: B-;
```
and then 
```
link-generator -l ../data/foo -s2  -u
```

Apparently, `LEFT-WALL` is not in any category, which resulted in an off-by-one numbering.