### PR TITLE
Get CPU time used for this thread only!

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,8 @@ Version 5.12.1 (XXX 2023)
  * Deduplicate linkages when overflow forces random selection. #1378 #1396
  * Fix direct dialect settings on connectors. #1382
  * Cleanup dictionary backends. #1391 thru #1395
- * English dict: paraphrasing fixes #1398
+ * English dict: paraphrasing fixes. #1398
+ * Report CPU time usage only for the current thread. #1399
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.

--- a/link-grammar/resources.c
+++ b/link-grammar/resources.c
@@ -50,7 +50,7 @@ static double current_usage_time(void)
 {
 #if !defined(_WIN32)
 	struct rusage u;
-	getrusage (RUSAGE_SELF, &u);
+	getrusage (RUSAGE_THREAD, &u);
 	return (u.ru_utime.tv_sec + ((double) u.ru_utime.tv_usec) / 1000000.0);
 #else
 	return ((double) clock())/CLOCKS_PER_SEC;


### PR DESCRIPTION
Otherwise, in a multi-threaded process, timeouts will be common, as the cpu usage will be summed over all threads.