### PR TITLE
Stop littering .lg_history files everywhere.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Version 5.12.1 (XXX 2023)
  * English dict: paraphrasing fixes. #1398
  * Report CPU time usage only for the current thread. #1399
  * Extensive performance optimizations for MST dictionaries. #1402
+ * Stop littering `.lg_history` files in current working dir. #1446
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -372,7 +372,7 @@ char *lg_readline(const char *mb_prompt)
 
 	if (!is_init)
 	{
-#define HFILE ".lg_history"
+#define HFILE "~/.cache/link-grammar/history"
 		is_init = true;
 
 		size_t sz = mbstowcs(NULL, mb_prompt, 0) + 4;
@@ -384,7 +384,9 @@ char *lg_readline(const char *mb_prompt)
 		history_w(hist, &ev, H_SETSIZE, 100);
 		history_w(hist, &ev, H_SETUNIQUE, 1);
 		el_wset(el, EL_HIST, history_w, hist);
-		history_w(hist, &ev, H_LOAD, HFILE);
+		char * chist = expand_homedir(HFILE);
+		history_w(hist, &ev, H_LOAD, chist);
+		free(chist);
 
 		el_set(el, EL_SIGNAL, 1); /* Restore tty setting on returning to shell */
 
@@ -421,7 +423,9 @@ char *lg_readline(const char *mb_prompt)
 	if (1 < numc)
 	{
 		history_w(hist, &ev, H_ENTER, wc_line);
-		history_w(hist, &ev, H_SAVE, HFILE);
+		char * chist = expand_homedir(HFILE);
+		history_w(hist, &ev, H_SAVE, chist);
+		free(chist);
 	}
 	/* fwprintf(stderr, L"==> got %d %ls", numc, wc_line); */
 

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -372,6 +372,8 @@ char *lg_readline(const char *mb_prompt)
 
 	if (!is_init)
 	{
+// This seems like the defacto convention for modern-day
+// dot-files on Linux systems. But what about Windows or Apple?
 #define HFILE "~/.cache/link-grammar/history"
 		is_init = true;
 
@@ -424,6 +426,7 @@ char *lg_readline(const char *mb_prompt)
 	{
 		history_w(hist, &ev, H_ENTER, wc_line);
 		char * chist = expand_homedir(HFILE);
+		create_dir(chist);
 		history_w(hist, &ev, H_SAVE, chist);
 		free(chist);
 	}

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -25,6 +25,7 @@
 #include <pwd.h>
 #include <signal.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <termios.h>
 #include <unistd.h>
@@ -105,6 +106,17 @@ char *expand_homedir(const char *filename)
 #endif
 
 	return eh_filename;
+}
+
+void create_dir(const char *filename)
+{
+#ifndef _WIN32
+	char *fpath = strdupa(filename);
+	char *p = strrchr(fpath, '/');
+	if (p) *p = 0;
+	// Ignore error if mkdir fails.
+	mkdir(fpath, S_IRWXU);
+#endif
 }
 
 #ifdef _WIN32

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -18,6 +18,7 @@
 #include "command-line.h"
 
 char *expand_homedir(const char *fn);
+void create_dir(const char *fn);
 void set_screen_width(Command_Options*);
 void initialize_screen_width(Command_Options *);
 


### PR DESCRIPTION
They are just .. everywhere on my system. Fixes #1443

This is a Linux-only solution. I don't know what the convention for Windows and Apple should be.