### PR TITLE
Configuration and word-pair support

### DIFF
--- a/data/demo-atomese/atomese-dict.scm
+++ b/data/demo-atomese/atomese-dict.scm
@@ -201,24 +201,24 @@
 ; with "ANY" connector types. These connect to "ANY" connectors that are
 ; added to word-pair disjuncts.
 ;
-(Evaluation (Predicate "*-word pair-*") (List (Word "###LEFT-WALL###") (Word "jumped")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "###LEFT-WALL###") (Word "fish")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "the") (Word "fish")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "fish") (Word "jumped")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "jumped") (Word "out")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "out") (Word "water")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "of") (Word "water")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "the") (Word "water")))
-(Evaluation (Predicate "*-word pair-*") (List (Word "out") (Word "of")))
+(Evaluation (Predicate "wrdpr") (List (Word "###LEFT-WALL###") (Word "jumped")))
+(Evaluation (Predicate "wrdpr") (List (Word "###LEFT-WALL###") (Word "fish")))
+(Evaluation (Predicate "wrdpr") (List (Word "the") (Word "fish")))
+(Evaluation (Predicate "wrdpr") (List (Word "fish") (Word "jumped")))
+(Evaluation (Predicate "wrdpr") (List (Word "jumped") (Word "out")))
+(Evaluation (Predicate "wrdpr") (List (Word "out") (Word "water")))
+(Evaluation (Predicate "wrdpr") (List (Word "of") (Word "water")))
+(Evaluation (Predicate "wrdpr") (List (Word "the") (Word "water")))
+(Evaluation (Predicate "wrdpr") (List (Word "out") (Word "of")))
 
 ; Set costs on two of the pairs.
 (cog-set-value!
-	(Evaluation (Predicate "*-word pair-*") (List (Word "the") (Word "fish")))
+	(Evaluation (Predicate "wrdpr") (List (Word "the") (Word "fish")))
 	(Predicate "*-Mutual Info Key-*")
 	(FloatValue 0 3.1))
 
 (cog-set-value!
-	(Evaluation (Predicate "*-word pair-*") (List (Word "jumped") (Word "out")))
+	(Evaluation (Predicate "wrdpr") (List (Word "jumped") (Word "out")))
 	(Predicate "*-Mutual Info Key-*")
 	(FloatValue 0 4.2))
 

--- a/data/demo-atomese/atomese-dict.scm
+++ b/data/demo-atomese/atomese-dict.scm
@@ -193,8 +193,8 @@
 ; will NOT parse, because there is no word pair with "water" coming before
 ; "jumped".
 ;
-(Evaluation (LgLink "ANY") (List (Word "###LEFT_WALL###") (Word "jumped")))
-(Evaluation (LgLink "ANY") (List (Word "###LEFT_WALL###") (Word "fish")))
+(Evaluation (LgLink "ANY") (List (Word "###LEFT-WALL###") (Word "jumped")))
+(Evaluation (LgLink "ANY") (List (Word "###LEFT-WALL###") (Word "fish")))
 (Evaluation (LgLink "ANY") (List (Word "the") (Word "fish")))
 (Evaluation (LgLink "ANY") (List (Word "fish") (Word "jumped")))
 (Evaluation (LgLink "ANY") (List (Word "jumped") (Word "out")))

--- a/data/demo-atomese/atomese-dict.scm
+++ b/data/demo-atomese/atomese-dict.scm
@@ -15,7 +15,9 @@
 ;
 ; ---------------------------------------------------------------------
 ; The four sections below allow one and only one phrase to be parsed:
-; "level playing field".
+; "level playing field". These sections are directly converted into
+; Link Grammar disjuncts having the same connectors, except that the
+; LG connectors are single links, that stand in for the connected words.
 
 (Section
 	(Word "###LEFT-WALL###")
@@ -193,24 +195,30 @@
 ; will NOT parse, because there is no word pair with "water" coming before
 ; "jumped".
 ;
-(Evaluation (LgLink "ANY") (List (Word "###LEFT-WALL###") (Word "jumped")))
-(Evaluation (LgLink "ANY") (List (Word "###LEFT-WALL###") (Word "fish")))
-(Evaluation (LgLink "ANY") (List (Word "the") (Word "fish")))
-(Evaluation (LgLink "ANY") (List (Word "fish") (Word "jumped")))
-(Evaluation (LgLink "ANY") (List (Word "jumped") (Word "out")))
-(Evaluation (LgLink "ANY") (List (Word "out") (Word "water")))
-(Evaluation (LgLink "ANY") (List (Word "of") (Word "water")))
-(Evaluation (LgLink "ANY") (List (Word "the") (Word "water")))
-(Evaluation (LgLink "ANY") (List (Word "out") (Word "of")))
+; The configuration file enables the automatic insertion of "ANY" links
+; into disjuncts. Thus, sentences like "Olga saw the fish" will also parse,
+; because "Olga" and "saw" are in the dictionary (above), and are decorated
+; with "ANY" connector types. These connect to "ANY" connectors that are
+; added to word-pair disjuncts.
+;
+(Evaluation (Predicate "*-word pair-*") (List (Word "###LEFT-WALL###") (Word "jumped")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "###LEFT-WALL###") (Word "fish")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "the") (Word "fish")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "fish") (Word "jumped")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "jumped") (Word "out")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "out") (Word "water")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "of") (Word "water")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "the") (Word "water")))
+(Evaluation (Predicate "*-word pair-*") (List (Word "out") (Word "of")))
 
 ; Set costs on two of the pairs.
 (cog-set-value!
-	(Evaluation (LgLink "ANY") (List (Word "the") (Word "fish")))
+	(Evaluation (Predicate "*-word pair-*") (List (Word "the") (Word "fish")))
 	(Predicate "*-Mutual Info Key-*")
 	(FloatValue 0 3.1))
 
 (cog-set-value!
-	(Evaluation (LgLink "ANY") (List (Word "jumped") (Word "out")))
+	(Evaluation (Predicate "*-word pair-*") (List (Word "jumped") (Word "out")))
 	(Predicate "*-Mutual Info Key-*")
 	(FloatValue 0 4.2))
 

--- a/data/demo-atomese/atomese-dict.scm
+++ b/data/demo-atomese/atomese-dict.scm
@@ -9,7 +9,7 @@
 ; It is intended that this file can be read in using the
 ; FileStorageNode provided by the AtomSpace.
 ;
-; CAUTION: IF YOU EDIT THIS FILE, BE SRE TO `MAKE INSTALL` AFTERWARDS.
+; CAUTION: IF YOU EDIT THIS FILE, BE SURE TO `MAKE INSTALL` AFTERWARDS.
 ; That is because the `storage.dict` is configured to get this file
 ; from the install location, and not the source tree!
 ;
@@ -171,4 +171,48 @@
 (Section (Word "6")
 	(ConnectorSeq (Connector (Word "fountain") (ConnectorDir "-"))))
 
+; ---------------------------------------------------------------------
+; Disjuncts can also be constructed from individual word-pairs. Using
+; these will results in a Maximum Spanning Tree (MST) or Maximum Planar
+; Graph (MPG) parse. Such disjuncts are not as "rigid" as those specified
+; by sections; instead they may have a variable number of connectors
+; in arbitrary order, preserving only the word order in the parsed
+; sentence.
+;
+; When used with existing disjuncts (controllable in the configuration
+; file), the use of word-pairs can supplement a poor selection of
+; disjuncts by adding additional (optional) links determined by the word
+; pairs.
+;
+; An example vocabulary is given below.  This allows sentences such as
+; "the fish jumped out of the water" to be parsed, as well as shorter
+; sentences made up of these same words, such as "the fish jumped" and
+; "jumped out", "out of water". There is no grammatical structure to what
+; can be parsed in this way, other than that there must be some word-pair
+; occurring in proper sentence order. Thus, for example "water jumped"
+; will NOT parse, because there is no word pair with "water" coming before
+; "jumped".
+;
+(Evaluation (LgLink "ANY") (List (Word "###LEFT_WALL###") (Word "jumped")))
+(Evaluation (LgLink "ANY") (List (Word "###LEFT_WALL###") (Word "fish")))
+(Evaluation (LgLink "ANY") (List (Word "the") (Word "fish")))
+(Evaluation (LgLink "ANY") (List (Word "fish") (Word "jumped")))
+(Evaluation (LgLink "ANY") (List (Word "jumped") (Word "out")))
+(Evaluation (LgLink "ANY") (List (Word "out") (Word "water")))
+(Evaluation (LgLink "ANY") (List (Word "of") (Word "water")))
+(Evaluation (LgLink "ANY") (List (Word "the") (Word "water")))
+(Evaluation (LgLink "ANY") (List (Word "out") (Word "of")))
+
+; Set costs on two of the pairs.
+(cog-set-value!
+	(Evaluation (LgLink "ANY") (List (Word "the") (Word "fish")))
+	(Predicate "*-Mutual Info Key-*")
+	(FloatValue 0 3.1))
+
+(cog-set-value!
+	(Evaluation (LgLink "ANY") (List (Word "jumped") (Word "out")))
+	(Predicate "*-Mutual Info Key-*")
+	(FloatValue 0 4.2))
+
+;
 ; ---------------------------------------------------------------------

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -109,16 +109,6 @@
 % config paramters.
 #define enable-sections 1;
 
-% Create expressions that consist entirely of word-pair relationships.
-% The disjuncts will have up to the specified number of connectors; 4 is
-% the defualt. Setting this to zero disables the creation of such
-% disjuncts. If `enable-sections` above is turned off, the result will be
-% pure MPG parsing.
-%
-% Each connector has a cost is that is determined by the config parameters,
-% above.
-#define pair-disjuncts 4;
-
 % Supplement existing sections with optional links, determined from
 % word-pair relations. Inside pairs reach out from the middle of the
 % disjunt; outside pairs are at the edges.  For example, if an existing
@@ -144,13 +134,36 @@
 % so that these are more costly than existing word-pairs.
 %
 % Setting to zero disables this.
-% If sections are disabled, the last four parameters have no effect.
-#define any-disjuncts 4;
+% If sections are disabled, the these parameters have no effect.
 #define left-inside-any 2;
 #define right-inside-any 2;
 #define left-outside-any 2;
 #define right-outside-any 2;
 
+% Create expressions that consist entirely of word-pair relationships.
+% The disjuncts will have up to the specified number of connectors; 4 is
+% the default. Setting this to zero disables the creation of such
+% disjuncts. If `enable-sections` above is turned off, the result will be
+% pure MPG parsing.
+%
+% Each connector has a cost is that is determined by the config parameters,
+% above.
+#define pair-disjuncts 4;
+
+% Supplement the above with additional connectors of type "ANY". This is
+% useful for providing links between words that don't already exist as
+% pairs in the dataset.
+#define pair-with-any 2;
+
+% Create expressions that consist entirely of "ANY" link-types.
+% The disjuncts will have up to the specified number of connectors; 4 is
+% the default. Setting this to zero disables the creation of such
+% disjuncts. If `enable-sections` and `pair-disjuncts` (above) are turned
+% off, the result will be pure random planar tree parsing.
+%
+% Each connector has a cost is that is determined by the config parameters,
+% above.
+#define any-disjuncts 4;
 
 % -----------------------
 % For this file to be read, at least one bogus entry is needed. It is

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -119,22 +119,23 @@
 % config paramters.
 #define enable-sections 1;
 
-% Supplement existing sections with optional links, determined from
-% word-pair relations. Inside pairs reach out from the middle of the
-% disjunt; outside pairs are at the edges.  For example, if an existing
-% disjunct `A- & B+` is supplemented with pairs, the new disjunct will be
-% `{LO-} & A- & {LI-} & {RI+} & B+ & {RO+}`, where `LI`, `LO`, `RI` and
-% `RO` are connectors that are obtained from word-pairs. The cost of these
-% connectors is determined by the pair-config, above.
+% Supplement existing sections with optional links, obtained from word-
+% pair relations.  For example, if an existing disjunct `A- & B+` on word
+% "wrd" is supplemented with pairs, the new disjunct will be
+% `{J- or K+} & A- & B+ & {L- or M+}`, where `J-` and `L-` are obtained
+% from pairs of the form ("other", "wrd") and `K+` and `M+` are obtained
+% from pairs of the for ("wrd", "more"). That is, the links `J`, `K`, `L`
+% and `M` are formed only if the AtomSpace has the corresponding word-pairs
+% in it.
+%
+% The cost of these connectors is determined by the pair-config, above.
 %
 % If set to zero, these supplementary links will not be generated. If set
 % to 2 or more, then that many extra optional connectors will be added.
 %
 % If sections are not enabled, then these parameters have no effect.
-#define left-inside-pairs 1;
-#define right-inside-pairs 1;
-#define left-outside-pairs 1;
-#define right-outside-pairs 1;
+#define left-pairs 1;
+#define right-pairs 1;
 
 % Same as above, but the supplementary connectors will all be of type `ANY`,
 % and thus can connect to anything. Since these can connect to anything,
@@ -145,10 +146,8 @@
 %
 % Setting to zero disables this.
 % If sections are disabled, the these parameters have no effect.
-#define left-inside-any 2;
-#define right-inside-any 2;
-#define left-outside-any 2;
-#define right-outside-any 2;
+#define left-any 2;
+#define right-any 2;
 
 % Create expressions that consist entirely of word-pair relationships.
 % The disjuncts will have up to the specified number of connectors; 4 is

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -88,6 +88,70 @@
 #define pair-cutoff 8.0;
 #define pair-default 2.0;
 
+% Default cost for `ANY` link types
+#define any-default 3.0;
+
+% -----------------------
+% Data structure configuration. By default, Link Grammar expressions and
+% disjuncts are created from Atomese Sections. But they can also be created
+% from word-pairs, thus offering a form of Maximum Spanning Tree (MST)
+% parsing, and Maximum Planar Graph (MPG) parsing. Also, existing sections
+% can be supplemented with word-pair links ("optional expressions", in LG).
+% Finally, if word pairs are not in the dictionary, but are needed to
+% obtain a full parse, the ANY link type can be used to provide the missing
+% link. Finally, if sections and word-pairs are disabled, but ANY is
+% enabled, then the parses will be random planar graphs, with a uniform
+% sampling (Just like the `any` language, each graph appears with equal
+% probability).  There are a dozen parameters that control the above.
+%
+% Obtain expressions from Atomese Sections. The default mode.
+% Set to 0 to disable.  Each section has a cost determined by the above
+% config paramters.
+#define enable-sections 1;
+
+% Create expressions that consist entirely of word-pair relationships.
+% The disjuncts will have up to the specified number of connectors; 4 is
+% the defualt. Setting this to zero disables the creation of such
+% disjuncts. If `enable-sections` above is turned off, the result will be
+% pure MPG parsing.
+%
+% Each connector has a cost is that is determined by the config parameters,
+% above.
+#define pair-disjuncts 4;
+
+% Supplement existing sections with optional links, determined from
+% word-pair relations. Inside pairs reach out from the middle of the
+% disjunt; outside pairs are at the edges.  For example, if an existing
+% disjunct `A- & B+` is supplemented with pairs, the new disjunct will be
+% `{LO-} & A- & {LI-} & {RI+} & B+ & {RO+}`, where `LI`, `LO`, `RI` and
+% `RO` are connectors that are obtained from word-pairs. The cost of these
+% connectors is determined by the pair-config, above.
+%
+% If set to zero, these supplementary links will not be generated. If set
+% to 2 or more, then that many extra optional connectors will be added.
+%
+% If sections are not enabled, then these parameters have no effect.
+#define left-inside-pairs 1;
+#define right-inside-pairs 1;
+#define left-outside-pairs 1;
+#define right-outside-pairs 1;
+
+% Same as above, but the supplementary connectors will all be of type `ANY`,
+% and thus can connect to anything. Since these can connect to anything,
+% they will not, in general, improve the parse. They are mostly useful for
+% dealing with new, unknown words, and generating quasi-random linkages to
+% those unknown words. The be effective, the cost should be set high enough
+% so that these are more costly than existing word-pairs.
+%
+% Setting to zero disables this.
+% If sections are disabled, the last four parameters have no effect.
+#define any-disjuncts 4;
+#define left-inside-any 2;
+#define right-inside-any 2;
+#define left-outside-any 2;
+#define right-outside-any 2;
+
+
 % -----------------------
 % For this file to be read, at least one bogus entry is needed. It is
 % meaningless; we only need to trick the code into reading this file.

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -152,7 +152,8 @@
 
 % Supplement the above with additional connectors of type "ANY". This is
 % useful for providing links between words that don't already exist as
-% pairs in the dataset.
+% pairs in the dataset. This has no effect, if `pair-disjuncts` (above)
+% is set to zero.
 #define pair-with-any 2;
 
 % Create expressions that consist entirely of "ANY" link-types.

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -80,6 +80,11 @@
 % `cost-max`.
 #define cost-default 2.0;
 
+% Word-pairs are encoded in the dictionary as
+%    (Evaluation pair-predicate (List (Word "leftword") (Word "rightword")))
+% The pair-predicate is configureable, as below.
+#define pair-predicate "(Predicate \"*-word pair-*\")";
+
 % Same as above, but for word-pairs. Note the different key!
 #define pair-key "(Predicate \"*-Mutual Info Key-*\")";
 #define pair-index 1;
@@ -89,7 +94,7 @@
 #define pair-default 2.0;
 
 % Default cost for `ANY` link types
-#define any-default 3.0;
+#define any-default 2.6;
 
 % -----------------------
 % Data structure configuration. By default, Link Grammar expressions and

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -83,7 +83,12 @@
 % Word-pairs are encoded in the dictionary as
 %    (Evaluation pair-predicate (List (Word "leftword") (Word "rightword")))
 % The pair-predicate is configureable, as below.
-#define pair-predicate "(Predicate \"*-word pair-*\")";
+#define pair-predicate "(Predicate \"wrdpr\")";
+
+% Due to historical design decisions, existing dictionaries use the
+% (LgLinkNode "ANY") to mark word pairs. We note this here, as a reminder.
+% Its commented out, because the demo does not use it.
+% #define pair-predicate "(LgLink \"ANY\")";
 
 % Same as above, but for word-pairs. Note the different key!
 #define pair-key "(Predicate \"*-Mutual Info Key-*\")";

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -64,7 +64,7 @@ Exp* make_pair_exprs(Dictionary dict, const Handle& germ);
 Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity);
 Exp* make_any_exprs(Dictionary dict, int arity);
 
-void or_enchain(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
+void or_enchain(Dictionary, Exp* &orhead, Exp*);
 void and_enchain_left(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
 void and_enchain_right(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
 

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -41,19 +41,24 @@ public:
 	// Any link type
 	double any_default;
 
-	// Supplements
+	// Basic Sections
 	bool enable_sections;
-	int pair_disjuncts;
+
+	// Supplements
 	int left_inside_pairs;
 	int right_inside_pairs;
 	int left_outside_pairs;
 	int right_outside_pairs;
 
-	int any_disjuncts;
 	int left_inside_any;
 	int right_inside_any;
 	int left_outside_any;
 	int right_outside_any;
+
+	// Disjuncts made from pairs
+	int pair_disjuncts;
+	int pair_with_any;
+	int any_disjuncts;
 };
 
 bool section_boolean_lookup(Dictionary dict, const char *s);

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -20,6 +20,7 @@ public:
 	StorageNodePtr stnp;
 	Handle linkp;     // (Predicate "*-LG connector string-*")
 	// Handle djp;       // (Predicate "*-LG disjunct string-*")
+	Handle prk;       // (Predicate "*-fetched-pair-*")
 
 	// Sections
 	Handle miks;      // (Predicate "*-Mutual Info Key cover-section")

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -64,4 +64,6 @@ Exp* make_pair_exprs(Dictionary dict, const Handle& germ);
 Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity);
 Exp* make_any_exprs(Dictionary dict, int arity);
 
+void or_enchain(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
+
 std::string cached_linkname(Local*, const Handle& pair);

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -65,5 +65,7 @@ Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity);
 Exp* make_any_exprs(Dictionary dict, int arity);
 
 void or_enchain(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
+void and_enchain_left(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
+void and_enchain_right(Dictionary, Exp* &orhead, Exp* &ortail, Exp*);
 
 std::string cached_linkname(Local*, const Handle& pair);

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -37,6 +37,23 @@ public:
 	double pair_offset;
 	double pair_cutoff;
 	double pair_default;
+
+	// Any link type
+	double any_default;
+
+	// Supplements
+	bool enable_sections;
+	int pair_disjuncts;
+	int left_inside_pairs;
+	int right_inside_pairs;
+	int left_outside_pairs;
+	int right_outside_pairs;
+
+	int any_disjuncts;
+	int left_inside_any;
+	int right_inside_any;
+	int left_outside_any;
+	int right_outside_any;
 };
 
 bool section_boolean_lookup(Dictionary dict, const char *s);

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -62,6 +62,7 @@ public:
 };
 
 bool section_boolean_lookup(Dictionary dict, const char *s);
+bool pair_boolean_lookup(Dictionary dict, const char *s);
 
 Exp* make_exprs(Dictionary dict, const Handle& germ);
 Exp* make_sect_exprs(Dictionary dict, const Handle& germ);

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -20,7 +20,6 @@ public:
 	StorageNodePtr stnp;
 	Handle linkp;     // (Predicate "*-LG connector string-*")
 	// Handle djp;       // (Predicate "*-LG disjunct string-*")
-	Handle lany;      // (LgLinkNode "ANY")
 
 	// Sections
 	Handle miks;      // (Predicate "*-Mutual Info Key cover-section")
@@ -31,6 +30,7 @@ public:
 	double cost_default;
 
 	// Word-pairs
+	Handle prp;       // (Predicate "*-word pair-*")
 	Handle mikp;      // (Predicate "*-Mutual Info Key-*")
 	int pair_index;   // Offset into the FloatValue
 	double pair_scale;

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -45,15 +45,11 @@ public:
 	bool enable_sections;
 
 	// Supplements
-	int left_inside_pairs;
-	int right_inside_pairs;
-	int left_outside_pairs;
-	int right_outside_pairs;
+	int left_pairs;
+	int right_pairs;
 
-	int left_inside_any;
-	int right_inside_any;
-	int left_outside_any;
-	int right_outside_any;
+	int left_any;
+	int right_any;
 
 	// Disjuncts made from pairs
 	int pair_disjuncts;

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -315,16 +315,10 @@ void and_enchain_right(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
 
 	/* Link new connectors to the tail */
 	if (nullptr == andtail)
-	{
-		andtail = andhead;
-		item->operand_next = andhead->operand_first;
-		andhead->operand_first = item;
-	}
-	else
-	{
-		andtail->operand_next = item;
-		andtail = item;
-	}
+		andtail = andhead->operand_first;
+
+	andtail->operand_next = item;
+	andtail = item;
 }
 
 Exp* make_exprs(Dictionary dict, const Handle& germ)

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -286,6 +286,46 @@ void or_enchain(Dictionary dict, Exp* &orhead, Exp* &ortail, Exp* item)
 	ortail = item;
 }
 
+void and_enchain_left(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
+{
+	if (nullptr == item) return; // no-op
+	if (nullptr == andhead)
+	{
+		andhead = make_and_node(dict->Exp_pool, item, NULL);
+		return;
+	}
+
+	/* Link new connectors to the head */
+	item->operand_next = andhead->operand_first;
+	andhead->operand_first = item;
+
+	if (nullptr == andtail)
+		andtail = item->operand_next;
+}
+
+void and_enchain_right(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
+{
+	if (nullptr == item) return; // no-op
+	if (nullptr == andhead)
+	{
+		andhead = make_and_node(dict->Exp_pool, item, NULL);
+		return;
+	}
+
+	/* Link new connectors to the tail */
+	if (nullptr == andtail)
+	{
+		andtail = andhead;
+		item->operand_next = andhead->operand_first;
+		andhead->operand_first = item;
+	}
+	else
+	{
+		andtail->operand_next = item;
+		andtail = item;
+	}
+}
+
 Exp* make_exprs(Dictionary dict, const Handle& germ)
 {
 	Local* local = (Local*) (dict->as_server);
@@ -310,6 +350,10 @@ Exp* make_exprs(Dictionary dict, const Handle& germ)
 		Exp* sects = make_sect_exprs(dict, germ);
 		or_enchain(dict, orhead, ortail, sects);
 	}
+
+	if (nullptr == ortail)
+		prt_error("Error: No expressions for the word `%s`\n",
+			germ->get_name().c_str());
 
 	if (nullptr == orhead) return ortail;
 	return orhead;

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -129,6 +129,9 @@ bool as_open(Dictionary dict)
 	// local->djp = local->asp->add_node(PREDICATE_NODE,
 	//	"*-LG disjunct string-*");
 
+	// Internal-use only. Do we have this pair yet?
+	local->prk = local->asp->add_node(PREDICATE_NODE, "*-fetched-pair-*");
+
 	// Costs are assumed to be minus the MI located at some key.
 	const char* miks = get_dict_define(dict, COST_KEY_STRING);
 	Handle mikh = Sexpr::decode_atom(miks);

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -89,6 +89,15 @@ static const char* get_dict_define(Dictionary dict, const char* namestr)
 	return string_set_add(unescaped, dict->string_set);
 }
 
+static const char* ldef(Dictionary dict, const char* name, const char* def)
+{
+	const char* str = linkgrammar_get_dict_define(dict, name);
+	if (str) return str;
+	prt_error("Warning: missing `%s` in config; default to %s\n",
+		 name, def);
+	return def;
+}
+
 /// Open a connection to a StorageNode.
 bool as_open(Dictionary dict)
 {
@@ -133,12 +142,7 @@ bool as_open(Dictionary dict)
 	Handle miki = Sexpr::decode_atom(mikp);
 	local->mikp = local->asp->add_atom(miki);
 
-	const char * str;
-#define LDEF(NAME,FLT) \
-	str = linkgrammar_get_dict_define(dict, NAME) ?  str : \
-		({ prt_error( \
-			"Warning: missing `%s` in config; default to %s\n", \
-			 NAME, FLT); FLT; })
+#define LDEF(NAME,DEF) ldef(dict, NAME, DEF)
 
 	local->cost_index = atoi(LDEF(COST_INDEX_STRING, "1"));
 	local->cost_scale = atof(LDEF(COST_SCALE_STRING, "-0.2"));

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -279,13 +279,22 @@ bool as_boolean_lookup(Dictionary dict, const char *s)
 
 // ===============================================================
 
+/// Add `item` to the linked list `orhead`, using a OR operator.
 void or_enchain(Dictionary dict, Exp* &orhead, Exp* item)
 {
 	if (nullptr == item) return; // no-op
 
 	if (nullptr == orhead)
 	{
-		orhead = make_or_node(dict->Exp_pool, item, NULL);
+		orhead = item;
+		return;
+	}
+
+	// Unary OR-nodes are not allowed; they will cause assorted
+	// algos to croak. So the first OR node must have two.
+	if (OR_type != orhead->type)
+	{
+		orhead = make_or_node(dict->Exp_pool, item, orhead);
 		return;
 	}
 
@@ -294,6 +303,9 @@ void or_enchain(Dictionary dict, Exp* &orhead, Exp* item)
 	orhead->operand_first = item;
 }
 
+/// Add `item` to the left end of the linked list `andhead`, using
+/// an AND operator. The `andtail` is used to track the right side
+/// of the list.
 void and_enchain_left(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
 {
 	if (nullptr == item) return; // no-op
@@ -311,6 +323,9 @@ void and_enchain_left(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
 		andtail = item->operand_next;
 }
 
+/// Add `item` to the right end of the linked list `andhead`, using
+/// an AND operator. The `andtail` is used to track the right side
+/// of the list.
 void and_enchain_right(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
 {
 	if (nullptr == item) return; // no-op
@@ -328,6 +343,10 @@ void and_enchain_right(Dictionary dict, Exp* &andhead, Exp* &andtail, Exp* item)
 	andtail = item;
 }
 
+/// Build expressions for the dictionary word held by `germ`.
+/// Exactly what is built is controlled by the configuration:
+/// it will be some mixture of sections, word-pairs, and ANY
+/// links.
 Exp* make_exprs(Dictionary dict, const Handle& germ)
 {
 	Local* local = (Local*) (dict->as_server);

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -93,7 +93,7 @@ static const char* ldef(Dictionary dict, const char* name, const char* def)
 	const char* str = linkgrammar_get_dict_define(dict, name);
 	if (str) return str;
 	prt_error("Warning: missing `%s` in config; default to %s\n",
-		 name, def);
+		name, def);
 	return def;
 }
 
@@ -272,10 +272,14 @@ bool as_boolean_lookup(Dictionary dict, const char *s)
 		s = "###LEFT-WALL###";
 
 	if (local->enable_sections)
-		found = found or section_boolean_lookup(dict, s);
+		found = section_boolean_lookup(dict, s);
 
-	if (0 < local->pair_disjuncts)
-		found = found or pair_boolean_lookup(dict, s);
+	if (0 < local->pair_disjuncts or
+	    0 < local->left_pairs or 0 < local->right_pairs)
+	{
+		bool have_pairs = pair_boolean_lookup(dict, s);
+		found = found or have_pairs;
+	}
 
 	return found;
 }
@@ -373,10 +377,8 @@ Exp* make_exprs(Dictionary dict, const Handle& germ)
 		if (0 < local->pair_with_any)
 		{
 			Exp* ap = make_any_exprs(dict, local->pair_with_any);
-			if (cpr)
-				cpr = make_and_node(dict->Exp_pool, cpr, ap);
-			else
-				cpr = ap;
+			Exp* dummy;
+			and_enchain_left(dict, cpr, dummy, ap);
 		}
 		or_enchain(dict, orhead, cpr);
 	}

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -342,7 +342,8 @@ Exp* make_exprs(Dictionary dict, const Handle& germ)
 	}
 
 	// Create disjuncts consisting entirely of word-pair links.
-	if (0 < local->pair_disjuncts)
+	if (0 < local->pair_disjuncts or
+	    0 < local->left_pairs or 0 < local->right_pairs)
 	{
 		Exp* cpr = make_cart_pairs(dict, germ, local->pair_disjuncts);
 

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -266,13 +266,21 @@ void as_close(Dictionary dict)
 /// else return false.
 bool as_boolean_lookup(Dictionary dict, const char *s)
 {
+	Local* local = (Local*) (dict->as_server);
+
 	bool found = dict_node_exists_lookup(dict, s);
 	if (found) return true;
 
 	if (0 == strcmp(s, LEFT_WALL_WORD))
 		s = "###LEFT-WALL###";
 
-	return section_boolean_lookup(dict, s);
+	if (local->enable_sections)
+		found = found or section_boolean_lookup(dict, s);
+
+	if (0 < local->pair_disjuncts)
+		found = found or pair_boolean_lookup(dict, s);
+
+	return found;
 }
 
 // ===============================================================

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -47,6 +47,22 @@ using namespace opencog;
 #define PAIR_CUTOFF_STRING "pair-cutoff"
 #define PAIR_DEFAULT_STRING "pair-default"
 
+#define ANY_DEFAULT_STRING "any-default"
+#define ENABLE_SECTIONS_STRING "enable-sections"
+
+#define PAIR_DISJUNCTS_STRING "pair-disjuncts"
+#define LEFT_INSIDE_PAIRS_STRING "left-inside-pairs"
+#define RIGHT_INSIDE_PAIRS_STRING "right-inside-pairs"
+#define LEFT_OUTSIDE_PAIRS_STRING "left-outside-pairs"
+#define RIGHT_OUTSIDE_PAIRS_STRING "right-outside-pairs"
+
+#define ANY_DISJUNCTS_STRING "any-disjuncts"
+#define LEFT_INSIDE_ANY_STRING "left-inside-any"
+#define RIGHT_INSIDE_ANY_STRING "right-inside-any"
+#define LEFT_OUTSIDE_ANY_STRING "left-outside-any"
+#define RIGHT_OUTSIDE_ANY_STRING "right-outside-any"
+
+
 /// Shared global
 static AtomSpacePtr external_atomspace;
 static StorageNodePtr external_storage;
@@ -121,7 +137,8 @@ bool as_open(Dictionary dict)
 #define LDEF(NAME,FLT) \
 	str = linkgrammar_get_dict_define(dict, NAME) ?  str : \
 		({ prt_error( \
-			"Warning: missing parameter `%s` in config file\n", NAME); FLT; })
+			"Warning: missing parameter `%s` in config file; default to %s\n", \
+			 NAME, FLT); FLT; })
 
 	local->cost_index = atoi(LDEF(COST_INDEX_STRING, "1"));
 	local->cost_scale = atof(LDEF(COST_SCALE_STRING, "-0.2"));
@@ -134,6 +151,21 @@ bool as_open(Dictionary dict)
 	local->pair_offset = atof(LDEF(PAIR_OFFSET_STRING, "0"));
 	local->pair_cutoff = atof(LDEF(PAIR_CUTOFF_STRING, "6"));
 	local->pair_default = atof(LDEF(PAIR_DEFAULT_STRING, "1.0"));
+
+	local->any_default = atof(LDEF(ANY_DEFAULT_STRING, "3.0"));
+	local->enable_sections = atoi(LDEF(ENABLE_SECTIONS_STRING, "1"));
+
+	local->pair_disjuncts = atoi(LDEF(PAIR_DISJUNCTS_STRING, "4"));
+	local->left_inside_pairs = atoi(LDEF(LEFT_INSIDE_PAIRS_STRING, "1"));
+	local->right_inside_pairs = atoi(LDEF(RIGHT_INSIDE_PAIRS_STRING, "1"));
+	local->left_outside_pairs = atoi(LDEF(LEFT_OUTSIDE_PAIRS_STRING, "1"));
+	local->right_outside_pairs = atoi(LDEF(RIGHT_OUTSIDE_PAIRS_STRING, "1"));
+
+	local->any_disjuncts = atoi(LDEF(ANY_DISJUNCTS_STRING, "4"));
+	local->left_inside_any = atoi(LDEF(LEFT_INSIDE_ANY_STRING, "2"));
+	local->right_inside_any = atoi(LDEF(RIGHT_INSIDE_ANY_STRING, "2"));
+	local->left_outside_any = atoi(LDEF(LEFT_OUTSIDE_ANY_STRING, "2"));
+	local->right_outside_any = atoi(LDEF(RIGHT_OUTSIDE_ANY_STRING, "2"));
 
 	dict->as_server = (void*) local;
 

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -54,16 +54,12 @@ using namespace opencog;
 #define PAIR_DISJUNCTS_STRING "pair-disjuncts"
 #define PAIR_WITH_ANY_STRING "pair-with-any"
 
-#define LEFT_INSIDE_PAIRS_STRING "left-inside-pairs"
-#define RIGHT_INSIDE_PAIRS_STRING "right-inside-pairs"
-#define LEFT_OUTSIDE_PAIRS_STRING "left-outside-pairs"
-#define RIGHT_OUTSIDE_PAIRS_STRING "right-outside-pairs"
+#define LEFT_PAIRS_STRING "left-pairs"
+#define RIGHT_PAIRS_STRING "right-pairs"
 
 #define ANY_DISJUNCTS_STRING "any-disjuncts"
-#define LEFT_INSIDE_ANY_STRING "left-inside-any"
-#define RIGHT_INSIDE_ANY_STRING "right-inside-any"
-#define LEFT_OUTSIDE_ANY_STRING "left-outside-any"
-#define RIGHT_OUTSIDE_ANY_STRING "right-outside-any"
+#define LEFT_ANY_STRING "left-any"
+#define RIGHT_ANY_STRING "right-any"
 
 
 /// Shared global
@@ -164,15 +160,11 @@ bool as_open(Dictionary dict)
 
 	local->enable_sections = atoi(LDEF(ENABLE_SECTIONS_STRING, "1"));
 
-	local->left_inside_pairs = atoi(LDEF(LEFT_INSIDE_PAIRS_STRING, "1"));
-	local->right_inside_pairs = atoi(LDEF(RIGHT_INSIDE_PAIRS_STRING, "1"));
-	local->left_outside_pairs = atoi(LDEF(LEFT_OUTSIDE_PAIRS_STRING, "1"));
-	local->right_outside_pairs = atoi(LDEF(RIGHT_OUTSIDE_PAIRS_STRING, "1"));
+	local->left_pairs = atoi(LDEF(LEFT_PAIRS_STRING, "1"));
+	local->right_pairs = atoi(LDEF(RIGHT_PAIRS_STRING, "1"));
 
-	local->left_inside_any = atoi(LDEF(LEFT_INSIDE_ANY_STRING, "2"));
-	local->right_inside_any = atoi(LDEF(RIGHT_INSIDE_ANY_STRING, "2"));
-	local->left_outside_any = atoi(LDEF(LEFT_OUTSIDE_ANY_STRING, "2"));
-	local->right_outside_any = atoi(LDEF(RIGHT_OUTSIDE_ANY_STRING, "2"));
+	local->left_any = atoi(LDEF(LEFT_ANY_STRING, "2"));
+	local->right_any = atoi(LDEF(RIGHT_ANY_STRING, "2"));
 
 	local->pair_disjuncts = atoi(LDEF(PAIR_DISJUNCTS_STRING, "4"));
 	local->pair_with_any = atoi(LDEF(PAIR_WITH_ANY_STRING, "2"));

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -332,18 +332,31 @@ Exp* make_exprs(Dictionary dict, const Handle& germ)
 
 	Exp* orhead = nullptr;
 
+	// Create disjuncts consisting entirely of "ANY" links.
 	if (0 < local->any_disjuncts)
 	{
 		Exp* any = make_any_exprs(dict, local->any_disjuncts);
 		or_enchain(dict, orhead, any);
 	}
 
+	// Create disjuncts consisting entirely of word-pair links.
 	if (0 < local->pair_disjuncts)
 	{
-		Exp* cpr = make_cart_pairs(dict, germ, 4);
+		Exp* cpr = make_cart_pairs(dict, germ, local->pair_disjuncts);
+
+		// Add "ANY" links, if requested.
+		if (0 < local->pair_with_any)
+		{
+			Exp* ap = make_any_exprs(dict, local->pair_with_any);
+			if (cpr)
+				cpr = make_and_node(dict->Exp_pool, cpr, ap);
+			else
+				cpr = ap;
+		}
 		or_enchain(dict, orhead, cpr);
 	}
 
+	// Create disjuncts from Sections
 	if (local->enable_sections)
 	{
 		Exp* sects = make_sect_exprs(dict, germ);

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -51,6 +51,8 @@ using namespace opencog;
 #define ENABLE_SECTIONS_STRING "enable-sections"
 
 #define PAIR_DISJUNCTS_STRING "pair-disjuncts"
+#define PAIR_WITH_ANY_STRING "pair-with-any"
+
 #define LEFT_INSIDE_PAIRS_STRING "left-inside-pairs"
 #define RIGHT_INSIDE_PAIRS_STRING "right-inside-pairs"
 #define LEFT_OUTSIDE_PAIRS_STRING "left-outside-pairs"
@@ -157,19 +159,22 @@ bool as_open(Dictionary dict)
 	local->pair_default = atof(LDEF(PAIR_DEFAULT_STRING, "1.0"));
 
 	local->any_default = atof(LDEF(ANY_DEFAULT_STRING, "3.0"));
+
 	local->enable_sections = atoi(LDEF(ENABLE_SECTIONS_STRING, "1"));
 
-	local->pair_disjuncts = atoi(LDEF(PAIR_DISJUNCTS_STRING, "4"));
 	local->left_inside_pairs = atoi(LDEF(LEFT_INSIDE_PAIRS_STRING, "1"));
 	local->right_inside_pairs = atoi(LDEF(RIGHT_INSIDE_PAIRS_STRING, "1"));
 	local->left_outside_pairs = atoi(LDEF(LEFT_OUTSIDE_PAIRS_STRING, "1"));
 	local->right_outside_pairs = atoi(LDEF(RIGHT_OUTSIDE_PAIRS_STRING, "1"));
 
-	local->any_disjuncts = atoi(LDEF(ANY_DISJUNCTS_STRING, "4"));
 	local->left_inside_any = atoi(LDEF(LEFT_INSIDE_ANY_STRING, "2"));
 	local->right_inside_any = atoi(LDEF(RIGHT_INSIDE_ANY_STRING, "2"));
 	local->left_outside_any = atoi(LDEF(LEFT_OUTSIDE_ANY_STRING, "2"));
 	local->right_outside_any = atoi(LDEF(RIGHT_OUTSIDE_ANY_STRING, "2"));
+
+	local->pair_disjuncts = atoi(LDEF(PAIR_DISJUNCTS_STRING, "4"));
+	local->pair_with_any = atoi(LDEF(PAIR_WITH_ANY_STRING, "2"));
+	local->any_disjuncts = atoi(LDEF(ANY_DISJUNCTS_STRING, "4"));
 
 	dict->as_server = (void*) local;
 

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -40,6 +40,7 @@ using namespace opencog;
 #define COST_CUTOFF_STRING "cost-cutoff"
 #define COST_DEFAULT_STRING "cost-default"
 
+#define PAIR_PREDICATE_STRING "pair-predicate"
 #define PAIR_KEY_STRING "pair-key"
 #define PAIR_INDEX_STRING "pair-index"
 #define PAIR_SCALE_STRING "pair-scale"
@@ -132,9 +133,6 @@ bool as_open(Dictionary dict)
 	// local->djp = local->asp->add_node(PREDICATE_NODE,
 	//	"*-LG disjunct string-*");
 
-	// Marks word-pairs.
-	local->lany = local->asp->add_node(LG_LINK_NODE, "ANY");
-
 	// Costs are assumed to be minus the MI located at some key.
 	const char* miks = get_dict_define(dict, COST_KEY_STRING);
 	Handle mikh = Sexpr::decode_atom(miks);
@@ -151,6 +149,10 @@ bool as_open(Dictionary dict)
 	local->cost_offset = atof(LDEF(COST_OFFSET_STRING, "0"));
 	local->cost_cutoff = atof(LDEF(COST_CUTOFF_STRING, "6"));
 	local->cost_default = atof(LDEF(COST_DEFAULT_STRING, "1.0"));
+
+	const char* prps = get_dict_define(dict, PAIR_PREDICATE_STRING);
+	Handle prph = Sexpr::decode_atom(prps);
+	local->prp = local->asp->add_atom(prph);
 
 	local->pair_index = atoi(LDEF(PAIR_INDEX_STRING, "1"));
 	local->pair_scale = atof(LDEF(PAIR_SCALE_STRING, "-0.2"));

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -256,7 +256,10 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 		Exp* andtail = nullptr;
 
 		if (inside_any)
-			andhead = make_and_node(dict->Exp_pool, inside_any, NULL);
+		{
+			Exp* optex = make_optional_node(dict->Exp_pool, inside_any);
+			andhead = make_and_node(dict->Exp_pool, optex, NULL);
+		}
 
 #ifdef EXTRA_OPTIONAL_PAIRS
 		Exp* optex = make_optional_node(dict->Exp_pool, epr);

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -218,17 +218,6 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 	Exp* orhead = nullptr;
 	Exp* ortail = nullptr;
 
-// #define OPTIONAL_ANY_LINK
-#ifdef OPTIONAL_ANY_LINK
-	Exp* any = make_any_exprs(dict, 4);
-	ortail = any;
-#endif // OPTIONAL_ANY_LINK
-
-#define OPTIONAL_PAIRS
-#ifdef OPTIONAL_PAIRS
-	ortail = make_cart_pairs(dict, germ, 4);
-#endif // OPTIONAL_PAIRS
-
 	// Loop over all Sections on the word.
 	HandleSeq sects = germ->getIncomingSetByType(SECTION);
 	for (const Handle& sect: sects)

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -219,7 +219,11 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 	Local* local = (Local*) (dict->as_server);
 	Exp* orhead = nullptr;
 
-	// Create some optional links; these may be nullptr's.
+	// Create some optional word-pair links; these may be nullptr's.
+	Exp* left_pairs = make_cart_pairs(dict, germ, local->left_pairs);
+	Exp* right_pairs = make_cart_pairs(dict, germ, local->right_pairs);
+
+	// Create some optional ANY-links; these may be nullptr's.
 	Exp* left_any = make_any_exprs(dict, local->left_any);
 	Exp* right_any = make_any_exprs(dict, local->right_any);
 
@@ -248,14 +252,6 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 
 		Exp* andhead = nullptr;
 		Exp* andtail = nullptr;
-
-#ifdef EXTRA_OPTIONAL_PAIRS
-		Exp* optex = make_optional_node(dict->Exp_pool, epr);
-		Exp* optey = make_optional_node(dict->Exp_pool, epr);
-		// andhead = make_and_node(dict->Exp_pool, optex, NULL);
-		andhead = make_and_node(dict->Exp_pool, optex, optey);
-		andtail = optey;
-#endif // EXTRA_OPTIONAL_PAIRS
 
 		// The connector sequence the second Atom.
 		// Loop over the connectors in the connector sequence.
@@ -289,6 +285,7 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 			continue;
 		}
 
+		// Tack on ANY connectors, as configured.
 		if (left_any)
 		{
 			Exp* optex = make_optional_node(dict->Exp_pool, left_any);
@@ -297,6 +294,18 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 		if (right_any)
 		{
 			Exp* optex = make_optional_node(dict->Exp_pool, right_any);
+			and_enchain_right(dict, andhead, andtail, optex);
+		}
+
+		// Tack on word-pair connectors, as configured.
+		if (left_pairs)
+		{
+			Exp* optex = make_optional_node(dict->Exp_pool, left_pairs);
+			and_enchain_left(dict, andhead, andtail, optex);
+		}
+		if (right_pairs)
+		{
+			Exp* optex = make_optional_node(dict->Exp_pool, right_pairs);
 			and_enchain_right(dict, andhead, andtail, optex);
 		}
 

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -339,16 +339,8 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 		printf("Word: '%s'  Exp: %s\n", wrd, lg_exp_stringify(andhead));
 #endif
 
-		// If there are two or more and-expressions,
-		// they get appended to a list hanging on a single OR-node.
-		if (ortail)
-		{
-			if (nullptr == orhead)
-				orhead = make_or_node(dict->Exp_pool, ortail, andhead);
-			else
-				ortail->operand_next = andhead;
-		}
-		ortail = andhead;
+		// Add it to the linked list.
+		or_enchain(dict, orhead, ortail, andhead);
 	}
 
 	if (nullptr == orhead) return ortail;

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -299,10 +299,16 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 			continue;
 		}
 
-		Exp* optel = make_optional_node(dict->Exp_pool, left_outside_any);
-		and_enchain_left(dict, andhead, andtail, optel);
-		Exp* opter = make_optional_node(dict->Exp_pool, right_outside_any);
-		and_enchain_right(dict, andhead, andtail, opter);
+		if (left_outside_any)
+		{
+			Exp* optex = make_optional_node(dict->Exp_pool, left_outside_any);
+			and_enchain_left(dict, andhead, andtail, optex);
+		}
+		if (right_outside_any)
+		{
+			Exp* optex = make_optional_node(dict->Exp_pool, right_outside_any);
+			and_enchain_right(dict, andhead, andtail, optex);
+		}
 
 		// Optional: shorten the expression,
 		// if there's only one connector in it.

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -13,7 +13,6 @@
 #include <opencog/persist/cog-storage/CogStorage.h>
 #include <opencog/persist/file/FileStorage.h>
 #include <opencog/persist/rocks/RocksStorage.h>
-#include <opencog/persist/sexpr/Sexpr.h>
 #include <opencog/nlp/types/atom_types.h>
 
 #undef STRINGIFY
@@ -33,6 +32,8 @@ using namespace opencog;
 
 // ===============================================================
 
+/// Count the number of times that the `germ` appears in some
+/// Section.
 static size_t count_sections(Local* local, const Handle& germ)
 {
 	// Are there any Sections in the local atomspace?
@@ -46,8 +47,9 @@ static size_t count_sections(Local* local, const Handle& germ)
 	return nsects;
 }
 
-/// Return true if the given word can be found in the dictionary,
-/// else return false.
+/// Return true if the given word can be found as the germ of some
+/// Section, else return false. As a side-effect, Sections are loaded
+/// from storage.
 bool section_boolean_lookup(Dictionary dict, const char *s)
 {
 	Local* local = (Local*) (dict->as_server);

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -219,7 +219,7 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 	Exp* ortail = nullptr;
 
 	// Create some optional links; these may be nullptr's.
-	Exp* left_inside_any = make_any_exprs(dict, local->left_inside_pairs);
+	Exp* left_inside_any = make_any_exprs(dict, local->left_inside_any);
 	Exp* right_inside_any = make_any_exprs(dict, local->right_inside_any);
 	Exp* left_outside_any = make_any_exprs(dict, local->left_outside_any);
 	Exp* right_outside_any = make_any_exprs(dict, local->right_outside_any);

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -220,16 +220,8 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 	Exp* orhead = nullptr;
 
 	// Create some optional links; these may be nullptr's.
-	Exp* left_inside_any = make_any_exprs(dict, local->left_inside_any);
-	Exp* right_inside_any = make_any_exprs(dict, local->right_inside_any);
-	Exp* left_outside_any = make_any_exprs(dict, local->left_outside_any);
-	Exp* right_outside_any = make_any_exprs(dict, local->right_outside_any);
-
-	Exp* inside_any = right_inside_any;
-	if (left_inside_any and right_inside_any)
-		inside_any = make_and_node(dict->Exp_pool, left_inside_any, right_inside_any);
-	else if (left_inside_any)
-		inside_any = left_inside_any;
+	Exp* left_any = make_any_exprs(dict, local->left_any);
+	Exp* right_any = make_any_exprs(dict, local->right_any);
 
 	// Loop over all Sections on the word.
 	HandleSeq sects = germ->getIncomingSetByType(SECTION);
@@ -256,12 +248,6 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 
 		Exp* andhead = nullptr;
 		Exp* andtail = nullptr;
-
-		if (inside_any)
-		{
-			Exp* optex = make_optional_node(dict->Exp_pool, inside_any);
-			andhead = make_and_node(dict->Exp_pool, optex, NULL);
-		}
 
 #ifdef EXTRA_OPTIONAL_PAIRS
 		Exp* optex = make_optional_node(dict->Exp_pool, epr);
@@ -303,14 +289,14 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 			continue;
 		}
 
-		if (left_outside_any)
+		if (left_any)
 		{
-			Exp* optex = make_optional_node(dict->Exp_pool, left_outside_any);
+			Exp* optex = make_optional_node(dict->Exp_pool, left_any);
 			and_enchain_left(dict, andhead, andtail, optex);
 		}
-		if (right_outside_any)
+		if (right_any)
 		{
-			Exp* optex = make_optional_node(dict->Exp_pool, right_outside_any);
+			Exp* optex = make_optional_node(dict->Exp_pool, right_any);
 			and_enchain_right(dict, andhead, andtail, optex);
 		}
 

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -99,7 +99,8 @@ bool section_boolean_lookup(Dictionary dict, const char *s)
 /// As of just right now, the above is held only in the local AtomSpace;
 /// it is never written back to storage.
 
-/// int to base-26 capital letters.
+/// int to base-26 capital letters. Except it has gaps in that
+/// sequence, and the order is reversed. Whatever. Doesn't matter.
 static std::string idtostr(uint64_t aid)
 {
 	std::string s;

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -216,7 +216,6 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 {
 	Local* local = (Local*) (dict->as_server);
 	Exp* orhead = nullptr;
-	Exp* ortail = nullptr;
 
 	// Create some optional links; these may be nullptr's.
 	Exp* left_inside_any = make_any_exprs(dict, local->left_inside_any);
@@ -334,10 +333,9 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 #endif
 
 		// Add it to the linked list.
-		or_enchain(dict, orhead, ortail, andhead);
+		or_enchain(dict, orhead, andhead);
 	}
 
-	if (nullptr == orhead) return ortail;
 	return orhead;
 }
 

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -161,14 +161,12 @@ Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity)
 	if (nullptr == epr) return nullptr;
 
 	Exp* optex = make_optional_node(dict->Exp_pool, epr);
-	andhead = make_and_node(dict->Exp_pool, optex, NULL);
-	andtail = andhead->operand_first;
+	and_enchain_right(dict, andhead, andtail, optex);
 
 	for (int i=1; i< arity; i++)
 	{
 		Exp* opt = make_optional_node(dict->Exp_pool, epr);
-		andtail->operand_next = opt;
-		andtail = opt;
+		and_enchain_right(dict, andhead, andtail, opt);
 	}
 
 	// Could verify that it all multiplies out as expected.

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -172,6 +172,8 @@ Exp* make_pair_exprs(Dictionary dict, const Handle& germ)
 /// from size zero to three. That's why its a Cartesian product.
 Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity)
 {
+	if (0 >= arity) return nullptr;
+
 	Exp* andhead = nullptr;
 	Exp* andtail = nullptr;
 

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -147,9 +147,9 @@ Exp* make_any_exprs(Dictionary dict, int arity)
 	Exp* aneg = make_connector_node(dict, dict->Exp_pool, "ANY", '-', false);
 	Exp* apos = make_connector_node(dict, dict->Exp_pool, "ANY", '+', false);
 
-	// XXX Configure
-	aneg->cost = 1.0;
-	apos->cost = 1.0;
+	Local* local = (Local*) (dict->as_server);
+	aneg->cost = local->any_default;
+	apos->cost = local->any_default;
 
 	Exp* any = make_or_node(dict->Exp_pool, aneg, apos);
 	Exp* optex = make_optional_node(dict->Exp_pool, any);

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -117,6 +117,8 @@ Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity)
 	Exp* andtail = nullptr;
 
 	Exp* epr = make_pair_exprs(dict, germ);
+	if (nullptr == epr) return nullptr;
+
 	Exp* optex = make_optional_node(dict->Exp_pool, epr);
 	andhead = make_and_node(dict->Exp_pool, optex, NULL);
 	andtail = andhead->operand_first;

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -43,14 +43,14 @@ static size_t fetch_pairs(Local* local, const Handle& germ)
 static bool have_pairs(Local* local, const Handle& germ)
 {
 	const AtomSpacePtr& asp = local->asp;
-	const Handle& hany = local->lany; // (LG_LINK_NODE, "ANY");
+	const Handle& hpr = local->prp; // (Predicate "word-pair")
 
 	// Are there any pairs in the local AtomSpace?
 	// If ther's at least one, just return `true`.
 	HandleSeq rprs = germ->getIncomingSetByType(LIST_LINK);
 	for (const Handle& rawpr : rprs)
 	{
-		Handle evpr = asp->get_link(EVALUATION_LINK, hany, rawpr);
+		Handle evpr = asp->get_link(EVALUATION_LINK, hpr, rawpr);
 		if (evpr) return true;
 	}
 
@@ -100,12 +100,12 @@ Exp* make_pair_exprs(Dictionary dict, const Handle& germ)
 	Exp* orhead = nullptr;
 	Exp* ortail = nullptr;
 
-	const Handle& hany = local->lany; // (LG_LINK_NODE, "ANY");
+	const Handle& hpr = local->prp; // (Predicate "pair")
 
 	HandleSeq rprs = germ->getIncomingSetByType(LIST_LINK);
 	for (const Handle& rawpr : rprs)
 	{
-		Handle evpr = asp->get_link(EVALUATION_LINK, hany, rawpr);
+		Handle evpr = asp->get_link(EVALUATION_LINK, hpr, rawpr);
 		if (nullptr == evpr) continue;
 
 		double cost = local->pair_default;

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -143,6 +143,8 @@ germ->get_name().c_str());
 
 Exp* make_any_exprs(Dictionary dict, int arity)
 {
+	if (arity <= 0) return nullptr;
+
 	// Create a pair of ANY-links that can connect both left or right.
 	Exp* aneg = make_connector_node(dict, dict->Exp_pool, "ANY", '-', false);
 	Exp* apos = make_connector_node(dict, dict->Exp_pool, "ANY", '+', false);

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -98,7 +98,6 @@ Exp* make_pair_exprs(Dictionary dict, const Handle& germ)
 	Local* local = (Local*) (dict->as_server);
 	const AtomSpacePtr& asp = local->asp;
 	Exp* orhead = nullptr;
-	Exp* ortail = nullptr;
 
 	const Handle& hpr = local->prp; // (Predicate "pair")
 
@@ -134,15 +133,7 @@ Exp* make_pair_exprs(Dictionary dict, const Handle& germ)
 
 		eee->cost = cost;
 
-		// Use an OR-node to create a linked list of expressions.
-		if (ortail)
-		{
-			if (nullptr == orhead)
-				orhead = make_or_node(dict->Exp_pool, ortail, eee);
-			else
-				ortail->operand_next = eee;
-		}
-		ortail = eee;
+		or_enchain(dict, orhead, eee);
 	}
 
 	return orhead;

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -130,24 +130,25 @@ Exp* make_cart_pairs(Dictionary dict, const Handle& germ, int arity)
 		andtail = opt;
 	}
 
-	// Should multiply out
+	// Could verify that it all multiplies out as expected.
 	// lg_assert(arity * size_of_expression(epr) ==
 	//           size_of_expression(andhead));
-printf("duuuude got %d pair exprs (prod = %d) for %s\n",
-size_of_expression(epr),
-size_of_expression(andhead),
-germ->get_name().c_str());
 
 	return andhead;
 }
 
 // ===============================================================
 
+/// Create exprs that are cartesian products of ANY links. The
+/// corresponding disjuncts will have `arity` number of connectors.
+/// If these are used all by themselves, the resulting parses will
+/// be random planar graphs; i.e. will be equivalent to the `any`
+/// language parses.
 Exp* make_any_exprs(Dictionary dict, int arity)
 {
 	if (arity <= 0) return nullptr;
 
-	// Create a pair of ANY-links that can connect both left or right.
+	// Create a pair of ANY-links that can connect either left or right.
 	Exp* aneg = make_connector_node(dict, dict->Exp_pool, "ANY", '-', false);
 	Exp* apos = make_connector_node(dict, dict->Exp_pool, "ANY", '+', false);
 

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -147,6 +147,8 @@ void free_Exp(Exp *e)
 /* Returns the number of connectors in the expression e */
 int size_of_expression(Exp * e)
 {
+	if (NULL == e) return 0;
+
 	int size = 0;
 
 	if (e->type == CONNECTOR_type) return 1;


### PR DESCRIPTION
If there aren't enough disjuncts to fully parse a sentences, individual word-pairs can be used to "plug the gaps": these appear as optional connectors on existing disjuncts.

If even that is not enough, then additional optional "ANY" connectors are added to disjuncts, thus always providing a parse, by simply guessing a random linkage.

The pull req includes configuration to enable all of this.