### PR TITLE
Fix the thread code inclusion problem in Emscripten builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ data/th/old_words/**
 # Visual Studio keeps adding the directory ".vs". If it got added while
 # rebasing and it is not git-ignored, it somehow breaks the rebase.
 .vs
+# a.wasm is created by "emcc" (in "emconfigure ./configure").
+# For now just ignore it.
+a.wasm

--- a/configure.ac
+++ b/configure.ac
@@ -119,37 +119,27 @@ AC_CHECK_FUNCS(prctl)
 AC_DEFINE(__STDC_FORMAT_MACROS)
 AC_DEFINE(__STDC_LIMIT_MACROS)
 
-# Don't use thread functions with Emscripten.
-# Emscripten does not like threads.
-if test "$EMSCRIPTEN" != ''; then
-	AC_CHECK_DEFINE(__EMSCRIPTEN__, [emscripten=yes],
-						 [AC_MSG_ERROR([EMSCRIPTEN environment variable found, but emcc is not used])])
-fi
+# Check for a keyword for Thread Local Storage declaration.
+# If found - define TLS to it.
+lg_tls=no
+AX_TLS(,:)
+test "$ac_cv_tls" != "none" && lg_tls=yes
 
-if test "x$emscripten" != "xyes"; then
+AX_PTHREAD
+if test -n "$ax_pthread_ok"; then
+	CC="${PTHREAD_CC:-CC}"
+	dnl #CCX="${PTHREAD_CC:-CCX}"
 
-	# Check for a keyword for Thread Local Storage declaration.
-	# If found - define TLS to it.
-	lg_tls=no
-	AX_TLS(,:)
-	test "$ac_cv_tls" != "none" && lg_tls=yes
-
-	AX_PTHREAD
-	if test -n "$ax_pthread_ok"; then
-		CC="${PTHREAD_CC:-CC}"
-		dnl #CCX="${PTHREAD_CC:-CCX}"
-
-		dnl Currently, libtool uses --nostdlib when linking shared libraries,
-		dnl which causes the -pthread flag to be ignored. Try to work around that
-		dnl by explicitly specifying the pthread library unless it is already set.
-		if test -z "$PTHREAD_LIBS"; then
-			PTHREAD_LIBS=-lpthread
-		fi
+	dnl Currently, libtool uses --nostdlib when linking shared libraries,
+	dnl which causes the -pthread flag to be ignored. Try to work around that
+	dnl by explicitly specifying the pthread library unless it is already set.
+	if test -z "$PTHREAD_LIBS"; then
+		PTHREAD_LIBS=-lpthread
 	fi
-
-	dnl Check if we can use C11 threads functions
-	AC_CHECK_HEADERS_ONCE([threads.h])
 fi
+
+dnl Check if we can use C11 threads functions
+AC_CHECK_HEADERS_ONCE([threads.h])
 
 dnl If the visibility __attribute__  is supported, define HAVE_VISIBILITY
 dnl and a variable CFLAG_VISIBILITY, to be added to CFLAGS/CXXFLAGS.

--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -10,9 +10,9 @@
 /*                                                                       */
 /*************************************************************************/
 
-#if HAVE_THREADS_H
+#if HAVE_THREADS_H && !__EMSCRIPTEN__
 #include <threads.h>
-#endif
+#endif // HAVE_THREADS_H && !__EMSCRIPTEN__
 
 /**
  * Support for the regular-expression based token matching system
@@ -177,7 +177,7 @@ static void alloc_key(void)
 
 static pcre2_match_data* alloc_match_data(void)
 {
-#if HAVE_THREADS_H
+#if HAVE_THREADS_H && !__EMSCRIPTEN__
 	call_once(&call_once_flag, alloc_key);
 
 	pcre2_match_data *pmd = (pcre2_match_data *) tss_get(re_md_key);
@@ -194,7 +194,7 @@ static pcre2_match_data* alloc_match_data(void)
 	pmd = pcre2_match_data_create(MAX_CAPTURE_GROUPS, NULL);
 	if (pmd) return pmd;
 
-#endif // HAVE_THREADS_H
+#endif // HAVE_THREADS_H && !__EMSCRIPTEN__
 	prt_error("Error: pcre2_match_data_create() failed\n");
 	return NULL;
 }

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -14,9 +14,9 @@
 
 #include <limits.h>
 #include <inttypes.h>                   // PRIu64
-#if HAVE_THREADS_H
+#if HAVE_THREADS_H && !__EMSCRIPTEN__
 #include <threads.h>
-#endif /* HAVE_THREADS_H */
+#endif /* HAVE_THREADS_H && !__EMSCRIPTEN__ */
 
 #include "link-includes.h"
 #include "api-structures.h"
@@ -124,7 +124,7 @@ struct count_context_s
 #define MAX_TABLE_SIZE(s) (s / 10) /* Low load factor, for speed */
 #define MAX_LOG2_TABLE_SIZE ((sizeof(size_t)==4) ? 25 : 34)
 
-#if HAVE_THREADS_H
+#if HAVE_THREADS_H && !__EMSCRIPTEN__
 /* Each thread will get it's own version of the `kept_table`.
  * If the program creates zillions of threads, then there will
  * be a mem-leak if this table is not released when each thread
@@ -147,7 +147,7 @@ static void make_key(void)
 {
 	tss_create(&key, free_tls_table);
 }
-#endif /* HAVE_THREADS_H */
+#endif /* HAVE_THREADS_H && !__EMSCRIPTEN__ */
 
 /**
  * Allocate memory for the connector-pair table and initialize table-size
@@ -164,14 +164,14 @@ static void table_alloc(count_context_t *ctxt, unsigned int shift)
 	static TLS Table_connector **kept_table = NULL;
 	static TLS unsigned int log2_kept_table_size = 0;
 
-#if HAVE_THREADS_H
+#if HAVE_THREADS_H && !__EMSCRIPTEN__
 	// Install a thread-exit handler, to free kept_table on thread-exit.
 	static once_flag flag = ONCE_FLAG_INIT;
 	call_once(&flag, make_key);
 
 	if (NULL == kept_table)
 		tss_set(key, &kept_table);
-#endif /* HAVE_THREADS_H */
+#endif /* HAVE_THREADS_H && !__EMSCRIPTEN__ */
 
 	if (shift == 0)
 		shift = ctxt->log2_table_size + 1; /* Double the table size */


### PR DESCRIPTION
See issue #1374 .

Remove the Emscripten check from `configure` and instead check `__EMSCRIPTEN__`  in the source code.
(For some reason this didn't work for me when I previously handled this problem.)
BTW, `AX_TLS` ` already takes care not to define `TLS`.

In addition, git-ignore the file `a.wasm` that is left after `emconfigure ./configure`.

Note: This error occurs inside an autoconf macro. I didn't try to find out why.
``` text
checking if the linker (/usr/local/src/emsdk/upstream/emscripten/emcc) is GNU ld... yes
em++: error: no input files
checking whether the /usr/local/src/emsdk/upstream/emscripten/em++ linker (/usr/local/src/emsdk/upstream/emscripten/emcc) supports shared libraries... yes
```