### PR TITLE
Add locks to sql dictionary, for thread-safety.

### DIFF
--- a/link-grammar/dict-sql/read-sql.c
+++ b/link-grammar/dict-sql/read-sql.c
@@ -19,6 +19,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#if HAVE_THREADS_H
+#include <threads.h> // for mtx_t
+#endif
+
 #include <sqlite3.h>
 
 #include "api-structures.h"
@@ -131,6 +135,10 @@ static const char * make_expression(Dictionary dict,
 /* ========================================================= */
 /* Dictionary word lookup procedures. */
 
+#if HAVE_THREADS_H
+static mtx_t global_mutex;
+#endif
+
 typedef struct
 {
 	Dictionary dict;
@@ -214,6 +222,9 @@ static char * escape_quotes(const char * s)
 static void
 db_lookup_exp(Dictionary dict, const char *s, cbdata* bs)
 {
+#if HAVE_THREADS_H
+	mtx_lock(&global_mutex);
+#endif
 	sqlite3 *db = dict->db_handle;
 	dyn_str *qry;
 
@@ -234,6 +245,10 @@ db_lookup_exp(Dictionary dict, const char *s, cbdata* bs)
 
 	lgdebug(D_SQL+1, "Found expression for class %s: %s\n",
 	        s, exp_stringify(bs->exp));
+
+#if HAVE_THREADS_H
+	mtx_unlock(&global_mutex);
+#endif
 }
 
 
@@ -270,12 +285,18 @@ static int morph_cb(void *user_data, int argc, char **argv, char **colName)
 	assert(NULL != bs->exp, "Missing disjuncts for word %s %s",
 		scriword, wclass);
 
+#if HAVE_THREADS_H
+	mtx_lock(&global_mutex);
+#endif
 	/* Put each word into a Dict_node. */
 	Dict_node *dn = dict_node_new();
 	dn->string = string_set_add(scriword, bs->dict->string_set);
 	dn->right = bs->dn;
 	dn->exp = bs->exp;
 	bs->dn = dn;
+#if HAVE_THREADS_H
+	mtx_unlock(&global_mutex);
+#endif
 
 	return 0;
 }
@@ -433,6 +454,9 @@ static void db_add_categories(Dictionary dict)
 	sqlite3 *db = dict->db_handle;
 	cbdata bs;
 	bs.dict = dict;
+#if HAVE_THREADS_H
+	mtx_lock(&global_mutex);
+#endif
 
 	/* How many lexical categories are there? Find out. */
 	sqlite3_exec(db, "SELECT count(DISTINCT classname) FROM Disjuncts;",
@@ -494,6 +518,9 @@ static void db_add_categories(Dictionary dict)
 
 	/* Set the termination entry. */
 	dict->category[dict->num_categories + 1].num_words = 0;
+#if HAVE_THREADS_H
+	mtx_unlock(&global_mutex);
+#endif
 }
 
 /* ========================================================= */
@@ -501,9 +528,9 @@ static void db_add_categories(Dictionary dict)
 
 static void* db_open(const char * fullname, const void * user_data)
 {
-	int fd;
-	struct stat buf;
-	sqlite3 *db;
+#if HAVE_THREADS_H
+	mtx_init(&global_mutex, mtx_plain);
+#endif
 
 	/* Is there a file here that can be read? */
 	FILE * fh =  fopen(fullname, "r");
@@ -512,13 +539,15 @@ static void* db_open(const char * fullname, const void * user_data)
 
 	/* Get the file size, in bytes. */
 	/* SQLite has a habit of leaving zero-length DB's lying around */
-	fd = fileno(fh);
+	struct stat buf;
+	int fd = fileno(fh);
 	fstat(fd, &buf);
 	fclose(fh);
 	if (0 == buf.st_size)
 		return NULL;
 
 	/* Found a file, of non-zero length. See if that works. */
+	sqlite3 *db;
 	if (sqlite3_open(fullname, &db))
 	{
 		prt_error("Error: Can't open database %s: %s\n",
@@ -544,7 +573,13 @@ static void db_start_lookup(Dictionary dict, Sentence sent)
 
 static void db_end_lookup(Dictionary dict, Sentence sent)
 {
+#if HAVE_THREADS_H
+	mtx_lock(&global_mutex);
+#endif
 	condesc_setup(dict);
+#if HAVE_THREADS_H
+	mtx_unlock(&global_mutex);
+#endif
 }
 
 Dictionary dictionary_create_from_db(const char *lang)


### PR DESCRIPTION
Multiple threads will race with one-another to update the dictionary. This will, in general, clobber the dictionary state. Protect it with a simple mutex lock.