### PR TITLE
mempool: count number of alloced and handed out.

### DIFF
--- a/link-grammar/memory-pool.c
+++ b/link-grammar/memory-pool.c
@@ -81,7 +81,7 @@ Pool_desc *pool_new(const char *func, const char *name,
 #ifdef POOL_FREE
 	mp->free_list = NULL;
 #endif // POOL_FREE
-	mp->curr_elements = 0;
+	mp->issued_elements = 0;
 	mp->num_elements = num_elements;
 
 	lgdebug(+D_MEMPOOL, "%sElement size %zu, alignment %zu (pool '%s' created in %s())\n",
@@ -107,7 +107,7 @@ void pool_delete (const char *func, Pool_desc *mp)
 	from_func = func;
 #endif
 	lgdebug(+D_MEMPOOL, "Used %zu (%zu) elements (%s deleted pool '%s' created in %s())\n",
-	        mp->curr_elements, mp->num_elements, from_func, mp->name, mp->func);
+	        mp->issued_elements, mp->num_elements, from_func, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */
 	size_t alloc_size = mp->data_size;
@@ -143,7 +143,7 @@ void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 		return NULL;
 	}
 
-	mp->curr_elements += vecsize; /* skipped space disregarded when vecsize > 1 */
+	mp->issued_elements += vecsize; /* skipped space disregarded when vecsize > 1 */
 
 #ifdef POOL_FREE
 	if ((NULL != mp->free_list) && (vecsize == 1))
@@ -163,7 +163,7 @@ void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 #ifdef POOL_EXACT
 		assert(!mp->exact || (NULL == mp->alloc_next),
 				 "Too many elements %zu>%zu (pool '%s' created in %s())",
-				 mp->curr_elements, mp->num_elements, mp->name, mp->func);
+				 mp->issued_elements, mp->num_elements, mp->name, mp->func);
 #endif /* POOL_EXACT */
 
 		/* No current block or current block exhausted - obtain another one. */
@@ -211,11 +211,11 @@ void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 void pool_reuse(Pool_desc *mp)
 {
 	lgdebug(+D_MEMPOOL, "Reuse %zu elements (pool '%s' created in %s())\n",
-	        mp->curr_elements, mp->name, mp->func);
+	        mp->issued_elements, mp->name, mp->func);
 	mp->ring = mp->chain;
 	mp->alloc_next = mp->ring;
 	if ((mp->ring != NULL) && (mp->zero_out)) memset(mp->ring, 0, mp->data_size);
-	mp->curr_elements = 0;
+	mp->issued_elements = 0;
 #ifdef POOL_FREE
 	mp->free_list = NULL;
 #endif // POOL_FREE
@@ -230,7 +230,7 @@ void pool_free(Pool_desc *mp, void *e)
 {
 	assert(mp->element_size >= FLDSIZE_NEXT);
 	if (NULL == e) return;
-	mp->curr_elements--;
+	mp->issued_elements--;
 
 	char *next = mp->free_list;
 	mp->free_list = e;
@@ -252,13 +252,13 @@ void *pool_alloc_vec(Pool_desc *mp, size_t vecsize)
 {
 	dassert(vecsize < mp->num_elements, "Pool block is too small %zu > %zu)",
 	        vecsize, mp->num_elements);
-	mp->curr_elements += vecsize;
+	mp->issued_elements += vecsize;
 	size_t alloc_size = mp->element_size * vecsize;
 
 #ifdef POOL_EXACT
-	assert(!mp->exact || mp->curr_elements <= mp->num_elements,
+	assert(!mp->exact || mp->issued_elements <= mp->num_elements,
 	       "Too many elements (%zu>%zu) (pool '%s' created in %s())",
-	       mp->curr_elements, mp->num_elements, mp->name, mp->func);
+	       mp->issued_elements, mp->num_elements, mp->name, mp->func);
 #endif /* POOL_EXACT */
 
 	/* Allocate a new element and chain it. */
@@ -283,7 +283,7 @@ void pool_reuse(Pool_desc *mp)
 {
 	if (NULL == mp) return;
 	lgdebug(+D_MEMPOOL, "Reuse %zu elements (pool '%s' created in %s())\n",
-	        mp->curr_elements, mp->name, mp->func);
+	        mp->issued_elements, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */
 	char *c_next;
@@ -299,11 +299,10 @@ void pool_reuse(Pool_desc *mp)
 	}
 
 	mp->chain = NULL;
-	mp->curr_elements = 0;
+	mp->issued_elements = 0;
 }
 
 /*
- * num_elements
  * Delete the given memory pool.
  */
 #undef pool_delete
@@ -319,7 +318,7 @@ void pool_delete (const char *func, Pool_desc *mp)
 	from_func = func;
 #endif
 	lgdebug(+D_MEMPOOL, "Used %zu (%zu) elements (%s deleted pool '%s' created in %s())\n",
-	        mp->curr_elements, mp->num_elements, from_func, mp->name, mp->func);
+	        mp->issued_elements, mp->num_elements, from_func, mp->name, mp->func);
 
 	/* Free its chained memory blocks. */
 	char *c_next;
@@ -340,7 +339,7 @@ void pool_delete (const char *func, Pool_desc *mp)
 #ifdef POOL_FREE
 void pool_free(Pool_desc *mp, void *e)
 {
-	mp->curr_elements--;
+	mp->issued_elements--;
 	assert(!ASAN_ADDRESS_IS_POISONED(e), "Double pool free of %p\n", e);
 	ASAN_POISON_MEMORY_REGION(e, sizeof(alloc_attr) + ((alloc_attr *)e)->size);
 }

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -88,6 +88,7 @@ struct  Pool_desc_s
 	 * feature is used (it is not used for now). */
 
 	size_t issued_elements;     // Number of elements issued to users.
+	size_t alloced_elements;    // Issued plus free (unissued) elements.
 
 	/* Flags that are used by pool_alloc(). */
 	bool zero_out;              // Zero out allocated elements.
@@ -104,9 +105,9 @@ typedef struct
 } Pool_location;
 
 /**
- * Return the number of allocated elements in the given pool.
+ * Return the number of elements issued to users.
  */
-static inline size_t pool_num_elements_alloced(Pool_desc *mp)
+static inline size_t pool_num_elements_issued(Pool_desc *mp)
 {
 	return mp->issued_elements;
 }
@@ -169,13 +170,11 @@ static inline void *pool_next(Pool_desc *mp, Pool_location *l)
 	return l->current_element;
 }
 
-#if 0 /* For planned memory management. */
-// Same as pool_num_elements_alloced() ...
-static size_t pool_size(Pool_desc *mp)
+/// Total number of elements in pool, both issued and currently free.
+static inline size_t pool_size(Pool_desc *mp)
 {
-	return mp->issued_elements;
+	return mp->alloced_elements;
 }
-#endif
 
 // Macros for our memory-pool usage debugging.
 // https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning

--- a/link-grammar/memory-pool.h
+++ b/link-grammar/memory-pool.h
@@ -87,7 +87,7 @@ struct  Pool_desc_s
 	/* num_elements is also used by the fake allocator if the POOL_EXACT
 	 * feature is used (it is not used for now). */
 
-	size_t curr_elements;       // Originally for debug. Now used by pool_next().
+	size_t issued_elements;     // Number of elements issued to users.
 
 	/* Flags that are used by pool_alloc(). */
 	bool zero_out;              // Zero out allocated elements.
@@ -108,7 +108,7 @@ typedef struct
  */
 static inline size_t pool_num_elements_alloced(Pool_desc *mp)
 {
-	return mp->curr_elements;
+	return mp->issued_elements;
 }
 
 static inline void *pool_alloc(Pool_desc *mp)
@@ -135,7 +135,7 @@ static inline void *pool_next(Pool_desc *mp, Pool_location *l)
 	assert(mp->free_list == NULL, "Cannot be called after pool_free()");
 #endif
 
-	if (l->element_number == mp->curr_elements) return NULL;
+	if (l->element_number == mp->issued_elements) return NULL;
 
 	if (l->element_number == 0)
 	{
@@ -170,9 +170,10 @@ static inline void *pool_next(Pool_desc *mp, Pool_location *l)
 }
 
 #if 0 /* For planned memory management. */
+// Same as pool_num_elements_alloced() ...
 static size_t pool_size(Pool_desc *mp)
 {
-	return mp->current_elements;
+	return mp->issued_elements;
 }
 #endif
 

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -272,7 +272,7 @@ static void free_table_lrcnt(count_context_t *ctxt)
 		}
 
 		const unsigned int num_values =
-			pool_num_elements_alloced(ctxt->sent->wordvec_pool);
+			pool_num_elements_issued(ctxt->sent->wordvec_pool);
 		lgdebug(+0, "Values %u (usage = non_max_null %u + other %u, "
 		        "other = any_null_zero %u + zero %u + nonzero %u); "
 		        "%u disjuncts in %u cache entries\n",

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -271,7 +271,8 @@ static void free_table_lrcnt(count_context_t *ctxt)
 				zero++;
 		}
 
-		const unsigned int num_values = ctxt->sent->wordvec_pool->curr_elements;
+		const unsigned int num_values =
+			pool_num_elements_alloced(ctxt->sent->wordvec_pool);
 		lgdebug(+0, "Values %u (usage = non_max_null %u + other %u, "
 		        "other = any_null_zero %u + zero %u + nonzero %u); "
 		        "%u disjuncts in %u cache entries\n",

--- a/link-grammar/parse/preparation.c
+++ b/link-grammar/parse/preparation.c
@@ -107,7 +107,7 @@ static void build_sentence_disjuncts(Sentence sent, float cost_cutoff,
 	                   /*zero_out*/true, /*align*/false, /*exact*/false);
 
 #ifdef DEBUG
-	size_t num_con_alloced = pool_num_elements_alloced(sent->Connector_pool);
+	size_t num_con_alloced = pool_num_elements_issued(sent->Connector_pool);
 #endif
 
 	for (w = 0; w < sent->length; w++)
@@ -127,7 +127,7 @@ static void build_sentence_disjuncts(Sentence sent, float cost_cutoff,
 	count_disjuncts_and_connectors(sent, &dcnt, &ccnt);
 	lgdebug(+D_PREP, "%u disjucts, %u connectors (%zu allocated)\n",
 	        dcnt, ccnt,
-	        pool_num_elements_alloced(sent->Connector_pool) - num_con_alloced);
+	        pool_num_elements_issued(sent->Connector_pool) - num_con_alloced);
 #endif
 
 	/* Delete the memory pools created in build_disjuncts_for_exp(). */


### PR DESCRIPTION
Distinguish between two numbers: how many pool elements have been issued to callers, and how many have been actually malloced.  I want the both numbers for debugging and mem management.