### PR TITLE
Cost adjust

### DIFF
--- a/link-grammar/dict-common/dict-structures.h
+++ b/link-grammar/dict-common/dict-structures.h
@@ -38,7 +38,7 @@ typedef enum
 } Exp_type;
 
 #ifndef SWIG
-#define COST_MAX_DEC_PLACES 3 /* Max. decimal places when printing. */
+#define COST_MAX_DEC_PLACES 5 /* Max. decimal places when printing. */
 static const float cost_epsilon = 1E-5f;
 
 #define EXPTAG_SZ 100 /* Initial size for the Exptag array. */

--- a/link-grammar/linkage/score.c
+++ b/link-grammar/linkage/score.c
@@ -87,6 +87,15 @@ static float compute_multi_cost(Linkage lkg)
 			// No-op if not a multi-connector.
 			if (false == rcon->multi) continue;
 
+			// If the multi-connector does not have a cost, then skip.
+// XXX at this time, there is no cncost in the condesc.
+			// if (0.0 == rcon->desc->cncost) continue;
+
+			// Initial offset; this will be immediately cancelled
+			// by the first use.
+			// mcost -= rcon->desc->cncost;
+mcost -= 1.0;
+
 			// Find the links using this connector.
 			for (size_t l = 0; l < lkg->num_links; l++)
 			{
@@ -98,12 +107,16 @@ static float compute_multi_cost(Linkage lkg)
 				{
 					// Skip if no match.
 					if (strcmp(rcon->desc->string, wrc->desc->string)) continue;
-	 mcost += 1.0;
+
+					// Increment for each use.
+					// mcost += rcon->desc->cncost;
+mcost += 1.0;
 				}
 			}
 		}
 		lword++; // increment only if disjunct is non-null.
 	}
+mcost *= -0.00001;
 	return mcost;
 }
 
@@ -115,7 +128,5 @@ void linkage_score(Linkage lkg, Parse_Options opts)
 	lkg->lifo.disjunct_cost = compute_disjunct_cost(lkg);
 	lkg->lifo.link_cost = compute_link_cost(lkg);
 
-float mcost = compute_multi_cost(lkg);
-// printf("duuude mcost=%f\n", mcost);
-lkg->lifo.disjunct_cost -= 0.00001 * mcost;
+	lkg->lifo.disjunct_cost += compute_multi_cost(lkg);
 }

--- a/link-grammar/linkage/score.c
+++ b/link-grammar/linkage/score.c
@@ -13,6 +13,7 @@
 
 #include <stdarg.h>
 #include "api-structures.h" // Needed for Parse_Options
+#include "connectors.h"
 #include "disjunct-utils.h" // Needed for Disjunct
 #include "linkage.h"
 #include "score.h"
@@ -68,10 +69,54 @@ static float compute_disjunct_cost(Linkage lkg)
 	return lcost;
 }
 
+/// Compute the extra cost of a multi-connector being used multiple
+/// times. Any cost on that multi-connector needs to be added for each
+/// usage of it.
+static float compute_multi_cost(Linkage lkg)
+{
+	size_t lword = 0;
+	float mcost = 0.0;
+	for (size_t i = 0; i < lkg->num_words; i++)
+	{
+		Disjunct * dj = lkg->chosen_disjuncts[i];
+		if (NULL == dj) continue;
+
+		// Look at the right-going connectors.
+		for (Connector* rcon = dj->right; rcon; rcon=rcon->next)
+		{
+			// No-op if not a multi-connector.
+			if (false == rcon->multi) continue;
+
+			// Find the links using this connector.
+			for (size_t l = 0; l < lkg->num_links; l++)
+			{
+				// The link is not even for this word. Ignore it.
+				if (lword != lkg->link_array[l].lw) continue;
+
+				// Find the links that are using our multi-connector.
+				for (Connector* wrc = lkg->link_array[l].rc; wrc; wrc=wrc->next)
+				{
+					// Skip if no match.
+					if (strcmp(rcon->desc->string, wrc->desc->string)) continue;
+dj->cost += 0.0001;
+	 mcost += 1.0;
+				}
+			}
+		}
+		lword++; // increment only if disjunct is non-null.
+	}
+	return mcost;
+}
+
 /** Assign parse score (cost) to linkage, used for parse ranking. */
 void linkage_score(Linkage lkg, Parse_Options opts)
 {
+float mcost = compute_multi_cost(lkg);
+
 	lkg->lifo.unused_word_cost = unused_word_cost(lkg);
 	lkg->lifo.disjunct_cost = compute_disjunct_cost(lkg);
 	lkg->lifo.link_cost = compute_link_cost(lkg);
+
+// printf("duuude mcost=%f\n", mcost);
+// lkg->lifo.disjunct_cost += 0.0001 * mcost;
 }

--- a/link-grammar/linkage/score.c
+++ b/link-grammar/linkage/score.c
@@ -98,7 +98,6 @@ static float compute_multi_cost(Linkage lkg)
 				{
 					// Skip if no match.
 					if (strcmp(rcon->desc->string, wrc->desc->string)) continue;
-dj->cost += 0.0001;
 	 mcost += 1.0;
 				}
 			}
@@ -111,12 +110,12 @@ dj->cost += 0.0001;
 /** Assign parse score (cost) to linkage, used for parse ranking. */
 void linkage_score(Linkage lkg, Parse_Options opts)
 {
-float mcost = compute_multi_cost(lkg);
 
 	lkg->lifo.unused_word_cost = unused_word_cost(lkg);
 	lkg->lifo.disjunct_cost = compute_disjunct_cost(lkg);
 	lkg->lifo.link_cost = compute_link_cost(lkg);
 
+float mcost = compute_multi_cost(lkg);
 // printf("duuude mcost=%f\n", mcost);
-// lkg->lifo.disjunct_cost += 0.0001 * mcost;
+lkg->lifo.disjunct_cost -= 0.00001 * mcost;
 }

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -329,7 +329,7 @@ static const char *process_some_linkages(FILE *in, Sentence sent,
 				fprintf(stdout, "\tLinkage %d, ", num_displayed+1);
 			}
 
-			fprintf(stdout, "cost vector = (UNUSED=%d DIS=%5.2f LEN=%d)\n",
+			fprintf(stdout, "cost vector = (UNUSED=%d DIS=%5.5f LEN=%d)\n",
 			        linkage_unused_word_cost(linkage),
 			        linkage_disjunct_cost(linkage),
 			        linkage_link_cost(linkage));


### PR DESCRIPTION
It seems there are several problems in this code.
Also, there are several other problems related to it.

Regarding `condesc_t::cncost` - this is an improper place to put a multi-connector cost:  There is a single `condesc_t` element for each connector string (i.e. **all** multi and non-multi connectors with the same connector string share a single `condesc_t` element). However, each multi-connector in the dict may have its own cost, and these costs may be different.

There is also a problem to store the cost in the connector due to the 64 bytes limitation.
A multi-connector cost table could be added to disjuncts, but there is a space constraint there too.
So the only good place for multi-connector costs seems to be in `Sentence_s` - a hash table for that can be added.

Among the problems that are related:
1. It seems there is a need to adjust not only the linkage cost but also the disjunct costs, so reading disjunct costs by the API would lead to consistent results. However, it seems it is not a good idea to update the disjunct costs in their `Disjunct_struct` because this will create a cost mess if relinking is needed (e.g. for implementing phantoms). To that end, an `adjust_cost` field could be added to `Disjunct_struct`, but again there is a space problem there.
2. The disjunct string (!as shown by `!disjunct`) should be updated, to be consistent with the adjusted disjunct costs. However, it is not clear how to textually represent multi-matches of multi-connectors. (I also discovered a bug there regarding multi-connectors that has no implications in the current dict/corpora and in your optional multi-connector examples).

Regarding the code, it seems it has several things which are wrong (or that I don't understand).
In any case, the code can be simplified and this will save fixing these things.
I will add my comments to the code itself.