### PR TITLE
count.c: Definitions to disable the use of various caches

### DIFF
--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -36,6 +36,9 @@
 typedef uint8_t null_count_m;  /* Storage representation of null_count */
 typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 
+/* Allow to disable the use of the various caches (for debug). */
+const bool ENABLE_WORD_SKIP_VECTOR = true;
+
 typedef struct Table_tracon_s Table_tracon;
 struct Table_tracon_s
 {
@@ -627,6 +630,8 @@ static void generate_word_skip_vector(count_context_t *ctxt, wordvecp wv,
                                       int start_word, int end_word,
                                       int lw, int rw)
 {
+	if (!ENABLE_WORD_SKIP_VECTOR) return;
+
 	if (le != NULL)
 	{
 		int check_word = start_word;

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -289,7 +289,7 @@ static void free_table_lrcnt(count_context_t *ctxt)
 				if (t->mlc0 != NULL)
 				{
 					cml++;
-					for (Disjunct *d = t->mlc0->d_lkg; d != NULL; d++)
+					for (Disjunct *d = t->mlc0->d; d != NULL; d++)
 						cml_disjunct++;
 				}
 			}
@@ -757,13 +757,13 @@ static void lrcnt_cache_match_list(wordvecp lrcnt_cache, count_context_t *ctxt,
 		Disjunct *d = get_match_list_element(mchxt, i);
 		if ((dir == 0) ? d->match_left : d->match_right)
 		{
-			ml[dcnt].d_lkg = d;
+			ml[dcnt].d = d;
 			assert(d->lrcount > 0, "Invalid linkage count %d", d->lrcount);
 			ml[dcnt].count = d->lrcount;
 			dcnt++;
 		}
 	}
-	ml[dcnt].d_lkg = NULL;
+	ml[dcnt].d = NULL;
 
 	lrcnt_cache->mlc0 = ml;
 }

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -38,6 +38,7 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 
 /* Allow to disable the use of the various caches (for debug). */
 const bool ENABLE_WORD_SKIP_VECTOR = true;
+const bool ENABLE_MATCH_LIST_CACHE = true;
 
 typedef struct Table_tracon_s Table_tracon;
 struct Table_tracon_s
@@ -742,6 +743,8 @@ static void lrcnt_cache_match_list(wordvecp lrcnt_cache, count_context_t *ctxt,
 	size_t dcnt = 0;
 	size_t i  = 0;
 	fast_matcher_t *mchxt = ctxt->mchxt;
+
+	if (!ENABLE_MATCH_LIST_CACHE) return;
 
 	for (i = mlb; get_match_list_element(mchxt, i) != NULL; i++)
 	{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -39,6 +39,8 @@ typedef uint8_t WordIdx_m;     /* Storage representation of word index */
 /* Allow to disable the use of the various caches (for debug). */
 const bool ENABLE_WORD_SKIP_VECTOR = true;
 const bool ENABLE_MATCH_LIST_CACHE = true;
+const bool ENABLE_TABLE_LRCNT = true;  // Also controls the above two caches.
+const bool USE_TABLE_TRACON = true;    // The table is always maintained.
 
 typedef struct Table_tracon_s Table_tracon;
 struct Table_tracon_s
@@ -1653,8 +1655,8 @@ count_context_t * alloc_count_context(Sentence sent, Tracon_sharing *ts)
 	memset(ctxt, 0, sizeof(count_context_t));
 
 	ctxt->sent = sent;
-	ctxt->is_short =
-		(sent->length <= min_len_word_vector) && !IS_GENERATION(ctxt->sent->dict);
+	ctxt->is_short = !ENABLE_TABLE_LRCNT ||
+		((sent->length <= min_len_word_vector) && !IS_GENERATION(ctxt->sent->dict));
 
 	if (!ctxt->is_short)
 	{

--- a/link-grammar/parse/count.c
+++ b/link-grammar/parse/count.c
@@ -47,7 +47,7 @@ struct Table_tracon_s
 {
 	Table_tracon     *next;
 	int              l_id, r_id;
-	Count_bin        count;      // normally int_32_t
+	Count_bin        count;      // Normally int32_t.
 	null_count_m     null_count;
 	size_t           hash;       // Generation needs more than 32 bits.
 };

--- a/link-grammar/parse/fast-match.c
+++ b/link-grammar/parse/fast-match.c
@@ -615,9 +615,9 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	}
 	else
 	{
-		for (cmx = mlcr; cmx->d_lkg != NULL; cmx++)
+		for (cmx = mlcr; cmx->d != NULL; cmx++)
 		{
-			cmx->d_lkg->match_left = false;
+			cmx->d->match_left = false;
 		}
 		mr_end = NULL; /* Prevent a gcc "may be uninitialized" warning */
 	}
@@ -646,11 +646,11 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	}
 	else
 	{
-		for (cmx = mlcl; cmx->d_lkg != NULL; cmx++)
+		for (cmx = mlcl; cmx->d != NULL; cmx++)
 		{
-			cmx->d_lkg->match_left = true;
-			cmx->d_lkg->match_right = false;
-			push_match_list_element(ctxt, lid, cmx->d_lkg);
+			cmx->d->match_left = true;
+			cmx->d->match_right = false;
+			push_match_list_element(ctxt, lid, cmx->d);
 		}
 	}
 
@@ -677,13 +677,13 @@ form_match_list(fast_matcher_t *ctxt, int w,
 	}
 	else
 	{
-		for (cmx = mlcr; cmx->d_lkg != NULL; cmx++)
+		for (cmx = mlcr; cmx->d != NULL; cmx++)
 		{
-			if ((lc != NULL) && !cmx->d_lkg->match_left) continue; /* lc optimization*/
-			cmx->d_lkg->match_right = true;
-			cmx->d_lkg->rcount_index = (uint32_t)(cmx - mlcr);
-			if (cmx->d_lkg->match_left) continue;
-			push_match_list_element(ctxt, lid, cmx->d_lkg);
+			if ((lc != NULL) && !cmx->d->match_left) continue; /* lc optimization*/
+			cmx->d->match_right = true;
+			cmx->d->rcount_index = (uint32_t)(cmx - mlcr);
+			if (cmx->d->match_left) continue;
+			push_match_list_element(ctxt, lid, cmx->d);
 		}
 	}
 

--- a/link-grammar/parse/fast-match.h
+++ b/link-grammar/parse/fast-match.h
@@ -22,8 +22,8 @@
 
 typedef struct match_list_cache_sruct
 {
-	Disjunct *d_lkg;        /* Disjuncts with a jet linkage */
-	Count_bin count;          /* The counts for that linkage */
+	Disjunct *d;                 /* disjuncts with a jet linkage */
+	Count_bin count;             /* the counts for that linkage */
 } match_list_cache;
 
 typedef struct Match_node_struct Match_node;


### PR DESCRIPTION
Add definitions to control the 4 caches used in `do_count()`:
``` c
const bool ENABLE_WORD_SKIP_VECTOR = true;
const bool ENABLE_MATCH_LIST_CACHE = true;
const bool ENABLE_TABLE_LRCNT = true;  // Also controls the above two caches.
const bool USE_TABLE_TRACON = true;    // The table is always maintained.
```
Disabling the lrcnt table also disables the match list cache and the word skip vector since they are kept in it.
On `USE_TABLE_TRACON=false`, the tracon table is still maintained since `mk_parse_set()` needs it. Also, in that case, its existence is used to validate for consistency when counts are recomputed (instead of using their cached value).

You can see that the caches have a low impact on short sentences but dramatically on long ones.
Disabling individual caches may help to debug changes in `do_count()`. e.g. it helped me to debug adding an "alternatives" check (an unpublished WIP).