### PR TITLE
Fix the extended ARRAY_SIZE definition and C compiler feature check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,6 +227,17 @@ CXXFLAGS="${CXXFLAGS} -Wall"
 CFLAGS="-std=c11 -D_BSD_SOURCE -D_SVID_SOURCE -D_GNU_SOURCE -D_ISOC11_SOURCE ${CFLAG_VISIBILITY} ${CFLAGS}"
 CXXFLAGS="-std=c++17 ${CFLAG_VISIBILITY} ${CXXFLAGS}"
 
+# _BSD_SOURCE and _SVID_SOURCE are deprecated in glibc>=2.20. _DEFAULT_SOURCE
+# is used there instead, but _BSD_SOURCE and _SVID_SOURCE can still be
+# specified (no effect). So just add it.
+CFLAGS="-D_DEFAULT_SOURCE ${CFLAGS}"
+CXXFLAGS="-D_DEFAULT_SOURCE ${CXXFLAGS}"
+
+#
+# After setting the compiler's C standard and flags,
+# we can check for supported features.
+#
+
 # Check for keywords to support pointer argument rejection
 # in #define ARRAY_SIZE (utilities.h).
 AX_GCC_BUILTIN(__builtin_types_compatible_p)
@@ -247,11 +258,6 @@ if test x${native_win32} = xyes; then
 	AC_DEFINE(_WIN32_WINNT, _WIN32_WINNT_VISTA)
 fi
 
-# _BSD_SOURCE and _SVID_SOURCE are deprecated in glibc>=2.20. _DEFAULT_SOURCE
-# is used there instead, but _BSD_SOURCE and _SVID_SOURCE can still be
-# specified (no effect). So just add it.
-CFLAGS="-D_DEFAULT_SOURCE ${CFLAGS}"
-CXXFLAGS="-D_DEFAULT_SOURCE ${CXXFLAGS}"
 
 # ====================================================================
 

--- a/configure.ac
+++ b/configure.ac
@@ -105,8 +105,6 @@ AC_PROG_LEX(noyywrap)
 # (with a mystery error about not finding regex.h)
 AC_LANG([C])
 
-AC_C_CONST
-
 AC_CHECK_FUNCS(strndup strtok_r sigaction malloc_trim)
 AC_CHECK_FUNCS(aligned_alloc posix_memalign _aligned_malloc)
 

--- a/configure.ac
+++ b/configure.ac
@@ -100,51 +100,6 @@ AC_PROG_LEX(noyywrap)
 	AC_MSG_ERROR([No flex/lex program found. Please install the "flex" or
                  "btyacc" package.])
 
-# The below says "use the C compiler for all remaining tests".
-# That way, if g++ is not installed, configure won't crap out
-# (with a mystery error about not finding regex.h)
-AC_LANG([C])
-
-AC_CHECK_FUNCS(strndup strtok_r sigaction malloc_trim)
-AC_CHECK_FUNCS(aligned_alloc posix_memalign _aligned_malloc)
-
-AC_FUNC_ALLOCA
-
-# For the Wordgraph display code
-AC_FUNC_FORK
-AC_CHECK_FUNCS(prctl)
-
-# CentOS-7 (at least) needs these to expose the C99 format and
-# limit macros in C++ source code.  They are needed for minisat.
-AC_DEFINE(__STDC_FORMAT_MACROS)
-AC_DEFINE(__STDC_LIMIT_MACROS)
-
-# Check for a keyword for Thread Local Storage declaration.
-# If found - define TLS to it.
-lg_tls=no
-AX_TLS(,:)
-test "$ac_cv_tls" != "none" && lg_tls=yes
-
-AX_PTHREAD
-if test -n "$ax_pthread_ok"; then
-	CC="${PTHREAD_CC:-CC}"
-	dnl #CCX="${PTHREAD_CC:-CCX}"
-
-	dnl Currently, libtool uses --nostdlib when linking shared libraries,
-	dnl which causes the -pthread flag to be ignored. Try to work around that
-	dnl by explicitly specifying the pthread library unless it is already set.
-	if test -z "$PTHREAD_LIBS"; then
-		PTHREAD_LIBS=-lpthread
-	fi
-fi
-
-dnl Check if we can use C11 threads functions
-AC_CHECK_HEADERS_ONCE([threads.h])
-
-dnl If the visibility __attribute__  is supported, define HAVE_VISIBILITY
-dnl and a variable CFLAG_VISIBILITY, to be added to CFLAGS/CXXFLAGS.
-LG_C_ATTRIBUTE_VISIBILITY
-
 # ====================================================================
 # Check for specific OSs
 
@@ -210,6 +165,10 @@ if test -n "$ax_pthread_ok" -a "x$freebsd" = "xyes"; then
 fi
 
 # ====================================================================
+# The below says "use the C compiler for all remaining tests".
+# That way, if g++ is not installed, configure won't crap out
+# (with a mystery error about not finding regex.h)
+AC_LANG([C])
 
 CXXFLAGS="${CXXFLAGS} -Wall"
 
@@ -242,6 +201,48 @@ CXXFLAGS="-D_DEFAULT_SOURCE ${CXXFLAGS}"
 # in #define ARRAY_SIZE (utilities.h).
 AX_GCC_BUILTIN(__builtin_types_compatible_p)
 AC_C_TYPEOF
+
+AC_CHECK_FUNCS(strndup strtok_r sigaction malloc_trim)
+AC_CHECK_FUNCS(aligned_alloc posix_memalign _aligned_malloc)
+
+# For the Wordgraph display code.
+AC_FUNC_FORK
+AC_CHECK_FUNCS(prctl)
+
+AC_FUNC_ALLOCA
+
+# Check for a keyword for Thread Local Storage declaration.
+# If found - define TLS to it.
+lg_tls=no
+AX_TLS(,:)
+test "$ac_cv_tls" != "none" && lg_tls=yes
+
+AX_PTHREAD
+if test -n "$ax_pthread_ok"; then
+	CC="${PTHREAD_CC:-CC}"
+	dnl #CCX="${PTHREAD_CC:-CCX}"
+
+	dnl Currently, libtool uses --nostdlib when linking shared libraries,
+	dnl which causes the -pthread flag to be ignored. Try to work around that
+	dnl by explicitly specifying the pthread library unless it is already set.
+	if test -z "$PTHREAD_LIBS"; then
+		PTHREAD_LIBS=-lpthread
+	fi
+fi
+
+# Check if we can use C11 threads functions.
+AC_CHECK_HEADERS_ONCE([threads.h])
+
+# If the visibility __attribute__  is supported, define HAVE_VISIBILITY
+# and a variable CFLAG_VISIBILITY, to be added to CFLAGS/CXXFLAGS.
+LG_C_ATTRIBUTE_VISIBILITY
+
+# CentOS-7 (at least) needs these to expose the C99 format and
+# limit macros in C++ source code.  They are needed for minisat.
+AC_DEFINE(__STDC_FORMAT_MACROS)
+AC_DEFINE(__STDC_LIMIT_MACROS)
+
+# End of checks for C compiler supported features.
 
 if test x${native_win32} = xyes; then
 	# We need the shlwapi for PathRemoveFileSpecA().

--- a/configure.ac
+++ b/configure.ac
@@ -229,6 +229,11 @@ CXXFLAGS="${CXXFLAGS} -Wall"
 CFLAGS="-std=c11 -D_BSD_SOURCE -D_SVID_SOURCE -D_GNU_SOURCE -D_ISOC11_SOURCE ${CFLAG_VISIBILITY} ${CFLAGS}"
 CXXFLAGS="-std=c++17 ${CFLAG_VISIBILITY} ${CXXFLAGS}"
 
+# Check for keywords to support pointer argument rejection
+# in #define ARRAY_SIZE (utilities.h).
+AX_GCC_BUILTIN(__builtin_types_compatible_p)
+AC_C_TYPEOF
+
 if test x${native_win32} = xyes; then
 	# We need the shlwapi for PathRemoveFileSpecA().
 	LDFLAGS="${LDFLAGS} -lshlwapi"

--- a/link-grammar/utilities.h
+++ b/link-grammar/utilities.h
@@ -226,7 +226,6 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
 #endif
 
 /* From ccan array_size.h and build_assert.h, which are under a CC0 license */
-#define BUILD_ASSERT_OR_ZERO(cond) (sizeof(char [1 - 2*!(cond)]) - 1)
 #if !defined(ARRAY_SIZE)
 /**
  * ARRAY_SIZE: Get the number of elements in a visible array
@@ -238,10 +237,11 @@ static inline char *_strndupa3(char *new_s, const char *s, size_t n)
  */
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]) + _array_size_chk(arr))
 
-#if HAVE_BUILTIN_TYPES_COMPATIBLE_P && HAVE_TYPEOF
+#if HAVE___BUILTIN_TYPES_COMPATIBLE_P && HAVE_TYPEOF
+#define BUILD_ASSERT_OR_ZERO(cond) (sizeof(char [1 - 2*!(cond)]) - 1)
 /* Two gcc extensions.
  * &a[0] degrades to a pointer: a different type from an array */
-#define _array_size_chk(arr)
+#define _array_size_chk(arr) \
 	BUILD_ASSERT_OR_ZERO(!__builtin_types_compatible_p(typeof(arr), \
 							typeof(&(arr)[0])))
 #else


### PR DESCRIPTION
- Fix the optional check for using a pointer in ARRAY_SIZE().

On the same occasion,  in  `configure.ac`:
- Move the C compiler feature check to be after setting the C compiler flags.
- Remove AC_C_CONST 