### PR TITLE
tracon-set.c grow_table(): Use MAX_TRACON_SET_TABLE_SIZE

### DIFF
--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -223,8 +223,8 @@ static void grow_table(Tracon_set *ss)
 			ss->table[p] = old.table[i];
 		}
 	}
-	ss->available_count = MAX_STRING_SET_TABLE_SIZE(ss->size) -
-		MAX_STRING_SET_TABLE_SIZE(old.size);
+	ss->available_count = MAX_TRACON_SET_TABLE_SIZE(ss->size) -
+		MAX_TRACON_SET_TABLE_SIZE(old.size);
 
 	tracon_set_stats(ss, ss, "after grow");
 	free(old.table);


### PR DESCRIPTION
This fixes a bug in `tracon-set.c`, existing there since I created it.
The use of  `MAX_STRING_SET_TABLE_SIZE` in `grow_table()` causes an inconsistent setting of the maximum loading factor, as `tracon_set_create()` and `tracon_set_reset()` use `MAX_TRACON_SET_TABLE_SIZE` and these definitions are now not the same.

After this fix, the maximum load factor of the tracon-set is always 3/8, as specified in `tracon-set.h` (in `string-set.h`  and `string-id.h` it got set to 3/4 in commit 397a3d46). The run time doesn't noticeably improve, which may hint at a possible increase of `MAX_TRACON_SET_TABLE_SIZE`.

The unintentional use of  `MAX_STRING_SET_TABLE_SIZE` went unnoticed because `string-set.h` is pulled into `tracon-set.c` through the inclusion of `connectors.h`. It would be better if internal module definitions were kept private and did not appear in internal API include files. So I propose to move the private `string-set.c` definitions from `string-set.h` to `string-set.c`, and the like for the other modules.

(This line is for a backreference in issue  #1487, in which I mentioned this PR.)