### PR TITLE
Fix russian dict to accomadate new cost computations

### DIFF
--- a/data/ru/4.0.dict
+++ b/data/ru/4.0.dict
@@ -7,10 +7,10 @@
 %%
 %% This file uses the utf8 encoding
 
-#define dictionary-version-number 5.11.0;
+#define dictionary-version-number 5.12.1;
 #define dictionary-locale         ru_RU.UTF-8;
-#define max-disjunct-cost         2.7;
-#define panic-max-disjunct-cost   4.0;
+#define max-disjunct-cost         4.1;
+#define panic-max-disjunct-cost   4.1;
 
 <costly-null>: [[[[]]]];
 


### PR DESCRIPTION
The pull req #1456 broke the existing russian dict. This fixes it.  Seems that a cost cutoff of 3.1 is too low, as it rejects many good linkages that come from
[[FOO]] & [[BAR]] disjuncts. a cutoff of 4.1 allows these, while rejecting the cost-6 linkages that ruin corpus-basic.

As of now, I get 45 errors in ru/corpus-basic.batch which is two less than the 47 that I got, before merging #1450