### PR TITLE
Update autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,18 +13,16 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Update the m4 macros
-autoreconf -fvi
-
 # If there's a config.cache file, we may need to delete it.
 # If we have an existing configure script, save a copy for comparison.
 if [ -f config.cache ] && [ -f configure ]; then
   cp configure configure.$$.tmp
 fi
 
-# Produce ./configure
-#
 echo "Creating configure..."
+
+# Update the m4 macros
+autoreconf -fvi
 
 run_configure=true
 for arg in $*; do

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,17 +16,6 @@ fi
 # Update the m4 macros
 autoreconf -fvi
 
-# Produce all the `GNUmakefile.in's and create neat missing things
-# like `install-sh', etc.
-#
-echo "automake --add-missing --copy --foreign"
-
-automake --add-missing --copy --foreign 2>> autogen.err || {
-    echo ""
-    echo "* * * warning: possible errors while running automake - check autogen.err"
-    echo ""
-}
-
 # If there's a config.cache file, we may need to delete it.
 # If we have an existing configure script, save a copy for comparison.
 if [ -f config.cache ] && [ -f configure ]; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,10 +2,6 @@
 #
 # Run this before configure
 #
-# This file blatantly ripped off from subversion.
-#
-# Note: this dependency on Perl is fine: only developers use autogen.sh
-#       and we can state that dev people need Perl on their machine
 
 rm -f autogen.err
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -26,13 +26,6 @@ fi
 #
 echo "Creating configure..."
 
-autoconf 2>> autogen.err || {
-    echo ""
-    echo "* * * warning: possible errors while running automake - check autogen.err"
-    echo ""
-    grep 'Undefined AX_ macro' autogen.err && exit 1
-}
-
 run_configure=true
 for arg in $*; do
     case $arg in

--- a/autogen.sh
+++ b/autogen.sh
@@ -6,7 +6,9 @@
 rm -f autogen.err
 
 automake --version | perl -ne 'if (/\(GNU automake\) (([0-9]+).([0-9]+))/) {print; if ($2 < 1 || ($2 == 1 && $3 < 4)) {exit 1;}}'
-
+# For version x.y>1.4, x should not be 0, and y should be [4-9] or more than one digit.
+automake --version >/dev/null &&
+   automake --version | test "`sed -En '/^automake \(GNU automake\) [^0]\.([4-9]|[1-9][0-9])/p'`"
 if [ $? -ne 0 ]; then
     echo "Error: you need automake 1.4 or later.  Please upgrade."
     exit 1

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,6 @@
 
 rm -f autogen.err
 
-automake --version | perl -ne 'if (/\(GNU automake\) (([0-9]+).([0-9]+))/) {print; if ($2 < 1 || ($2 == 1 && $3 < 4)) {exit 1;}}'
 # For version x.y>1.4, x should not be 0, and y should be [4-9] or more than one digit.
 automake --version >/dev/null &&
    automake --version | test "`sed -En '/^automake \(GNU automake\) [^0]\.([4-9]|[1-9][0-9])/p'`"
@@ -14,20 +13,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if test ! -d `aclocal --print-ac-dir 2>> autogen.err`; then
-  echo "Bad aclocal (automake) installation"
-  exit 1
-fi
-
 # Update the m4 macros
 autoreconf -fvi
 
-# Produce aclocal.m4, so autoconf gets the automake macros it needs
-#
 case `uname` in
-    CYGWIN*)
-        include_dir='-I m4' # Needed for Cygwin only.
-        ;;
     Darwin)
         [ "$LIBTOOLIZE" = "" ] && LIBTOOLIZE=glibtoolize
         ;;
@@ -37,10 +26,6 @@ esac
     echo "error: libtoolize failed"
     exit 1
 }
-
-echo "Creating aclocal.m4: aclocal $include_dir $ACLOCAL_FLAGS"
-
-aclocal $include_dir $ACLOCAL_FLAGS 2>> autogen.err
 
 # Produce all the `GNUmakefile.in's and create neat missing things
 # like `install-sh', etc.

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,6 +5,24 @@
 
 rm -f autogen.err
 
+run_configure=true
+while [ -n "$1" ]
+do
+    case "$1" in
+        --no-configure)
+            run_configure=false
+            shift
+            ;;
+        --clean)
+            # Start from a clean state.
+            rm -rf config.cache autom4te*.cache
+            shift
+            ;;
+        *)
+            break 2
+    esac
+done
+
 # For version x.y>1.4, x should not be 0, and y should be [4-9] or more than one digit.
 automake --version >/dev/null &&
    automake --version | test "`sed -En '/^automake \(GNU automake\) [^0]\.([4-9]|[1-9][0-9])/p'`"
@@ -44,17 +62,6 @@ if [ -f config.cache ]; then
   )
   rm -f "$OLD_CONFIGURE"
 fi
-
-run_configure=true
-for arg in $*; do
-    case $arg in
-        --no-configure)
-            run_configure=false
-            ;;
-        *)
-            ;;
-    esac
-done
 
 if $run_configure; then
     mkdir -p build

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,6 +3,11 @@
 # Run this before configure
 #
 
+if [ ! -f "autogen.sh" ]; then
+    echo "$0: This script must be run in the top-level directory"
+    exit 1
+fi
+
 rm -f autogen.err
 
 run_configure=true

--- a/autogen.sh
+++ b/autogen.sh
@@ -15,8 +15,10 @@ fi
 
 # If there's a config.cache file, we may need to delete it.
 # If we have an existing configure script, save a copy for comparison.
+# (Based on Subversion's autogen.sh, see also the deletion code below.)
+OLD_CONFIGURE="${TMPDIR:-/tmp}/configure.$$.tmp"
 if [ -f config.cache ] && [ -f configure ]; then
-  cp configure configure.$$.tmp
+  cp configure "$OLD_CONFIGURE"
 fi
 
 echo "Creating configure..."
@@ -29,6 +31,18 @@ if [ $status -ne 0 ]; then
     echo "* * * Warning: autoreconf returned bad status ($status) - check autogen.err"
     echo ""
     exit 1
+fi
+
+# If we have a config.cache file, toss it if the configure script has
+# changed, or if we just built it for the first time.
+if [ -f config.cache ]; then
+  (
+    [ -f "$OLD_CONFIGURE" ] && cmp configure "$OLD_CONFIGURE" > /dev/null 2>&1
+  ) || (
+    echo "Tossing config.cache, since configure has changed."
+    rm config.cache
+  )
+  rm -f "$OLD_CONFIGURE"
 fi
 
 run_configure=true

--- a/autogen.sh
+++ b/autogen.sh
@@ -21,7 +21,7 @@ fi
 
 echo "Creating configure..."
 
-# Update the m4 macros
+# Regenerate configuration scripts with the latest autotools updates.
 autoreconf -fvi 2>autogen.err
 status=$?
 if [ $status -ne 0 ]; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -22,7 +22,14 @@ fi
 echo "Creating configure..."
 
 # Update the m4 macros
-autoreconf -fvi
+autoreconf -fvi 2>autogen.err
+status=$?
+if [ $status -ne 0 ]; then
+    echo ""
+    echo "* * * Warning: autoreconf returned bad status ($status) - check autogen.err"
+    echo ""
+    exit 1
+fi
 
 run_configure=true
 for arg in $*; do

--- a/autogen.sh
+++ b/autogen.sh
@@ -59,6 +59,8 @@ done
 if $run_configure; then
     mkdir -p build
     cd build
+    echo
+    echo "Running 'configure'..."
     ../configure --enable-maintainer-mode "$@"
     status=$?
     if [ $status -eq 0 ]; then

--- a/autogen.sh
+++ b/autogen.sh
@@ -9,7 +9,7 @@ rm -f autogen.err
 automake --version >/dev/null &&
    automake --version | test "`sed -En '/^automake \(GNU automake\) [^0]\.([4-9]|[1-9][0-9])/p'`"
 if [ $? -ne 0 ]; then
-    echo "Error: you need automake 1.4 or later.  Please upgrade."
+    echo "$0: Error: you need automake 1.4 or later.  Please upgrade."
     exit 1
 fi
 
@@ -21,14 +21,14 @@ if [ -f config.cache ] && [ -f configure ]; then
   cp configure "$OLD_CONFIGURE"
 fi
 
-echo "Creating 'configure'..."
+echo "$0: Creating 'configure'..."
 
 # Regenerate configuration scripts with the latest autotools updates.
 autoreconf -fvi 2>autogen.err
 status=$?
 if [ $status -ne 0 ]; then
     echo ""
-    echo "* * * Warning: autoreconf returned bad status ($status) - check autogen.err"
+    echo "$0: * * * Warning: autoreconf returned bad status ($status) - check autogen.err"
     echo ""
     exit 1
 fi
@@ -39,7 +39,7 @@ if [ -f config.cache ]; then
   (
     [ -f "$OLD_CONFIGURE" ] && cmp configure "$OLD_CONFIGURE" > /dev/null 2>&1
   ) || (
-    echo "Tossing config.cache, since 'configure' has changed."
+    echo "$0: Tossing config.cache, since 'configure' has changed."
     rm config.cache
   )
   rm -f "$OLD_CONFIGURE"
@@ -60,17 +60,17 @@ if $run_configure; then
     mkdir -p build
     cd build
     echo
-    echo "Running 'configure'..."
+    echo "$0: Running 'configure'..."
     ../configure --enable-maintainer-mode "$@"
     status=$?
     if [ $status -eq 0 ]; then
       echo
-      echo "Now type 'make' to compile link-grammar (in the 'build' directory)."
+      echo "$0: Now type 'make' to compile link-grammar (in the 'build' directory)."
     else
       echo
-      echo "'configure' returned a bad status ($status)."
+      echo "$0: 'configure' returned a bad status ($status)."
     fi
 else
     echo
-    echo "Now run 'configure' and 'make' to compile link-grammar."
+    echo "$0: Now run 'configure' and 'make' to compile link-grammar."
 fi

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,17 +16,6 @@ fi
 # Update the m4 macros
 autoreconf -fvi
 
-case `uname` in
-    Darwin)
-        [ "$LIBTOOLIZE" = "" ] && LIBTOOLIZE=glibtoolize
-        ;;
-esac
-
-    ${LIBTOOLIZE:=libtoolize} --force --copy || {
-    echo "error: libtoolize failed"
-    exit 1
-}
-
 # Produce all the `GNUmakefile.in's and create neat missing things
 # like `install-sh', etc.
 #

--- a/autogen.sh
+++ b/autogen.sh
@@ -21,7 +21,7 @@ if [ -f config.cache ] && [ -f configure ]; then
   cp configure "$OLD_CONFIGURE"
 fi
 
-echo "Creating configure..."
+echo "Creating 'configure'..."
 
 # Regenerate configuration scripts with the latest autotools updates.
 autoreconf -fvi 2>autogen.err
@@ -39,7 +39,7 @@ if [ -f config.cache ]; then
   (
     [ -f "$OLD_CONFIGURE" ] && cmp configure "$OLD_CONFIGURE" > /dev/null 2>&1
   ) || (
-    echo "Tossing config.cache, since configure has changed."
+    echo "Tossing config.cache, since 'configure' has changed."
     rm config.cache
   )
   rm -f "$OLD_CONFIGURE"
@@ -68,7 +68,7 @@ if $run_configure; then
       echo "Now type 'make' to compile link-grammar (in the 'build' directory)."
     else
       echo
-      echo "\"configure\" returned a bad status ($status)."
+      echo "'configure' returned a bad status ($status)."
     fi
 else
     echo

--- a/autogen.sh
+++ b/autogen.sh
@@ -9,6 +9,10 @@ run_configure=true
 while [ -n "$1" ]
 do
     case "$1" in
+        --help|-help|-h)
+            echo "Usage: $0 [--no-configure] [--clean]"
+            exit 0
+            ;;
         --no-configure)
             run_configure=false
             shift

--- a/mingw/README-MinGW64.md
+++ b/mingw/README-MinGW64.md
@@ -63,7 +63,7 @@ Then build and install link-grammar with
 
      mkdir build
      cd build
-     ../configure
+     sh ../configure
      make
      make install
 


### PR DESCRIPTION
Remove the calls to `aclocal`, `libtoolize`, `autoconf`, and `automake`, which became unneeded after the recent addition of `autoreconf` to `autogen.sh` (PR #1516, see also issue #1492).

On the same occasion:
- Replace `perl` with `sed`.
But is this check needed anymore since version 1.4 is ancient?
- Remove `config.cache` if needed.
The "original" `autogen.sh` contains only the first half of the code to remove `config.cache` when `configure` changes. 
Add the second half of the code that removes `config.cache` if needed.
- Prefix messages with the script name.
The Autoconf system is careful to prefix its messages with the program name. Do so for the messages here, too, so their source is clear.
- Add --clean.
Stale or corrupted caches may cause mysterious problems. Add an option to start from a clean state.
- Add --help.
- Add invocation directory consistency check.
Insist that `autogen.sh` is invoked from the top-level directory.

I checked it on MacOS (old system - 11.6.2), Cygwin, MinGW64, and Linux.
On MinGW64, `configure` doesn't have an x bit. Instead of changing `autogen.sh`, I changed `README-MinGW64.md`.