### PR TITLE
Revert "Provide a thread-safe Exp pool for the dictionary."

### DIFF
--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -377,7 +377,7 @@ Dict_node * dict_node_wild_lookup(Dictionary dict, const char *s)
  */
 Exp *Exp_create(Pool_desc *mp)
 {
-	Exp *e = pool_alloc_concurrent(mp);
+	Exp *e = pool_alloc(mp);
 	e->tag_type = Exptag_none;
 	e->operand_next = NULL;
 	e->cost = 0.0;
@@ -391,7 +391,7 @@ Exp *Exp_create(Pool_desc *mp)
  */
 Exp *Exp_create_dup(Pool_desc *mp, Exp *old_e)
 {
-	Exp *new_e = pool_alloc_concurrent(mp);
+	Exp *new_e = pool_alloc(mp);
 
 	*new_e = *old_e;
 

--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -84,10 +84,6 @@ Pool_desc *pool_new(const char *func, const char *name,
 	mp->curr_elements = 0;
 	mp->num_elements = num_elements;
 
-#if HAVE_THREADS_H
-	mtx_init(&mp->mutex, mtx_plain);
-#endif
-
 	lgdebug(+D_MEMPOOL, "%sElement size %zu, alignment %zu (pool '%s' created in %s())\n",
 	        POOL_ALLOCATOR?"":"(Fake pool allocator) ",
 	        mp->element_size, mp->alignment, mp->name, mp->func);

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -14,10 +14,6 @@
 
 #include <stddef.h>                     // max_align_t
 
-#if HAVE_THREADS_H
-#include <threads.h>                    // mtx_t
-#endif
-
 #include "link-includes.h"
 #include "error.h"
 #include "utilities.h"                  // GNUC_MALLOC (XXX separate include?)
@@ -98,10 +94,6 @@ struct  Pool_desc_s
 #ifdef POOL_EXACT
 	bool exact;                 // Abort if more than num_elements are needed.
 #endif /* POOL_EXACT */
-
-#if HAVE_THREADS_H
-	mtx_t mutex;                // Optional pool thread-safety lock.
-#endif
 };
 
 typedef struct
@@ -119,23 +111,9 @@ static inline size_t pool_num_elements_alloced(Pool_desc *mp)
 	return mp->curr_elements;
 }
 
-// Lock-free version, when every thread has it's own pool.
 static inline void *pool_alloc(Pool_desc *mp)
 {
 	return pool_alloc_vec(mp, 1);
-}
-
-// Locking version, when multiple threads share a single pool.
-static inline void *pool_alloc_concurrent(Pool_desc *mp)
-{
-#if HAVE_THREADS_H
-	mtx_lock(&mp->mutex);
-	void* rv = pool_alloc_vec(mp, 1);
-	mtx_unlock(&mp->mutex);
-	return rv;
-#else
-	return pool_alloc_vec(mp, 1);
-#endif
 }
 
 /**


### PR DESCRIPTION
Reverts opencog/link-grammar#1381

The one-big-lock #1387 removes the need for this. I like the idea of lock-free code.