### PR TITLE
link-generator: Provide fix for missing disjunct costs.

### DIFF
--- a/link-grammar/linkage/linkage.c
+++ b/link-grammar/linkage/linkage.c
@@ -903,8 +903,13 @@ float linkage_get_disjunct_cost(const Linkage linkage, WordIdx w)
 	dj = linkage->chosen_disjuncts[w];
 
 	/* dj may be null, if the word didn't participate in the parse. */
-	if (dj) return dj->cost;
-	return 0.0;
+	if (NULL == dj)
+		return 0.0;
+
+	if (dj->is_category)
+		return dj->category[0].cost;
+
+	return dj->cost;
 }
 
 const char * linkage_get_word(const Linkage linkage, WordIdx w)

--- a/link-grammar/linkage/score.c
+++ b/link-grammar/linkage/score.c
@@ -61,8 +61,9 @@ static float compute_disjunct_cost(Linkage lkg)
 	lcost =  0.0;
 	for (i = 0; i < lkg->num_words; i++)
 	{
-		if (lkg->chosen_disjuncts[i] != NULL)
-			lcost += lkg->chosen_disjuncts[i]->cost;
+		Disjunct * dj = lkg->chosen_disjuncts[i];
+		if (dj != NULL)
+			lcost += dj->is_category ? dj->category[0].cost : dj->cost;
 	}
 	return lcost;
 }


### PR DESCRIPTION
Costs on disjuncts were missing, when the generator was running.