### PR TITLE
pcre: enable JIT

### DIFF
--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -213,7 +213,10 @@ static bool reg_comp(Regex_node *rn)
 	re->re_code = pcre2_compile((PCRE2_SPTR)rn->pattern, PCRE2_ZERO_TERMINATED,
 	                            options, &rc, &erroffset, NULL);
 	if (re->re_code != NULL)
+	{
+		pcre2_jit_compile(re->re_code, PCRE2_JIT_COMPLETE);
 		return true;
+	}
 
 	/* We have an error. */
 	PCRE2_UCHAR errbuf[ERRBUFFLEN];

--- a/link-grammar/tokenize/anysplit.c
+++ b/link-grammar/tokenize/anysplit.c
@@ -336,6 +336,7 @@ static bool gr_reg_comp(grapheme_regex *re)
 	                         PCRE2_UTF, &rc, &erroffset, NULL);
 	if (re->code != NULL)
 	{
+		pcre2_jit_compile(re->code, PCRE2_JIT_COMPLETE);
 		re->match_data = pcre2_match_data_create_from_pattern(re->code, NULL);
 		if (re->match_data == NULL)
 		{


### PR DESCRIPTION
Reduces VM use and allows for faster matches