### PR TITLE
Minor optimization for freeing dict-nodes.

### DIFF
--- a/link-grammar/dict-ram/dict-ram.c
+++ b/link-grammar/dict-ram/dict-ram.c
@@ -25,12 +25,16 @@
 
 /* ======================================================================== */
 
-static void free_dict_node_recursive(Dict_node * dn)
+void free_dict_node_recursive(Dict_node * dn)
 {
-	if (dn == NULL) return;
-	free_dict_node_recursive(dn->left);
-	free_dict_node_recursive(dn->right);
-	free(dn);
+	while (dn != NULL)
+	{
+		free_dict_node_recursive(dn->left);
+
+		Dict_node * rn = dn->right;
+		free(dn);
+		dn = rn;
+	}
 }
 
 void free_dictionary_root(Dictionary dict)

--- a/link-grammar/dict-ram/dict-ram.h
+++ b/link-grammar/dict-ram/dict-ram.h
@@ -20,6 +20,7 @@ Dict_node * dict_node_wild_lookup(Dictionary dict, const char *s);
 bool dict_node_exists_lookup(Dictionary dict, const char *s);
 
 void free_dictionary_root(Dictionary dict);
+void free_dict_node_recursive(Dict_node*);
 
 Exp * Exp_create(Pool_desc *);
 Exp * Exp_create_dup(Pool_desc *, Exp *);


### PR DESCRIPTION
This avoids blowing up the stack during dictionary-free.

This also exposes the dict-node-free function for externals use; I need it for Atomese caching WIP.