### PR TITLE
Solves issue #1479 by fixing the connector/tracon hashing

### DIFF
--- a/link-grammar/connectors.c
+++ b/link-grammar/connectors.c
@@ -541,7 +541,7 @@ static bool condesc_grow(ConTable *ct)
 
 condesc_t *condesc_add(ConTable *ct, const char *constring)
 {
-	uint32_t hash = (connector_hash_t)connector_str_hash(constring);
+	uint32_t hash = (connector_uc_hash_t)connector_str_hash(constring);
 	hdesc_t *h = condesc_find(ct, constring, hash);
 
 	if (NULL == h->desc)

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -309,6 +309,29 @@ static inline uint32_t string_hash(const char *s)
 	return i;
 }
 
+typedef uint32_t connector_hash_t;
+
+static inline connector_hash_t connector_hash(const Connector *c)
+{
+	return c->desc->uc_num +
+		(c->multi << 19) +
+		(((connector_hash_t)c->desc->lc_mask & 1) << 20) +
+		(connector_hash_t)c->desc->lc_letters;
+}
+
+/**
+ * \p c is assumed to be non-NULL.
+ */
+static inline connector_hash_t connector_list_hash(const Connector *c)
+{
+	connector_hash_t accum = connector_hash(c);
+
+	for (c = c->next; c != NULL; c = c->next)
+		accum = (19 * accum) + connector_hash(c);
+
+	return accum;
+}
+
 /**
  * Hash function for the classic parser linkage memoization.
  */

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -50,7 +50,7 @@
 
 typedef uint64_t lc_enc_t;
 
-typedef uint32_t connector_hash_t;
+typedef uint32_t connector_uc_hash_t;
 
 #define CD_HEAD_DEPENDENT    (1<<0) /* Has a leading 'h' or 'd'. */
 #define CD_HEAD              (1<<1) /* 0: dependent; 1: head; */
@@ -85,7 +85,7 @@ struct condesc_struct
 
 	const char *string;  /* The connector name w/o the direction mark, e.g. AB */
 	// float *cost;    /* Array of cost by connector length (cost[0]: default) */
-	connector_hash_t uc_num; /* uc part enumeration. */
+	connector_uc_hash_t uc_num; /* uc part enumeration. */
 	uint8_t length_limit; /* If not 0, it gives the limit of the length of the
 	                       * link that can be used on this connector type. The
 	                       * value UNLIMITED_LEN specifies no limit.
@@ -111,7 +111,7 @@ typedef struct length_limit_def
 typedef struct hdesc
 {
 	condesc_t *desc;
-	connector_hash_t str_hash;
+	connector_uc_hash_t str_hash;
 } hdesc_t;
 
 typedef struct

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -236,17 +236,15 @@ struct disjunct_dup_table_s
 static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt,
                                              Disjunct * d, bool string_too)
 {
-	unsigned int i;
-	i = 0;
-	for (Connector *e = d->left; e != NULL; e = e->next) {
-		i = (41 * (i + e->desc->uc_num)) + (unsigned int)e->desc->lc_letters + 7;
-	}
-	for (Connector *e = d->right; e != NULL; e = e->next) {
-		i = (41 * (i + e->desc->uc_num)) + (unsigned int)e->desc->lc_letters + 7;
-	}
+	unsigned int i = 0;
+
+	if (NULL != d->left)
+		i = connector_list_hash(d->left);
+	if (NULL != d->right)
+		i += 19 * connector_list_hash(d->right);
 	if (string_too)
 		i += string_hash(d->word_string);
-	i += (i>>10);
+	//i += (i>>10);
 
 	d->dup_hash = i;
 	return (i & (dt->dup_table_size-1));

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -447,7 +447,7 @@ static void power_table_init(Sentence sent, Tracon_sharing *ts, power_table *pt)
 static void clean_table(unsigned int size, C_list **t)
 {
 	/* Table entry tombstone. */
-#define UC_NUM_TOMBSTONE ((connector_hash_t)-1)
+#define UC_NUM_TOMBSTONE ((connector_uc_hash_t)-1)
 	static condesc_t desc_no_match =
 	{
 		.string = "TOMBSTONE",

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -15,12 +15,11 @@
 
 #include "const-prime.h"
 #include "connectors.h"
+#ifdef TRACON_SET_DEBUG
+#include "disjunct-utils.h"            // print_connector_list_str
+#endif
 #include "tracon-set.h"
 #include "utilities.h"
-
-#ifdef TRACON_SET_DEBUG
-#include <inttypes.h>                   // format macros
-#endif
 
 /**
  * This is an adaptation of the string_set module for detecting unique
@@ -85,12 +84,49 @@ static unsigned int find_prime_for(size_t count)
 }
 #endif
 
+#ifdef TRACON_SET_DEBUG
+static void tracon_set_print(Tracon_set *ss)
+{
+	if (test_enabled("tracon-set-print"))
+	{
+		clist_slot *t;
+
+		printf("tracon_set_print %p:\n", ss);
+		for (size_t i = 0; i < ss->size; i++)
+		{
+			t = &ss->table[i];
+			if (0 == t->hash) continue;
+			tid_hash_t x = ss->mod_func(t->hash);
+			char *cstr = print_connector_list_str(t->clist, 0);
+			printf("[%zu]: h %zu pri %u sec %u %c %s\n", i, (size_t)t->hash, t->pri_collN,
+			       t->sec_collN, "yn"[i == x], cstr);
+			free(cstr);
+		}
+	}
+}
+
+static void tracon_set_stats(Tracon_set *a, Tracon_set *ss, const char *where)
+{
+	lgdebug(+D_TRACON_SET,
+	        "%p: %s: reset %u prime_idx %u acc %zu used %2.2f%% "
+	        "coll/acc %.4f chain %.4f\n",
+	        a, where, ss->resetN, ss->prime_idx, ss->addN,
+	        100.f * ((int)MAX_TRACON_SET_TABLE_SIZE(ss->size) - ss->available_count) / ss->size,
+	        1.* ss->pri_collN/ss->addN,
+	        1. * (ss->pri_collN + ss->sec_collN) / ss->addN);
+}
+#else
+static void tracon_set_print(Tracon_set *ss){};
+static void tracon_set_stats(Tracon_set *a, Tracon_set *ss, const char *where){};
+#endif
+
 void tracon_set_reset(Tracon_set *ss)
 {
 #ifdef TRACON_SET_DEBUG
-	lgdebug(+D_TRACON_SET, "%p: prime_idx %u available_count %zu\n",
-	        ss, ss->prime_idx, ss->available_count);
+	ss->resetN++;
 #endif
+	tracon_set_stats(ss, ss, "reset");
+	tracon_set_print(ss);
 	memset(ss->table, 0, ss->size * sizeof(clist_slot));
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
 }
@@ -134,16 +170,6 @@ static bool connector_list_equal(const Connector *c1, const Connector *c2)
 	return (c1 == NULL) && (c2 == NULL);
 }
 
-#ifdef TRACON_SET_DEBUG
-uint64_t fp_count;
-uint64_t coll_count;
-static void prt_stat(void)
-{
-	lgdebug(D_TRACON_SET, "tracon_set: %"PRIu64" accesses, chain %.4f\n",
-	        fp_count, 1.*(fp_count+coll_count)/fp_count);
-}
-#endif
-
 static bool place_found(const Connector *c, const clist_slot *slot,
                         tid_hash_t hash, Tracon_set *ss)
 {
@@ -161,10 +187,6 @@ static bool place_found(const Connector *c, const clist_slot *slot,
 static tid_hash_t find_place(const Connector *c, tid_hash_t h,
                              Tracon_set *ss)
 {
-#ifdef TRACON_SET_DEBUG
-	if (fp_count == 0) atexit(prt_stat);
-	fp_count++;
-#endif
 	unsigned int coll_num = 0;
 	tid_hash_t key = ss->mod_func(h);
 
@@ -172,7 +194,16 @@ static tid_hash_t find_place(const Connector *c, tid_hash_t h,
 	while (!place_found(c, &ss->table[key], h, ss))
 	{
 #ifdef TRACON_SET_DEBUG
-		coll_count++;
+		if (0 == coll_num)
+		{
+			ss->pri_collN++;
+			ss->table[key].pri_collN++;
+		}
+		else
+		{
+			ss->sec_collN++;
+			ss->table[key].sec_collN++;
+		}
 #endif
 		key += 2 * ++coll_num - 1;
 		if (key >= ss->size) key = ss->mod_func(key);
@@ -185,10 +216,7 @@ static void grow_table(Tracon_set *ss)
 {
 	Tracon_set old = *ss;
 
-#ifdef TRACON_SET_DEBUG
-	uint64_t fp_count_save = fp_count;
-	prt_stat();
-#endif
+	tracon_set_stats(ss, &old, "before grow");
 	ss->prime_idx++;
 	ss->size = s_prime[ss->prime_idx];
 	ss->mod_func = prime_mod_func[ss->prime_idx];
@@ -205,12 +233,7 @@ static void grow_table(Tracon_set *ss)
 	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size) -
 		MAX_STRING_SET_TABLE_SIZE(old.size);
 
-#ifdef TRACON_SET_DEBUG
-	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
-	fp_count = fp_count_save;
-	lgdebug(+D_TRACON_SET, " %p: prime_idx %u, available_count %zu\n",
-	        ss, ss->prime_idx, ss->available_count);
-#endif
+	tracon_set_stats(ss, ss, "after grow");
 	free(old.table);
 }
 
@@ -222,6 +245,9 @@ void tracon_set_shallow(bool shallow, Tracon_set *ss)
 Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 {
 	assert(clist != NULL, "Can't insert a null list");
+#ifdef TRACON_SET_DEBUG
+	ss->addN++;
+#endif
 
 	/* We may need to add it to the table. If the table got too big,
 	 * first we grow it. */
@@ -249,10 +275,8 @@ Connector *tracon_set_lookup(const Connector *clist, Tracon_set *ss)
 void tracon_set_delete(Tracon_set *ss)
 {
 	if (ss == NULL) return;
-#ifdef TRACON_SET_DEBUG
-	lgdebug(+D_TRACON_SET, " %p: prime_idx %u, available_count %zu\n",
-	        ss, ss->prime_idx, ss->available_count);
-#endif
+	tracon_set_stats(ss, ss, "delete");
+	tracon_set_print(ss);
 	free(ss->table);
 	free(ss);
 }

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -93,12 +93,12 @@ Tracon_set *tracon_set_create(void)
 {
 	Tracon_set *ss = (Tracon_set *) malloc(sizeof(Tracon_set));
 
-	ss->prime_idx = 0;
+	memset(ss, 0, sizeof(Tracon_set));
+	// ss->prime_idx = 0;
 	ss->size = s_prime[ss->prime_idx];
 	ss->mod_func = prime_mod_func[ss->prime_idx];
 	ss->table = (clist_slot *) malloc(ss->size * sizeof(clist_slot));
 	memset(ss->table, 0, ss->size * sizeof(clist_slot));
-	ss->shallow = false;
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
 
 	return ss;

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -49,18 +49,9 @@
 
 static tid_hash_t hash_connectors(const Connector *c, unsigned int shallow)
 {
-	tid_hash_t accum = shallow && c->shallow;
+	tid_hash_t accum = (shallow && c->shallow) ? 1000003 : 0;
 
-	for (; c != NULL; c = c->next)
-	{
-		accum = (19 * accum) +
-		c->desc->uc_num +
-		(((unsigned int)c->multi)<<19) +
-		((((unsigned int)c->desc->lc_mask) & 1)<<20) +
-		(((unsigned int)c->desc->lc_letters)<<22);
-	}
-
-	return accum;
+	return accum + connector_list_hash(c);
 }
 
 #if 0

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -48,9 +48,9 @@
  * (only, their value remains intact).
  */
 
-static unsigned int hash_connectors(const Connector *c, unsigned int shallow)
+static tid_hash_t hash_connectors(const Connector *c, unsigned int shallow)
 {
-	unsigned int accum = shallow && c->shallow;
+	tid_hash_t accum = shallow && c->shallow;
 
 	for (; c != NULL; c = c->next)
 	{
@@ -145,7 +145,7 @@ static void prt_stat(void)
 #endif
 
 static bool place_found(const Connector *c, const clist_slot *slot,
-                        unsigned int hash, Tracon_set *ss)
+                        tid_hash_t hash, Tracon_set *ss)
 {
 	if (slot->clist == NULL) return true;
 	if (hash != slot->hash) return false;
@@ -158,15 +158,15 @@ static bool place_found(const Connector *c, const clist_slot *slot,
  * lookup the given string in the table.  Return an index
  * to the place it is, or the place where it should be.
  */
-static unsigned int find_place(const Connector *c, unsigned int h,
-                               Tracon_set *ss)
+static tid_hash_t find_place(const Connector *c, tid_hash_t h,
+                             Tracon_set *ss)
 {
 #ifdef TRACON_SET_DEBUG
 	if (fp_count == 0) atexit(prt_stat);
 	fp_count++;
 #endif
 	unsigned int coll_num = 0;
-	unsigned int key = ss->mod_func(h);
+	tid_hash_t key = ss->mod_func(h);
 
 	/* Quadratic probing. */
 	while (!place_found(c, &ss->table[key], h, ss))
@@ -198,7 +198,7 @@ static void grow_table(Tracon_set *ss)
 	{
 		if (old.table[i].clist != NULL)
 		{
-			unsigned int p = find_place(old.table[i].clist, old.table[i].hash, ss);
+			tid_hash_t p = find_place(old.table[i].clist, old.table[i].hash, ss);
 			ss->table[p] = old.table[i];
 		}
 	}
@@ -227,8 +227,8 @@ Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 	 * first we grow it. */
 	if (ss->available_count == 0) grow_table(ss);
 
-	unsigned int h = hash_connectors(clist, ss->shallow);
-	unsigned int p = find_place(clist, h, ss);
+	tid_hash_t h = hash_connectors(clist, ss->shallow);
+	tid_hash_t p = find_place(clist, h, ss);
 
 	if (ss->table[p].clist != NULL)
 		return &ss->table[p].clist;
@@ -241,8 +241,8 @@ Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 
 Connector *tracon_set_lookup(const Connector *clist, Tracon_set *ss)
 {
-	unsigned int h = hash_connectors(clist, ss->shallow);
-	unsigned int p = find_place(clist, h, ss);
+	tid_hash_t h = hash_connectors(clist, ss->shallow);
+	tid_hash_t p = find_place(clist, h, ss);
 	return ss->table[p].clist;
 }
 

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -87,6 +87,10 @@ static unsigned int find_prime_for(size_t count)
 
 void tracon_set_reset(Tracon_set *ss)
 {
+#ifdef TRACON_SET_DEBUG
+	lgdebug(+D_TRACON_SET, "%p: prime_idx %u available_count %zu\n",
+	        ss, ss->prime_idx, ss->available_count);
+#endif
 	memset(ss->table, 0, ss->size * sizeof(clist_slot));
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
 }
@@ -102,6 +106,11 @@ Tracon_set *tracon_set_create(void)
 	ss->table = (clist_slot *) malloc(ss->size * sizeof(clist_slot));
 	memset(ss->table, 0, ss->size * sizeof(clist_slot));
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
+
+#ifdef TRACON_SET_DEBUG
+	lgdebug(+D_TRACON_SET, "%p: prime_idx %u available_count %zu\n",
+	        ss, ss->prime_idx, ss->available_count);
+#endif
 
 	return ss;
 }
@@ -178,6 +187,7 @@ static void grow_table(Tracon_set *ss)
 
 #ifdef TRACON_SET_DEBUG
 	uint64_t fp_count_save = fp_count;
+	prt_stat();
 #endif
 	ss->prime_idx++;
 	ss->size = s_prime[ss->prime_idx];
@@ -198,6 +208,8 @@ static void grow_table(Tracon_set *ss)
 #ifdef TRACON_SET_DEBUG
 	/* printf("growing from %zu to %zu\n", old.size, ss->size); */
 	fp_count = fp_count_save;
+	lgdebug(+D_TRACON_SET, " %p: prime_idx %u, available_count %zu\n",
+	        ss, ss->prime_idx, ss->available_count);
 #endif
 	free(old.table);
 }
@@ -237,6 +249,10 @@ Connector *tracon_set_lookup(const Connector *clist, Tracon_set *ss)
 void tracon_set_delete(Tracon_set *ss)
 {
 	if (ss == NULL) return;
+#ifdef TRACON_SET_DEBUG
+	lgdebug(+D_TRACON_SET, " %p: prime_idx %u, available_count %zu\n",
+	        ss, ss->prime_idx, ss->available_count);
+#endif
 	free(ss->table);
 	free(ss);
 }

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -55,7 +55,8 @@ static tid_hash_t hash_connectors(const Connector *c, unsigned int shallow)
 	{
 		accum = (19 * accum) +
 		c->desc->uc_num +
-		(((unsigned int)c->multi)<<20) +
+		(((unsigned int)c->multi)<<19) +
+		((((unsigned int)c->desc->lc_mask) & 1)<<20) +
 		(((unsigned int)c->desc->lc_letters)<<22);
 	}
 

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -78,8 +78,8 @@ static unsigned int find_prime_for(size_t count)
 	for (i = 0; i < MAX_S_PRIMES; i ++)
 	   if (count < MAX_TRACON_SET_TABLE_SIZE(s_prime[i])) return i;
 
-	assert(0, "%zu: Absurdly big count", count);
-	return 0;
+	lgdebug(+0, "Warning: %zu: Absurdly big count", count);
+	return -1;
 }
 #endif
 

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -73,23 +73,7 @@ static unsigned int find_prime_for(size_t count)
 
 void tracon_set_reset(Tracon_set *ss)
 {
-	size_t ncount = MAX(ss->count, ss->ocount);
-
-	/* Table sizing heuristic: The number of tracons as a function of
-	 * word number is usually first increasing and then decreasing.
-	 * Continue the trend of the last 2 words. */
-	if (ss->count > ss->ocount)
-		ncount = ncount * 3 / 4;
-	else
-		ncount = ncount * 4 / 3;
-	unsigned int prime_idx = find_prime_for(ncount);
-	if (prime_idx < ss->prime_idx) ss->prime_idx = prime_idx;
-
-	ss->size = s_prime[ss->prime_idx];
-	ss->mod_func = prime_mod_func[ss->prime_idx];
 	memset(ss->table, 0, ss->size * sizeof(clist_slot));
-	ss->ocount = ss->count;
-	ss->count = 0;
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
 }
 
@@ -102,7 +86,6 @@ Tracon_set *tracon_set_create(void)
 	ss->mod_func = prime_mod_func[ss->prime_idx];
 	ss->table = (clist_slot *) malloc(ss->size * sizeof(clist_slot));
 	memset(ss->table, 0, ss->size * sizeof(clist_slot));
-	ss->count = ss->ocount = 0;
 	ss->shallow = false;
 	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size);
 
@@ -219,7 +202,6 @@ Connector **tracon_set_add(Connector *clist, Tracon_set *ss)
 		return &ss->table[p].clist;
 
 	ss->table[p].hash = h;
-	ss->count++;
 	ss->available_count--;
 
 	return &ss->table[p].clist;

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -11,6 +11,8 @@
 /*                                                                       */
 /*************************************************************************/
 
+#define D_TRACON_SET 8                 // Debug level for this file
+
 #ifdef DEBUG
 #include <inttypes.h>                   // format macros
 #endif
@@ -128,7 +130,7 @@ uint64_t fp_count;
 uint64_t coll_count;
 static void prt_stat(void)
 {
-	lgdebug(+5, "tracon_set: %"PRIu64" accesses, chain %.4f\n",
+	lgdebug(D_TRACON_SET, "tracon_set: %"PRIu64" accesses, chain %.4f\n",
 	        fp_count, 1.*(fp_count+coll_count)/fp_count);
 }
 #define PRT_STAT(...) __VA_ARGS__

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -61,6 +61,17 @@ static unsigned int hash_connectors(const Connector *c, unsigned int shallow)
 	return accum;
 }
 
+#if 0
+/**
+ * @count Expected number of table elements.
+ * @return Prime number to use
+ *
+ * This function was used for shrinking the table in a try to cause less
+ * cache/swap trashing if the table temporary grows very big. However, it
+ * had a bug, and it is not clear when to shrink the table - shrinking it
+ * unnecessarily can cause an overhead of a table growth. Keep for
+ * possible reimlementation of a similar idea.
+ */
 static unsigned int find_prime_for(size_t count)
 {
 	size_t i;
@@ -70,6 +81,7 @@ static unsigned int find_prime_for(size_t count)
 	assert(0, "%zu: Absurdly big count", count);
 	return 0;
 }
+#endif
 
 void tracon_set_reset(Tracon_set *ss)
 {

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include "api-types.h"
+#include "connectors.h"
 #include "const-prime.h"
 #include "error.h"
 
@@ -27,7 +28,7 @@
 #endif
 #endif
 
-typedef size_t tid_hash_t;
+typedef connector_hash_t tid_hash_t;
 typedef struct
 {
 	Connector *clist;

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -38,8 +38,8 @@ typedef struct
 	size_t size;       /* the current size of the table */
 	size_t available_count;     /* number of available entries */
 	clist_slot *table; /* the table itself */
-	unsigned int prime_idx;     /* current prime number table index */
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
+	unsigned int prime_idx;     /* current prime number table index */
 	bool shallow;      /* consider shallow connector */
 } Tracon_set;
 

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -32,6 +32,10 @@ typedef struct
 {
 	Connector *clist;
 	tid_hash_t hash;
+#ifdef TRACON_SET_DEBUG
+	unsigned int pri_collN;
+	unsigned int sec_collN;
+#endif
 } clist_slot;
 
 typedef struct
@@ -42,6 +46,13 @@ typedef struct
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */
 	unsigned int prime_idx;     /* current prime number table index */
 	bool shallow;      /* consider shallow connector */
+#ifdef TRACON_SET_DEBUG
+	/* size_t is used here instead of uint64_t to prevent the need for PRIu64. */
+	size_t addN;       /* Number of tries to add */
+	size_t pri_collN;  /* Number of primary collisions */
+	size_t sec_collN;  /* Number of secondary collisions */
+	unsigned int resetN;       /* Number of table resets */
+#endif
 } Tracon_set;
 
 /* If the table gets too big, we grow it. Too big is defined as being

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -27,10 +27,11 @@
 #endif
 #endif
 
+typedef size_t tid_hash_t;
 typedef struct
 {
 	Connector *clist;
-	unsigned int hash;
+	tid_hash_t hash;
 } clist_slot;
 
 typedef struct

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -21,6 +21,12 @@
 #include "const-prime.h"
 #include "error.h"
 
+#ifdef DEBUG
+#ifndef TRACON_SET_DEBUG
+#define TRACON_SET_DEBUG
+#endif
+#endif
+
 typedef struct
 {
 	Connector *clist;

--- a/link-grammar/tracon-set.h
+++ b/link-grammar/tracon-set.h
@@ -30,9 +30,7 @@ typedef struct
 typedef struct
 {
 	size_t size;       /* the current size of the table */
-	size_t count;      /* number of things currently in the table */
 	size_t available_count;     /* number of available entries */
-	size_t ocount;     /* the count before reset */
 	clist_slot *table; /* the table itself */
 	unsigned int prime_idx;     /* current prime number table index */
 	prime_mod_func_t mod_func;  /* the function to compute a prime modulo */


### PR DESCRIPTION
The cause of the performance problem is almost unbelievable: Neglecting to use a single bit from the connector descriptor. This bit is `Connector:desc->lc_mask & 1`. If we neglect it, the hash components for the connector strings `"dSTRING"` and `"STRING"` are identical.

The hash function used in `eliminate_duplicate_disjuncts()` has the same problem,  but it didn't cause extra collisions, most probably because the hash of the opposite jet is totally independent and thus adds enough entropy. However, I changed it too.

The new hash function is defined in `connectors.h`.

Additional changes:
- **tracon-set.c: Remove table shrinking**
The idea was to adapt to the pattern we see in the `en` and `ru` dicts, when the middle sentence words have many more disjuncts than the other words. It may not be so in the language learning project. This heuristic also has a bug in the case of packing for parsing (it happens to use the number of disjuncts per originating Gword, not word). The removal didn't have a noticeable performance reduction, and there are several better performance enhancement ideas to implement for packing speed.
- **Better debugging**
This is how I found the problem.
- **tracon-set: Add typedef for hash integer width**
Added to see if a wider hash will be better. It was somewhat slower, so it is still `uint32_t`.

I also found a bug that causes a few additional `tracon-set_reset()` calls, but its overhead is low so it is not fixed here.

BTW, I noted another potential problem, but a fix I tried didn't have a noticeable effect:
If a collision happens again on the same table slot (usually having a different hash value than the one already cached in that slot) the quadratic probing will be done independently on the hash value, colliding with all the previous collision resolution slots. It seems this can be mostly fixed by adding a term that depends on the hash value, e.g. `(h & 0x0f)`. I tried this and it didn't seem to improve the performance, I guess because collisions are now very rare.  So I didn't implement this.