### PR TITLE
Use per-thread match descriptions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@ Version 5.12.0 (XXX 2022)
  * Major Atomese dictionary extensions, including generation support.
  * Minor tweaks to `any` uniform random parse tree language.
  * Include U+202F NARROW NO-BREAK SPACE as a space character.
- * Fix PCRE2 regex so that it's thread safe!
+ * Fix the various regexes so that they're thread safe!
 
 Version 5.11.0 (27 Sept 2022)
  * Prototype support for dictionary in the AtomSpace.

--- a/bindings/js/link-parser/build.sh
+++ b/bindings/js/link-parser/build.sh
@@ -16,7 +16,6 @@ cp ../../../link-parser/.libs/link-parser link-parser.bc
 # is not available on Apple Mac's (I guess it's called .shlib ??)
 # So change to .a which should work for all OS'es.
 emcc -O3 link-parser.bc ../../../link-grammar/.libs/liblink-grammar.a \
-	libpthread.a \
 	--pre-js pre.js \
 	-s WASM=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \

--- a/bindings/js/link-parser/build.sh
+++ b/bindings/js/link-parser/build.sh
@@ -16,6 +16,7 @@ cp ../../../link-parser/.libs/link-parser link-parser.bc
 # is not available on Apple Mac's (I guess it's called .shlib ??)
 # So change to .a which should work for all OS'es.
 emcc -O3 link-parser.bc ../../../link-grammar/.libs/liblink-grammar.a \
+	libpthread.a \
 	--pre-js pre.js \
 	-s WASM=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,7 @@ AX_TLS(,:)
 test "$ac_cv_tls" != "none" && lg_tls=yes
 
 dnl Don't use thread functions with Emscripten.
+dnl Why? The regex code will not link without threads...
 if test "$EMSCRIPTEN" != ''; then
 	AC_CHECK_DEFINE(__EMSCRIPTEN__, [emscripten=yes],
 						 [AC_MSG_ERROR([EMSCRIPTION environment variable found, but emcc is not used])])

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -64,7 +64,6 @@ typedef struct {
 typedef struct {
 	regex_t re_code;
 	unsigned int Nre_md;
-	regmatch_t re_md[];
 } reg_info;
 #endif
 
@@ -84,6 +83,27 @@ typedef struct {
 /* ========================================================================= */
 
 #if HAVE_REGEX_H
+
+static tss_t re_md_key;
+
+static regmatch_t* get_re_md(void)
+{
+	if (0 == re_md_key)
+	{
+		int trc = tss_create(&re_md_key, free);
+		assert(thrd_success == trc, "Unable to create thread key");
+	}
+
+	regmatch_t* md = (regmatch_t*) tss_get(re_md_key);
+	if (md) return md;
+
+	md = (regmatch_t*) malloc(sizeof(regmatch_t) * 2 * MAX_CAPTURE_GROUPS);
+	assert(md, "Unable to allocate pcre2 match data struct");
+
+	tss_set(re_md_key, md);
+	return md;
+}
+
 /**
  * Find an upper limit to the number of capture groups in the pattern.
  */
@@ -112,12 +132,13 @@ static bool reg_comp(Regex_node *rn)
 #endif
 
 	const bool nosub = (rn->capture_group < 0);
-	const unsigned int Novector = nosub ? 0 : (max_capture_groups(rn) + 1);
 	int options = REG_EXTENDED|REG_ENHANCED|REG_GNU|(nosub ? REG_NOSUB : 0);
 
-	reg_info *re = malloc(sizeof(reg_info) + sizeof(regmatch_t) * 2 * Novector);
-	memset(re, 0, sizeof(reg_info)); /* No need to initialize re_md. */
+	const unsigned int Novector = nosub ? 0 : (max_capture_groups(rn) + 1);
+	assert(Novector < MAX_CAPTURE_GROUPS, "Too many capture groups");
 
+	reg_info *re = malloc(sizeof(reg_info));
+	memset(re, 0, sizeof(reg_info));
 	re->Nre_md = Novector;
 
 	int rc = regcomp(&re->re_code, rn->pattern, options);
@@ -140,7 +161,7 @@ static bool reg_match(const char *s, const Regex_node *rn)
 {
 	reg_info *re = (reg_info *)rn->re;
 	size_t nmatch = (rn->capture_group < 0) ? 0 : re->Nre_md;
-	int rc = regexec(&re->re_code, s, nmatch, re->re_md, /*eflags*/0);
+	int rc = regexec(&re->re_code, s, nmatch, get_re_md(), /*eflags*/0);
 
 	if (rc == REG_NOMATCH) return false;
 	if (rc == 0) return true;
@@ -156,7 +177,6 @@ static bool reg_match(const char *s, const Regex_node *rn)
 static void reg_span(Regex_node *rn, int *start, int *end)
 {
 	int cgn = rn->capture_group;
-	reg_info *re = rn->re;
 
 	if (unlikely(cgn > rn->capture_group))
 	{
@@ -164,8 +184,9 @@ static void reg_span(Regex_node *rn, int *start, int *end)
 	}
 	else
 	{
-		*start = re->re_md[cgn].rm_so;
-		*end = re->re_md[cgn].rm_eo;
+		regmatch_t* re_md = get_re_md();
+		*start = re_md[cgn].rm_so;
+		*end = re_md[cgn].rm_eo;
 	}
 }
 
@@ -178,7 +199,11 @@ static void reg_free(Regex_node *rn)
 	rn->re = NULL;
 }
 
-static void reg_finish(void) {}
+static void reg_finish(void)
+{
+	tss_delete(re_md_key);
+	re_md_key = 0;
+}
 #endif // HAVE_REGEX_H
 
 /* ========================================================================= */

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -84,6 +84,7 @@ typedef struct {
 
 #if HAVE_REGEX_H
 
+#ifndef __EMSCRIPTEN__
 static tss_t re_md_key;
 
 static regmatch_t* get_re_md(void)
@@ -103,6 +104,14 @@ static regmatch_t* get_re_md(void)
 	tss_set(re_md_key, md);
 	return md;
 }
+
+#else // __EMSCRIPTEN__ is defined; no threads available.
+static regmatch_t* get_re_md(void)
+{
+	static regmatch_t md[2 * MAX_CAPTURE_GROUPS];
+	return &md;
+}
+#endif // __EMSCRIPTEN__
 
 /**
  * Find an upper limit to the number of capture groups in the pattern.
@@ -201,8 +210,10 @@ static void reg_free(Regex_node *rn)
 
 static void reg_finish(void)
 {
+#ifndef __EMSCRIPTEN__
 	tss_delete(re_md_key);
 	re_md_key = 0;
+#endif
 }
 #endif // HAVE_REGEX_H
 


### PR DESCRIPTION
This performs the per-thread management of the match descriptions for the other two supported (but deprecated) regex libs.