### PR TITLE
Improve the connector hashing and extend condesc_t

### DIFF
--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -329,6 +329,7 @@ static inline uint32_t string_hash(const char *s)
 }
 
 typedef uint32_t connector_hash_t;
+static const connector_hash_t FIBONACCI_MULT = 0x9E3779B9;
 
 static inline connector_hash_t connector_hash(const Connector *c)
 {
@@ -351,7 +352,7 @@ static inline connector_hash_t connector_list_hash(const Connector *c)
 
 	for (c = c->next; c != NULL; c = c->next)
 #if FEEDBACK_HASH
-		accum = (accum<<6) + (accum<<16) + (accum >> 16) - connector_hash(c);
+		accum = (accum<<7) + (accum<<14) + (accum >> 16) - connector_hash(c);
 #else
 		// Bad.
 		accum = (19 * accum) + connector_hash(c);

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -31,6 +31,9 @@
  */
 #define MAX_SENTENCE 254        /* Maximum number of words in a sentence */
 
+/* Length-limits for how far connectors can reach out. */
+#define UNLIMITED_LEN 255
+
 /* Since tracon IDs are unique per sentence, for convenience NULL
  * connectors (zero-length tracons) have tracon IDs equal to the word
  * number on which their disjunct resides. To that end an initial block
@@ -99,9 +102,6 @@ struct condesc_struct
 	uint8_t uc_start;    /* uc start position */
 };
 typedef struct condesc_struct condesc_t;
-
-/* Length-limits for how far connectors can reach out. */
-#define UNLIMITED_LEN 255
 
 typedef struct length_limit_def
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -79,6 +79,14 @@ static inline bool is_connector_subscript_char(unsigned char c)
 }
 /* End of connector string character validation. */
 
+typedef struct condesc_struct condesc_t;
+
+typedef struct hdesc
+{
+	condesc_t *desc;
+	connector_uc_hash_t str_hash;
+} hdesc_t;
+
 /* Note: If more byte-size fields are needed, to save space
  * uc_length and uc_start may be moved to struct hdesc. */
 struct condesc_struct
@@ -101,7 +109,6 @@ struct condesc_struct
 	uint8_t uc_length;   /* uc part length */
 	uint8_t uc_start;    /* uc start position */
 };
-typedef struct condesc_struct condesc_t;
 
 typedef struct length_limit_def
 {
@@ -110,12 +117,6 @@ typedef struct length_limit_def
 	struct length_limit_def *next;
 	int length_limit;
 } length_limit_def_t;
-
-typedef struct hdesc
-{
-	condesc_t *desc;
-	connector_uc_hash_t str_hash;
-} hdesc_t;
 
 typedef struct
 {

--- a/link-grammar/connectors.h
+++ b/link-grammar/connectors.h
@@ -342,14 +342,18 @@ static inline connector_hash_t connector_hash(const Connector *c)
 /**
  * \p c is assumed to be non-NULL.
  */
+// To check hash functions, enable the "N" printing in
+// eliminate_duplicate_disjuncts().
+#define FEEDBACK_HASH 1
 static inline connector_hash_t connector_list_hash(const Connector *c)
 {
 	connector_hash_t accum = connector_hash(c);
 
 	for (c = c->next; c != NULL; c = c->next)
-#ifdef FEEDBACK_HASH
-		accum = (19 * accum) + (accum >> 24) + connector_hash(c);
+#if FEEDBACK_HASH
+		accum = (accum<<6) + (accum<<16) + (accum >> 16) - connector_hash(c);
 #else
+		// Bad.
 		accum = (19 * accum) + connector_hash(c);
 #endif
 

--- a/link-grammar/dict-atomese/lookup-atomese.cc
+++ b/link-grammar/dict-atomese/lookup-atomese.cc
@@ -422,8 +422,8 @@ static void update_condesc(Dictionary dict)
 		if (NULL == condesc) continue;
 		if (UINT32_MAX != condesc->uc_num) continue;
 
-		calculate_connector_info(condesc);
-		condesc->length_limit = UNLIMITED_LEN;
+		calculate_connector_info(&ct->hdesc[n]);
+		condesc->more->length_limit = UNLIMITED_LEN;
 		sdesc[i++] = condesc;
 	}
 
@@ -438,16 +438,16 @@ static void update_condesc(Dictionary dict)
 	{
 		condesc_t **condesc = &sdesc[n];
 
-		if (condesc[0]->uc_length != condesc[-1]->uc_length)
+		if (condesc[0]->more->uc_length != condesc[-1]->more->uc_length)
 		{
 			/* We know that the UC part has been changed. */
 			uc_num++;
 		}
 		else
 		{
-			const char *uc1 = &condesc[0]->string[condesc[0]->uc_start];
-			const char *uc2 = &condesc[-1]->string[condesc[-1]->uc_start];
-			if (0 != strncmp(uc1, uc2, condesc[0]->uc_length))
+			const char *uc1 = &condesc[0]->more->string[condesc[0]->more->uc_start];
+			const char *uc2 = &condesc[-1]->more->string[condesc[-1]->more->uc_start];
+			if (0 != strncmp(uc1, uc2, condesc[0]->more->uc_length))
 			{
 				uc_num++;
 			}

--- a/link-grammar/dict-atomese/word-pairs.cc
+++ b/link-grammar/dict-atomese/word-pairs.cc
@@ -385,7 +385,7 @@ static Exp* get_sent_pair_exprs(Dictionary dict, const Handle& germ,
 	{
 		assert(CONNECTOR_type == orch->type, "unexpected expression!");
 
-		if (links.end() != links.find(orch->condesc->string))
+		if (links.end() != links.find(orch->condesc->more->string))
 		{
 			Exp* cpe = (Exp*) pool_alloc(pool);
 			*cpe = *orch;

--- a/link-grammar/dict-common/dict-locale.c
+++ b/link-grammar/dict-common/dict-locale.c
@@ -204,7 +204,7 @@ const char * linkgrammar_get_dict_locale(Dictionary dict)
 		}
 		else
 		{
-			locale = dn->exp->condesc->string;
+			locale = dn->exp->condesc->more->string;
 		}
 	}
 
@@ -318,7 +318,7 @@ const char * linkgrammar_get_dict_version(Dictionary dict)
 	if (NULL == dn) return "[unknown]";
 
 	e = dn->exp;
-	ver = strdup(&e->condesc->string[1]);
+	ver = strdup(&e->condesc->more->string[1]);
 	p = strchr(ver, 'v');
 	while (p)
 	{

--- a/link-grammar/dict-common/dict-utils.c
+++ b/link-grammar/dict-common/dict-utils.c
@@ -94,7 +94,7 @@ static Exp *create_external_exp(const Exp *e, Exp **exp_mem, Parse_Options opts)
 
 const char * lg_exp_get_string(const Exp* exp)
 {
-	return exp->condesc->string;
+	return exp->condesc->more->string;
 }
 
 /**
@@ -273,7 +273,7 @@ static bool exp_has_connector(const Exp * e, int depth,
 	if (e->type == CONNECTOR_type)
 	{
 		if (direction != e->dir) return false;
-		return string_set_cmp(e->condesc->string, cs);
+		return string_set_cmp(e->condesc->more->string, cs);
 	}
 
 	if (depth == 0) return false;

--- a/link-grammar/dict-common/print-dict.c
+++ b/link-grammar/dict-common/print-dict.c
@@ -194,7 +194,7 @@ static void print_expression_parens(Dictionary dict, dyn_str *e, const Exp *n,
 	if (n->type == CONNECTOR_type)
 	{
 		if (n->multi) dyn_strcat(e, "@");
-		dyn_strcat(e, n->condesc ? n->condesc->string : "error-null-connector");
+		dyn_strcat(e, n->condesc ? n->condesc->more->string : "error-null-connector");
 		dyn_strcat(e, (const char []){ n->dir, '\0' });
 	}
 	else if (is_expression_optional(n))
@@ -257,7 +257,7 @@ static bool exp_contains_connector(const Exp *e, int *pos, int find_pos)
 	{
 #if 0
 		printf("exp_contains_connector: pos=%d C=%s%s%c %s\n",
-		       *pos,e->multi?"@":"",e->condesc->string,e->dir,
+		       *pos,e->multi?"@":"",e->condesc->more->string,e->dir,
 		       (find_pos == *pos) ? "FOUND" : "");
 #endif
 		return (find_pos == (*pos)++);
@@ -317,7 +317,7 @@ static void print_connector_macros(cmacro_context *cmc, const Exp *n)
 			cmc->is_after_connector = true;
 			if (n->multi) dyn_strcat(cmc->e, "@");
 			dyn_strcat(cmc->e,
-			           n->condesc ? n->condesc->string : "error-null-connector");
+			           n->condesc ? n->condesc->more->string : "error-null-connector");
 			dyn_strcat(cmc->e, (const char []){ n->dir, '\0' });
 			cmc->find_pos++; /* each expression position is used only once */
 		}
@@ -388,7 +388,7 @@ GNUC_UNUSED void prt_exp(Exp *e, int i)
 	else
 	{
 		for(int j =0; j<i; j++) printf(" ");
-		printf("con=%s\n", e->condesc->string);
+		printf("con=%s\n", e->condesc->more->string);
 	}
 }
 #endif
@@ -503,7 +503,7 @@ static void prt_exp_all(dyn_str *s, Exp *e, int i, Dictionary dict)
 	{
 		append_string(s, " %s%s%c cost=%s%s\n",
 		              e->multi ? "@" : "",
-		              e->condesc ? e->condesc->string : "(condesc=(null))",
+		              e->condesc ? e->condesc->more->string : "(condesc=(null))",
 		              e->dir, cost_stringify(e->cost),
 		              stringify_Exp_tag(e, dict));
 	}

--- a/link-grammar/dict-file/dictionary.c
+++ b/link-grammar/dict-file/dictionary.c
@@ -47,7 +47,7 @@ static const char * word_only_connector(Dict_node * dn)
 {
 	Exp * e = dn->exp;
 	if (CONNECTOR_type == e->type)
-		return e->condesc->string;
+		return e->condesc->more->string;
 	return NULL;
 }
 

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -363,6 +363,7 @@ unsigned int eliminate_duplicate_disjuncts(Disjunct *dw, bool multi_string)
 		{
 			if (d->dup_hash != dx->dup_hash) continue;
 			if (disjuncts_equal(dx, d, multi_string)) break;
+			//fprintf(stderr, "N"); // The same hash but a different disjunct.
 		}
 
 		if (dx != NULL)

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -234,10 +234,10 @@ struct disjunct_dup_table_s
  * This is the old version that doesn't check for domination, just
  * equality.
  */
-static inline unsigned int old_hash_disjunct(disjunct_dup_table *dt,
-                                             Disjunct * d, bool string_too)
+static inline connector_hash_t old_hash_disjunct(disjunct_dup_table *dt,
+                                                 Disjunct * d, bool string_too)
 {
-	unsigned int i = 0;
+	connector_hash_t i = 0;
 
 	if (NULL != d->left)
 		i = connector_list_hash(d->left);
@@ -365,7 +365,7 @@ unsigned int eliminate_duplicate_disjuncts(Disjunct *dw, bool multi_string)
 	for (Disjunct *d = dw; d != NULL; d = d->next)
 	{
 		Disjunct *dx;
-		unsigned int h = old_hash_disjunct(dt, d, /*string_too*/!multi_string);
+		connector_hash_t h = old_hash_disjunct(dt, d, /*string_too*/!multi_string);
 
 		for (dx = dt->dup_table[h]; dx != NULL; dx = dx->dup_table_next)
 		{

--- a/link-grammar/disjunct-utils.c
+++ b/link-grammar/disjunct-utils.c
@@ -223,8 +223,8 @@ static unsigned int count_connectors(Sentence sent)
 typedef struct disjunct_dup_table_s disjunct_dup_table;
 struct disjunct_dup_table_s
 {
-	unsigned int dup_table_size;
-	unsigned int log2_size;
+	unsigned int table_size_minus_1;
+	unsigned int log2_divisor;
 	Disjunct *dup_table[];
 };
 
@@ -250,7 +250,7 @@ static inline connector_hash_t old_hash_disjunct(disjunct_dup_table *dt,
 
 	i *= FIBONACCI_MULT;
 	// Feed back log2(table_size) MSBs.
-	return ((i ^ (i>>(32-dt->log2_size))) & (dt->dup_table_size-1));
+	return ((i ^ (i>>dt->log2_divisor)) & (dt->table_size_minus_1));
 }
 
 /**
@@ -324,8 +324,8 @@ static disjunct_dup_table * disjunct_dup_table_new(size_t sz)
 	disjunct_dup_table *dt;
 
 	dt = malloc(sz * sizeof(Disjunct *) + sizeof(disjunct_dup_table));
-	dt->dup_table_size = sz;
-	dt->log2_size = power_of_2_log2(sz);
+	dt->table_size_minus_1 = sz - 1;
+	dt->log2_divisor = (sizeof(connector_hash_t)*CHAR_BIT) - power_of_2_log2(sz);
 
 	memset(dt->dup_table, 0, sz * sizeof(Disjunct *));
 

--- a/link-grammar/disjunct-utils.h
+++ b/link-grammar/disjunct-utils.h
@@ -63,7 +63,7 @@ struct Disjunct_struct
 	/* Shared by different steps. For what | when. */
 	union
 	{
-		uint32_t dup_hash;        /* Duplicate elimination | before pruning */
+		connector_hash_t dup_hash;/* Duplicate elimination | before pruning */
 		int32_t ordinal;          /* Generation mode | after d. elimination */
 	}; /* 4 bytes */
 

--- a/link-grammar/linkage/analyze-linkage.c
+++ b/link-grammar/linkage/analyze-linkage.c
@@ -46,12 +46,12 @@ const char *intersect_strings(String_set *sset, const Connector *c1,
 	lc_enc_t lc_label = lc1_letters | lc2_letters;
 
 	/* This catches ~95% of the cases (it would work without this). */
-	if (lc_label == lc1_letters) return &connector_string(c1)[d1->uc_start];
-	if (lc_label == lc2_letters) return &connector_string(c2)[d2->uc_start];
+	if (lc_label == lc1_letters) return &connector_string(c1)[d1->more->uc_start];
+	if (lc_label == lc2_letters) return &connector_string(c2)[d2->more->uc_start];
 
-	memcpy(l, &connector_string(c1)[d1->uc_start], d1->uc_length);
+	memcpy(l, &connector_string(c1)[d1->more->uc_start], d1->more->uc_length);
 
-	for (size_t i = d1->uc_length; /* see note below */; i++)
+	for (size_t i = d1->more->uc_length; /* see note below */; i++)
 	{
 		l[i] = lc_label & LC_MASK;
 		if (l[i] == '\0') l[i] = '*';
@@ -67,8 +67,8 @@ const char *intersect_strings(String_set *sset, const Connector *c1,
 	 * So after MAX_CONNECTOR_LC_LENGTH shifts lc_label must be 0. */
 
 #ifdef DEBUG
-	const char *s1 =  &connector_string(c1)[d1->uc_start];
-	const char *s2 =  &connector_string(c1)[d1->uc_start];
+	const char *s1 =  &connector_string(c1)[d1->more->uc_start];
+	const char *s2 =  &connector_string(c1)[d1->more->uc_start];
 	do
 	{
 		assert(is_connector_name_char(*s1) == is_connector_name_char(*s2),

--- a/link-grammar/parse/parse.c
+++ b/link-grammar/parse/parse.c
@@ -364,7 +364,7 @@ static int linkage_equiv_p(Linkage lpv, Linkage lnx)
 		if (plk->lc != nlk->lc)
 		{
 			if (plk->lc->desc != nlk->lc->desc)
-				return strcmp(plk->lc->desc->string, nlk->lc->desc->string);
+				return strcmp(connector_string(plk->lc), connector_string(nlk->lc));
 
 			int md = plk->lc->multi - nlk->lc->multi;
 			if (md) return md;
@@ -372,7 +372,7 @@ static int linkage_equiv_p(Linkage lpv, Linkage lnx)
 		if (plk->rc != nlk->rc)
 		{
 			if (plk->rc->desc != nlk->rc->desc)
-				return strcmp(plk->rc->desc->string, nlk->rc->desc->string);
+				return strcmp(connector_string(plk->rc), connector_string(nlk->rc));
 
 			int md = plk->rc->multi - nlk->rc->multi;
 			if (md) return md;

--- a/link-grammar/parse/prune.c
+++ b/link-grammar/parse/prune.c
@@ -448,10 +448,14 @@ static void clean_table(unsigned int size, C_list **t)
 {
 	/* Table entry tombstone. */
 #define UC_NUM_TOMBSTONE ((connector_uc_hash_t)-1)
-	static condesc_t desc_no_match =
+	static hdesc_t hdesc_no_match =
 	{
 		.string = "TOMBSTONE",
+	};
+	static condesc_t desc_no_match =
+	{
 		.uc_num = UC_NUM_TOMBSTONE, /* get_power_table_entry() will skip. */
+		.more = &hdesc_no_match
 	};
 	static Connector con_no_match =
 	{

--- a/link-grammar/prepare/build-disjuncts.c
+++ b/link-grammar/prepare/build-disjuncts.c
@@ -391,7 +391,7 @@ static void print_Tconnector_list(Tconnector *t)
 	for (; t != NULL; t = t->next)
 	{
 		if (t->e->multi) printf("@");
-		printf("%s", t->e->condesc->string);
+		printf("%s", t->e->condesc->more->string);
 		printf("%c", t->e->dir);
 		if (t->next != NULL) printf(" ");
 	}

--- a/link-grammar/sat-solver/sat-encoder.cpp
+++ b/link-grammar/sat-solver/sat-encoder.cpp
@@ -514,7 +514,7 @@ Exp* SATEncoder::join_alternatives(int w)
 void SATEncoder::generate_link_cw_ordinary_definition(size_t wi, int pi,
                                                       Exp* e, size_t wj)
 {
-  const char* Ci = e->condesc->string;
+  const char* Ci = e->condesc->more->string;
   char dir = e->dir;
   double cost = e->cost;
   Lit lhs = Lit(_variables->link_cw(wj, wi, pi, Ci));
@@ -1684,7 +1684,7 @@ void SATEncoderConjunctionFreeSentences::determine_satisfaction(int w, char* nam
 void SATEncoderConjunctionFreeSentences::generate_satisfaction_for_connector(
     int wi, int pi, Exp *e, char* var)
 {
-  const char* Ci = e->condesc->string;
+  const char* Ci = e->condesc->more->string;
   char dir = e->dir;
   bool multi = e->multi;
   double cost = e->cost;

--- a/link-grammar/sat-solver/word-tag.hpp
+++ b/link-grammar/sat-solver/word-tag.hpp
@@ -28,7 +28,7 @@ struct PositionConnector
       eps_right(er), eps_left(el), word_xnode(w_xnode)
   {
     if (word_xnode == NULL) {
-       cerr << "Internal error: Word" << w << ": " << "; connector: '" << e->condesc->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
+       cerr << "Internal error: Word" << w << ": " << "; connector: '" << e->condesc->more->string << "'; X_node: " << (word_xnode?word_xnode->string: "(null)") << endl;
     }
 
     // Initialize some fields in the connector struct.

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -170,7 +170,7 @@ static bool place_found(const Connector *c, const clist_slot *slot,
 	if (hash != slot->hash) return false;
 	if (!connector_list_equal(slot->clist, c)) return false;
 	if (ss->shallow && (slot->clist->shallow != c->shallow)) return false;
-	return connector_list_equal(slot->clist, c);
+	return true;
 }
 
 /**

--- a/link-grammar/tracon-set.c
+++ b/link-grammar/tracon-set.c
@@ -52,7 +52,7 @@ static tid_hash_t hash_connectors(const Connector *c, unsigned int shallow)
 {
 	tid_hash_t accum = (shallow && c->shallow) ? 1000003 : 0;
 
-	return accum + connector_list_hash(c);
+	return (accum + connector_list_hash(c)) * FIBONACCI_MULT;
 }
 
 #if 0

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -534,4 +534,16 @@ static inline size_t next_power_of_two_up(size_t i)
 	return j;
 }
 
+/**
+ * Return log2 of a given power-of-2 \p i.
+ */
+static inline unsigned int power_of_2_log2(size_t i)
+{
+	unsigned int n = 0;
+	while (i >>= 1)
+		n++;
+	return n;
+}
+
+
 #endif /* _LINK_GRAMMAR_UTILITIES_H_ */

--- a/link-parser/link-generator.c
+++ b/link-parser/link-generator.c
@@ -35,9 +35,9 @@
 int verbosity_level = 1;
 
 static const char prompt[] = "linkgenerator> ";
-static const char *use_prompt(int verbosity)
+static const char *use_prompt(int verbosity_setting)
 {
-	return (0 == verbosity)? "" : prompt;
+	return (0 == verbosity_setting)? "" : prompt;
 }
 
 /* Argument parsing for the generator */


### PR DESCRIPTION
This patch enumerates the connector descriptors and uses this number in the connector hash functions.
(I also plan to use it as an array index in a future parse speedup.)

It also extends the information obtained through Connector::desc without increasing its 32-bit size by adding a pointer to `condesc_t` pointing to extra data. This will allow us to add more data per connector type, e.g., costs for multi-connectors (#1351, #1352) and a cost table per connection length (I think mentioned in #632, and a placeholder added in 2c1d9791d2). The idea is that the data needed during parsing for easy_match is still directly available, while obtaining other data before and after the parsing may need an extra redirection.

The hashing functions have also improved, and they should now keep the collisions low, hopefully without pathological cases (the current hash doesn't differentiate between connectors with more than 4 UP and 4 LC characters, and increasing `connector_hash_t` to `size_t` turned out to be too costly).
I handled two types of collisions:
1. Different connector lists that map to the same 32-bit hash value. Enabling the existing per-connector feedback hash (with different multiplications constants) reduced them by 2+ orders of magnitude.
2. Extra collisions due to different hash values that hashed to the same slot. The added Fibonacci multiplication significantly reduced them.

I've also included a few minor efficiency tweaks. I tested the speed on the corpus batches and the `big-dict` (from #1479), and it seems there is a small speedup (but this patch is not about speedup).