### PR TITLE
regex-morph.c: add ifdef with HAVE_THREADS_H

### DIFF
--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -10,7 +10,9 @@
 /*                                                                       */
 /*************************************************************************/
 
+#if HAVE_THREADS_H
 #include <threads.h>
+#endif
 
 /**
  * Support for the regular-expression based token matching system


### PR DESCRIPTION
This `#include` has been added after #1178, so it is not covered in that PR.