### PR TITLE
Fix a FIXME from wordgraph

### DIFF
--- a/link-grammar/linkage/sane.c
+++ b/link-grammar/linkage/sane.c
@@ -18,10 +18,38 @@
 #include "error.h"
 #include "linkage.h"
 #include "sane.h"
-#include "tokenize/tok-structures.h"    // Wordgraph_pathpos_s
+#include "tokenize/tok-structures.h"    // Morpheme_type
 #include "tokenize/word-structures.h"   // Word_struct
 #include "tokenize/wordgraph.h"
 #include "utilities.h"
+
+// Wordgraph_pathpos_s
+struct Wrdgr_path_s
+{
+	Gword *word;		/* Position in the Wordgraph */
+	const Gword **path; /* Linkage candidate wordgraph path */
+};
+typedef struct Wrdgr_path_s Wrdgr_pathpos;
+
+static size_t wrdgr_path_len(Wrdgr_pathpos *wp)
+{
+	size_t len = 0;
+	if (wp)
+		while (wp[len].word != NULL) len++;
+	return len;
+}
+
+static Wrdgr_pathpos *wrdgr_path_resize(Wrdgr_pathpos *wp, size_t len)
+{
+	wp = realloc(wp, (len+1) * sizeof(*wp));
+	wp[len].word = NULL;
+	return wp;
+}
+
+static void wrdgr_path_free(Wrdgr_pathpos *wp)
+{
+	free(wp);
+}
 
 /**
  * Construct word paths (one or more) through the Wordgraph.
@@ -41,11 +69,11 @@
  * null linkage.
  */
 #define D_WPA 7
-static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
+static void wordgraph_path_append(Wrdgr_pathpos **nwp, const Gword **path,
                                   Gword *current_word, /* add to the path */
                                   Gword *p)      /* add to the path queue */
 {
-	size_t n = wordgraph_pathpos_len(*nwp);
+	size_t n = wrdgr_path_len(*nwp);
 
 	assert(NULL != p, "Tried to add a NULL word to the word queue");
 	if (current_word == p)
@@ -55,7 +83,7 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 	}
 
 	/* Check if the path queue already contains the word to be added to it. */
-	const Wordgraph_pathpos *wpt = NULL;
+	const Wrdgr_pathpos *wpt = NULL;
 
 	if (NULL != *nwp)
 	{
@@ -90,7 +118,7 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 	if ((NULL == wpt) || (p != wpt->word))
 	{
 		/* Not already in the path queue - add it. */
-		*nwp = wordgraph_pathpos_resize(*nwp, n+1);
+		*nwp = wrdgr_path_resize(*nwp, n+1);
 	}
 	else
 	{
@@ -115,13 +143,13 @@ static void wordgraph_path_append(Wordgraph_pathpos **nwp, const Gword **path,
 }
 
 /**
- * Free the Wordgraph paths and the Wordgraph_pathpos array.
+ * Free the Wordgraph paths and the Wrdgr_pathpos array.
  * In case of a match, the final path is still needed so this function is
  * then invoked with free_final_path=false.
  */
-static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
+static void wordgraph_path_free(Wrdgr_pathpos *wp, bool free_final_path)
 {
-	Wordgraph_pathpos *twp;
+	Wrdgr_pathpos *twp;
 
 	if (NULL == wp) return;
 	for (twp = wp; NULL != twp->word; twp++)
@@ -129,7 +157,7 @@ static void wordgraph_path_free(Wordgraph_pathpos *wp, bool free_final_path)
 		if (free_final_path || (MT_INFRASTRUCTURE != twp->word->morpheme_type))
 			gwordlist_cfree(twp->path);
 	}
-	wordgraph_pathpos_free(wp);
+	wrdgr_path_free(wp);
 }
 
 #define NO_WORD (MAX_SENTENCE+1)
@@ -276,9 +304,9 @@ static size_t num_islands(const Linkage lkg, const Gword **wg_path)
 #define D_SLM 8
 bool sane_linkage_morphism(Sentence sent, Linkage lkg, Parse_Options opts)
 {
-	Wordgraph_pathpos *wp_new = NULL;
-	Wordgraph_pathpos *wp_old = NULL;
-	Wordgraph_pathpos *wpp = NULL;
+	Wrdgr_pathpos *wp_new = NULL;
+	Wrdgr_pathpos *wp_old = NULL;
+	Wrdgr_pathpos *wpp = NULL;
 	Gword **next; /* next Wordgraph words of the current word */
 	size_t i;
 	unsigned int null_count_found = 0;

--- a/link-grammar/tokenize/tok-structures.h
+++ b/link-grammar/tokenize/tok-structures.h
@@ -171,17 +171,12 @@ struct Gword_struct
 	Gword **null_subwords;       /* Null subwords represented by this word */
 };
 
-/* Wordgraph path word-positions,
- * used in wordgraph_flatten() and sane_linkage_morphism().
- * FIXME Separate to two different structures. */
+/* Wordgraph path word-positions */
 struct Wordgraph_pathpos_s
 {
 	Gword *word;      /* Position in the Wordgraph */
-	/* Only for wordgraph_flatten(). */
 	bool same_word;   /* Still the same word - mark it as "optional" */
 	bool next_ok;     /* OK to proceed to the next Wordgraph word */
 	bool used;        /* Debug - the word has been issued */
-	/* Only for sane_morphism(). */
-	const Gword **path; /* Linkage candidate wordgraph path */
 };
 #endif


### PR DESCRIPTION
Fix an old FIXME about sharing the `Wordgraph_pathpos` structure.