### PR TITLE
Provide a thread-safe Exp pool for the dictionary.

### DIFF
--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -439,7 +439,7 @@ Dict_node * strict_lookup_list(const Dictionary dict, const char *s)
  */
 Exp *Exp_create(Pool_desc *mp)
 {
-	Exp *e = pool_alloc(mp);
+	Exp *e = pool_alloc_concurrent(mp);
 	e->tag_type = Exptag_none;
 	e->operand_next = NULL;
 	e->cost = 0.0;
@@ -453,7 +453,7 @@ Exp *Exp_create(Pool_desc *mp)
  */
 Exp *Exp_create_dup(Pool_desc *mp, Exp *old_e)
 {
-	Exp *new_e = pool_alloc(mp);
+	Exp *new_e = pool_alloc_concurrent(mp);
 
 	*new_e = *old_e;
 

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -84,6 +84,10 @@ Pool_desc *pool_new(const char *func, const char *name,
 	mp->curr_elements = 0;
 	mp->num_elements = num_elements;
 
+#if HAVE_THREADS_H
+	mtx_init(&mp->mutex, mtx_plain);
+#endif
+
 	lgdebug(+D_MEMPOOL, "%sElement size %zu, alignment %zu (pool '%s' created in %s())\n",
 	        POOL_ALLOCATOR?"":"(Fake pool allocator) ",
 	        mp->element_size, mp->alignment, mp->name, mp->func);


### PR DESCRIPTION
In the Atomese dictionary backend, multiple threads update the same dict.