### PR TITLE
make_expression(): Fix dialect setting on Connectors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Version 5.12.1 (XXX 2023)
  * Fix regex thread-safety issue. #1370
  * Disable aspell; it leaks memory. #1373
  * Deduplicate linkages when overflow forces random selection. #1378
+ * Fix direct dialect settings on connectors. #1382
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.

--- a/link-grammar/dict-file/read-dict.c
+++ b/link-grammar/dict-file/read-dict.c
@@ -738,7 +738,7 @@ static Exp *make_expression(Dictionary dict)
 					           badchar);
 					return NULL;
 				}
-				if (nl->tag_type != Exptag_none)
+				if ((nl->type == CONNECTOR_type) || (nl->tag_type != Exptag_none))
 				{
 					nl = make_unary_node(dict->Exp_pool, nl);
 				}


### PR DESCRIPTION
The reason of the problem and how it is fixed are described in the commit message.
See also the discussion starting at https://github.com/opencog/link-grammar/discussions/1310#discussioncomment-4743306.