### PR TITLE
Rename autoconf to autogen and don't run configure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: install packages
       run: sudo apt-get install autoconf-archive flex libpcre2-dev
-    - name: autoconf
-      run: ./autogen.sh
+    - name: autogen
+      run: ./autogen.sh --no-configure
     - name: configure
       run: ./configure
     - name: make


### PR DESCRIPTION
Since autogen.sh does more than run autoconf, rename this step from autoconf to autogen.

Since there is a separate step that runs configure afterward, tell autogen.sh not to run configure.