### PR TITLE
Fix multiple deduplication bugs

### DIFF
--- a/link-grammar/linkage/linkage.h
+++ b/link-grammar/linkage/linkage.h
@@ -67,6 +67,7 @@ struct Linkage_s
 	Linkage_info    lifo;         /* Parse_set index and cost information */
 	bool            is_sent_long; /* num_words >= twopass_length */
 
+	bool            dupe;         /* Duplicate marker */
 	PP_domains *    pp_domains;   /* PP domain info, one for each link */
 
 	Sentence        sent;         /* Used for common linkage data */

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -863,7 +863,7 @@ static Count_bin pseudocount(count_context_t * ctxt,
                            unsigned int null_count)
 {
 	/* This check is not necessary for correctness, but it saves CPU time.
-	 * If a cross link would result, immediatly return 0. Note that there is
+	 * If a cross link would result, immediately return 0. Note that there is
 	 * no need to check here if the nearest_word fields are in the range
 	 * [lw, rw] due to the way start_word/end_word are computed, and due to
 	 * nearest_word checks in form_match_list(). */

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -632,7 +632,7 @@ form_match_list(fast_matcher_t *ctxt, int w,
 		{
 			(*cmx)->match_left = false;
 		}
-		mr_end = NULL; /* Prevent a gcc "mnay be uninitialkized" warning */
+		mr_end = NULL; /* Prevent a gcc "may be uninitialized" warning */
 	}
 
 	/* Construct the list of things that could match the left. */

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -337,6 +337,16 @@ static void deduplicate_linkages(Sentence sent, int linkage_limit)
 		uint32_t wi;
 		for (wi=0; wi<lpv->num_words; wi++)
 		{
+			// Parses with non-zero null count will have null words,
+			// i.e. word without chosen_disjuncts. Avoid a null-pointer
+			// deref in this case.
+			if (NULL == lpv->chosen_disjuncts[wi])
+			{
+				// If one is null, both should be null. (I think this
+				// will always be true, but I'm not sure.)
+				if (NULL == lnx->chosen_disjuncts[wi]) continue;
+				break;
+			}
 			if (lpv->chosen_disjuncts[wi]->word_string !=
 			    lnx->chosen_disjuncts[wi]->word_string) break;
 		}

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -304,13 +304,15 @@ static void deduplicate_linkages(Sentence sent)
 
 	// Phase one: Mark
 	uint32_t num_dupes = 0;
+	uint32_t tgt = 0;
 	for (uint32_t i=1; i<nl; i++)
 	{
-		Linkage lpv = &sent->lnkages[i-1];
+		Linkage lpv = &sent->lnkages[tgt];
 		Linkage lnx = &sent->lnkages[i];
 
 		// Mark
 		lnx->dupe = false;
+		tgt ++;
 
 		// Rule out obvious mismatches.
 		if (lpv->num_links != lnx->num_links) continue;
@@ -331,24 +333,23 @@ static void deduplicate_linkages(Sentence sent)
 		// If we are here, then lpv and lnx are the same linkage.
 		lnx->dupe = true;
 		num_dupes ++;
-
-		i--; // Do not advance i; there may be more!
+		tgt--;
 	}
 
 	// Phase two: Sweep
-	uint32_t off = 0;
-	for (uint32_t i=1; i<nl; i++)
+	tgt = 0;
+	for (uint32_t isrc=1; isrc<nl; isrc++)
 	{
-		Linkage lnx = &sent->lnkages[i];
+		Linkage lnx = &sent->lnkages[isrc];
 		if (lnx->dupe)
 		{
 			// Free stuff
 			continue;
 		}
-		off++;
-		if (off == i) continue; // Nothing to do, yet.
+		tgt++;
+		if (tgt == isrc) continue; // Nothing to do, yet.
 
-		Linkage lpv = &sent->lnkages[off];
+		Linkage lpv = &sent->lnkages[tgt];
 
 		// Move one linkage.
 		memmove(lpv, lnx, sizeof(struct Linkage_s));

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -171,7 +171,7 @@ static void process_linkages(Sentence sent, extractor_t* pex,
 
 	/* Pick random linkages if we get more than what was asked for. */
 	bool pick_randomly = sent->overflowed ||
-	    (sent->num_linkages_found > (int) sent->num_linkages_alloced);
+	    (sent->num_linkages_found > (int) opts->linkage_limit);
 
 	sent->num_valid_linkages = 0;
 	size_t N_invalid_morphism = 0;
@@ -292,11 +292,10 @@ static void process_linkages(Sentence sent, extractor_t* pex,
  * This can be done in a single pass, after the linkages have been
  * sorted. We only need to check nearest neighbors.
  */
-static void deduplicate_linkages(Sentence sent)
+static void deduplicate_linkages(Sentence sent, int linkage_limit)
 {
 	/* No need for deduplication, if random selection wasn't done. */
-	if (!sent->overflowed &&
-	    (sent->num_linkages_found <= (int) sent->num_linkages_alloced))
+	if (!sent->overflowed && (sent->num_linkages_found <= linkage_limit))
 		return;
 
 	uint32_t nl = sent->num_linkages_alloced;
@@ -372,7 +371,7 @@ static void sort_linkages(Sentence sent, Parse_Options opts)
 	      sizeof(struct Linkage_s),
 	      (int (*)(const void *, const void *))opts->cost_model.compare_fn);
 
-	deduplicate_linkages(sent);
+	deduplicate_linkages(sent, opts->linkage_limit);
 	print_time(opts, "Sorted all linkages");
 }
 

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -329,6 +329,19 @@ static void deduplicate_linkages(Sentence sent, int linkage_limit)
 		}
 		if (li != lpv->num_links) continue;
 
+		// Compare words. The chosen_disjuncts->word_string is the
+		// dictionary word. It can happen that two different dictionary
+		// words can have the same disjunct, and thus result in the same
+		// linkage. For backwards compat, we will report these as being
+		// different, as printing will reveal the differences in words.
+		uint32_t wi;
+		for (wi=0; wi<lpv->num_words; wi++)
+		{
+			if (lpv->chosen_disjuncts[wi]->word_string !=
+			    lnx->chosen_disjuncts[wi]->word_string) break;
+		}
+		if (wi != lpv->num_words) continue;
+
 		// If we are here, then lpv and lnx are the same linkage.
 		lnx->dupe = true;
 		num_dupes ++;

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -343,7 +343,7 @@ static void deduplicate_linkages(Sentence sent)
 		Linkage lnx = &sent->lnkages[isrc];
 		if (lnx->dupe)
 		{
-			// Free stuff
+			free_linkage(lnx);
 			continue;
 		}
 		tgt++;


### PR DESCRIPTION
This fixes multiple issues reported for #1378, including:
* Bad identification of region to copy
* Failure to compare dictionary words
* Inefficient copying