### PR TITLE
Use correct guard macro for glibc heap functions

### DIFF
--- a/link-grammar/parse/extract-links.c
+++ b/link-grammar/parse/extract-links.c
@@ -278,7 +278,7 @@ void free_extractor(extractor_t * pex)
 	pex->x_table_size = 0;
 	pex->x_table = NULL;
 
-#if defined __GNUC__
+#if defined __GLIBC__
 	// MST parsing can result in pathological cases, with almost a
 	// billion elts in the Parse_choice_pool. This blows up the
 	// resident-set size (RSS) over time. Avoid this issue by trimming.
@@ -294,7 +294,7 @@ void free_extractor(extractor_t * pex)
 
 	xfree((void *) pex, sizeof(extractor_t));
 
-#if defined __GNUC__
+#if defined __GLIBC__
 	// malloc_trim() is a gnu extension.  An alternative would be
 	// to call madvise(MADV_DONTNEED) but this is more complicated.
 	if (trim) malloc_trim(0);


### PR DESCRIPTION
* `__GNUC__` == Compiling with `-std=gnu*`
* `__GLIBC__` == Compiling against glibc

Bug: https://bugs.gentoo.org/903749