### PR TITLE
Disable aspell by default.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Version 5.12.1 (XXX 2023)
  * Assorted enhancements and fixes for the AtomSpace dictionary. #1362
  * Fix missing HAVE_THREADS_H, affects Apple Homebrew. #1363
  * Fix regex thread-safety issue. #1370
+ * Disable aspell; it leaks memory. #1373
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.

--- a/README.md
+++ b/README.md
@@ -806,6 +806,10 @@ aspell is used, else hunspell is used.
 Spell guessing may be disabled at runtime, in the link-parser client
 with the `!spell=0` flag.  Enter `!help` for more details.
 
+Caution: aspell version 0.60.8 and possibly others have a memory leak.
+The use of spell-guessing in production servers is strongly discouraged.
+Keeping spell-guessing disabled (`=0`) in `Parse_Options` is safe.
+
 
 ### Multi-threading
 It is safe to use link-grammar for parsing in multiple threads.

--- a/configure.ac
+++ b/configure.ac
@@ -1152,10 +1152,19 @@ $PACKAGE-$VERSION  build configuration settings
 	AtomSpace-backed dictionary:    ${HaveAtomese}
 	Definitions:                    ${LG_DEFS}
 	Libraries:                      ${lglibs}
-])"
+"])
 # Show LDFLAGS if set (usually by environment of argument).
 if test -n "$LDFLAGS"; then
 	AS_ECHO(["	Loader flags:                   $LDFLAGS"])
 else
 	AS_ECHO([])
+fi
+
+if test "x${ASpellFound}" == "xyes"; then
+	AS_ECHO_N(["
+   ----------
+   Caution: Aspell version 0.60.8 and possibly others leak memory!
+   Do not enable spell-guessing in production servers!
+   ----------
+"])
 fi

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -99,11 +99,10 @@ Parse_Options parse_options_create(void)
 	po->use_sat_solver = false;
 #endif
 	po->linkage_limit = 100;
-#if defined HAVE_HUNSPELL || defined HAVE_ASPELL
-	po->use_spell_guess = 7;
-#else
+
+	// Disable spell-guessing by default. Aspell 0.60.8 and possibly
+	// others leak memory.
 	po->use_spell_guess = 0;
-#endif /* defined HAVE_HUNSPELL || defined HAVE_ASPELL */
 
 	po->cost_model.compare_fn = &VDAL_compare_parse;
 	po->cost_model.type = VDAL;

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -610,6 +610,7 @@ int main(int argc, char * argv[])
 	parse_options_set_short_length(opts, 16);
 	parse_options_set_islands_ok(opts, false);
 	parse_options_set_display_morphology(opts, false);
+	parse_options_set_spell_guess(opts, 7);
 
 	/* Get the panic disjunct cost from the dictionary. */
 	const char *panic_max_cost_str =

--- a/tests/multi-thread.cc
+++ b/tests/multi-thread.cc
@@ -156,6 +156,12 @@ int main(int argc, char* argv[])
 	{
 		Dictionary dict = dicte;
 		opts[i] = parse_options_create();
+		if (0 == i%3)
+		{
+			dict = dicte; // English
+			// FYI, Aspell leaks memory. But we test anyway. #1373
+			parse_options_set_spell_guess(opts[i], 7);
+		}
 		if (1 == i%3)
 		{
 			dict = dictr; // Russian


### PR DESCRIPTION
Apparently, aspell leaks memory. See discussion #1373 for details.