### PR TITLE
Convert cost cutoffs to MI cutoffs

### DIFF
--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -59,7 +59,18 @@
 #define cost-key "(Predicate "*-Mutual Info Key cover-section")";
 #define cost-index 1;
 
-% The cost will be used is a linear rescaling of the raw data above.
+% If the value at the key+index above is less than this cutoff,
+% the Section will not be added to the local dictionary.
+% In this example, the raw cost is the MI, and MI of less than
+% 4 will be rejected.
+#define cost-cutoff 4.0;
+
+% Sections with a missing cost will be assigned this default. To
+% ignore sections with a missing cost, set it to some value less
+% than `cost-cutoff`.
+#define cost-default 4.01;
+
+% The cost used by LG will be a linear rescaling of the raw data above.
 % The rescaling is y=mx+b where m==`cost-scale` and b==`cost-offset`
 % and x== the value fished out of the vector above.
 %
@@ -71,20 +82,11 @@
 #define cost-scale -0.25;
 #define cost-offset 3.0;
 
-% Sections whose computed cost is greater than this will not be added
-% to the local dictionary.
-#define cost-cutoff 2.0;
-
-% Sections with a missing cost will be assigned this default. To ignore
-% sections with a missing cost, set it to some value greater than
-% `cost-cutoff`.
-#define cost-default 1.99;
-
 % Disjuncts with a cost larger than this will not be used during
 % parsing. This can be over-ridden with the !cost-max parser option.
 % This applies both to the available disjuncts, and the ones created
 % dynamically, from pairs.
-% #define max-disjunct-cost 3;
+#define max-disjunct-cost 3.0;
 
 % -----------------------
 % If disjuncts are not directly available, they can be created on the
@@ -112,19 +114,23 @@
 % The highest-possible MI depends on the dataset, but is roughly
 % equal to log_2 of the number of word-pairs in the dataset. The
 % MI for most "good" word-pairs will be in the 4 to 20 range.
-% Use this to provide a default mapping.
 %
-% Multiplying by -0.25 gives them a cost of -1.0 or more negative.
-% Setting the offset to 3.0 gives them a cost of 2.0 or less.
-% This maps the MI interval [4,12] to [2,0] with MI's larger than
-% 12 being mapped to negative costs (thus encouraging cycles).
+% Setting the cutoff to 4.0 causes MI of less than 4 to be dropped.
+#define pair-cutoff 4.0;
+
+% The pair-default is used for pairs without MI. To ignore pairs with
+% missing MI, set this to less than the pair-cutoff.
+#define pair-default 4.01;
+
+% The LG cost system is "backwards" from MI: the higher the cost, the
+% less desirable the disjunct. The linear rescaling serves to remap
+% Atomese MI's into LG costs. The rescaling is in the form of mx+b.
 %
-% Setting the cutoff to 2.0 causes MI of less than 4 to be dropped.
-% Setting the default assigns a default cost to pairs without MI.
+% The below maps the MI interval [4,12] to [2,0], with MI's larger
+% than 12 being mapped to negative costs (thus encouraging cycles).
+%
 #define pair-scale -0.25;
 #define pair-offset 3.0;
-#define pair-cutoff 2.0;
-#define pair-default 1.99;
 
 % Keep in mind that the parser ranks parses from lowest to highest cost.
 % If word-pair links have a negative cost, the parser is incentivized to

--- a/link-grammar/dict-atomese/local-as.h
+++ b/link-grammar/dict-atomese/local-as.h
@@ -18,26 +18,26 @@ public:
 	std::mutex dict_mutex; // Avoid corruption of Dictionary
 	bool using_external_as;
 	AtomSpacePtr asp;
-	StorageNodePtr stnp; // Might be nullptr
-	Handle linkp;     // (Predicate "*-LG link string-*")
-	Handle prk;       // (Predicate "*-fetched-pair-*")
+	StorageNodePtr stnp;   // Might be nullptr
+	Handle linkp;          // (Predicate "*-LG link string-*")
+	Handle prk;            // (Predicate "*-fetched-pair-*")
 
 	// Sections
-	Handle miks;      // (Predicate "*-Mutual Info Key cover-section")
-	int cost_index;   // Offset into the FloatValue
+	Handle miks;           // (Predicate "*-Mutual Info Key cover-section")
+	int cost_index;        // Offset into the FloatValue
+	double cost_cutoff;    // MI below this is rejected
 	double cost_scale;
 	double cost_offset;
-	double cost_cutoff;
 	double cost_default;
 
 	// Word-pairs
-	Handle prp;       // (Predicate "*-word pair-*")
-	Handle mikey;     // (Predicate "*-Mutual Info Key-*")
-	Handle miformula; // (DefinedProcedure "*-dynamic MI ANY")
-	int pair_index;   // Offset into the FloatValue
+	Handle prp;            // (Predicate "*-word pair-*")
+	Handle mikey;          // (Predicate "*-Mutual Info Key-*")
+	Handle miformula;      // (DefinedProcedure "*-dynamic MI ANY")
+	int pair_index;        // Offset into the FloatValue
+	double pair_cutoff;    // MI below this is rejected
 	double pair_scale;
 	double pair_offset;
-	double pair_cutoff;
 	double pair_default;
 
 	// Any link type

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -39,19 +39,19 @@ using namespace opencog;
 #define STORAGE_NODE_STRING "storage-node"
 #define COST_KEY_STRING "cost-key"
 #define COST_INDEX_STRING "cost-index"
-#define COST_SCALE_STRING "cost-scale"
-#define COST_OFFSET_STRING "cost-offset"
 #define COST_CUTOFF_STRING "cost-cutoff"
 #define COST_DEFAULT_STRING "cost-default"
+#define COST_SCALE_STRING "cost-scale"
+#define COST_OFFSET_STRING "cost-offset"
 
 #define PAIR_PREDICATE_STRING "pair-predicate"
 #define PAIR_KEY_STRING "pair-key"
 #define PAIR_INDEX_STRING "pair-index"
 #define PAIR_FORMULA_STRING "pair-formula"
-#define PAIR_SCALE_STRING "pair-scale"
-#define PAIR_OFFSET_STRING "pair-offset"
 #define PAIR_CUTOFF_STRING "pair-cutoff"
 #define PAIR_DEFAULT_STRING "pair-default"
+#define PAIR_SCALE_STRING "pair-scale"
+#define PAIR_OFFSET_STRING "pair-offset"
 
 #define ANY_DEFAULT_STRING "any-default"
 #define ENABLE_SECTIONS_STRING "enable-sections"
@@ -187,10 +187,10 @@ bool as_open(Dictionary dict)
 		local->miks = local->asp->add_atom(mikh);
 
 		local->cost_index = atoi(LDEF(COST_INDEX_STRING, "1"));
+		local->cost_cutoff = atof(LDEF(COST_CUTOFF_STRING, "4.0"));
+		local->cost_default = atof(LDEF(COST_DEFAULT_STRING, "4.01"));
 		local->cost_scale = atof(LDEF(COST_SCALE_STRING, "-0.25"));
 		local->cost_offset = atof(LDEF(COST_OFFSET_STRING, "3.0"));
-		local->cost_cutoff = atof(LDEF(COST_CUTOFF_STRING, "2.0"));
-		local->cost_default = atof(LDEF(COST_DEFAULT_STRING, "1.99"));
 		local->extra_pairs = atoi(LDEF(EXTRA_PAIRS_STRING, "1"));
 		local->extra_any = atoi(LDEF(EXTRA_ANY_STRING, "1"));
 	}
@@ -223,10 +223,15 @@ bool as_open(Dictionary dict)
 	local->prp = local->asp->add_atom(prph);
 
 	local->pair_index = atoi(LDEF(PAIR_INDEX_STRING, "1"));
+	local->pair_cutoff = atof(LDEF(PAIR_CUTOFF_STRING, "4.0"));
+	local->pair_default = atof(LDEF(PAIR_DEFAULT_STRING, "4.01"));
 	local->pair_scale = atof(LDEF(PAIR_SCALE_STRING, "-0.25"));
 	local->pair_offset = atof(LDEF(PAIR_OFFSET_STRING, "3.0"));
-	local->pair_cutoff = atof(LDEF(PAIR_CUTOFF_STRING, "2.0"));
-	local->pair_default = atof(LDEF(PAIR_DEFAULT_STRING, "1.99"));
+
+	// The pair code applies the cutoff after scaling, not before.
+	// So we rejigger it here, so that works.
+	local->pair_cutoff =
+		local->pair_scale * local->pair_cutoff + local->pair_offset;
 
 	local->any_default = atof(LDEF(ANY_DEFAULT_STRING, "2.6"));
 

--- a/link-grammar/dict-atomese/sections.cc
+++ b/link-grammar/dict-atomese/sections.cc
@@ -230,23 +230,22 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 	HandleSeq sects = germ->getIncomingSetByType(SECTION);
 	for (const Handle& sect: sects)
 	{
-		// Apparently, some sections are missing costs. This is
+		// Apparently, some sections are missing MI's. This is
 		// most likey due to some data-processing bug, where the
 		// MI's were not recomputed. For now, we will silently
 		// ignore this issue, and assign a default to them.
-		double cost = local->cost_default;
+		double mi = local->cost_default;
 
 		const ValuePtr& mivp = sect->getValue(local->miks);
 		if (mivp)
 		{
 			// MI is the second entry in the vector.
 			const FloatValuePtr& fmivp = FloatValueCast(mivp);
-			double mi = fmivp->value()[local->cost_index];
-			cost = (local->cost_scale * mi) + local->cost_offset;
+			mi = fmivp->value()[local->cost_index];
 		}
 
-		// If the cost is too high, just skip this.
-		if (local->cost_cutoff < cost)
+		// If the MI is too low, just skip this.
+		if (mi < local->cost_cutoff)
 			continue;
 
 		Exp* andhead = nullptr;
@@ -303,6 +302,7 @@ Exp* make_sect_exprs(Dictionary dict, const Handle& germ)
 			andhead = tmp;
 		}
 
+		double cost = (local->cost_scale * mi) + local->cost_offset;
 		andhead->cost = cost;
 
 		// Save the exp-section pairing in the AtomSpace.


### PR DESCRIPTION
It is easier to think about MI's than costs. The MI's have obvious boundaries and behaviors; the costs are wonky and hard to understand.