### PR TITLE
PCRE2 reg_comp(): Disable JIT

### DIFF
--- a/link-grammar/dict-common/regex-morph.c
+++ b/link-grammar/dict-common/regex-morph.c
@@ -214,7 +214,8 @@ static bool reg_comp(Regex_node *rn)
 	                            options, &rc, &erroffset, NULL);
 	if (re->re_code != NULL)
 	{
-		pcre2_jit_compile(re->re_code, PCRE2_JIT_COMPLETE);
+		// JIT is not used due to a significant slowdown. (Strings too short?)
+		//pcre2_jit_compile(re->re_code, PCRE2_JIT_COMPLETE);
 		return true;
 	}
 


### PR DESCRIPTION
(Enabled in PR #1365.)
It is what causes the significant slowdown of `ru`.
I still left it enabled in `anysplit.c` since it seems to be slightly faster.

P.S. Maybe combining same-name patterns as alternations, may make JIT faster (need to check).
For `ru` it may be done by supporting something like:
``` text
MORPH-END-\0: /оряя$/
MORPH-END-\0: /еряя$/
...
```