### PR TITLE
Deduplicate linkages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 5.12.1 (XXX 2023)
  * Fix missing HAVE_THREADS_H, affects Apple Homebrew. #1363
  * Fix regex thread-safety issue. #1370
  * Disable aspell; it leaks memory. #1373
+ * Deduplicate linkages when overflow forces random selection. #1378
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.

--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -162,6 +162,7 @@ struct Sentence_s
 	/* Parse results */
 	int    num_linkages_found;  /* Total number before postprocessing.  This
 	                               is returned by the do_count() function */
+	bool   overflowed;          /* True, if counting overflowed. */
 	size_t num_linkages_alloced;/* Total number of linkages allocated.
 	                               the number post-processed might be fewer
 	                               because some are non-canonical */

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -786,7 +786,7 @@ static void list_random_links(Linkage lkg, unsigned int *rand_state,
 
 	if (set == NULL || set->first == NULL) return;
 
-	/* Most of the times there is only one list element. */
+	/* Most of the time, there is only one list element. */
 	if (set->first->next == NULL)
 	{
 		pc = set->first;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -316,10 +316,10 @@ static void deduplicate_linkages(Sentence sent)
 		uint32_t li;
 		for (li=0; li<lpv->num_links; li++)
 		{
-			if (lpv->link_array[li].lw != lnx->link_array[li].lw) break;
-			if (lpv->link_array[li].rw != lnx->link_array[li].rw) break;
 			if (lpv->link_array[li].lc != lnx->link_array[li].lc) break;
 			if (lpv->link_array[li].rc != lnx->link_array[li].rc) break;
+			if (lpv->link_array[li].lw != lnx->link_array[li].lw) break;
+			if (lpv->link_array[li].rw != lnx->link_array[li].rw) break;
 		}
 		if (li != lpv->num_links) continue;
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -282,11 +282,11 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 	}
 }
 
-/* The scan appear more than one, if, for example, the dictionary
- * contains entries such as
+/* Remove duplicate linkages in the link array. Duplicates can appear
+ * if, for example, the dictionary contains entries such as
  *    foo: A- & {B+} & {B+};
  * Then there will be two distinct parses, one connecting to the first
- * optional B+, and another, connecting to the second B+. But both of
+ * optional `B+`, and another, connecting to the second `B+`. But both of
  * these are "the same linkage". We fish these out and remove them here.
  *
  * This is rather uncommon for the English & Russian dicts, but can

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -329,7 +329,8 @@ static void deduplicate_linkages(Sentence sent)
 		nl--;
 		sent->num_linkages_alloced --;
 		sent->num_valid_linkages --;
-		i--; // Do not advance i.
+		sent->num_linkages_post_processed --;
+		i--; // Do not advance i; there may be more!
 	}
 }
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -11,6 +11,8 @@
 /*                                                                       */
 /*************************************************************************/
 #include <limits.h>
+#include <math.h>
+
 #include "api-structures.h"
 #include "count.h"
 #include "dict-common/dict-common.h"   // For Dictionary_s
@@ -298,6 +300,8 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 static void deduplicate_linkages(Sentence sent)
 {
 	uint32_t nl = sent->num_linkages_alloced;
+	if (2 > nl) return;
+
 	for (uint32_t i=1; i<nl; i++)
 	{
 		Linkage lpv = &sent->lnkages[i-1];
@@ -310,14 +314,21 @@ static void deduplicate_linkages(Sentence sent)
 
 		// Compare links
 		uint32_t li;
-		for (li=0; li<lkg->num_links; li++)
+		for (li=0; li<lpv->num_links; li++)
 		{
 			if (lpv->link_array[li].lw != lnx->link_array[li].lw) break;
 			if (lpv->link_array[li].rw != lnx->link_array[li].rw) break;
 			if (lpv->link_array[li].lc != lnx->link_array[li].lc) break;
 			if (lpv->link_array[li].rc != lnx->link_array[li].rc) break;
 		}
-		if (li != lkg->num_links) continue;
+		if (li != lpv->num_links) continue;
+
+		// If we are here, then lpv and lnx are the same linkage.
+		// Shuffle down all linkages.
+		memmove(lpv, lnx, (nl-i)* sizeof(struct Linkage_s));
+		nl--;
+		sent->num_linkages_alloced --;
+		i--; // Do not advance i.
 	}
 }
 


### PR DESCRIPTION
When linkages are selected randomly, it can happen that many of them are duplicates.  When the size of the alloced linkage array is just under the number found, as many as half can be duplicates!  