### PR TITLE
Allow to control linkage deduplication

### DIFF
--- a/link-grammar/api-structures.h
+++ b/link-grammar/api-structures.h
@@ -51,8 +51,11 @@
 
 /* Performance tuning.
  * For short sentences, encoding takes more resources than it saves. If
- * this overhead is improved, this limit can be set lower. */
-#define SENTENCE_MIN_LENGTH_TRAILING_HASH 6
+ * this overhead is improved, this limit can be set lower.
+ * Update: For a consistent linkage deduplication, encoding (which
+ * included tracon sharing) should always be done. And now the overhead
+ * is negligible. */
+#define SENTENCE_MIN_LENGTH_TRAILING_HASH 0
 
 /* Pruning per null-count is costly for sentences whose parsing time
  * is relatively small. If a better pruning per null-count is implemented,

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -434,8 +434,21 @@ int VDAL_compare_linkages(Linkage l1, Linkage l2)
  */
 static void deduplicate_linkages(Sentence sent, int linkage_limit)
 {
+	int linkage_dedup = -1;
+	const char *test_linkage_dedup = test_enabled("linkage-dedup");
+	/* Never dedup: linkage-dedup:0; Always dedup: linkage-dedup:1 . */
+
+	if (test_linkage_dedup != NULL)
+	{
+		if ((test_linkage_dedup[0] != ':') || (test_linkage_dedup[1] == '\0'))
+			linkage_dedup = 1; /* just linkage-dedup w/o value defaults to 1 */
+		else
+			linkage_dedup = atoi(test_linkage_dedup + 1);
+	}
+
 	/* No need for deduplication, if random selection wasn't done. */
-	if (!sent->overflowed && (sent->num_linkages_found <= linkage_limit))
+	if ((linkage_dedup == 0) || ((linkage_dedup < 0) &&
+	    !sent->overflowed && (sent->num_linkages_found <= linkage_limit)))
 		return;
 
 	// Deduplicate the valid linkages only; its not worth wasting


### PR DESCRIPTION
See the discussion at PR #1396.

- Add `-test=linkage-dedup:N`
Without this argument, the default is to perform linkage deduplication iff there is sampling.
With this argument:
`-test=linkage-dedup:0` : Never do linkage deduplication.
`-test=linkage-dedup:1` or `-test=linkage-dedup`: Always do linkage deduplication.
- By default, perform connector encoding for any sentence length
  ... so linkage deduplication due to multi-connectors, which depend on connector memory sharing, will be done for short sentences too.

This patch replaces PR #1410.

