### PR TITLE
Fix CC passing in Makefile.am

### DIFF
--- a/link-grammar/Makefile.am
+++ b/link-grammar/Makefile.am
@@ -30,7 +30,7 @@ else
    pkgdatadir_realpath := $(pkgdatadir)
 endif
 
-DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir_realpath)\" -DCC=\"$(CC)\"
+DEFS = @DEFS@ -DVERSION=\"@VERSION@\" -DDICTIONARY_DIR=\"$(pkgdatadir_realpath)\" -DCC=\"$(firstword $(CC))\"
 
 # $(top_builddir) to pick up autogened link-grammar/link-features.h
 AM_CPPFLAGS = -I$(top_builddir) -I$(top_srcdir)


### PR DESCRIPTION
Depending on `autoconf` and system compiler version, `AC_PROG_CC` sometimes inserts compiler flags into the `CC` variable, making `CC` not a single word. For example, on `autoconf` 2.73 and `clang` 21.18 I got `CC="clang -std=gnu23"`. This peculiar semantic breaks the `CC` string injection resulting in compilation error:

```
In file included from <built-in>:409:
<command line>:60:12: warning: missing terminating '"' character [-Winvalid-pp-token]
   60 | #define CC "clang
      |            ^
config.c:126:26: error: expected ';' after return statement
  126 |         return "Compiled with: " LG_COMP "\n"
      |                                 ^
      |                                 ;
1 warning and 1 error generated.
```

This PR changes the `CC` passing to only pass the first word of the `CC` string, fixing this issue.