### PR TITLE
Reduce the size of the string set

### DIFF
--- a/link-grammar/string-id.h
+++ b/link-grammar/string-id.h
@@ -49,8 +49,8 @@ struct String_id_s
 };
 
 /* If the table gets too big, we grow it. Too big is defined as being
- * more than 3/8 full. There's a huge boost from keeping this sparse. */
-#define MAX_STRING_SET_TABLE_SIZE(s) ((s) * 3 / 8)
+ * more than 3/4 full. There's a huge boost from keeping this sparse. */
+#define MAX_STRING_SET_TABLE_SIZE(s) ((s) * 3 / 4)
 
 String_id *string_id_create(void);
 unsigned int  string_id_add(const char *source_string, String_id *ss);

--- a/link-grammar/string-set.h
+++ b/link-grammar/string-set.h
@@ -45,8 +45,8 @@ struct String_set_s
 };
 
 /* If the table gets too big, we grow it. Too big is defined as being
- * more than 3/8 full. There's a huge boost from keeping this sparse. */
-#define MAX_STRING_SET_TABLE_SIZE(s) ((s) * 3 / 8)
+ * more than 3/4 full. There's a huge boost from keeping this sparse. */
+#define MAX_STRING_SET_TABLE_SIZE(s) ((s) * 3 / 4)
 
 String_set * string_set_create(void);
 const char * string_set_add(const char * source_string, String_set * ss);


### PR DESCRIPTION
After recent fixes, it seems that the size of the string set can be reduced.