### PR TITLE
Use actions/checkout@v4

### DIFF
--- a/.github/workflows/bindings-js.xxx-yml-xxx
+++ b/.github/workflows/bindings-js.xxx-yml-xxx
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install packages
       run: sudo apt-get install autoconf-archive flex libpcre2-dev
     - name: autoconf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install packages
       run: sudo apt-get install autoconf-archive flex libpcre2-dev
     - name: autoconf


### PR DESCRIPTION
This should eliminate the warning currently shown on your CI builds:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
