### PR TITLE
Add flag to disable built-in capitalization rules.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Version 5.12.3 (XXX 2023)
  * Assorted Atomese fixes.
  * Fix SAT-solver build breaks.
+ * Add dictionary flag to disable built-in capitlization rules. #1468
 
 Version 5.12.2 (9 March 2023)
  * Fix null-pointer deref in Atomese code.

--- a/data/demo-atomese/storage.dict
+++ b/data/demo-atomese/storage.dict
@@ -14,6 +14,9 @@
 #define dictionary-locale         en_US.UTF-8;
 #define dictionary-version-number 5.12.3;
 
+% Never use LG built-in capitalization and downcasing rules.
+#define disable-downcasing true;
+
 % -----------------------
 % Dictionary data location.
 % The dictionary location is specified with a StorageNode. Any valid

--- a/link-grammar/dict-common/dict-common.h
+++ b/link-grammar/dict-common/dict-common.h
@@ -39,6 +39,7 @@ static const float DEFAULT_MAX_DISJUNCT_COST = 2.7f;
 #define LG_DISJUNCT_COST                        "max-disjunct-cost"
 #define LG_DICTIONARY_VERSION_NUMBER            "dictionary-version-number"
 #define LG_DICTIONARY_LOCALE                    "dictionary-locale"
+#define LG_DISABLE_DOWNCASING                   "disable-downcasing"
 
 /* Forward decls */
 typedef struct Afdict_class_struct Afdict_class;
@@ -136,6 +137,7 @@ struct Dictionary_s
 	bool         right_wall_defined;
 	bool         shuffle_linkages;
 	bool         dynamic_lookup;
+	bool         disable_downcasing;
 
 	/* Duplicate words are disallowed in 4.0.dict unless
 	 * allow_duplicate_words is defined to "true".

--- a/link-grammar/dict-common/dict-locale.c
+++ b/link-grammar/dict-common/dict-locale.c
@@ -448,6 +448,12 @@ bool dictionary_setup_defines(Dictionary dict)
 
 	dictionary_setup_locale(dict);
 
+	dict->disable_downcasing = false;
+	const char * ddn =
+		linkgrammar_get_dict_define(dict, LG_DISABLE_DOWNCASING);
+	if (NULL != ddn && 0 != strcmp(ddn, "false") && 0 != strcmp(ddn, "0"))
+		dict->disable_downcasing = true;
+
 	if (!dictionary_setup_max_disjunct_cost(dict)) return false;
 
 	return true;

--- a/link-grammar/tokenize/tokenize.c
+++ b/link-grammar/tokenize/tokenize.c
@@ -1550,6 +1550,9 @@ static bool mprefix_split(Sentence sent, Gword *unsplit_word, const char *word)
  */
 static bool is_capitalizable(const Dictionary dict, const Gword *word)
 {
+	/* Do not use these hard-coded capitalization rules. */
+	if (dict->disable_downcasing) return false;
+
 	/* Words at the start of sentences are capitalizable */
 	if (MT_WALL == word->prev[0]->morpheme_type) return true;
 	if (MT_INFRASTRUCTURE == word->prev[0]->morpheme_type) return true;


### PR DESCRIPTION
These rules are messing with the Atomese dicts, which use a different approach to the problem. Add a brute-force flag to disable them. Existing dictionaries are not affected.