### PR TITLE
Fix very old max cost bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Version 5.12.1 (XXX 2023)
  * English dict: paraphrasing fixes. #1398
  * Report CPU time usage only for the current thread. #1399
  * Extensive performance optimizations for MST dictionaries. #1402
+ * Fix incorrect maxcost computation. This is a very old bug. #1450
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.


### PR DESCRIPTION
The point of cost-max was not to compute the total cost of an expression, but to determine which expressions had single connectors that exceeded a threshold. This allows disjuncts which high-cost individual connectors to be rejected, without otherwise altering parse ranking.

See #1449 for details.