### PR TITLE
Remove 64-bit macOS check and everything based on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,9 +596,6 @@ configure with:
 ./configure --disable-java-bindings
 ```
 
-By default, java requires a 64-bit binary, and not all macOS systems
-have a 64-bit devel environment installed.
-
 If you do want Java bindings, be sure to set the JDK_HOME environment
 variable to wherever `<Headers/jni.h>` is.   Set the JAVA_HOME variable
 to the location of the java compiler.  Make sure you have ant

--- a/configure.ac
+++ b/configure.ac
@@ -776,14 +776,6 @@ AC_SUBST(REGEX_CFLAGS)
 JNIfound=no
 
 if test "x$enable_java_bindings" = "xyes"; then
-
-	if test x${apple_osx} = xyes; then
-		# Java on Apple OSX requires a 64-bit build. However, even
-		# modern 64-bit Apple machines build 32-bit binaries by default.
-		# So force a 64-bit build if a 64-bit CPU is found.
-		CFLAGS="-arch x86_64 ${CFLAGS}"
-	fi
-
 	absolute_srcdir=`(cd "$srcdir"; pwd)`
 	JAVA_SRCDIR=$absolute_srcdir/bindings/java
 	if test "$native_win32" = yes; then

--- a/configure.ac
+++ b/configure.ac
@@ -174,18 +174,6 @@ esac
 AC_MSG_RESULT([$cygwin])
 AM_CONDITIONAL(OS_CYGWIN, test "x$cygwin" = "xyes")
 
-AC_MSG_CHECKING([for 64-bit Apple OSX])
-case "$host_os" in
-  x86_64-*darwin*)
-    apple_osx=yes
-    ;;
-  *)
-    apple_osx=no
-    ;;
-esac
-AC_MSG_RESULT([$apple_osx])
-AM_CONDITIONAL(OS_X, test "x$apple_osx" = "xyes")
-
 AC_MSG_CHECKING([for NetBSD])
 case "$host_os" in
   *netbsd*)

--- a/configure.ac
+++ b/configure.ac
@@ -385,11 +385,6 @@ AC_ARG_ENABLE( sat-solver,
 	fi], [enable_sat_solver=no])
 
 AS_IF([test "x$enable_sat_solver" = xyes], [
-	# The sat-solver code is in C++; so the link-grammar library should now
-	# directly require libstdc++ instead of indirectly depend on its
-	# availability via the minisat2 library.
-	#test x${apple_osx} = xyes || AC_CHECK_LIB(stdc++, main)
-
 	# We want to check for C++; the easiest way to do this is to
 	# use c++ to compile stdio.h and bomb if it fails.
 	AC_LANG([C++])


### PR DESCRIPTION
This check doesn't work and nothing based on it is needed so remove all of it.

More specifics in each commit message.