### PR TITLE
link-parser's history file location control

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ CXXFLAGS="-D_DEFAULT_SOURCE ${CXXFLAGS}"
 AX_GCC_BUILTIN(__builtin_types_compatible_p)
 AC_C_TYPEOF
 
-AC_CHECK_FUNCS(strndup strtok_r sigaction malloc_trim)
+AC_CHECK_FUNCS(strndup strtok_r sigaction malloc_trim asprintf)
 AC_CHECK_FUNCS(aligned_alloc posix_memalign _aligned_malloc)
 
 # For the Wordgraph display code.

--- a/link-parser/Makefile.am
+++ b/link-parser/Makefile.am
@@ -12,7 +12,9 @@ link_parser_SOURCES = link-parser.c \
                       parser-utilities.h \
                       parser-utilities.c \
                       command-line.h \
-                      lg_readline.h
+                      lg_readline.h \
+							 lg_xdg.c \
+							 lg_xdg.h
 
 # -I$(top_builddir) to pick up autogened link-grammar/link-features.h
 link_parser_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -59,7 +59,7 @@ static wchar_t * prompt(EditLine *el)
 //    arguments. So replace them with a new struct "io_params".
 static const char *history_file;
 
-static const char history_file_basename[] = "lg_history";
+static const char history_file_basename[] = "_history";
 
 void find_history_filepath(const char *dictname, const char *argv0,
                            const char *prog)
@@ -67,13 +67,21 @@ void find_history_filepath(const char *dictname, const char *argv0,
 	const char *xdg_prog = xdg_get_program_name(argv0);
 	if (NULL == xdg_prog) xdg_prog = prog;
 
+	// Prefix the history file name with a dict indication.
+	// To support sharing the history file by several similar dicts,
+	// use the dict name up to the first ":" if exists.
+	char *dictpref = strdup(dictname);
+	dictpref[strcspn(dictpref, ":")] = '\0';
+
 	// Find the location of the history file.
-	const char *hfile =
-		xdg_make_path(XDG_BD_STATE, "%s/%s", xdg_prog, history_file_basename);
+	const char *hfile = xdg_make_path(XDG_BD_STATE, "%s/%s%s", xdg_prog,
+	                                  dictpref, history_file_basename);
+	free(dictpref);
+
 	if (NULL == hfile)
 	{
-		prt_error("Warning: xdg_get_home(XDG_BD_STATE) failed - "
-		          "history file will be in the current directory\n");
+		prt_error("Warning: xdg_get_home(XDG_BD_STATE) failed; "
+		          "input history will not be supported.\n");
 		history_file = strdup("dev/null");
 		return;
 	}

--- a/link-parser/lg_readline.c
+++ b/link-parser/lg_readline.c
@@ -39,6 +39,7 @@
 
 #include "command-line.h"
 #include "parser-utilities.h"
+#include "lg_xdg.h"
 
 extern Switch default_switches[];
 static const Switch **sorted_names; /* sorted command names */
@@ -46,6 +47,38 @@ static wchar_t * wc_prompt = NULL;
 static wchar_t * prompt(EditLine *el)
 {
 	return wc_prompt;
+}
+
+// lg_readline()is called via a chain of functions:
+// fget_input_string -> get_line -> get_terminal_line -> lg_readline.
+// To avoid changing all of them, this variable is static for now.
+// FIXME: Move the call of find_history_filepath() to lg_readline(), and
+// implement one of these:
+// 1. Add the dictionary, argv[0] and prog to the call of each function.
+// 2. Option 1 is cumbersome since the first 3 functions have numerous
+//    arguments. So replace them with a new struct "io_params".
+static const char *history_file;
+
+static const char history_file_basename[] = "lg_history";
+
+void find_history_filepath(const char *dictname, const char *argv0,
+                           const char *prog)
+{
+	const char *xdg_prog = xdg_get_program_name(argv0);
+	if (NULL == xdg_prog) xdg_prog = prog;
+
+	// Find the location of the history file.
+	const char *hfile =
+		xdg_make_path(XDG_BD_STATE, "%s/%s", xdg_prog, history_file_basename);
+	if (NULL == hfile)
+	{
+		prt_error("Warning: xdg_get_home(XDG_BD_STATE) failed - "
+		          "history file will be in the current directory\n");
+		history_file = strdup("dev/null");
+		return;
+	}
+
+	history_file = hfile;
 }
 
 /**
@@ -372,7 +405,6 @@ char *lg_readline(const char *mb_prompt)
 
 	if (!is_init)
 	{
-#define HFILE ".lg_history"
 		is_init = true;
 
 		size_t sz = mbstowcs(NULL, mb_prompt, 0) + 4;
@@ -384,7 +416,7 @@ char *lg_readline(const char *mb_prompt)
 		history_w(hist, &ev, H_SETSIZE, 100);
 		history_w(hist, &ev, H_SETUNIQUE, 1);
 		el_wset(el, EL_HIST, history_w, hist);
-		history_w(hist, &ev, H_LOAD, HFILE);
+		history_w(hist, &ev, H_LOAD, history_file);
 
 		el_set(el, EL_SIGNAL, 1); /* Restore tty setting on returning to shell */
 
@@ -410,6 +442,7 @@ char *lg_readline(const char *mb_prompt)
 	{
 		el_end(el);
 		history_wend(hist);
+		free((void *)history_file);
 		free(wc_prompt);
 		wc_prompt = NULL;
 		hist = NULL;
@@ -421,7 +454,7 @@ char *lg_readline(const char *mb_prompt)
 	if (1 < numc)
 	{
 		history_w(hist, &ev, H_ENTER, wc_line);
-		history_w(hist, &ev, H_SAVE, HFILE);
+		history_w(hist, &ev, H_SAVE, history_file);
 	}
 	/* fwprintf(stderr, L"==> got %d %ls", numc, wc_line); */
 

--- a/link-parser/lg_readline.h
+++ b/link-parser/lg_readline.h
@@ -9,6 +9,14 @@
 /*                                                                         */
 /***************************************************************************/
 
-#ifdef HAVE_EDITLINE
+#if HAVE_EDITLINE
 char *lg_readline(const char *mb_prompt);
 #endif /* HAVE_EDITLINE */
+
+#if HAVE_WIDECHAR_EDITLINE
+void find_history_filepath(const char *, const char *, const char *);
+#else
+// Defining here an empty inline function causes a mysterious ld
+// error on MinGW.
+#define find_history_filepath(a, b, c)
+#endif /* HAVE_WIDECHAR_EDITLINE */

--- a/link-parser/lg_xdg.c
+++ b/link-parser/lg_xdg.c
@@ -91,6 +91,8 @@ static bool make_dirpath(const char *path)
 	// Skip Windows UNC path \\X
 	if (is_sep(dir[0]) && is_sep(dir[1]))
 	{
+		const char *p;
+
 		// Start from the root or network share
 		for (p = dir + 2; *p != '\0'; p++)
 			if (is_sep(*p)) break;
@@ -103,6 +105,7 @@ static bool make_dirpath(const char *path)
 		char sep = *p;
 		if (is_sep(*p))
 		{
+			if (is_sep(p[-1])) continue; // Ignore directory separator sequences
 			*p = '\0'; // Now dir is the path up to this point
 			//prt_error("DEBUG: mkdir: '%s'\n", dir);
 			mkdir(dir, S_IRWXU); // Try to create the directory
@@ -120,6 +123,12 @@ static bool make_dirpath(const char *path)
 	return true;
 }
 
+/**
+ * @brief Get the home directory for the given XDG base directory type.
+ *
+ * @param bd_type The XDG base directory type.
+ * @return const char* The home directory path (freed by caller).
+ */
 const char *xdg_get_home(xdg_basedir_type bd_type)
 {
 	const char *def_suffix = xdg_def[bd_type].rel_path;
@@ -165,6 +174,12 @@ const char *xdg_get_home(xdg_basedir_type bd_type)
 	return def_dir;
 }
 
+/**
+ * @brief Get the program name from the provided path.
+ *
+ * @param argv0 The path to the executable.
+ * @return const char* The program name.
+ */
 const char *xdg_get_program_name(const char *argv0)
 {
 	if ((NULL == argv0) || ('\0' == argv0[0])) return NULL;
@@ -178,9 +193,21 @@ const char *xdg_get_program_name(const char *argv0)
 	return basename;
 }
 
+
+/**
+ * @brief Construct a full path within the specified XDG base directory.
+ *
+ * @param bd_type The XDG base directory type.
+ * @param fmt The format string for the path.
+ * @param ... Additional arguments for the format string.
+ * @return const char* The constructed full path (freed by caller).
+ */
+
 const char *xdg_make_path(xdg_basedir_type bd_typec, const char *fmt, ...)
 {
 	const char *xdg_home = xdg_get_home(bd_typec);
+
+	if (NULL == xdg_home) return NULL;
 
 	char *xdg_fmt;
 	asprintf(&xdg_fmt, "%s/%s", xdg_home, fmt);

--- a/link-parser/lg_xdg.c
+++ b/link-parser/lg_xdg.c
@@ -1,0 +1,203 @@
+/***************************************************************************/
+/* Amir Plivatsky                                                          */
+/*                                                                         */
+/* Use of the link grammar parsing system is subject to the terms of the   */
+/* license set forth in the LICENSE file included with this software.      */
+/* This license allows free redistribution and use in source and binary    */
+/* forms, with or without modification, subject to certain conditions.     */
+/*                                                                         */
+/***************************************************************************/
+
+/**
+ * This file includes minimal implementation of the XDG
+ * specification version 0.8. See:
+ * https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ *
+ * It is supports just what needed to support the history file location.
+ */
+
+#if HAVE_WIDECHAR_EDITLINE
+#include <ctype.h>
+#include <stdarg.h>
+
+#include "link-grammar/link-includes.h"
+#include <sys/stat.h>
+#include <stdbool.h>
+#include <stdlib.h>                     // malloc etc.
+#include <string.h>
+#include <errno.h>
+
+#include "lg_xdg.h"
+#include "parser-utilities.h"
+
+typedef struct
+{
+	const char *rel_path;
+	const char *env_var;
+} xdg_definition;;
+
+xdg_definition xdg_def[] =
+{
+	{ "/.local/state", "XDG_STATE_HOME"  },
+	// Add more definitions if needed.
+};
+
+static bool is_empty(const char *path)
+{
+	return path == NULL || path[0] == '\0';
+}
+
+static bool is_absolute_path(const char *path)
+{
+	if (is_empty(path)) return false; // Empty path is not absolute
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+	// Check for Windows absolute paths.
+	if ((isalpha((unsigned char)path[0]) && path[1] == ':' &&
+	     (path[2] == '\\' || path[2] == '/')) ||
+	    (path[0] == '\\' && path[1] == '\\'))
+	{
+		return true;
+	}
+#endif
+
+	// Check for POSIX absolute path.
+	if (path[0] == '/') return true;
+
+	return false; // Path is not absolute
+}
+
+static bool is_sep(int c)
+{
+#if defined(_WIN32) || defined(__CYGWIN__)
+	if (c == '\\') return true;
+#endif
+	if (c == '/') return true;
+
+	return false;
+}
+
+/**
+ * Make directories for each directory component of \p path.
+ * If the last component is not ending with "/", it is considered
+ * a file name.
+ */
+static bool make_dirpath(const char *path)
+{
+	char *dir = strdup(path);
+	struct stat sb;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+	// Skip Windows UNC path \\X
+	if (is_sep(dir[0]) && is_sep(dir[1]))
+	{
+		// Start from the root or network share
+		for (p = dir + 2; *p != '\0'; p++)
+			if (is_sep(*p)) break;
+		if (*p == '\0') return true;  // No further subdirectories
+	}
+#endif
+
+	for (char *p = dir+1; '\0' != *p; p++)
+	{
+		char sep = *p;
+		if (is_sep(*p))
+		{
+			*p = '\0'; // Now dir is the path up to this point
+			//prt_error("DEBUG: mkdir: '%s'\n", dir);
+			mkdir(dir, S_IRWXU); // Try to create the directory
+			if (stat(dir, &sb) != 0 || !S_ISDIR(sb.st_mode))
+			{
+				prt_error("Error: Cannot create directory '%s'\n", dir);
+				free(dir);
+				return false;
+			}
+			*p = sep;
+		}
+	}
+
+	free(dir);
+	return true;
+}
+
+const char *xdg_get_home(xdg_basedir_type bd_type)
+{
+	const char *def_suffix = xdg_def[bd_type].rel_path;
+	const char *evars[] = { xdg_def[bd_type].env_var, "HOME",
+#if defined(_WIN32) || defined(__CYGWIN__)
+		"USERPROFILE"
+#endif
+	};
+	char *dir;
+
+	size_t num_evars = sizeof(evars)/sizeof(evars[0]);
+	size_t i;
+	for (i = 0; i < num_evars; i++)
+	{
+		dir = getenv(evars[i]);
+		if (is_empty(dir)) continue;
+
+		if (is_absolute_path(dir)) break;
+		if (num_evars - 1 != i) // Avoid a double notification
+		{
+			prt_error("Warning: %s is not an absolute path (ignored).\n",
+			          evars[i]);
+		}
+	}
+
+	if (!is_absolute_path(dir))
+	{
+		prt_error("Error: %s is not set or is not an absolute path.\n",
+		          evars[num_evars - 1]);
+		return NULL;
+	}
+
+	char *def_dir;
+	// def_suffix is a directory - append '/' so make_dirpath() will create it.
+	int n = asprintf(&def_dir, "%s%s/", dir, (i > 0) ? def_suffix : "");
+	if (!make_dirpath(def_dir))
+	{
+		free(def_dir);
+		return NULL;
+	}
+	def_dir[n-1] = '\0'; // Remove the last '/'
+
+	return def_dir;
+}
+
+const char *xdg_get_program_name(const char *argv0)
+{
+	if ((NULL == argv0) || ('\0' == argv0[0])) return NULL;
+
+	const char *basename = argv0;
+	for (const char *p = argv0; *p != '\0'; p++)
+		if (is_sep(*p)) basename = p + 1;
+
+	if (0 == strcmp(basename, "..")) return NULL;
+
+	return basename;
+}
+
+const char *xdg_make_path(xdg_basedir_type bd_typec, const char *fmt, ...)
+{
+	const char *xdg_home = xdg_get_home(bd_typec);
+
+	char *xdg_fmt;
+	asprintf(&xdg_fmt, "%s/%s", xdg_home, fmt);
+
+	va_list filename_components;
+	va_start(filename_components, fmt);
+	char *xdg_filepath;
+	vasprintf(&xdg_filepath, xdg_fmt, filename_components);
+	va_end(filename_components);
+
+	free((void *)xdg_home);
+	free(xdg_fmt);
+	if (!make_dirpath(xdg_filepath))
+	{
+		free(xdg_filepath);
+		return NULL;
+	}
+	return xdg_filepath;
+}
+#endif /* HAVE_WIDECHAR_EDITLINE */

--- a/link-parser/lg_xdg.h
+++ b/link-parser/lg_xdg.h
@@ -1,0 +1,15 @@
+#ifndef _LG_XDG_H
+#define _LG_XDG_H
+
+#include "link-grammar/link-includes.h"              // GNUC_PRINTF
+
+typedef enum {
+	 XDG_BD_STATE, // XDG_BD_CONFIG, XDG_BD_DATA, XDG_BD_CACHE
+} xdg_basedir_type;
+
+const char *xdg_get_home(xdg_basedir_type);
+const char *xdg_get_program_name(const char *);
+const char *xdg_make_path(xdg_basedir_type, const char *fmt, ...)
+	GNUC_PRINTF(2,3);
+
+#endif //_LG_XDG_H

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -53,6 +53,7 @@
 
 #include "parser-utilities.h"
 #include "command-line.h"
+#include "lg_readline.h"                // find_history_file
 
 #define DISPLAY_MAX 1024
 
@@ -62,6 +63,7 @@ static char * debug = (char *)"";
 static char * test = (char *)"";
 static bool isatty_io; /* Both input and output are tty. */
 
+static const char prog[] = "link-parser"; // If cannot obtain the program name
 static const char prompt[] = "linkparser> ";
 static const char *use_prompt(int verbosity_level)
 {
@@ -697,6 +699,9 @@ int main(int argc, char * argv[])
 		prt_error("Info: Library version %s. Enter \"!help\" for help.\n",
 			linkgrammar_get_version());
 	}
+
+	if (isatty_io)
+		find_history_filepath(dictionary_get_lang(dict), argv[0], prog);
 
 	/* Main input loop */
 	while (true)

--- a/link-parser/link-parser.c
+++ b/link-parser/link-parser.c
@@ -63,7 +63,6 @@ static char * debug = (char *)"";
 static char * test = (char *)"";
 static bool isatty_io; /* Both input and output are tty. */
 
-static const char prog[] = "link-parser"; // If cannot obtain the program name
 static const char prompt[] = "linkparser> ";
 static const char *use_prompt(int verbosity_level)
 {
@@ -701,7 +700,9 @@ int main(int argc, char * argv[])
 	}
 
 	if (isatty_io)
-		find_history_filepath(dictionary_get_lang(dict), argv[0], prog);
+	{
+		find_history_filepath(dictionary_get_lang(dict), argv[0], "link-parser");
+	}
 
 	/* Main input loop */
 	while (true)

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -573,6 +573,7 @@ int __mingw_vfprintf (FILE * __restrict__ stream, const char * __restrict__ fmt,
 	int n = vsnprintf(NULL, 0, fmt, vl);
 	if (0 > n) return n;
 	char *buf = malloc(n+1);
+	if (NULL == buf) return -1;
 	n = vsnprintf(buf, n+1, fmt, vl);
 	if (0 > n)
 	{

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -593,7 +593,7 @@ int __mingw_vprintf (const char * __restrict__ fmt, va_list vl)
 #endif /* __MINGW32__ */
 
 #if !HAVE_ASPRINTF
-int vasprintf(char ** __restrict__ buf, const char * __restrict__ fmt, va_list vl)
+int vasprintf(char ** restrict buf, const char * restrict fmt, va_list vl)
 {
 	va_list vl_copy;
 	va_copy(vl_copy, vl);

--- a/link-parser/parser-utilities.c
+++ b/link-parser/parser-utilities.c
@@ -35,6 +35,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if !HAVE_ASPRINTF
+#include <stdarg.h>
+#endif // !HAVE_ASPRINTF
 
 #include "parser-utilities.h"
 #include "lg_readline.h"
@@ -587,3 +590,38 @@ int __mingw_vprintf (const char * __restrict__ fmt, va_list vl)
 	return __mingw_vfprintf(stdout, fmt, vl);
 }
 #endif /* __MINGW32__ */
+
+#if !HAVE_ASPRINTF
+int vasprintf(char ** __restrict__ buf, const char * __restrict__ fmt, va_list vl)
+{
+	va_list vl_copy;
+	va_copy(vl_copy, vl);
+
+	int n = vsnprintf(NULL, 0, fmt, vl);
+	if (n < 0) {
+		va_end(vl_copy);
+		return n;
+	}
+
+	*buf = malloc(n + 1);
+	if (*buf == NULL) {
+		va_end(vl_copy);
+		return -1;
+	}
+
+	n = vsnprintf(*buf, n + 1, fmt, vl_copy);
+	if (n < 0) free(*buf);
+
+	va_end(vl_copy);
+	return n;
+}
+
+int asprintf(char ** restrict buf, const char * restrict fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	int result = vasprintf(buf, fmt, args);
+	va_end(args);
+	return result;
+}
+#endif /* !HAVE_ASPRINTF */

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -25,6 +25,9 @@ void initialize_screen_width(Command_Options *);
 #define MAX_INPUT_LINE 2048
 
 #ifdef _WIN32
+#ifndef mkdir
+#define mkdir(d, a) mkdir(d)
+#endif
 #ifndef __MINGW32__
 /* There is no ssize_t definition in native Windows. */
 #include <BaseTsd.h>
@@ -47,9 +50,9 @@ int lg_isatty(int);
 bool get_line(const char *, char **, unsigned int, FILE *, FILE *, bool);
 
 #if !HAVE_ASPRINTF
-int vasprintf(char ** __restrict__, const char * __restrict__, va_list)
+int vasprintf(char ** restrict, const char * restrict, va_list)
 	GNUC_PRINTF(2,0);
-int asprintf(char ** __restrict__, const char * __restrict__, ...)
+int asprintf(char ** restrict, const char * restrict, ...)
 	GNUC_PRINTF(2,3);
 #endif /* !HAVE_ASPRINTF */
 

--- a/link-parser/parser-utilities.h
+++ b/link-parser/parser-utilities.h
@@ -13,6 +13,7 @@
 #ifndef _PARSER_UTILITIES_
 #define _PARSER_UTILITIES_
 
+
 #include "../link-grammar/link-includes.h"
 
 #include "command-line.h"
@@ -44,4 +45,12 @@ int lg_isatty(int);
 #endif /* _WIN32 */
 
 bool get_line(const char *, char **, unsigned int, FILE *, FILE *, bool);
+
+#if !HAVE_ASPRINTF
+int vasprintf(char ** __restrict__, const char * __restrict__, va_list)
+	GNUC_PRINTF(2,0);
+int asprintf(char ** __restrict__, const char * __restrict__, ...)
+	GNUC_PRINTF(2,3);
+#endif /* !HAVE_ASPRINTF */
+
 #endif // _PARSER_UTILITIES_


### PR DESCRIPTION
In this PR:
The location of the history file is according to, in this order.
`XDG_STATE_HOME`
`HOME`

The history file name is X_history when X is the dict name to support a different history file per dict. For example, `en_history`. To support using the same history file for more than one dict, X is the dict name until the first `:`. For example, the dicts `en` and `en:test` use the save history file `en_history`.

I tested it on MinGW (no editline, just that it doesn't break compilation), Cygwin, macOS, and Linux.
It cannot be tested on MSVC because the MSVC build recently became broken in more than one way (PR soon). (The only test needed for now is that the changes of this PR don't break the build, as there is no editline support for Windows.)

This PR includes a minimal XDG support module I wrote instead of using a system library. One reason is that the current libraries don't support XDG_STATE_HOME, which was added to the standard relatively recently.

Comments:
- If XDG_STATE_HOMOCE is invalid (not absolute or not writeable), it is ignored. However, if HOME is invalid (undefined, not absolute, or not writeable), there is no fallback, and the history is disabled.
- Currently, verbosity=4, intended to show the location of files, doesn't show the location of the history file because the `verbosity` variable is currently not in the needed scope.

EDIT: I tried to configure with HAVE_ASPRINTF=0 and got a segfault. So, I forced-push a fix. (This also demonstrates that using `#if HAVE_FEATURE` is better than `#ifdef HAVE_FEATURE` because it allows such easy tests.)

Ref. PR #1446.
