### PR TITLE
Improve the CPU and memory efficiency of the match-list cache

### DIFF
--- a/link-grammar/parse/count.h
+++ b/link-grammar/parse/count.h
@@ -24,7 +24,7 @@ Count_bin *table_lookup(count_context_t *, int, int,
                         unsigned int, size_t *);
 int do_parse(Sentence, fast_matcher_t*, count_context_t*, Parse_Options);
 bool no_count(count_context_t *, int, Connector *, unsigned int, unsigned int);
-Disjunct ***get_cached_match_list(count_context_t *, int, int, Connector *);
+match_list_cache *get_cached_match_list(count_context_t *, int, int, Connector *);
 
 count_context_t *alloc_count_context(Sentence, Tracon_sharing*);
 void free_count_context(count_context_t*, Sentence);

--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -492,7 +492,7 @@ Parse_set * mk_parse_set(fast_matcher_t *mchxt,
 		}
 		/* End of nonzero leftcount/rightcount range cache check. */
 
-		Disjunct ***mlcl = NULL, ***mlcr = NULL;
+		match_list_cache *mlcl = NULL, *mlcr = NULL;
 
 		if (le != NULL)
 			mlcl = get_cached_match_list(ctxt, 0, w, le);

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -20,6 +20,12 @@
 #include "link-includes.h"              // for Sentence
 #include "memory-pool.h"
 
+typedef struct match_list_cache_sruct
+{
+	Disjunct *d_lkg;        /* Disjuncts with a jet linkage */
+	Count_bin count;          /* The counts for that linkage */
+} match_list_cache;
+
 typedef struct Match_node_struct Match_node;
 struct Match_node_struct
 {
@@ -49,7 +55,7 @@ fast_matcher_t* alloc_fast_matcher(const Sentence, unsigned int *[]);
 void free_fast_matcher(Sentence sent, fast_matcher_t*);
 
 size_t form_match_list(fast_matcher_t *, int, Connector *, int, Connector *,
-                       int, Disjunct ***, Disjunct ***);
+                       int, match_list_cache *, match_list_cache *);
 
 /**
  * Return the match-list element at the given index.

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -42,10 +42,6 @@ struct fast_matcher_s
 	Disjunct ** match_list;      /* match-list stack */
 	size_t match_list_end;       /* index to the match-list stack end */
 	size_t match_list_size;      /* number of allocated elements */
-
-	/* Match list cache. */
-	Pool_desc *mld_pool; /* disjuncts pointers */
-	Pool_desc *mlc_pool; /* linkage counts */
 };
 
 /* See the source file for documentation. */


### PR DESCRIPTION
This patch simplifies the match-list cache code and saves 8 bytes per "word vector" element that doesn't have a count.
It also uses a single memory pool for the cache (instead of two).