### PR TITLE
Measure usage of condesc and exp pool sizes.

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -567,10 +567,17 @@ void condesc_init(Dictionary dict, size_t num_con)
 {
 	ConTable *ct = &dict->contable;
 
-	condesc_table_alloc(ct, num_con);
 	ct->mempool = pool_new(__func__, "ConTable",
-								  /*num_elements*/1024, sizeof(condesc_t),
+								  /*num_elements*/num_con, sizeof(condesc_t),
 								  /*zero_out*/true, /*align*/true, /*exact*/false);
+
+	// Connector hash table must be an exact power of two.
+	int nbits = 0;
+	while (num_con) { nbits++; num_con >>= 1; }
+
+	// 4 times larger, to provide a reasonable hash table load factor.
+	nbits += 2;
+	condesc_table_alloc(ct, 1<<nbits);
 
 	ct->length_limit_def = NULL;
 	ct->length_limit_def_next = &ct->length_limit_def;

--- a/link-grammar/dict-common/dict-common.c
+++ b/link-grammar/dict-common/dict-common.c
@@ -372,7 +372,7 @@ void dictionary_delete(Dictionary dict)
 
 /**
  * Initialize generation mode, if requested.
- * Since the dictionary_create*() functions don't support Parse_Options as
+ * Since the dictionary_create_*() functions don't support Parse_Options as
  * an argument, use the "test" parse-option, which is in a global variable:
  * If it contains "generate", enable generation mode.
  * If an argument "walls" is also supplied ("generate:walls"), then

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -191,8 +191,16 @@ dictionary_six_str(const char * lang,
 		dict->end_lookup = dict_lookup_noop;
 
 		dict->dialect_tag.set = string_id_create();
-		condesc_init(dict, 1<<13);
-		Exp_pool_size = 1<<13;
+
+		// Actual usage:
+		// Lang  Exp   Condesc
+		//  en   47K    2.3K
+		//  ru  300K    5.5K
+		//  th    8K    2.0K
+		// The pool sizes are slightly under a power of two,
+		// so that malloc doesn't round up to next power of two.
+		condesc_init(dict, 3060);
+		Exp_pool_size = 8188;
 
 		if (!test_enabled("no-macro-tag"))
 		{
@@ -202,14 +210,15 @@ dictionary_six_str(const char * lang,
 	}
 	else
 	{
-		/*
-		 * Affix dictionary.
-		 */
+		/* Affix dictionary. */
 		afclass_init(dict);
 		dict->insert_entry = load_affix;
 		dict->exists_lookup = return_true;
-		condesc_init(dict, 1<<9);
-		Exp_pool_size = 1<<5;
+
+		// English dict is the largest of all;
+		// it has 16 exprs and 8 connectors in the affix table.
+		condesc_init(dict, 16);
+		Exp_pool_size = 30;
 	}
 
 	dict->dfine.set = string_id_create();

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -200,7 +200,7 @@ dictionary_six_str(const char * lang,
 		// The pool sizes are slightly under a power of two,
 		// so that malloc doesn't round up to next power of two.
 		condesc_init(dict, 3060);
-		Exp_pool_size = 8188;
+		Exp_pool_size = 16380;
 
 		if (!test_enabled("no-macro-tag"))
 		{


### PR DESCRIPTION
The changes here are effectively a no-op; the previous and new sizes are almost unchanged. The difference is that, this time, I left a note in the comments explaining the choices.