### PR TITLE
Bugfix tracon table size management.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 Version 5.12.5 (XXX 2024)
- * Nothing yet!
+ * Bugfix tracon table size management. #1486
 
 Version 5.12.4 (28 March 2024)
  * Minor English dict fixes. #1470

--- a/link-grammar/string-id.c
+++ b/link-grammar/string-id.c
@@ -154,7 +154,8 @@ static void grow_table(String_id *ss)
 			ss->table[p] = old.table[i];
 		}
 	}
-	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size);
+	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size) -
+		MAX_STRING_SET_TABLE_SIZE(old.size);
 
 	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
 	free(old.table);

--- a/link-grammar/string-set.c
+++ b/link-grammar/string-set.c
@@ -175,7 +175,8 @@ static void grow_table(String_set *ss)
 			ss->table[p] = old.table[i];
 		}
 	}
-	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size);
+	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size) -
+		MAX_STRING_SET_TABLE_SIZE(old.size);
 
 	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
 	free(old.table);

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -191,7 +191,8 @@ static void grow_table(Tracon_set *ss)
 			ss->table[p] = old.table[i];
 		}
 	}
-	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size);
+	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size) -
+		MAX_STRING_SET_TABLE_SIZE(old.size);
 
 	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
 	PRT_STAT(fp_count = fp_count_save);


### PR DESCRIPTION
This only affects the large/crazy dictionaries built by the learn project. Per debugging session in #1479 and specifically this comment: https://github.com/opencog/link-grammar/discussions/1479#discussioncomment-8963112