### PR TITLE
Revert "Add mutex to protect the condesc table."

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -543,9 +543,6 @@ static bool condesc_grow(ConTable *ct)
 condesc_t *condesc_add(ConTable *ct, const char *constring)
 {
 	uint32_t hash = (connector_hash_t)connector_str_hash(constring);
-#if HAVE_THREADS_H
-	mtx_lock(&ct->mutex);
-#endif
 	hdesc_t *h = condesc_find(ct, constring, hash);
 
 	if (NULL == h->desc)
@@ -563,9 +560,6 @@ condesc_t *condesc_add(ConTable *ct, const char *constring)
 		}
 	}
 
-#if HAVE_THREADS_H
-	mtx_unlock(&ct->mutex);
-#endif
 	return h->desc;
 }
 
@@ -574,9 +568,6 @@ void condesc_init(Dictionary dict, size_t num_con)
 	ConTable *ct = &dict->contable;
 
 	condesc_table_alloc(ct, num_con);
-#if HAVE_THREADS_H
-	mtx_init(&ct->mutex, mtx_plain);
-#endif
 	ct->mempool = pool_new(__func__, "ConTable",
 								  /*num_elements*/1024, sizeof(condesc_t),
 								  /*zero_out*/true, /*align*/true, /*exact*/false);
@@ -597,5 +588,4 @@ void condesc_setup(Dictionary dict)
 	mtx_unlock(&dict->contable.mutex);
 #endif
 }
-
-/* ========================= END OF FILE =========================== */
+/* ========================= END OF FILE ============================== */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -19,10 +19,6 @@
 #include <stdbool.h>
 #include <stdint.h>  // for uint8_t
 
-#if HAVE_THREADS_H
-#include <threads.h> // for mtx_t
-#endif
-
 #include "api-types.h"
 #include "error.h"
 #include "memory-pool.h"
@@ -112,9 +108,6 @@ typedef struct hdesc
 
 typedef struct
 {
-#if HAVE_THREADS_H
-	mtx_t mutex;          /* Provide multi-thread safety */
-#endif
 	hdesc_t *hdesc;       /* Hashed connector descriptors table */
 	condesc_t **sdesc;    /* Alphabetically sorted descriptors */
 	size_t size;          /* Allocated size */


### PR DESCRIPTION
Reverts opencog/link-grammar#1380

The one-big-lock #1387 removes the need for this. I like the idea of lock-free code.  Sorry for the churn.