### PR TITLE
Fix typo around use of AVOID_VERSION

### DIFF
--- a/bindings/perl/Makefile.am
+++ b/bindings/perl/Makefile.am
@@ -52,7 +52,7 @@ if OS_NETBSD
 AVOID_VERSION = -avoid-version
 endif
 
-clinkgrammar_la_LDFLAGS = -version-info $(AVOID_VERSION) @VERSION_INFO@ \
+clinkgrammar_la_LDFLAGS = -version-info @VERSION_INFO@ $(AVOID_VERSION)\
 								  $(PERL_LDFLAGS) -module -no-undefined
 clinkgrammar_la_LIBADD = $(top_builddir)/link-grammar/liblink-grammar.la
 


### PR DESCRIPTION
Fix typo in d4cc201e, which places $(AVOID_VERSION) between '-version-info' and '@VERSION_INFO@', leading to:

libtool:   error: CURRENT '-avoid-version' must be a nonnegative integer
libtool:   error: '-avoid-version' is not valid version information

on those platforms where it's defined.