### PR TITLE
Move condesc table update to dictionary backend

### DIFF
--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -692,11 +692,6 @@ int sentence_parse(Sentence sent, Parse_Options opts)
 		return -2;
 	}
 
-	/* When a dynamic dictionary is used, expressions are read on demand,
-	 * so the connector descriptor table is not yet ready at this point. */
-	if (IS_DYNAMIC_DICT(dict))
-		condesc_setup(dict);
-
 	resources_reset(opts->resources);
 	for (WordIdx w = 0; w < sent->length; w++)
 	{

--- a/link-grammar/api.c
+++ b/link-grammar/api.c
@@ -528,9 +528,9 @@ static int do_sentence_split(Sentence sent, Parse_Options opts)
 int sentence_split(Sentence sent, Parse_Options opts)
 {
 	Dictionary dict = sent->dict;
-	dict->start_parse(dict, sent);
+	dict->start_lookup(dict, sent);
 	int rc = do_sentence_split(sent, opts);
-	dict->end_parse(dict, sent);
+	dict->end_lookup(dict, sent);
 	return rc;
 }
 

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -21,9 +21,10 @@
 #undef STRINGIFY
 
 extern "C" {
-#include "../link-includes.h"            // For Dictionary
-#include "../dict-common/dict-common.h"  // for Dictionary_s
-#include "../dict-common/dict-utils.h"   // for size_of_expression()
+#include "../link-includes.h"              // For Dictionary
+#include "../dict-common/dict-common.h"    // for Dictionary_s
+#include "../dict-common/dict-internals.h" // for dict_node_new()
+#include "../dict-common/dict-utils.h"     // for size_of_expression()
 #include "../dict-ram/dict-ram.h"
 #include "lookup-atomese.h"
 };
@@ -442,8 +443,7 @@ Exp* make_exprs(Dictionary dict, const Handle& germ)
 /// the dictionary.
 static Dict_node * make_dn(Dictionary dict, Exp* exp, const char* ssc)
 {
-	Dict_node* dn = (Dict_node*) malloc(sizeof(Dict_node));
-	memset(dn, 0, sizeof(Dict_node));
+	Dict_node* dn = dict_node_new();
 	dn->string = ssc;
 	dn->exp = exp;
 
@@ -462,7 +462,7 @@ static Dict_node * make_dn(Dictionary dict, Exp* exp, const char* ssc)
 	}
 
 	// Perform the lookup. We cannot return the dn above, as the
-	// as_free_llist() below will delete it, leading to mem corruption.
+	// dict_node_free_lookup() will delete it, leading to mem corruption.
 	dn = dict_node_lookup(dict, ssc);
 	return dn;
 }

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -316,6 +316,9 @@ void as_start_lookup(Dictionary dict, Sentence sent)
 
 void as_end_lookup(Dictionary dict, Sentence sent)
 {
+	Local* local = (Local*) (dict->as_server);
+	std::lock_guard<std::mutex> guard(local->dict_mutex);
+
 	// Deal with any new connector descriptors that have arrived.
 	condesc_setup(dict);
 }

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -316,6 +316,8 @@ void as_start_parse(Dictionary dict, Sentence sent)
 
 void as_end_parse(Dictionary dict, Sentence sent)
 {
+	// Deal with any new connector descriptors that have arrived.
+	condesc_setup(dict);
 }
 
 /// Return true if the given word can be found in the dictionary,

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -310,11 +310,11 @@ void as_close(Dictionary dict)
 
 // ===============================================================
 
-void as_start_parse(Dictionary dict, Sentence sent)
+void as_start_lookup(Dictionary dict, Sentence sent)
 {
 }
 
-void as_end_parse(Dictionary dict, Sentence sent)
+void as_end_lookup(Dictionary dict, Sentence sent)
 {
 	// Deal with any new connector descriptors that have arrived.
 	condesc_setup(dict);

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -310,6 +310,14 @@ void as_close(Dictionary dict)
 
 // ===============================================================
 
+void as_start_parse(Dictionary dict, Sentence sent)
+{
+}
+
+void as_end_parse(Dictionary dict, Sentence sent)
+{
+}
+
 /// Return true if the given word can be found in the dictionary,
 /// else return false.
 bool as_boolean_lookup(Dictionary dict, const char *s)

--- a/link-grammar/dict-atomese/lookup-atomese.h
+++ b/link-grammar/dict-atomese/lookup-atomese.h
@@ -8,13 +8,17 @@
 
 #include "../dict-common/dict-api.h"
 
-bool as_open(Dictionary dict);
-void as_close(Dictionary dict);
+bool as_open(Dictionary);
+void as_close(Dictionary);
 
-bool as_boolean_lookup(Dictionary dict, const char *s);
-Dict_node * as_lookup_list(Dictionary dict, const char *s);
-Dict_node * as_lookup_wild(Dictionary dict, const char *s);
-void as_clear_cache(Dictionary dict);
+bool as_boolean_lookup(Dictionary, const char *);
+Dict_node * as_lookup_list(Dictionary, const char *);
+Dict_node * as_lookup_wild(Dictionary, const char *);
 
-void as_add_categories(Dictionary dict);
-void as_storage_close(Dictionary dict);
+void as_start_parse(Dictionary, Sentence);
+void as_end_parse(Dictionary, Sentence);
+
+void as_clear_cache(Dictionary);
+
+void as_add_categories(Dictionary);
+void as_storage_close(Dictionary);

--- a/link-grammar/dict-atomese/lookup-atomese.h
+++ b/link-grammar/dict-atomese/lookup-atomese.h
@@ -14,7 +14,6 @@ void as_close(Dictionary dict);
 bool as_boolean_lookup(Dictionary dict, const char *s);
 Dict_node * as_lookup_list(Dictionary dict, const char *s);
 Dict_node * as_lookup_wild(Dictionary dict, const char *s);
-void as_free_llist(Dictionary dict, Dict_node *llist);
 void as_clear_cache(Dictionary dict);
 
 void as_add_categories(Dictionary dict);

--- a/link-grammar/dict-atomese/lookup-atomese.h
+++ b/link-grammar/dict-atomese/lookup-atomese.h
@@ -15,8 +15,8 @@ bool as_boolean_lookup(Dictionary, const char *);
 Dict_node * as_lookup_list(Dictionary, const char *);
 Dict_node * as_lookup_wild(Dictionary, const char *);
 
-void as_start_parse(Dictionary, Sentence);
-void as_end_parse(Dictionary, Sentence);
+void as_start_lookup(Dictionary, Sentence);
+void as_end_lookup(Dictionary, Sentence);
 
 void as_clear_cache(Dictionary);
 

--- a/link-grammar/dict-atomese/read-atomese.c
+++ b/link-grammar/dict-atomese/read-atomese.c
@@ -102,8 +102,8 @@ Dictionary dictionary_create_from_atomese(const char *dictdir)
 	dict->lookup_wild = as_lookup_wild;
 	dict->free_lookup = dict_node_free_lookup;
 	dict->exists_lookup = as_boolean_lookup;
-	dict->start_parse = as_start_parse;
-	dict->end_parse = as_end_parse;
+	dict->start_lookup = as_start_lookup;
+	dict->end_lookup = as_end_lookup;
 	dict->clear_cache = as_clear_cache;
 	dict->close = as_close;
 

--- a/link-grammar/dict-atomese/read-atomese.c
+++ b/link-grammar/dict-atomese/read-atomese.c
@@ -102,6 +102,8 @@ Dictionary dictionary_create_from_atomese(const char *dictdir)
 	dict->lookup_wild = as_lookup_wild;
 	dict->free_lookup = dict_node_free_lookup;
 	dict->exists_lookup = as_boolean_lookup;
+	dict->start_parse = dict_parse_noop;
+	dict->end_parse = dict_parse_noop;
 	dict->clear_cache = as_clear_cache;
 	dict->close = as_close;
 

--- a/link-grammar/dict-atomese/read-atomese.c
+++ b/link-grammar/dict-atomese/read-atomese.c
@@ -102,8 +102,8 @@ Dictionary dictionary_create_from_atomese(const char *dictdir)
 	dict->lookup_wild = as_lookup_wild;
 	dict->free_lookup = dict_node_free_lookup;
 	dict->exists_lookup = as_boolean_lookup;
-	dict->start_parse = dict_parse_noop;
-	dict->end_parse = dict_parse_noop;
+	dict->start_parse = as_start_parse;
+	dict->end_parse = as_end_parse;
 	dict->clear_cache = as_clear_cache;
 	dict->close = as_close;
 

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -166,8 +166,8 @@ struct Dictionary_s
 
 	void (*insert_entry)(Dictionary, Dict_node *, int);
 
-	void (*start_parse)(Dictionary, Sentence);
-	void (*end_parse)(Dictionary, Sentence);
+	void (*start_lookup)(Dictionary, Sentence);
+	void (*end_lookup)(Dictionary, Sentence);
 	Dict_node* (*lookup_list)(Dictionary, const char*);
 	Dict_node* (*lookup_wild)(Dictionary, const char*);
 	void (*free_lookup)(Dictionary, Dict_node*);

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -165,10 +165,14 @@ struct Dictionary_s
 #endif
 
 	void (*insert_entry)(Dictionary, Dict_node *, int);
+
+	void (*start_parse)(Dictionary, Sentence);
+	void (*end_parse)(Dictionary, Sentence);
 	Dict_node* (*lookup_list)(Dictionary, const char*);
 	Dict_node* (*lookup_wild)(Dictionary, const char*);
 	void (*free_lookup)(Dictionary, Dict_node*);
 	bool (*exists_lookup)(Dictionary, const char*);
+
 	void (*clear_cache)(Dictionary);
 	void (*close)(Dictionary);
 

--- a/link-grammar/dict-common/dict-internals.c
+++ b/link-grammar/dict-common/dict-internals.c
@@ -17,6 +17,10 @@ void dict_node_noop(Dictionary dict)
 {
 }
 
+void dict_parse_noop(Dictionary dict, Sentence sent)
+{
+}
+
 Dict_node * dict_node_new(void)
 {
    return (Dict_node*) malloc(sizeof(Dict_node));

--- a/link-grammar/dict-common/dict-internals.c
+++ b/link-grammar/dict-common/dict-internals.c
@@ -18,7 +18,7 @@ void dict_node_noop(Dictionary dict)
 {
 }
 
-void dict_parse_noop(Dictionary dict, Sentence sent)
+void dict_lookup_noop(Dictionary dict, Sentence sent)
 {
 }
 

--- a/link-grammar/dict-common/dict-internals.c
+++ b/link-grammar/dict-common/dict-internals.c
@@ -10,6 +10,7 @@
 /*************************************************************************/
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "dict-internals.h"
 
@@ -23,7 +24,9 @@ void dict_parse_noop(Dictionary dict, Sentence sent)
 
 Dict_node * dict_node_new(void)
 {
-   return (Dict_node*) malloc(sizeof(Dict_node));
+   Dict_node* dn = (Dict_node*) malloc(sizeof(Dict_node));
+	memset(dn, 0, sizeof(Dict_node));
+   return dn;
 }
 
 void dict_node_free_list(Dict_node *llist)

--- a/link-grammar/dict-common/dict-internals.h
+++ b/link-grammar/dict-common/dict-internals.h
@@ -17,4 +17,4 @@ void dict_node_noop(Dictionary dict);
 void dict_node_free_list(Dict_node *llist);
 void dict_node_free_lookup(Dictionary, Dict_node*);
 
-void dict_parse_noop(Dictionary, Sentence);
+void dict_lookup_noop(Dictionary, Sentence);

--- a/link-grammar/dict-common/dict-internals.h
+++ b/link-grammar/dict-common/dict-internals.h
@@ -16,3 +16,5 @@ Dict_node * dict_node_new(void);
 void dict_node_noop(Dictionary dict);
 void dict_node_free_list(Dict_node *llist);
 void dict_node_free_lookup(Dictionary, Dict_node*);
+
+void dict_parse_noop(Dictionary, Sentence);

--- a/link-grammar/dict-common/idiom.c
+++ b/link-grammar/dict-common/idiom.c
@@ -14,7 +14,7 @@
 #include "api-types.h"
 #include "dict-api.h"
 #include "dict-common.h"
-#include "dict-ram/dict-ram.h"
+#include "dict-internals.h"
 #include "error.h"
 #include "idiom.h"
 #include "string-set.h"
@@ -109,7 +109,7 @@ static Dict_node * make_idiom_Dict_nodes(Dictionary dict, const char * string)
 		s = strchr(s, '_');
 		if ((NULL != sm) && (s > sm)) s = NULL;
 		if (NULL != s) *s++ = '\0';
-		Dict_node *dn_new = (Dict_node *) malloc(sizeof (Dict_node));
+		Dict_node *dn_new = dict_node_new();
 		dn_new->right = dn;
 		dn = dn_new;
 		dn->string = string_set_add(t, dict->string_set);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -187,8 +187,8 @@ dictionary_six_str(const char * lang,
 		dict->free_lookup = dict_node_free_lookup;
 		dict->exists_lookup = dict_node_exists_lookup;
 		dict->clear_cache = dict_node_noop;
-		dict->start_parse = dict_parse_noop;
-		dict->end_parse = dict_parse_noop;
+		dict->start_lookup = dict_lookup_noop;
+		dict->end_lookup = dict_lookup_noop;
 
 		dict->dialect_tag.set = string_id_create();
 		condesc_init(dict, 1<<13);

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -187,6 +187,9 @@ dictionary_six_str(const char * lang,
 		dict->free_lookup = dict_node_free_lookup;
 		dict->exists_lookup = dict_node_exists_lookup;
 		dict->clear_cache = dict_node_noop;
+		dict->start_parse = dict_parse_noop;
+		dict->end_parse = dict_parse_noop;
+
 		dict->dialect_tag.set = string_id_create();
 		condesc_init(dict, 1<<13);
 		Exp_pool_size = 1<<13;

--- a/link-grammar/dict-file/word-file.c
+++ b/link-grammar/dict-file/word-file.c
@@ -86,7 +86,7 @@ Dict_node * read_word_file(Dictionary dict, Dict_node * dn, char * filename)
 			free_insert_list(dn);
 			return NULL;
 		}
-		Dict_node * dn_new = malloc(sizeof(Dict_node));
+		Dict_node * dn_new = dict_node_new();
 		dn_new->left = dn;
 		dn = dn_new;
 		dn->string = s;

--- a/link-grammar/dict-file/word-file.c
+++ b/link-grammar/dict-file/word-file.c
@@ -12,8 +12,9 @@
 
 #include "error.h"
 #include "dict-common/dict-common.h"
-#include "dict-common/dict-defines.h" // for MAX_WORD
-#include "dict-common/dict-utils.h" // for patch_subscript()
+#include "dict-common/dict-defines.h"   // for MAX_WORD
+#include "dict-common/dict-internals.h"
+#include "dict-common/dict-utils.h"     // for patch_subscript()
 #include "dict-common/file-utils.h"
 #include "string-set.h"
 #include "read-dict.h"

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -538,6 +538,15 @@ static void db_close(Dictionary dict)
 	dict->db_handle = NULL;
 }
 
+static void db_start_lookup(Dictionary dict, Sentence sent)
+{
+}
+
+static void db_end_lookup(Dictionary dict, Sentence sent)
+{
+	condesc_setup(dict);
+}
+
 Dictionary dictionary_create_from_db(const char *lang)
 {
 	char *dbname;
@@ -577,8 +586,8 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->lookup_wild = db_lookup_wild;
 	dict->free_lookup = dict_node_free_lookup;
 	dict->exists_lookup = db_lookup;
-	dict->start_lookup = dict_lookup_noop;
-	dict->end_lookup = dict_lookup_noop;
+	dict->start_lookup = db_start_lookup;
+	dict->end_lookup = db_end_lookup;
 	dict->clear_cache = dict_node_noop;
 	dict->close = db_close;
 

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -577,8 +577,8 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->lookup_wild = db_lookup_wild;
 	dict->free_lookup = dict_node_free_lookup;
 	dict->exists_lookup = db_lookup;
-	dict->start_parse = dict_parse_noop;
-	dict->end_parse = dict_parse_noop;
+	dict->start_lookup = dict_lookup_noop;
+	dict->end_lookup = dict_lookup_noop;
 	dict->clear_cache = dict_node_noop;
 	dict->close = db_close;
 

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -271,8 +271,7 @@ static int morph_cb(void *user_data, int argc, char **argv, char **colName)
 		scriword, wclass);
 
 	/* Put each word into a Dict_node. */
-	Dict_node *dn = malloc(sizeof(Dict_node));
-	memset(dn, 0, sizeof(Dict_node));
+	Dict_node *dn = dict_node_new();
 	dn->string = string_set_add(scriword, bs->dict->string_set);
 	dn->right = bs->dn;
 	dn->exp = bs->exp;

--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -578,6 +578,8 @@ Dictionary dictionary_create_from_db(const char *lang)
 	dict->lookup_wild = db_lookup_wild;
 	dict->free_lookup = dict_node_free_lookup;
 	dict->exists_lookup = db_lookup;
+	dict->start_parse = dict_parse_noop;
+	dict->end_parse = dict_parse_noop;
 	dict->clear_cache = dict_node_noop;
 	dict->close = db_close;
 


### PR DESCRIPTION
The connector table update was racing across multiple threads.
This moves it to where it can be safely updated, without placing
locks in the common code.

The highlight of the show is 11e37638ba2c48459dd6866e52992f8d7c02548a
and this is the commit about which all other changes made today were all about.

Oh, and, of course, the lock:
7678c7949f9613891f70f758897ee1f073b4ebd9
It was all about the lock!