### PR TITLE
Fix pcre2 memleak, issue #1366

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Version 5.12.1 (XXX 2023)
  * Assorted enhancements and fixes for the AtomSpace dictionary. #1362
  * Fix missing HAVE_THREADS_H, affects Apple Homebrew. #1363
+ * Fix pcre2 version 10.41 memleak. #1367
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -167,6 +167,13 @@ static void reg_free(Regex_node *rn)
 /* ========================================================================= */
 #if HAVE_PCRE2_H
 
+// It might have been nice to perform this allocation once per
+// dictionary, but, alas, this won't work: pcre2 version 10.41 and
+// newer allocate internal memory for each call to pcre2_match(),
+// and this grows without bound, until pcre2_match_data_free() is
+// called. Apparently, the existing unit tests were able to clobber
+// 4GB of RAM, clobbering the OOM killer on small RAM machines.
+// See issue #1366 for details.
 #define ALLOCTE_MATCH_DATA(var) \
 	pcre2_match_data *var = pcre2_match_data_create(MAX_CAPTURE_GROUPS, NULL);
 #define FRE_MATCH_DATA(var) pcre2_match_data_free(var);


### PR DESCRIPTION
Appearntly, there are cascading mallocs which cannot be avoided.