### PR TITLE
Disable the use of cost cutoffs in the English dict.

### DIFF
--- a/data/en/4.0.dialect
+++ b/data/en/4.0.dialect
@@ -44,6 +44,10 @@
 %    sense in a headline context, it can, and will generate bad
 %    parses when applied to non-headline contexts. By making
 %    determiners optional, many other rules are thrown off.
+%
+% Dialects can be disabled by setting the cost to any large value,
+% as long as it is greater than the `max-disjunct-cost` setting in
+% the dictionary.
 
 [default]
 no-headline
@@ -51,13 +55,13 @@ bad-spelling: 0
 colloquial: 0
 
 [no-headline]
-headline: 4
+headline: 99
 
 [headline]
 headline: 0
 
 [no-bad-spelling]
-bad-spelling: 4
+bad-spelling: 99
 
 % Examples.
 %[irish1]  %this is a test

--- a/data/en/4.0.dict
+++ b/data/en/4.0.dict
@@ -14,8 +14,10 @@
 #define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.
-#define max-disjunct-cost         2.7;
-#define panic-max-disjunct-cost   4.0;
+% Setting this to 5 or larger effectively disables the use of cost
+% cutoffs, as nothing in this dict can go this high.
+#define max-disjunct-cost         10.0;
+#define panic-max-disjunct-cost   10.0;
 
  % _ORGANIZATION OF THE DICTIONARY_
  %

--- a/data/en/4.0.dict.m4
+++ b/data/en/4.0.dict.m4
@@ -23,8 +23,10 @@ changecom(`%')
 #define dictionary-locale         en_US.UTF-8;
 
 % The default largest disjunct cost to consider during parsing.
-#define max-disjunct-cost         2.7;
-#define panic-max-disjunct-cost   4.0;
+% Setting this to 5 or larger effectively disables the use of cost
+% cutoffs, as nothing in this dict can go this high.
+#define max-disjunct-cost         10.0;
+#define panic-max-disjunct-cost   10.0;
 
  % _ORGANIZATION OF THE DICTIONARY_
  %


### PR DESCRIPTION
Per discussions in #1453