### PR TITLE
extract-links.c: Don't keep the links in Parse_choice

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -30,7 +30,7 @@ typedef struct Parse_choice_struct Parse_choice;
 
 /* Parse_choice records a parse of the word range set[0]->lw to
  * set[1]->rw, when the middle disjunct md is of word set[0]->rw
- * (which is always equal to set[1]->lw, link[0]->rw, and link[1]->lw).
+ * (which is always equal to set[1]->lw).
  * See make_choice() below.
  * The number of linkages in this parse is the multiplication of the
  * counts of the two Parse_set elements. */
@@ -39,8 +39,8 @@ struct Parse_choice_struct
 {
 	Parse_choice * next;
 	Parse_set * set[2];
-	Link        link[2]; /* the lc fields of these is NULL if there is no link used */
-	Disjunct    *md;     /* the chosen disjunct for the middle word */
+	Disjunct    *md;           /* the chosen disjunct for the middle word */
+	Connector   *lc, *rc;      /* the connectors on the middle word */
 };
 
 /* Parse_set serves as a header of Parse_choice chained elements, that
@@ -48,9 +48,10 @@ struct Parse_choice_struct
  * tracons l_id and r_id on words lw and rw, correspondingly. */
 struct Parse_set_struct
 {
-	short          lw, rw;     /* left and right word index */
-	unsigned int   null_count; /* number of island words */
-	int            l_id, r_id; /* tracons on words lw, rw */
+	uint8_t        lw, rw;     /* left and right word index */
+	uint8_t        null_count; /* number of island words */
+	int32_t        l_id, r_id; /* tracons on words lw, rw */
+	Connector      *le, *re;
 
 	count_t count;             /* The number of ways to parse. */
 #ifdef RECOUNT
@@ -100,25 +101,17 @@ struct extractor_s
  */
 
 static Parse_choice *
-make_choice(Parse_set *lset, Connector * llc, Connector * lrc,
-            Parse_set *rset, Connector * rlc, Connector * rrc,
+make_choice(Parse_set *lset, Connector * lrc,
+            Parse_set *rset, Connector * rlc,
             Disjunct *md, extractor_t* pex)
 {
 	Parse_choice *pc;
 	pc = pool_alloc(pex->Parse_choice_pool);
 	pc->next = NULL;
 	pc->set[0] = lset;
-	pc->link[0].link_name = NULL;
-	pc->link[0].lw = lset->lw;
-	pc->link[0].rw = lset->rw;
-	pc->link[0].lc = llc;
-	pc->link[0].rc = lrc;
 	pc->set[1] = rset;
-	pc->link[1].link_name = NULL;
-	pc->link[1].lw = rset->lw;
-	pc->link[1].rw = rset->rw;
-	pc->link[1].lc = rlc;
-	pc->link[1].rc = rrc;
+	pc->lc = lrc;
+	pc->rc = rlc;
 	pc->md = md;
 	return pc;
 }
@@ -142,12 +135,12 @@ static void put_choice_in_set(Parse_set *s, Parse_choice *pc)
 }
 
 static void record_choice(
-    Parse_set *lset, Connector * llc, Connector * lrc,
-    Parse_set *rset, Connector * rlc, Connector * rrc,
+    Parse_set *lset, Connector * lrc,
+    Parse_set *rset, Connector * rlc,
     Disjunct *md, Parse_set *s, extractor_t* pex)
 {
-	put_choice_in_set(s, make_choice(lset, llc, lrc,
-	                                 rset, rlc, rrc,
+	put_choice_in_set(s, make_choice(lset, lrc,
+	                                 rset, rlc,
 	                                 md, pex));
 }
 
@@ -281,6 +274,8 @@ static Pset_bucket * x_table_store(int lw, int rw,
 	n->set.null_count = null_count;
 	n->set.l_id = (NULL != le) ? le->tracon_id : lw;
 	n->set.r_id = (NULL != re) ? re->tracon_id : rw;
+	n->set.le = le;
+	n->set.re = re;
 	n->set.count = 0;
 	n->set.first = NULL;
 	n->set.tail = NULL;
@@ -412,8 +407,8 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 											  null_count-1, pex);
 					if (pset == NULL) continue;
 					dummy = dummy_set(lw, w, null_count-1, pex);
-					record_choice(dummy, NULL, NULL,
-									  pset, dis->right, NULL,
+					record_choice(dummy, NULL,
+									  pset, dis->right,
 									  dis, &xt->set, pex);
 					RECOUNT({xt->set.recount += pset->recount;})
 				}
@@ -424,8 +419,8 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 			if (pset != NULL)
 			{
 				dummy = dummy_set(lw, w, null_count-1, pex);
-				record_choice(dummy, NULL, NULL,
-								  pset,  NULL, NULL,
+				record_choice(dummy, NULL,
+								  pset,  NULL,
 								  NULL, &xt->set, pex);
 				RECOUNT({xt->set.recount += pset->recount;})
 			}
@@ -547,9 +542,8 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 								if (ls[i] == NULL) continue;
 								/* this ordering is probably not consistent with
 								 * that needed to use list_links */
-								record_choice(ls[i], le, d->left,
+								record_choice(ls[i], d->left,
 								              rset,  NULL /* d->right */,
-								              re,  /* the NULL indicates no link*/
 								              d, &xt->set, pex);
 								RECOUNT({xt->set.recount += (w_count_t)ls[i]->recount * rset->recount;})
 							}
@@ -594,9 +588,9 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 									if (rs[j] == NULL) continue;
 									/* this ordering is probably not consistent with
 									 * that needed to use list_links */
-									record_choice(lset, NULL /* le */,
+									record_choice(lset,
 									              d->left,  /* NULL indicates no link */
-									              rs[j], d->right, re,
+									              rs[j], d->right,
 									              d, &xt->set, pex);
 									RECOUNT({xt->set.recount += lset->recount * rs[j]->recount;})
 								}
@@ -612,8 +606,8 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 								for (j=0; j<4; j++)
 								{
 									if (rs[j] == NULL) continue;
-									record_choice(ls[i], le, d->left,
-									              rs[j], d->right, re,
+									record_choice(ls[i], d->left,
+									              rs[j], d->right,
 									              d, &xt->set, pex);
 									RECOUNT({xt->set.recount += ls[i]->recount * rs[j]->recount;})
 								}
@@ -692,6 +686,7 @@ bool build_parse_set(extractor_t* pex, Sentence sent,
 	return set_overflowed(pex);
 }
 
+#if 0
 /**
  * Assemble the link array and the chosen_disjuncts of a linkage.
  */
@@ -708,11 +703,36 @@ static void issue_link(Linkage lkg, bool lr, Disjunct *md, Link *link)
 
 	lkg->chosen_disjuncts[lr ? link->lw : link->rw] = md;
 }
+#endif
 
-static void issue_links_for_choice(Linkage lkg, Parse_choice *pc)
+/**
+ * Assemble the link array and the chosen_disjuncts of a linkage.
+ */
+static void issue_link(Linkage lkg, int lr, Parse_choice *pc,
+                       const Parse_set *set)
 {
-	issue_link(lkg, /*lr*/false, pc->md, &pc->link[0]);
-	issue_link(lkg, /*lr*/true, pc->md, &pc->link[1]);
+	Connector *lc = lr ? pc->rc : set->le;
+	if (lc == NULL) return;
+
+	Connector *rc = lr ? set->re : pc->lc;
+	if (rc != NULL)
+	{
+		assert(lkg->num_links < lkg->lasz, "Linkage array too small!");
+		Link *link = &lkg->link_array[lkg->num_links];
+		link->lw = pc->set[lr]->lw;
+		link->rw = pc->set[lr]->rw;
+		link->lc = lc;
+		link->rc = rc;
+		lkg->num_links++;
+	}
+	lkg->chosen_disjuncts[lr ? pc->set[1]->lw : pc->set[0]->rw] = pc->md;
+}
+
+static void issue_links_for_choice(Linkage lkg, Parse_choice *pc,
+                                   const Parse_set *set)
+{
+	issue_link(lkg, /*lr*/0, pc, set);
+	issue_link(lkg, /*lr*/1, pc, set);
 }
 
 /**
@@ -773,7 +793,7 @@ static void list_links(Linkage lkg, const Parse_set * set, int index)
 		index -= n;
 	}
 	assert(pc != NULL, "walked off the end in list_links");
-	issue_links_for_choice(lkg, pc);
+	issue_links_for_choice(lkg, pc, set);
 	list_links(lkg, pc->set[0], index % pc->set[0]->count);
 	list_links(lkg, pc->set[1], index / pc->set[0]->count);
 }
@@ -806,7 +826,7 @@ static void list_random_links(Linkage lkg, unsigned int *rand_state,
 		}
 	}
 
-	issue_links_for_choice(lkg, pc);
+	issue_links_for_choice(lkg, pc, set);
 	list_random_links(lkg, rand_state, pc->set[0]);
 	list_random_links(lkg, rand_state, pc->set[1]);
 }


### PR DESCRIPTION
See the discussion at #1402.

This patch reduces the size of `Parse_choice` from 96 bytes to 48, at the expanse of increasing `Parse_set` from 40 to 56.

My test script (to compare the linkages before and after this patch) encountered a problem due to the linkages with repeated multi-connector sequences that are now considered duplicates, so I am preparing a PR to discard such sequences in `eliminate_duplicate_disjuncts()`.

