### PR TITLE
Provide an optimzed condesc for the Atomese dict.

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -289,7 +289,7 @@ static void connector_encode_lc(const char *lc_string, condesc_t *desc)
  *
  * Note: check_connector() has already validated the connector string.
  */
-static void calculate_connector_info(condesc_t * c)
+void calculate_connector_info(condesc_t * c)
 {
 	const char *s;
 
@@ -365,7 +365,7 @@ static uint32_t connector_str_hash(const char *s)
 /**
  * Compare connector UC parts, for qsort.
  */
-static int condesc_by_uc_constring(const void * a, const void * b)
+int condesc_by_uc_constring(const void * a, const void * b)
 {
 	const condesc_t * const * cda = a;
 	const condesc_t * const * cdb = b;
@@ -550,6 +550,7 @@ condesc_t *condesc_add(ConTable *ct, const char *constring)
 		lgdebug(+11, "Creating connector '%s' (%zu)\n", constring, ct->num_con);
 		h->desc = pool_alloc(ct->mempool);
 		h->desc->string = constring;
+		h->desc->uc_num = UINT32_MAX;
 		h->str_hash = hash;
 		ct->num_con++;
 
@@ -589,4 +590,5 @@ void condesc_setup(Dictionary dict)
 	set_all_condesc_length_limit(dict);
 	free(dict->contable.sdesc);
 }
+
 /* ========================= END OF FILE ============================== */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -121,6 +121,7 @@ typedef struct
 	size_t size;          /* Allocated size */
 	size_t num_con;       /* Number of connector types */
 	size_t num_uc;        /* Number of connector types with different UC part */
+	size_t last_num;      /* All condescs up to here have been done already. */
 	Pool_desc *mempool;
 	length_limit_def_t *length_limit_def;
 	length_limit_def_t **length_limit_def_next;
@@ -200,6 +201,8 @@ static inline unsigned int connector_uc_num(const Connector * c)
 Connector * connector_new(Pool_desc *, const condesc_t *, Parse_Options);
 void set_connector_farthest_word(Exp *, int, int, Parse_Options);
 void free_connectors(Connector *);
+void calculate_connector_info(condesc_t *);
+int condesc_by_uc_constring(const void *, const void *);
 
 /**
  * Compare only the uppercase part of two connectors.


### PR DESCRIPTION
The original form took up 30% of CPU time, growing up to 80% It also limited multi-threading performance.