### PR TITLE
systest: Add lgverbosity, lgtests, lgwhatis

### DIFF
--- a/systest/lgerror
+++ b/systest/lgerror
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Written by <amirpli@gmail.com>.
-#%DESC link-grammar: List all the sentences that have an error in one batch out file but not the other
+#%DESC List all the sentences that have an error in one batch out file but not the other
 #
 # How to use:
 # lg.old > /tmp/b-old.out
@@ -11,6 +11,8 @@ use warnings;
 use strict;
 
 (my $prog = $0) =~ s/.*\///;
+(my $progdir = $0) =~ s,/[^/]+$,,;
+
 my $W = 250;
 my $zflag;
 
@@ -18,8 +20,9 @@ while (defined $ARGV[0] && $ARGV[0] =~ /^-(.*)/) {
 	my $argv = shift;
 	my $flag = $1;
 
-	$flag eq 'help' and do {
-		exec('sh-flags', $0)
+	$flag eq '-help' and do {
+		system("$progdir/sh-flags", $0);
+		usage();
 	};
 	$flag eq 'z' and do { #- -0 Be silent on 0 errors
 		$zflag = $argv;
@@ -27,9 +30,13 @@ while (defined $ARGV[0] && $ARGV[0] =~ /^-(.*)/) {
 	};
 }
 
+sub usage
+{
+	die "$prog: Missing file argument.\nUsage: $prog batch-result-old batch-result-new\n";
+}
 
-my $f1 = shift or die "$prog: Missing file argument\n";
-my $f2 = shift or die "$prog: Missing file argument\n";
+my $f1 = shift or usage();
+my $f2 = shift or usage();
 
 my $max_width = `cat $f1 $f2 | wc -L` * 2;
 $W = $max_width > $W ? $max_width :$W;

--- a/systest/lgtests
+++ b/systest/lgtests
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Written by <amirpli@gmail.com>
+#%DESC List test_enabled("teststring") tests
+
+cd ${0%/*}/..
+
+shopt -s globstar
+exec perl -ne \
+  'printf "%-30s %s:%d\n", $1, $ARGV, $. if /\btest_enabled\([^,]*(?:,\s)?"([^"]+)"/; eof and close ARGV' **/*.[ch]* |\
+  sort

--- a/systest/lgverbosity
+++ b/systest/lgverbosity
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Written by <amirpli@gmail.com>
+#%DESC List function and file verbosity levels
+
+cd ${0%/*}/..
+
+shopt -s globstar
+perl -ne \
+ 'BEGIN { $func_fieldwidth = 30; }
+  $filedebug = "";
+  if (/(?:verbosity_level|lgdebug)\(\+?(D_SPEC\+\d+)/)
+  {
+    $line = $.;
+    $verbosity = $1;
+    while (<>)
+    {
+      next if /{/;
+      $more_info = $_;
+      last;
+    }
+    $more_info =~ s/^\s+//;
+    chomp($more_info);
+    $out = sprintf "%-10s %-15s %s", $verbosity, "", $more_info;
+  }
+  elsif (/^#define\s+(D_[A-Z]+)\s+(\S+)\s*(.*)$/)
+  {
+    $line = $.;
+    $out = sprintf "%-10s %-15s %s", $1, $2, $3;
+    $filedebug = /for this file/;
+  }
+  $func = "";
+  $func = $1 if /([\w:]+)\(.*[\),]\s*$/;
+  if ($. > $line && $out)
+  {
+    ($file) = $ARGV =~ m|link-grammar/(.*)|;
+    if ($func)
+    {
+      $func = $func ."()";
+      $func = "...".substr($func, -($func_fieldwidth-3))
+        if $func =~ /::/ && length($func) > $func_fieldwidth;
+    }
+    $func = "Whole file" if $filedebug;
+    printf "%-30s %${func_fieldwidth}s %s\n", $file.":", $func, $out;
+    $out = "";
+  }
+ ' \
+**/*.[ch]* | sort -n -k 4

--- a/systest/lgwhatis
+++ b/systest/lgwhatis
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+# Written by <amirpli@gmail.com>
+#%DESC Show description of script's directory programs according to embedded #%DESC
+
+use strict;
+use warnings;
+
+(my $progdir = $0) =~ s,/[^/]+$,,;
+
+opendir(PROGDIR, $progdir) || die "$0: Cannor opendir '$progdir': $!";
+(my @files = readdir(PROGDIR)) || die "$0: Cannor readdir '$progdir': $!";
+chdir $progdir;
+
+FILE: foreach my $f (@files) {
+	next if $f =~ /^\./ || -d $f;
+	open(PROGF, $f) || die "$0: Cannor open '$f': $!";
+	foreach (<PROGF>) {
+		if (s/^#%DESC\s+//) {
+			printf "%-20s %s", $f, $_;
+			next FILE;
+		}
+	}
+	printf "%-20s *** No description ***\n", $f;
+}

--- a/systest/sh-flags
+++ b/systest/sh-flags
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+# Written by <amirpli@gmail.com>
+#%DESC Show shell/Perl script flags
+#
+# Note the ":" for an option that is not to be documented.
+#For example:
+# In Bash scripts:
+#
+#   --help)
+#           exec sh-flags $0
+#           ;;
+#   -n) # Only configure - no compilation
+#           no_compilation=1
+#           shift
+#           ;;
+#   -q) # show configuration parameters
+#           qflag=1
+#           shift
+#           ;;
+#   -old) : # Unused, for backward compatibility
+#           shift
+#           ;;
+#
+#
+# In Perl scripts:
+#
+#while (defined $ARGV[0] && $ARGV[0] =~ /^-(.*)/) {
+#       my $argv = shift;
+#       my $flag = $1;
+
+#       $flag eq '-help' and do {
+#               exec('sh-flags', $0)
+#       };
+#       $flag eq 'l' and do { #- -l Use LEN in cost comparisons
+#               $lflag = $argv;
+#               next;
+#       };
+#       (($flag eq 'md5') || ($flag eq 'md5u')) and do { #- -md5 Emit md5
+#                                                        #- -md5u Same but discard dups
+#               $md5flag = $argv;
+#               next;
+#       };
+#}
+
+use strict;
+use warnings;
+
+(my $prog = $0) =~ s/.*\///;
+die "$prog: Missing argument\n" unless defined $ARGV[0];
+my $printflags;
+my $infile = $ARGV[0];
+open(F, $infile) or die "$prog: Cannot open '$infile': $!\n";
+
+while (<F>) {
+	if (/^#%DESC|^#%?Usage/i)
+	{
+		print;
+		next;
+	}
+	# Skip all lines unless case label with a comment, or #-
+	# But ignore ## comments.
+	if (/^\s*([^(]+)\)\s+#[^#](.*)/ || / #-\s+(\S+)\s+(\S+.*)$/)
+	{
+		unless ($printflags)
+		{
+			print "Flags:\n";
+			$printflags = 1;
+		}
+		print "$1: $2\n";
+	}
+}


### PR DESCRIPTION
My scripts originally included hard-coded paths.
I fixed them to use `!#/usr/bin/env PROG`, and also to locate the scripts or source directory according to the program's invocation path. I also added support for executing them when they are not in the `PATH` (even though it might be a good idea to include `/.../systest` in the `PATH`).

Here I patched the existing `lgerror` and added 4 scripts.

The following are also included here (after I improved them accordingly):

- lgverbosity - List function and file verbosity levels
- lgtests         - List test_enabled("teststring") tests
- lgwhatis      - Show description of script's directory programs

A utility that is invoked by the "lg*" scripts when the `--help` argument is used:
- sh-flags        - Show script's flags and their description

Most of the other scripts need also the configuration directory to locate the binaries, and I will need to find an automatic way to locate it before I can include these scripts.  One way is to use an initialization file `~/.lgconf`, with a line like:
`binddir=build` # relative to the source directory
Or for me (`/tmp` is a `tmpfs` filesystem):
`builddir=/tmp/link-grammar/$branch`

For further patches to existing `systest` scripts, I will apply the PRs myself for not to bother you.
However, for new `systest` scripts I will still send the PRs for your review.
