### PR TITLE
Get rid of the old goofball maxcost computation.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Version 5.12.1 (XXX 2023)
  * English dict: paraphrasing fixes. #1398
  * Report CPU time usage only for the current thread. #1399
  * Extensive performance optimizations for MST dictionaries. #1402
- * Fix incorrect maxcost computation. This is a very old bug. #1450
+ * Remove old broken max-cost computations. #1456
 
 Version 5.12.0 (26 Nov 2022)
  * Fix crash when using the Atomese dictionary backend.


### PR DESCRIPTION
It was confusing, broken, and prevented good parses from happening. See #1450 #1449 and #783 and #1453