### PR TITLE
tests.py: divert_end(): Read the entire output

### DIFF
--- a/bindings/python-examples/tests.py
+++ b/bindings/python-examples/tests.py
@@ -1512,7 +1512,8 @@ class divert_start(object):
         if not self.filename:
             return ""
         os.lseek(self.fd, os.SEEK_SET, 0)
-        content = os.read(self.fd, 1024) # 1024 is more than needed
+        with os.fdopen(self.fd, 'rb') as file:
+            content = file.read()
         os.dup2(self.savedfd, self.fd)
         os.close(self.savedfd)
         os.unlink(self.filename)


### PR DESCRIPTION
Reading a fixed amount of bytes (in this case 1024) may truncate a utf8 character, leading to Python errors.
Encountered on MacOS in the `test_tahi` test:

Traceback (most recent call last):
  File "/usr/local/src/link-grammar-devel/autogen/bindings/python-examples/tests.py", line 1300, in test_thai
    for line in save_stderr.divert_end().decode().split("\n"):
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xef in position 1023: unexpected end of data
